### PR TITLE
security: close remaining CodeQL findings

### DIFF
--- a/bantz-browser/src/renderer/renderer.js
+++ b/bantz-browser/src/renderer/renderer.js
@@ -393,7 +393,13 @@ function setupNavigationEvents() {
 function navigateToUrl() {
   const url = normalizeNavigationUrl(urlBar.value);
   if (!url) return;
-  webview.src = url;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
+    webview.src = parsed.toString();
+  } catch {
+    // ignore
+  }
 }
 
 function normalizeNavigationUrl(input) {
@@ -1423,8 +1429,15 @@ async function executeType(el, text) {
 function navigateTo(target) {
   const url = normalizeNavigationUrl(target);
   if (!url) return;
-  addMessage(`🌐 Gidiliyor: ${url}`, 'system');
-  webview.src = url;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
+    const safeUrl = parsed.toString();
+    addMessage(`🌐 Gidiliyor: ${safeUrl}`, 'system');
+    webview.src = safeUrl;
+  } catch {
+    // ignore
+  }
 }
 
 /**

--- a/bantz-extension/background.js
+++ b/bantz-extension/background.js
@@ -17,19 +17,15 @@ const state = {
   currentProfile: null,
 };
 
-function sanitizeForLog(value) {
-  let text;
-  if (typeof value === 'string') {
-    text = value;
-  } else {
-    try {
-      text = JSON.stringify(value);
-    } catch {
-      text = String(value);
-    }
-  }
-  return text.replace(/[\r\n\t]/g, ' ').replace(/[\u0000-\u001f\u007f]/g, ' ');
-}
+const KNOWN_MESSAGE_TYPES = new Set([
+  'scan',
+  'click',
+  'scroll',
+  'type',
+  'navigate',
+  'overlay',
+  'profile'
+]);
 
 /**
  * Connect to Bantz daemon WebSocket server
@@ -100,7 +96,8 @@ function sendToDaemon(message) {
  * Handle incoming messages from daemon
  */
 function handleDaemonMessage(message) {
-  console.log('[Bantz] Received:', sanitizeForLog(message));
+  const safeType = (message && KNOWN_MESSAGE_TYPES.has(message.type)) ? message.type : 'unknown';
+  console.log('[Bantz] Received message type:', safeType);
   
   switch (message.type) {
     case 'scan':
@@ -172,7 +169,7 @@ function handleDaemonMessage(message) {
       break;
       
     default:
-      console.log('[Bantz] Unknown message type:', sanitizeForLog(message && message.type));
+      console.log('[Bantz] Unknown message type');
   }
 }
 


### PR DESCRIPTION
Follow-up to fully clear CodeQL alerts:

- Avoid logging untrusted values (log injection) in bantz-extension/background.js
- Add explicit http/https protocol checks at the sink before assigning to webview.src in bantz-browser/src/renderer/renderer.js

These changes are intentionally sink-local so CodeQL can reason about them.