### PR TITLE
ci: fix CodeQL workflow (v4 + manual dispatch)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "master" ]
   pull_request:
     branches: [ "main", "master" ]
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'  # Her Pazartesi 06:00 UTC
 
@@ -27,15 +28,15 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
- Adds workflow_dispatch so CodeQL can be re-run manually\n- Updates github/codeql-action from v3 to v4\n\nNote: Repo Code Scanning default setup was disabled because it conflicts with advanced CodeQL workflows (SARIF upload rejected when default setup is enabled).