### PR TITLE
feat(issue-18): 📖 Page Content Extraction and LLM Summarization

### DIFF
--- a/bantz-extension/background.js
+++ b/bantz-extension/background.js
@@ -24,7 +24,8 @@ const KNOWN_MESSAGE_TYPES = new Set([
   'type',
   'navigate',
   'overlay',
-  'profile'
+  'profile',
+  'extract'
 ]);
 
 /**
@@ -167,6 +168,11 @@ function handleDaemonMessage(message) {
         profile: message.profile 
       });
       break;
+    
+    case 'extract':
+      // Extract page content for summarization
+      sendToActiveTab({ type: 'bantz:extract' });
+      break;
       
     default:
       console.log('[Bantz] Unknown message type');
@@ -239,6 +245,18 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         type: 'click_result',
         success: message.success,
         message: message.message,
+      });
+      break;
+    
+    case 'bantz:extract_result':
+      // Forward extracted content to daemon
+      sendToDaemon({
+        type: 'extract_result',
+        url: message.url,
+        title: message.title,
+        content: message.content,
+        extracted_at: message.extracted_at,
+        content_length: message.content_length,
       });
       break;
       

--- a/src/bantz/llm/persona.py
+++ b/src/bantz/llm/persona.py
@@ -63,6 +63,43 @@ JARVIS_RESPONSES: Dict[str, List[str]] = {
         "İşte bugünün haberleri efendim.",
     ],
     
+    # Page reading / extraction
+    "reading_page": [
+        "Sayfayı okuyorum efendim...",
+        "İçeriği analiz ediyorum efendim...",
+        "Sayfayı inceliyorum efendim...",
+        "Okuyorum efendim, bir saniye...",
+    ],
+    
+    # Summary ready
+    "summary_ready": [
+        "Buyurun efendim.",
+        "İşte özet efendim.",
+        "Özetledim efendim.",
+        "Analiz hazır efendim.",
+    ],
+    
+    # Answering question
+    "answering": [
+        "Bakayım efendim...",
+        "Kontrol ediyorum efendim...",
+        "Cevaplıyorum efendim...",
+    ],
+    
+    # Answer ready
+    "answer_ready": [
+        "Buyurun efendim.",
+        "Şöyle söyleyeyim efendim.",
+        "Evet efendim.",
+    ],
+    
+    # Content not found
+    "no_content": [
+        "Sayfadan içerik çıkaramadım efendim.",
+        "Bu sayfada özetlenecek içerik bulamadım efendim.",
+        "Sayfa içeriği okunamadı efendim.",
+    ],
+    
     # Opening something
     "opening": [
         "Açıyorum efendim.",

--- a/src/bantz/router/context.py
+++ b/src/bantz/router/context.py
@@ -154,6 +154,11 @@ class ConversationContext:
     # News briefing state
     _news_briefing: Any = field(default=None, repr=False)
     _pending_news_search: Optional[str] = field(default=None, repr=False)
+    
+    # Page summarizer state
+    _page_summarizer: Any = field(default=None, repr=False)
+    _pending_page_summarize: Optional[str] = field(default=None, repr=False)
+    _pending_page_question: Optional[str] = field(default=None, repr=False)
 
     def set_pending_agent_plan(self, *, task_id: str, steps: list[QueueStep]) -> None:
         """Store a planned agent task awaiting user confirmation."""
@@ -197,6 +202,45 @@ class ConversationContext:
         """Clear pending news search."""
         self._pending_news_search = None
 
+    # Page summarizer management
+    def set_page_summarizer(self, summarizer: Any) -> None:
+        """Store page summarizer instance for follow-up commands."""
+        self._page_summarizer = summarizer
+
+    def get_page_summarizer(self) -> Any:
+        """Get the current page summarizer instance."""
+        return self._page_summarizer
+
+    def clear_page_summarizer(self) -> None:
+        """Clear the page summarizer state."""
+        self._page_summarizer = None
+        self._pending_page_summarize = None
+        self._pending_page_question = None
+
+    def set_pending_page_summarize(self, detail_level: str = "short") -> None:
+        """Mark that a page summarization is pending."""
+        self._pending_page_summarize = detail_level
+
+    def get_pending_page_summarize(self) -> Optional[str]:
+        """Get pending page summarize detail level."""
+        return self._pending_page_summarize
+
+    def clear_pending_page_summarize(self) -> None:
+        """Clear pending page summarize."""
+        self._pending_page_summarize = None
+
+    def set_pending_page_question(self, question: str) -> None:
+        """Mark that a page question is pending."""
+        self._pending_page_question = question
+
+    def get_pending_page_question(self) -> Optional[str]:
+        """Get pending page question."""
+        return self._pending_page_question
+
+    def clear_pending_page_question(self) -> None:
+        """Clear pending page question."""
+        self._pending_page_question = None
+
     def snapshot(self) -> dict[str, Any]:
         return {
             "mode": self.mode,
@@ -212,4 +256,7 @@ class ConversationContext:
             "pending_agent_plan": bool(self._pending_agent_plan),
             "has_news_briefing": self._news_briefing is not None,
             "pending_news_search": self._pending_news_search,
+            "has_page_summarizer": self._page_summarizer is not None,
+            "pending_page_summarize": self._pending_page_summarize,
+            "pending_page_question": self._pending_page_question,
         }

--- a/src/bantz/router/nlu.py
+++ b/src/bantz/router/nlu.py
@@ -547,6 +547,52 @@ def parse_intent(text: str) -> Parsed:
         return Parsed(intent="news_briefing", slots={"query": "gündem"})
 
     # ─────────────────────────────────────────────────────────────────
+    # Page Summarization Commands (Jarvis-style)
+    # ─────────────────────────────────────────────────────────────────
+    
+    # Question about page content: "Bu CEO kim?", "Fiyatı ne?", "Kim yazmış?"
+    # Must check BEFORE general summarize patterns
+    m = re.search(r"\b(bu|şu|o)\s+(.+?)(\s+kim|\s+ne\s+zaman|\s+neden|\s+nas[ıi]l|\s+nerede)\b.*\?", t)
+    if m:
+        question = text.strip()
+        return Parsed(intent="page_question", slots={"question": question})
+    
+    # Direct questions: "CEO kim?", "Fiyatı ne?", "Kaç para?", "Ne zaman?"
+    if re.search(r"\b(kim|ne|neden|nas[ıi]l|nerede|ka[çc])\b.*\?$", t):
+        question = text.strip()
+        return Parsed(intent="page_question", slots={"question": question})
+    
+    # Detailed summarize: "detaylı anlat", "tam anlat", "daha detaylı özetle"
+    if re.search(r"\b(tam|daha\s+)?(detayl[ıi]|uzun)\s*(anlat|[öo]zetle|a[çc][ıi]kla)\b", t):
+        return Parsed(intent="page_summarize_detailed", slots={})
+    
+    # Detailed summarize: "detaylı olarak anlat", "ayrıntılı açıkla"
+    if re.search(r"\b(detayl[ıi]\s+olarak|ayr[ıi]nt[ıi]l[ıi])\s*(anlat|[öo]zetle|a[çc][ıi]kla)\b", t):
+        return Parsed(intent="page_summarize_detailed", slots={})
+    
+    # Short summarize: "bu sayfayı özetle", "bu haberi anlat", "şu makaleyi oku"
+    # Note: Turkish suffixes can be -ı/-i/-u/-ü or -yı/-yi/-yu/-yü or -nı/-ni/-nu/-nü
+    # içerik -> içeriği (k->ğ mutation)
+    if re.search(r"\b(bu|[şs]u)\s*(sayfa|haber|i[çc]eri[gğk]|makale|yaz[ıi])([yniıuü]+)?\s+([öo]zetle|anlat|a[çc][ıi]kla|oku)\b", t):
+        return Parsed(intent="page_summarize", slots={})
+    
+    # Short summarize: "bunu özetle", "şunu anlat"
+    if re.search(r"\b(bunu|[şs]unu)\s*([öo]zetle|anlat|a[çc][ıi]kla)\b", t):
+        return Parsed(intent="page_summarize", slots={})
+    
+    # Short summarize: "özetle", "anlat bakalım", "ne anlatıyor", "ne yazıyor"
+    if re.search(r"\b(ne\s+anlat[ıi]yor|ne\s+yaz[ıi]yor|ne\s+diyor|neler\s+var)\b", t):
+        return Parsed(intent="page_summarize", slots={})
+    
+    # Short summarize: "anlayamadım anlat", "anlamadım açıkla"
+    if re.search(r"\b(anlaya?mad[ıi]m|anlamad[ıi]m).*(anlat|a[çc][ıi]kla|[öo]zetle)\b", t):
+        return Parsed(intent="page_summarize", slots={})
+    
+    # Summarize with question marker: "bu ne anlatıyor bana?"
+    if re.search(r"\b(bu|[şs]u)\s+(ne\s+anlat|ne\s+yaz|ne\s+di)\b", t):
+        return Parsed(intent="page_summarize", slots={})
+
+    # ─────────────────────────────────────────────────────────────────
     # Original skills
     # ─────────────────────────────────────────────────────────────────
 

--- a/src/bantz/router/types.py
+++ b/src/bantz/router/types.py
@@ -45,6 +45,10 @@ Intent = Literal[
     "news_open_result",
     "news_open_current",
     "news_more",
+    # Page Summarization intents
+    "page_summarize",
+    "page_summarize_detailed",
+    "page_question",
     # Advanced desktop input
     "pc_mouse_move",
     "pc_mouse_click",

--- a/src/bantz/skills/__init__.py
+++ b/src/bantz/skills/__init__.py
@@ -5,6 +5,7 @@ Provides various skills for Bantz assistant including:
 - daily: Basic daily tasks (browser, notifications, etc.)
 - pc: PC control (apps, mouse, keyboard)
 - news: Jarvis-style news briefing system
+- summarizer: Page content extraction and LLM summarization
 """
 
 from bantz.skills.daily import (
@@ -25,6 +26,14 @@ from bantz.skills.news import (
     is_news_intent,
 )
 
+from bantz.skills.summarizer import (
+    PageSummary,
+    ExtractedPage,
+    PageSummarizer,
+    MockPageSummarizer,
+    extract_question,
+)
+
 __all__ = [
     # Daily skills
     "open_btop",
@@ -40,4 +49,10 @@ __all__ = [
     "MockNewsBriefing",
     "extract_news_query",
     "is_news_intent",
+    # Summarizer skills
+    "PageSummary",
+    "ExtractedPage",
+    "PageSummarizer",
+    "MockPageSummarizer",
+    "extract_question",
 ]

--- a/src/bantz/skills/summarizer.py
+++ b/src/bantz/skills/summarizer.py
@@ -1,0 +1,661 @@
+"""
+Page Content Summarization Skill.
+
+Jarvis-style page summarization using LLM:
+- Extract page content via extension
+- Generate short/detailed summaries
+- Answer questions about page content
+- Format for TTS and overlay display
+
+Example:
+    User: [on news page] "Bu haberi özetle"
+    Bantz: "Okuyorum efendim..."
+           [extracts content, sends to LLM]
+    Bantz: "Buyurun efendim."
+           [shows summary in overlay]
+    Bantz: [TTS] "Bu haberde Tesla'nın yeni modeli tanıtılıyor..."
+    User: "Daha detaylı anlat"
+    Bantz: [detailed version with key points]
+    User: "Bu CEO kim?"
+    Bantz: [answers from context]
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from datetime import datetime
+import logging
+import re
+
+if TYPE_CHECKING:
+    from bantz.browser.extension_bridge import ExtensionBridge
+    from bantz.llm.ollama_client import OllamaClient
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class PageSummary:
+    """Summary of a web page."""
+    
+    title: str
+    url: str
+    short_summary: str       # 1-2 sentences
+    detailed_summary: str    # 3-5 paragraphs
+    key_points: List[str]    # Bullet points
+    source_content: str = "" # Original content (for Q&A)
+    generated_at: datetime = field(default_factory=datetime.now)
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for overlay/serialization."""
+        return {
+            "title": self.title,
+            "url": self.url,
+            "short_summary": self.short_summary,
+            "detailed_summary": self.detailed_summary,
+            "key_points": self.key_points,
+            "generated_at": self.generated_at.isoformat(),
+        }
+
+
+@dataclass
+class ExtractedPage:
+    """Raw extracted page content."""
+    
+    url: str
+    title: str
+    content: str
+    content_length: int
+    extracted_at: str
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ExtractedPage":
+        """Create from extension response dict."""
+        return cls(
+            url=data.get("url", ""),
+            title=data.get("title", ""),
+            content=data.get("content", ""),
+            content_length=data.get("content_length", 0),
+            extracted_at=data.get("extracted_at", ""),
+        )
+    
+    @property
+    def has_content(self) -> bool:
+        """Check if extraction has meaningful content."""
+        return len(self.content.strip()) > 100
+
+
+# =============================================================================
+# LLM Prompts
+# =============================================================================
+
+
+SUMMARY_SYSTEM_PROMPT = """Sen Jarvis tarzında çalışan bir asistansın. Görevin verilen web sayfası içeriğini analiz edip özetlemek.
+
+Kurallar:
+- Türkçe yanıt ver
+- Objektif ve bilgilendirici ol
+- İçeriğin ana fikrini yakala
+- Gereksiz detayları atla
+- Reklam veya navigasyon elementlerini görmezden gel
+"""
+
+SHORT_SUMMARY_PROMPT = """Aşağıdaki web sayfası içeriğini 1-2 cümleyle özetle.
+Sadece ana konuyu ve en önemli bilgiyi içer.
+Çok kısa ve öz ol.
+
+Başlık: {title}
+URL: {url}
+
+İçerik:
+{content}
+
+Kısa özet:"""
+
+DETAILED_SUMMARY_PROMPT = """Aşağıdaki web sayfası içeriğini detaylı olarak özetle.
+
+3-5 paragraf olsun:
+1. Ana konu ve bağlam
+2. Önemli detaylar
+3. Sonuç veya etkileri
+
+Ayrıca 3-5 maddelik "Önemli Noktalar" listesi hazırla.
+
+Başlık: {title}
+URL: {url}
+
+İçerik:
+{content}
+
+Detaylı özet:"""
+
+QUESTION_ANSWER_PROMPT = """Aşağıdaki web sayfası içeriğine dayanarak soruyu cevapla.
+Sadece içerikte bulunan bilgileri kullan.
+Eğer bilgi yoksa "Bu konuda sayfada bilgi bulamadım" de.
+
+Başlık: {title}
+İçerik:
+{content}
+
+Soru: {question}
+
+Cevap:"""
+
+
+# =============================================================================
+# Page Summarizer
+# =============================================================================
+
+
+class PageSummarizer:
+    """
+    Jarvis-style page summarization system.
+    
+    Extracts content from current page via extension, generates summaries
+    using LLM, and formats for TTS and overlay display.
+    
+    Example:
+        summarizer = PageSummarizer(extension_bridge, llm_client)
+        
+        # Extract and summarize
+        summary = await summarizer.summarize("short")
+        
+        # Format for TTS
+        tts_text = summarizer.format_for_tts(summary)
+        
+        # Format for overlay
+        overlay_data = summarizer.format_for_overlay(summary)
+        
+        # Answer question
+        answer = await summarizer.answer_question("CEO kim?")
+    """
+    
+    def __init__(
+        self,
+        extension_bridge: Optional["ExtensionBridge"] = None,
+        llm_client: Optional["OllamaClient"] = None,
+        extract_timeout: float = 5.0,
+        llm_timeout: float = 60.0,
+    ):
+        """
+        Initialize page summarizer.
+        
+        Args:
+            extension_bridge: Browser extension bridge for content extraction
+            llm_client: LLM client for summarization
+            extract_timeout: Timeout for extraction
+            llm_timeout: Timeout for LLM calls
+        """
+        self.bridge = extension_bridge
+        self.llm = llm_client
+        self.extract_timeout = extract_timeout
+        self.llm_timeout = llm_timeout
+        
+        # State
+        self._last_extracted: Optional[ExtractedPage] = None
+        self._last_summary: Optional[PageSummary] = None
+    
+    # =========================================================================
+    # Extraction
+    # =========================================================================
+    
+    async def extract_current_page(self) -> Optional[ExtractedPage]:
+        """
+        Extract content from current browser page.
+        
+        Returns:
+            ExtractedPage with content or None if extraction failed
+        """
+        if not self.bridge:
+            logger.warning("[Summarizer] No extension bridge configured")
+            return None
+        
+        if not self.bridge.has_client():
+            logger.warning("[Summarizer] No extension client connected")
+            return None
+        
+        # Request extraction from extension
+        result = self.bridge.request_extract()
+        
+        if not result:
+            logger.warning("[Summarizer] Extraction returned no result")
+            return None
+        
+        extracted = ExtractedPage.from_dict(result)
+        
+        if not extracted.has_content:
+            logger.warning(f"[Summarizer] Insufficient content: {extracted.content_length} chars")
+            return None
+        
+        self._last_extracted = extracted
+        logger.info(f"[Summarizer] Extracted: {extracted.title[:50]}... ({extracted.content_length} chars)")
+        
+        return extracted
+    
+    # =========================================================================
+    # Summarization
+    # =========================================================================
+    
+    async def summarize(
+        self,
+        detail_level: str = "short",
+        extracted: Optional[ExtractedPage] = None,
+    ) -> Optional[PageSummary]:
+        """
+        Generate summary of page content.
+        
+        Args:
+            detail_level: "short" for 1-2 sentences, "detailed" for full analysis
+            extracted: Pre-extracted content (uses last extracted if None)
+            
+        Returns:
+            PageSummary or None if summarization failed
+        """
+        # Use provided or last extracted content
+        page = extracted or self._last_extracted
+        
+        if not page:
+            # Try to extract first
+            page = await self.extract_current_page()
+            if not page:
+                logger.warning("[Summarizer] No content to summarize")
+                return None
+        
+        if not self.llm:
+            logger.warning("[Summarizer] No LLM client configured")
+            return None
+        
+        try:
+            # Generate short summary
+            short_summary = await self._generate_short_summary(page)
+            
+            # Generate detailed summary if requested
+            if detail_level == "detailed":
+                detailed_summary, key_points = await self._generate_detailed_summary(page)
+            else:
+                detailed_summary = ""
+                key_points = []
+            
+            summary = PageSummary(
+                title=page.title,
+                url=page.url,
+                short_summary=short_summary,
+                detailed_summary=detailed_summary,
+                key_points=key_points,
+                source_content=page.content,
+            )
+            
+            self._last_summary = summary
+            logger.info(f"[Summarizer] Generated summary: {len(short_summary)} chars short, {len(detailed_summary)} chars detailed")
+            
+            return summary
+            
+        except Exception as e:
+            logger.error(f"[Summarizer] Summarization failed: {e}")
+            return None
+    
+    async def _generate_short_summary(self, page: ExtractedPage) -> str:
+        """Generate short 1-2 sentence summary."""
+        from bantz.llm.ollama_client import LLMMessage
+        
+        prompt = SHORT_SUMMARY_PROMPT.format(
+            title=page.title,
+            url=page.url,
+            content=page.content[:6000],  # Limit content for short summary
+        )
+        
+        messages = [
+            LLMMessage(role="system", content=SUMMARY_SYSTEM_PROMPT),
+            LLMMessage(role="user", content=prompt),
+        ]
+        
+        response = self.llm.chat(messages, temperature=0.3, max_tokens=200)
+        return response.strip()
+    
+    async def _generate_detailed_summary(
+        self, page: ExtractedPage
+    ) -> tuple[str, List[str]]:
+        """Generate detailed summary with key points."""
+        from bantz.llm.ollama_client import LLMMessage
+        
+        prompt = DETAILED_SUMMARY_PROMPT.format(
+            title=page.title,
+            url=page.url,
+            content=page.content,
+        )
+        
+        messages = [
+            LLMMessage(role="system", content=SUMMARY_SYSTEM_PROMPT),
+            LLMMessage(role="user", content=prompt),
+        ]
+        
+        response = self.llm.chat(messages, temperature=0.4, max_tokens=800)
+        
+        # Parse response to extract key points
+        detailed_summary, key_points = self._parse_detailed_response(response)
+        
+        return detailed_summary, key_points
+    
+    def _parse_detailed_response(self, response: str) -> tuple[str, List[str]]:
+        """Parse LLM response to separate summary and key points."""
+        key_points = []
+        
+        # Try to find "Önemli Noktalar" section
+        patterns = [
+            r"(?:Önemli\s+Noktalar|Ana\s+Noktalar|Maddeler|Özet\s+Noktaları)[\s:]*\n((?:[-•*]\s*.+\n?)+)",
+            r"\n((?:[-•*]\s*.+\n){3,})",  # Fallback: any bullet list with 3+ items
+        ]
+        
+        detailed_text = response
+        
+        for pattern in patterns:
+            match = re.search(pattern, response, re.IGNORECASE)
+            if match:
+                bullets_text = match.group(1)
+                # Extract individual points
+                for line in bullets_text.split('\n'):
+                    line = line.strip()
+                    if line and line[0] in '-•*':
+                        point = line.lstrip('-•* ').strip()
+                        if point:
+                            key_points.append(point)
+                
+                if key_points:
+                    # Remove key points section from detailed text
+                    detailed_text = response[:match.start()].strip()
+                    break
+        
+        # Limit to 5 key points
+        key_points = key_points[:5]
+        
+        return detailed_text, key_points
+    
+    # =========================================================================
+    # Question Answering
+    # =========================================================================
+    
+    async def answer_question(self, question: str) -> Optional[str]:
+        """
+        Answer a question about the current page content.
+        
+        Args:
+            question: User's question about the page
+            
+        Returns:
+            Answer string or None if cannot answer
+        """
+        # Get content (from last summary or extracted)
+        content = None
+        title = ""
+        
+        if self._last_summary and self._last_summary.source_content:
+            content = self._last_summary.source_content
+            title = self._last_summary.title
+        elif self._last_extracted:
+            content = self._last_extracted.content
+            title = self._last_extracted.title
+        else:
+            # Try to extract first
+            extracted = await self.extract_current_page()
+            if extracted:
+                content = extracted.content
+                title = extracted.title
+        
+        if not content:
+            logger.warning("[Summarizer] No content available for Q&A")
+            return None
+        
+        if not self.llm:
+            logger.warning("[Summarizer] No LLM client configured")
+            return None
+        
+        try:
+            from bantz.llm.ollama_client import LLMMessage
+            
+            prompt = QUESTION_ANSWER_PROMPT.format(
+                title=title,
+                content=content[:6000],  # Limit for context
+                question=question,
+            )
+            
+            messages = [
+                LLMMessage(role="system", content=SUMMARY_SYSTEM_PROMPT),
+                LLMMessage(role="user", content=prompt),
+            ]
+            
+            response = self.llm.chat(messages, temperature=0.3, max_tokens=300)
+            return response.strip()
+            
+        except Exception as e:
+            logger.error(f"[Summarizer] Q&A failed: {e}")
+            return None
+    
+    # =========================================================================
+    # Formatting
+    # =========================================================================
+    
+    def format_for_tts(self, summary: Optional[PageSummary] = None) -> str:
+        """
+        Format summary for text-to-speech.
+        Uses short summary for TTS to keep it concise.
+        
+        Args:
+            summary: PageSummary to format (uses last summary if None)
+            
+        Returns:
+            TTS-friendly text string
+        """
+        s = summary or self._last_summary
+        
+        if not s:
+            return "Özet bulunamadı."
+        
+        # Use short summary for TTS
+        if s.short_summary:
+            return s.short_summary
+        elif s.detailed_summary:
+            # Truncate detailed for TTS
+            return s.detailed_summary[:200] + "..."
+        else:
+            return f"{s.title} sayfası analiz edildi."
+    
+    def format_for_overlay(
+        self, summary: Optional[PageSummary] = None, detailed: bool = False
+    ) -> Dict[str, Any]:
+        """
+        Format summary for overlay display.
+        
+        Args:
+            summary: PageSummary to format (uses last summary if None)
+            detailed: Whether to include detailed summary and key points
+            
+        Returns:
+            Dict formatted for overlay widget
+        """
+        s = summary or self._last_summary
+        
+        if not s:
+            return {
+                "type": "summary",
+                "title": "Özet Yok",
+                "content": "Henüz içerik özetlenmedi.",
+                "items": [],
+            }
+        
+        if detailed and (s.detailed_summary or s.key_points):
+            # Detailed view with key points
+            items = []
+            for i, point in enumerate(s.key_points, 1):
+                items.append({
+                    "index": i,
+                    "text": point,
+                    "type": "point",
+                })
+            
+            return {
+                "type": "summary_detailed",
+                "title": s.title,
+                "url": s.url,
+                "content": s.detailed_summary or s.short_summary,
+                "items": items,
+                "generated_at": s.generated_at.isoformat(),
+            }
+        else:
+            # Short view
+            return {
+                "type": "summary",
+                "title": s.title,
+                "url": s.url,
+                "content": s.short_summary,
+                "items": [],
+                "generated_at": s.generated_at.isoformat(),
+            }
+    
+    # =========================================================================
+    # State Access
+    # =========================================================================
+    
+    @property
+    def has_summary(self) -> bool:
+        """Check if we have a generated summary."""
+        return self._last_summary is not None
+    
+    @property
+    def has_content(self) -> bool:
+        """Check if we have extracted content."""
+        return self._last_extracted is not None
+    
+    @property
+    def last_summary(self) -> Optional[PageSummary]:
+        """Get the last generated summary."""
+        return self._last_summary
+    
+    @property
+    def last_extracted(self) -> Optional[ExtractedPage]:
+        """Get the last extracted content."""
+        return self._last_extracted
+    
+    def clear(self) -> None:
+        """Clear all state."""
+        self._last_extracted = None
+        self._last_summary = None
+
+
+# =============================================================================
+# Mock Summarizer for Testing
+# =============================================================================
+
+
+class MockPageSummarizer(PageSummarizer):
+    """Mock summarizer for testing without real extension/LLM."""
+    
+    def __init__(
+        self,
+        mock_content: Optional[str] = None,
+        mock_title: str = "Test Sayfası",
+        mock_url: str = "https://example.com/test",
+    ):
+        super().__init__(extension_bridge=None, llm_client=None)
+        
+        self._mock_content = mock_content or (
+            "Bu bir test içeriğidir. Tesla CEO'su Elon Musk yeni bir açıklama yaptı. "
+            "Şirketin yeni modeli Model Z, 2025'te piyasaya çıkacak. "
+            "Fiyatı 50.000 dolar civarında olacak. "
+            "Musk, bu modelin elektrikli araç pazarını değiştireceğini söyledi."
+        )
+        self._mock_title = mock_title
+        self._mock_url = mock_url
+    
+    async def extract_current_page(self) -> Optional[ExtractedPage]:
+        """Return mock extracted page."""
+        extracted = ExtractedPage(
+            url=self._mock_url,
+            title=self._mock_title,
+            content=self._mock_content,
+            content_length=len(self._mock_content),
+            extracted_at=datetime.now().isoformat(),
+        )
+        self._last_extracted = extracted
+        return extracted
+    
+    async def summarize(
+        self,
+        detail_level: str = "short",
+        extracted: Optional[ExtractedPage] = None,
+    ) -> Optional[PageSummary]:
+        """Return mock summary."""
+        page = extracted or self._last_extracted
+        if not page:
+            page = await self.extract_current_page()
+        
+        if not page:
+            return None
+        
+        summary = PageSummary(
+            title=page.title,
+            url=page.url,
+            short_summary="Tesla yeni Model Z'yi 2025'te piyasaya sürecek, fiyatı 50.000 dolar olacak.",
+            detailed_summary=(
+                "Tesla CEO'su Elon Musk, şirketin yeni elektrikli araç modeli Model Z'yi duyurdu. "
+                "Araç 2025 yılında piyasaya çıkacak ve yaklaşık 50.000 dolar fiyat etiketiyle satışa sunulacak.\n\n"
+                "Musk, Model Z'nin elektrikli araç pazarını köklü bir şekilde değiştireceğini belirtti. "
+                "Yeni model, daha uzun menzil ve gelişmiş otonom sürüş özellikleriyle dikkat çekiyor."
+            ) if detail_level == "detailed" else "",
+            key_points=[
+                "Tesla Model Z 2025'te çıkacak",
+                "Fiyatı 50.000 dolar civarında",
+                "Elektrikli araç pazarını değiştirecek",
+                "Gelişmiş otonom sürüş özellikleri var",
+            ] if detail_level == "detailed" else [],
+            source_content=page.content,
+        )
+        
+        self._last_summary = summary
+        return summary
+    
+    async def answer_question(self, question: str) -> Optional[str]:
+        """Return mock answer based on question keywords."""
+        q_lower = question.lower()
+        
+        if "ceo" in q_lower or "musk" in q_lower:
+            return "Tesla'nın CEO'su Elon Musk'tır."
+        elif "fiyat" in q_lower or "kaç" in q_lower:
+            return "Model Z'nin fiyatı yaklaşık 50.000 dolar olacak."
+        elif "ne zaman" in q_lower or "tarih" in q_lower:
+            return "Model Z 2025 yılında piyasaya çıkacak."
+        else:
+            return "Bu konuda sayfada detaylı bilgi bulamadım."
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def extract_question(text: str) -> Optional[str]:
+    """
+    Extract question from user utterance.
+    
+    Examples:
+        "Bu CEO kim?" -> "Bu CEO kim?"
+        "Bana şunu anlat: fiyatı ne?" -> "fiyatı ne?"
+        "Anlat bakalım ne olmuş" -> "ne olmuş"
+    """
+    # Direct question patterns
+    question_markers = [
+        r"^(.+\?)\s*$",                              # Ends with ?
+        r"(?:anlat|söyle|açıkla)\s*(?:bakalım\s*)?(.+)",  # "anlat X"
+        r"(?:bu|şu)\s+(.+)",                         # "bu X kim"
+        r"(?:ne|kim|neden|nasıl|nerede|kaç)\s+(.+)", # Question words
+    ]
+    
+    for pattern in question_markers:
+        match = re.search(pattern, text.strip(), re.IGNORECASE)
+        if match:
+            return match.group(0).strip()
+    
+    return text.strip() if text.strip() else None

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,1067 @@
+"""
+Comprehensive tests for Page Summarization (Issue #18).
+
+Tests cover:
+- PageSummary and ExtractedPage dataclasses
+- PageSummarizer class
+- MockPageSummarizer for testing
+- NLU intent recognition
+- Router handler integration
+- Extension bridge extract functionality
+- Context state management
+- Persona responses
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock, AsyncMock, patch
+
+
+# =============================================================================
+# Test PageSummary Dataclass
+# =============================================================================
+
+
+class TestPageSummary:
+    """Tests for PageSummary dataclass."""
+    
+    def test_create_short_summary(self):
+        """Test creating a short summary."""
+        from bantz.skills.summarizer import PageSummary
+        
+        summary = PageSummary(
+            title="Test Başlık",
+            url="https://example.com/test",
+            short_summary="Bu bir test özetidir.",
+            detailed_summary="",
+            key_points=[],
+        )
+        
+        assert summary.title == "Test Başlık"
+        assert summary.url == "https://example.com/test"
+        assert summary.short_summary == "Bu bir test özetidir."
+        assert summary.detailed_summary == ""
+        assert summary.key_points == []
+        assert isinstance(summary.generated_at, datetime)
+    
+    def test_create_detailed_summary(self):
+        """Test creating a detailed summary with key points."""
+        from bantz.skills.summarizer import PageSummary
+        
+        summary = PageSummary(
+            title="Detaylı Haber",
+            url="https://news.example.com/article",
+            short_summary="Kısa özet.",
+            detailed_summary="Bu detaylı bir özetdir.\n\nİkinci paragraf.",
+            key_points=["Nokta 1", "Nokta 2", "Nokta 3"],
+            source_content="Orijinal içerik burada.",
+        )
+        
+        assert len(summary.key_points) == 3
+        assert "Nokta 1" in summary.key_points
+        assert summary.source_content == "Orijinal içerik burada."
+    
+    def test_to_dict(self):
+        """Test converting summary to dictionary."""
+        from bantz.skills.summarizer import PageSummary
+        
+        summary = PageSummary(
+            title="Test",
+            url="https://test.com",
+            short_summary="Özet",
+            detailed_summary="Detay",
+            key_points=["A", "B"],
+        )
+        
+        data = summary.to_dict()
+        
+        assert data["title"] == "Test"
+        assert data["url"] == "https://test.com"
+        assert data["short_summary"] == "Özet"
+        assert data["detailed_summary"] == "Detay"
+        assert data["key_points"] == ["A", "B"]
+        assert "generated_at" in data
+
+
+# =============================================================================
+# Test ExtractedPage Dataclass
+# =============================================================================
+
+
+class TestExtractedPage:
+    """Tests for ExtractedPage dataclass."""
+    
+    def test_create_extracted_page(self):
+        """Test creating extracted page."""
+        from bantz.skills.summarizer import ExtractedPage
+        
+        page = ExtractedPage(
+            url="https://example.com",
+            title="Example Page",
+            content="This is the page content.",
+            content_length=25,
+            extracted_at="2024-01-01T12:00:00",
+        )
+        
+        assert page.url == "https://example.com"
+        assert page.title == "Example Page"
+        assert page.content_length == 25
+    
+    def test_from_dict(self):
+        """Test creating from extension response dict."""
+        from bantz.skills.summarizer import ExtractedPage
+        
+        data = {
+            "url": "https://test.com",
+            "title": "Test Page",
+            "content": "Test content here.",
+            "content_length": 18,
+            "extracted_at": "2024-01-15T10:30:00",
+        }
+        
+        page = ExtractedPage.from_dict(data)
+        
+        assert page.url == "https://test.com"
+        assert page.title == "Test Page"
+        assert page.content == "Test content here."
+    
+    def test_from_dict_with_missing_fields(self):
+        """Test creating from incomplete dict."""
+        from bantz.skills.summarizer import ExtractedPage
+        
+        data = {"url": "https://test.com"}
+        
+        page = ExtractedPage.from_dict(data)
+        
+        assert page.url == "https://test.com"
+        assert page.title == ""
+        assert page.content == ""
+        assert page.content_length == 0
+    
+    def test_has_content_true(self):
+        """Test has_content returns True for substantial content."""
+        from bantz.skills.summarizer import ExtractedPage
+        
+        page = ExtractedPage(
+            url="https://test.com",
+            title="Test",
+            content="A" * 200,
+            content_length=200,
+            extracted_at="",
+        )
+        
+        assert page.has_content is True
+    
+    def test_has_content_false_short(self):
+        """Test has_content returns False for short content."""
+        from bantz.skills.summarizer import ExtractedPage
+        
+        page = ExtractedPage(
+            url="https://test.com",
+            title="Test",
+            content="Short",
+            content_length=5,
+            extracted_at="",
+        )
+        
+        assert page.has_content is False
+    
+    def test_has_content_false_empty(self):
+        """Test has_content returns False for empty content."""
+        from bantz.skills.summarizer import ExtractedPage
+        
+        page = ExtractedPage(
+            url="https://test.com",
+            title="Test",
+            content="   ",
+            content_length=3,
+            extracted_at="",
+        )
+        
+        assert page.has_content is False
+
+
+# =============================================================================
+# Test MockPageSummarizer
+# =============================================================================
+
+
+class TestMockPageSummarizer:
+    """Tests for MockPageSummarizer."""
+    
+    @pytest.mark.asyncio
+    async def test_extract_current_page(self):
+        """Test mock extraction."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer(
+            mock_title="Test Sayfa",
+            mock_url="https://test.com/page",
+        )
+        
+        extracted = await summarizer.extract_current_page()
+        
+        assert extracted is not None
+        assert extracted.title == "Test Sayfa"
+        assert extracted.url == "https://test.com/page"
+        assert extracted.has_content
+    
+    @pytest.mark.asyncio
+    async def test_summarize_short(self):
+        """Test short summarization."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        
+        summary = await summarizer.summarize(detail_level="short")
+        
+        assert summary is not None
+        assert summary.short_summary != ""
+        assert summary.detailed_summary == ""
+        assert summary.key_points == []
+    
+    @pytest.mark.asyncio
+    async def test_summarize_detailed(self):
+        """Test detailed summarization."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        
+        summary = await summarizer.summarize(detail_level="detailed")
+        
+        assert summary is not None
+        assert summary.short_summary != ""
+        assert summary.detailed_summary != ""
+        assert len(summary.key_points) > 0
+    
+    @pytest.mark.asyncio
+    async def test_answer_question_ceo(self):
+        """Test answering CEO question."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        await summarizer.extract_current_page()
+        
+        answer = await summarizer.answer_question("CEO kim?")
+        
+        assert answer is not None
+        assert "Musk" in answer or "CEO" in answer
+    
+    @pytest.mark.asyncio
+    async def test_answer_question_price(self):
+        """Test answering price question."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        await summarizer.extract_current_page()
+        
+        answer = await summarizer.answer_question("Fiyatı ne?")
+        
+        assert answer is not None
+        assert "dolar" in answer.lower() or "50" in answer
+    
+    @pytest.mark.asyncio
+    async def test_answer_question_date(self):
+        """Test answering date question."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        await summarizer.extract_current_page()
+        
+        answer = await summarizer.answer_question("Ne zaman çıkacak?")
+        
+        assert answer is not None
+        assert "2025" in answer
+    
+    @pytest.mark.asyncio
+    async def test_answer_question_unknown(self):
+        """Test answering unknown question."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        await summarizer.extract_current_page()
+        
+        answer = await summarizer.answer_question("Başka bir şey?")
+        
+        assert answer is not None
+        assert "bulamadım" in answer.lower() or "bilgi" in answer.lower()
+    
+    def test_format_for_tts(self):
+        """Test TTS formatting."""
+        from bantz.skills.summarizer import MockPageSummarizer, PageSummary
+        
+        summarizer = MockPageSummarizer()
+        summary = PageSummary(
+            title="Test",
+            url="https://test.com",
+            short_summary="Bu kısa özet.",
+            detailed_summary="Bu detaylı özet.",
+            key_points=["Nokta 1"],
+        )
+        
+        tts = summarizer.format_for_tts(summary)
+        
+        assert tts == "Bu kısa özet."
+    
+    def test_format_for_tts_no_summary(self):
+        """Test TTS formatting without summary."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        
+        tts = summarizer.format_for_tts(None)
+        
+        assert "bulunamadı" in tts.lower()
+    
+    def test_format_for_overlay_short(self):
+        """Test overlay formatting for short summary."""
+        from bantz.skills.summarizer import MockPageSummarizer, PageSummary
+        
+        summarizer = MockPageSummarizer()
+        summary = PageSummary(
+            title="Test Başlık",
+            url="https://test.com",
+            short_summary="Kısa özet.",
+            detailed_summary="",
+            key_points=[],
+        )
+        
+        data = summarizer.format_for_overlay(summary, detailed=False)
+        
+        assert data["type"] == "summary"
+        assert data["title"] == "Test Başlık"
+        assert data["content"] == "Kısa özet."
+        assert data["items"] == []
+    
+    def test_format_for_overlay_detailed(self):
+        """Test overlay formatting for detailed summary."""
+        from bantz.skills.summarizer import MockPageSummarizer, PageSummary
+        
+        summarizer = MockPageSummarizer()
+        summary = PageSummary(
+            title="Detaylı Başlık",
+            url="https://test.com",
+            short_summary="Kısa.",
+            detailed_summary="Bu detaylı açıklama.",
+            key_points=["Nokta A", "Nokta B"],
+        )
+        
+        data = summarizer.format_for_overlay(summary, detailed=True)
+        
+        assert data["type"] == "summary_detailed"
+        assert data["content"] == "Bu detaylı açıklama."
+        assert len(data["items"]) == 2
+        assert data["items"][0]["text"] == "Nokta A"
+    
+    def test_state_properties(self):
+        """Test state properties."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        
+        assert summarizer.has_summary is False
+        assert summarizer.has_content is False
+        assert summarizer.last_summary is None
+        assert summarizer.last_extracted is None
+    
+    @pytest.mark.asyncio
+    async def test_state_after_operations(self):
+        """Test state after extraction and summarization."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        
+        await summarizer.extract_current_page()
+        assert summarizer.has_content is True
+        assert summarizer.last_extracted is not None
+        
+        await summarizer.summarize("short")
+        assert summarizer.has_summary is True
+        assert summarizer.last_summary is not None
+    
+    def test_clear_state(self):
+        """Test clearing state."""
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        summarizer = MockPageSummarizer()
+        # Manually set some state
+        summarizer._last_extracted = "test"
+        summarizer._last_summary = "test"
+        
+        summarizer.clear()
+        
+        assert summarizer.has_content is False
+        assert summarizer.has_summary is False
+
+
+# =============================================================================
+# Test PageSummarizer (with mocks)
+# =============================================================================
+
+
+class TestPageSummarizer:
+    """Tests for PageSummarizer class."""
+    
+    def test_init_no_dependencies(self):
+        """Test initialization without dependencies."""
+        from bantz.skills.summarizer import PageSummarizer
+        
+        summarizer = PageSummarizer()
+        
+        assert summarizer.bridge is None
+        assert summarizer.llm is None
+        assert summarizer.has_content is False
+        assert summarizer.has_summary is False
+    
+    def test_init_with_dependencies(self):
+        """Test initialization with dependencies."""
+        from bantz.skills.summarizer import PageSummarizer
+        
+        mock_bridge = MagicMock()
+        mock_llm = MagicMock()
+        
+        summarizer = PageSummarizer(
+            extension_bridge=mock_bridge,
+            llm_client=mock_llm,
+            extract_timeout=10.0,
+        )
+        
+        assert summarizer.bridge is mock_bridge
+        assert summarizer.llm is mock_llm
+        assert summarizer.extract_timeout == 10.0
+    
+    @pytest.mark.asyncio
+    async def test_extract_no_bridge(self):
+        """Test extraction fails without bridge."""
+        from bantz.skills.summarizer import PageSummarizer
+        
+        summarizer = PageSummarizer(extension_bridge=None)
+        
+        result = await summarizer.extract_current_page()
+        
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_extract_no_client(self):
+        """Test extraction fails when no extension client connected."""
+        from bantz.skills.summarizer import PageSummarizer
+        
+        mock_bridge = MagicMock()
+        mock_bridge.has_client.return_value = False
+        
+        summarizer = PageSummarizer(extension_bridge=mock_bridge)
+        
+        result = await summarizer.extract_current_page()
+        
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_extract_success(self):
+        """Test successful extraction."""
+        from bantz.skills.summarizer import PageSummarizer
+        
+        mock_bridge = MagicMock()
+        mock_bridge.has_client.return_value = True
+        mock_bridge.request_extract.return_value = {
+            "url": "https://test.com",
+            "title": "Test Page",
+            "content": "A" * 200,
+            "content_length": 200,
+            "extracted_at": "2024-01-01T12:00:00",
+        }
+        
+        summarizer = PageSummarizer(extension_bridge=mock_bridge)
+        
+        result = await summarizer.extract_current_page()
+        
+        assert result is not None
+        assert result.title == "Test Page"
+        assert result.has_content is True
+        assert summarizer.has_content is True
+    
+    @pytest.mark.asyncio
+    async def test_extract_insufficient_content(self):
+        """Test extraction fails with insufficient content."""
+        from bantz.skills.summarizer import PageSummarizer
+        
+        mock_bridge = MagicMock()
+        mock_bridge.has_client.return_value = True
+        mock_bridge.request_extract.return_value = {
+            "url": "https://test.com",
+            "title": "Test",
+            "content": "Short",
+            "content_length": 5,
+            "extracted_at": "",
+        }
+        
+        summarizer = PageSummarizer(extension_bridge=mock_bridge)
+        
+        result = await summarizer.extract_current_page()
+        
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_summarize_no_content(self):
+        """Test summarization fails without content."""
+        from bantz.skills.summarizer import PageSummarizer
+        
+        mock_bridge = MagicMock()
+        mock_bridge.has_client.return_value = False
+        
+        summarizer = PageSummarizer(extension_bridge=mock_bridge)
+        
+        result = await summarizer.summarize("short")
+        
+        assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_summarize_no_llm(self):
+        """Test summarization fails without LLM."""
+        from bantz.skills.summarizer import PageSummarizer, ExtractedPage
+        
+        summarizer = PageSummarizer(llm_client=None)
+        summarizer._last_extracted = ExtractedPage(
+            url="https://test.com",
+            title="Test",
+            content="A" * 200,
+            content_length=200,
+            extracted_at="",
+        )
+        
+        result = await summarizer.summarize("short")
+        
+        assert result is None
+
+
+# =============================================================================
+# Test NLU Intent Recognition
+# =============================================================================
+
+
+class TestNLUPageSummarizePatterns:
+    """Tests for page summarization NLU patterns."""
+    
+    def test_page_summarize_bu_sayfayi(self):
+        """Test 'bu sayfayı özetle' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("bu sayfayı özetle")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_su_haberi(self):
+        """Test 'şu haberi anlat' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("şu haberi anlat")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_bu_icerigi(self):
+        """Test 'bu içeriği özetle' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("şu içeriği özetle")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_bu_makaleyi(self):
+        """Test 'bu makaleyi oku' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("bu makaleyi oku")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_bunu_ozetle(self):
+        """Test 'bunu özetle' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("bunu özetle")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_sunu_anlat(self):
+        """Test 'şunu anlat' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("şunu anlat")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_ne_anlatiyor(self):
+        """Test 'ne anlatıyor' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("ne anlatıyor")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_neler_var(self):
+        """Test 'neler var' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("neler var")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_anlayamadim(self):
+        """Test 'anlayamadım anlat' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("anlayamadım anlat")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_anlamadim_acikla(self):
+        """Test 'anlamadım açıkla' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("anlamadım açıkla")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_summarize_bu_ne_anlatiyor(self):
+        """Test 'bu ne anlatıyor' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("bu ne anlatıyor")
+        
+        assert result.intent == "page_summarize"
+
+
+class TestNLUPageSummarizeDetailedPatterns:
+    """Tests for detailed summarization NLU patterns."""
+    
+    def test_detailed_detayli_anlat(self):
+        """Test 'detaylı anlat' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("detaylı anlat")
+        
+        assert result.intent == "page_summarize_detailed"
+    
+    def test_detailed_daha_detayli(self):
+        """Test 'daha detaylı özetle' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("daha detaylı özetle")
+        
+        assert result.intent == "page_summarize_detailed"
+    
+    def test_detailed_tam_anlat(self):
+        """Test 'tam detaylı anlat' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("tam detaylı anlat")
+        
+        assert result.intent == "page_summarize_detailed"
+    
+    def test_detailed_uzun_ozetle(self):
+        """Test 'uzun özetle' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("uzun özetle")
+        
+        assert result.intent == "page_summarize_detailed"
+    
+    def test_detailed_detayli_olarak(self):
+        """Test 'detaylı olarak anlat' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("detaylı olarak anlat")
+        
+        assert result.intent == "page_summarize_detailed"
+    
+    def test_detailed_ayrintili(self):
+        """Test 'ayrıntılı açıkla' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("ayrıntılı açıkla")
+        
+        assert result.intent == "page_summarize_detailed"
+
+
+class TestNLUPageQuestionPatterns:
+    """Tests for page question NLU patterns."""
+    
+    def test_question_bu_ceo_kim(self):
+        """Test 'Bu CEO kim?' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("Bu CEO kim?")
+        
+        assert result.intent == "page_question"
+        assert "CEO kim" in result.slots.get("question", "")
+    
+    def test_question_fiyati_ne(self):
+        """Test 'Fiyatı ne?' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("Fiyatı ne?")
+        
+        assert result.intent == "page_question"
+    
+    def test_question_ne_zaman(self):
+        """Test 'Ne zaman çıkacak?' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("Ne zaman çıkacak?")
+        
+        assert result.intent == "page_question"
+    
+    def test_question_neden(self):
+        """Test 'Bu neden oldu?' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("Bu neden oldu?")
+        
+        assert result.intent == "page_question"
+    
+    def test_question_nasil(self):
+        """Test 'Bu nasıl oldu?' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("Bu nasıl oldu?")
+        
+        assert result.intent == "page_question"
+    
+    def test_question_nerede(self):
+        """Test 'Nerede olacak?' pattern."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("Nerede olacak?")
+        
+        assert result.intent == "page_question"
+
+
+# =============================================================================
+# Test Context State Management
+# =============================================================================
+
+
+class TestContextPageSummarizerState:
+    """Tests for context page summarizer state management."""
+    
+    def test_set_and_get_page_summarizer(self):
+        """Test setting and getting page summarizer."""
+        from bantz.router.context import ConversationContext
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        ctx = ConversationContext()
+        summarizer = MockPageSummarizer()
+        
+        ctx.set_page_summarizer(summarizer)
+        result = ctx.get_page_summarizer()
+        
+        assert result is summarizer
+    
+    def test_clear_page_summarizer(self):
+        """Test clearing page summarizer."""
+        from bantz.router.context import ConversationContext
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        ctx = ConversationContext()
+        ctx.set_page_summarizer(MockPageSummarizer())
+        ctx.set_pending_page_summarize("detailed")
+        ctx.set_pending_page_question("Test?")
+        
+        ctx.clear_page_summarizer()
+        
+        assert ctx.get_page_summarizer() is None
+        assert ctx.get_pending_page_summarize() is None
+        assert ctx.get_pending_page_question() is None
+    
+    def test_pending_page_summarize(self):
+        """Test pending page summarize state."""
+        from bantz.router.context import ConversationContext
+        
+        ctx = ConversationContext()
+        
+        ctx.set_pending_page_summarize("short")
+        assert ctx.get_pending_page_summarize() == "short"
+        
+        ctx.set_pending_page_summarize("detailed")
+        assert ctx.get_pending_page_summarize() == "detailed"
+        
+        ctx.clear_pending_page_summarize()
+        assert ctx.get_pending_page_summarize() is None
+    
+    def test_pending_page_question(self):
+        """Test pending page question state."""
+        from bantz.router.context import ConversationContext
+        
+        ctx = ConversationContext()
+        
+        ctx.set_pending_page_question("CEO kim?")
+        assert ctx.get_pending_page_question() == "CEO kim?"
+        
+        ctx.clear_pending_page_question()
+        assert ctx.get_pending_page_question() is None
+    
+    def test_snapshot_includes_page_summarizer(self):
+        """Test snapshot includes page summarizer state."""
+        from bantz.router.context import ConversationContext
+        from bantz.skills.summarizer import MockPageSummarizer
+        
+        ctx = ConversationContext()
+        ctx.set_page_summarizer(MockPageSummarizer())
+        ctx.set_pending_page_summarize("detailed")
+        ctx.set_pending_page_question("Test?")
+        
+        snapshot = ctx.snapshot()
+        
+        assert snapshot["has_page_summarizer"] is True
+        assert snapshot["pending_page_summarize"] == "detailed"
+        assert snapshot["pending_page_question"] == "Test?"
+
+
+# =============================================================================
+# Test Persona Responses
+# =============================================================================
+
+
+class TestPersonaPageSummarizeResponses:
+    """Tests for Jarvis persona page summarization responses."""
+    
+    def test_reading_page_response(self):
+        """Test reading page response."""
+        from bantz.llm.persona import JarvisPersona
+        
+        persona = JarvisPersona()
+        response = persona.get_response("reading_page")
+        
+        assert response is not None
+        assert len(response) > 0
+        assert "efendim" in response.lower() or "okuyorum" in response.lower()
+    
+    def test_summary_ready_response(self):
+        """Test summary ready response."""
+        from bantz.llm.persona import JarvisPersona
+        
+        persona = JarvisPersona()
+        response = persona.get_response("summary_ready")
+        
+        assert response is not None
+        assert "efendim" in response.lower()
+    
+    def test_answering_response(self):
+        """Test answering response."""
+        from bantz.llm.persona import JarvisPersona
+        
+        persona = JarvisPersona()
+        response = persona.get_response("answering")
+        
+        assert response is not None
+        assert len(response) > 0
+    
+    def test_answer_ready_response(self):
+        """Test answer ready response."""
+        from bantz.llm.persona import JarvisPersona
+        
+        persona = JarvisPersona()
+        response = persona.get_response("answer_ready")
+        
+        assert response is not None
+    
+    def test_no_content_response(self):
+        """Test no content response."""
+        from bantz.llm.persona import JarvisPersona
+        
+        persona = JarvisPersona()
+        response = persona.get_response("no_content")
+        
+        assert response is not None
+        assert "efendim" in response.lower()
+
+
+# =============================================================================
+# Test Helper Functions
+# =============================================================================
+
+
+class TestHelperFunctions:
+    """Tests for helper functions."""
+    
+    def test_extract_question_with_question_mark(self):
+        """Test extracting question with question mark."""
+        from bantz.skills.summarizer import extract_question
+        
+        result = extract_question("CEO kim?")
+        
+        assert result is not None
+        assert "kim" in result.lower()
+    
+    def test_extract_question_anlat_prefix(self):
+        """Test extracting question with anlat prefix."""
+        from bantz.skills.summarizer import extract_question
+        
+        result = extract_question("anlat bakalım fiyatı ne")
+        
+        assert result is not None
+    
+    def test_extract_question_empty(self):
+        """Test extracting from empty string."""
+        from bantz.skills.summarizer import extract_question
+        
+        result = extract_question("")
+        
+        assert result is None
+    
+    def test_extract_question_whitespace(self):
+        """Test extracting from whitespace."""
+        from bantz.skills.summarizer import extract_question
+        
+        result = extract_question("   ")
+        
+        assert result is None
+
+
+# =============================================================================
+# Test Router Handler Integration
+# =============================================================================
+
+
+class TestRouterPageSummarizeIntegration:
+    """Tests for router page summarize handler integration."""
+    
+    def test_page_summarize_no_bridge(self):
+        """Test page_summarize without bridge connection."""
+        from bantz.router.engine import Router
+        from bantz.router.policy import Policy
+        from bantz.router.context import ConversationContext
+        from bantz.logs.logger import JsonlLogger
+        
+        with patch("bantz.browser.extension_bridge.get_bridge") as mock_get_bridge:
+            mock_get_bridge.return_value = None
+            
+            logger = JsonlLogger("/tmp/test.log")
+            # Allow page_summarize in policy
+            policy = Policy(
+                deny_patterns=[],
+                confirm_patterns=[],
+                deny_even_if_confirmed_patterns=[],
+                intent_levels={"page_summarize": 1},  # Allow intent
+            )
+            router = Router(policy, logger)
+            ctx = ConversationContext()
+            
+            result = router.handle("bu sayfayı özetle", ctx)
+            
+            # Either bridge error or policy error is acceptable
+            assert result.ok is False
+    
+    def test_page_summarize_no_client(self):
+        """Test page_summarize without extension client."""
+        from bantz.router.engine import Router
+        from bantz.router.policy import Policy
+        from bantz.router.context import ConversationContext
+        from bantz.logs.logger import JsonlLogger
+        
+        with patch("bantz.browser.extension_bridge.get_bridge") as mock_get_bridge:
+            mock_bridge = MagicMock()
+            mock_bridge.has_client.return_value = False
+            mock_get_bridge.return_value = mock_bridge
+            
+            logger = JsonlLogger("/tmp/test.log")
+            # Allow page_summarize in policy
+            policy = Policy(
+                deny_patterns=[],
+                confirm_patterns=[],
+                deny_even_if_confirmed_patterns=[],
+                intent_levels={"page_summarize": 1},  # Allow intent
+            )
+            router = Router(policy, logger)
+            ctx = ConversationContext()
+            
+            result = router.handle("bu sayfayı özetle", ctx)
+            
+            # Either client error or policy error is acceptable
+            assert result.ok is False
+    
+    def test_page_summarize_intent_recognized(self):
+        """Test page_summarize intent is correctly recognized."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("bu sayfayı özetle")
+        
+        assert result.intent == "page_summarize"
+    
+    def test_page_question_intent_recognized(self):
+        """Test page_question intent is correctly recognized."""
+        from bantz.router.nlu import parse_intent
+        
+        result = parse_intent("Bu CEO kim?")
+        
+        assert result.intent == "page_question"
+        assert "question" in result.slots
+
+
+# =============================================================================
+# Test Types
+# =============================================================================
+
+
+class TestTypesPageSummarize:
+    """Tests for types include page summarize intents."""
+    
+    def test_page_summarize_intent_in_types(self):
+        """Test page_summarize is in Intent type."""
+        from bantz.router.types import Intent
+        
+        # This should not raise - type checking
+        intent: Intent = "page_summarize"
+        assert intent == "page_summarize"
+    
+    def test_page_summarize_detailed_intent_in_types(self):
+        """Test page_summarize_detailed is in Intent type."""
+        from bantz.router.types import Intent
+        
+        intent: Intent = "page_summarize_detailed"
+        assert intent == "page_summarize_detailed"
+    
+    def test_page_question_intent_in_types(self):
+        """Test page_question is in Intent type."""
+        from bantz.router.types import Intent
+        
+        intent: Intent = "page_question"
+        assert intent == "page_question"
+
+
+# =============================================================================
+# Test Skills __init__ Exports
+# =============================================================================
+
+
+class TestSkillsExports:
+    """Tests for skills package exports."""
+    
+    def test_import_page_summary(self):
+        """Test PageSummary can be imported from skills."""
+        from bantz.skills import PageSummary
+        
+        assert PageSummary is not None
+    
+    def test_import_extracted_page(self):
+        """Test ExtractedPage can be imported from skills."""
+        from bantz.skills import ExtractedPage
+        
+        assert ExtractedPage is not None
+    
+    def test_import_page_summarizer(self):
+        """Test PageSummarizer can be imported from skills."""
+        from bantz.skills import PageSummarizer
+        
+        assert PageSummarizer is not None
+    
+    def test_import_mock_page_summarizer(self):
+        """Test MockPageSummarizer can be imported from skills."""
+        from bantz.skills import MockPageSummarizer
+        
+        assert MockPageSummarizer is not None
+    
+    def test_import_extract_question(self):
+        """Test extract_question can be imported from skills."""
+        from bantz.skills import extract_question
+        
+        assert extract_question is not None


### PR DESCRIPTION
## 🎯 Summary

Implements Issue #18: **Sayfa İçeriği Çıkarma ve Özetleme (Article Extraction)**

This PR adds Jarvis-style page summarization capabilities with LLM integration.

## 🚀 Features

### Extension Content Extraction
- `extractPageContent()` function in content.js
- Extracts title, main content, URL with 8000 character limit
- Smart content selectors (article, main, role=main, etc.)
- Removes navigation, ads, and unwanted elements

### Python Integration
- `request_extract()` method in ExtensionBridge
- `extract_result` message handling
- 5-second timeout for extraction

### PageSummarizer Skill
- `PageSummary` dataclass with short/detailed summaries
- `ExtractedPage` dataclass for raw content
- `PageSummarizer` class with LLM integration
- `MockPageSummarizer` for testing

### LLM Summarization
- Short summary: 1-2 sentences
- Detailed summary: 3-5 paragraphs with key points
- Question answering about page content
- Turkish prompts and responses

### NLU Patterns
- `page_summarize`: "bu sayfayı özetle", "şu haberi anlat"
- `page_summarize_detailed`: "detaylı anlat", "uzun özetle"
- `page_question`: "Bu CEO kim?", "Fiyatı ne?"

### Router Integration
- Handler for page_summarize intent
- Handler for page_summarize_detailed intent
- Handler for page_question intent
- Context state management for follow-up commands

### Jarvis Persona Responses
- `reading_page`: "Sayfayı okuyorum efendim..."
- `summary_ready`: "Buyurun efendim."
- `answering`: "Bakayım efendim..."
- `no_content`: "Sayfadan içerik çıkaramadım efendim."

## 📊 Testing

- **80 new tests** for summarizer functionality
- Tests cover dataclasses, MockPageSummarizer, NLU patterns
- Tests for context state management
- Tests for persona responses
- **1033 total tests passing** (953 + 80)

## 🗣️ Example Usage

```
User: [on news page] "Bu haberi özetle"
Bantz: "Sayfayı okuyorum efendim..."
       [extracts content, sends to LLM]
Bantz: "Buyurun efendim."
       [shows summary in overlay]
       [TTS] "Bu haberde Tesla'nın yeni modeli tanıtılıyor..."

User: "Daha detaylı anlat"
Bantz: [shows detailed summary with key points]

User: "Bu CEO kim?"
Bantz: "Tesla'nın CEO'su Elon Musk'tır efendim."
```

## 📁 Files Changed

| File | Changes |
|------|---------|
| `bantz-extension/content.js` | +extractPageContent(), +getCleanText() |
| `bantz-extension/background.js` | +extract message handling |
| `src/bantz/browser/extension_bridge.py` | +request_extract(), +extract_result |
| `src/bantz/skills/summarizer.py` | **NEW** - PageSummarizer, PageSummary |
| `src/bantz/router/nlu.py` | +page_summarize patterns |
| `src/bantz/router/engine.py` | +page_summarize handlers |
| `src/bantz/router/context.py` | +page_summarizer state |
| `src/bantz/router/types.py` | +page_summarize intents |
| `src/bantz/llm/persona.py` | +reading_page, summary_ready responses |
| `src/bantz/skills/__init__.py` | +summarizer exports |
| `tests/test_summarizer.py` | **NEW** - 80 comprehensive tests |

## ✅ Acceptance Criteria

- [x] Extension: `extract` komutu sayfa içeriğini döndürür
- [x] Title + main content + URL çıkarılır
- [x] 8000 karakter limit (LLM context için)
- [x] "bu haberi özetle" → kısa özet (1-2 cümle)
- [x] "detaylı anlat" → uzun özet (3-5 paragraf)
- [x] Key points bullet list olarak çıkar
- [x] Overlay'de özet görünür (format_for_overlay)
- [x] TTS ile kısa özet okunur (format_for_tts)
- [x] "Bu CEO kim?" gibi sorular cevaplanır (answer_question)
- [x] İçerik çıkarılamazsa net hata mesajı (no_content persona)

Closes #18