### PR TITLE
feat(router): Issue #21 - Query Clarification System

### DIFF
--- a/src/bantz/router/__init__.py
+++ b/src/bantz/router/__init__.py
@@ -1,0 +1,28 @@
+"""Router module for intent parsing and command routing."""
+from bantz.router.clarifier import (
+    QueryClarifier,
+    QueryAnalysis,
+    ClarificationType,
+    ClarificationQuestion,
+    ClarificationState,
+    MockQueryClarifier,
+)
+from bantz.router.query_expander import (
+    QueryExpander,
+    ExpandedQuery,
+    QuerySuggestion,
+    MockQueryExpander,
+)
+
+__all__ = [
+    "QueryClarifier",
+    "QueryAnalysis",
+    "ClarificationType",
+    "ClarificationQuestion",
+    "ClarificationState",
+    "MockQueryClarifier",
+    "QueryExpander",
+    "ExpandedQuery",
+    "QuerySuggestion",
+    "MockQueryExpander",
+]

--- a/src/bantz/router/clarifier.py
+++ b/src/bantz/router/clarifier.py
@@ -1,0 +1,677 @@
+"""Query Clarification System (Issue #21).
+
+Belirsiz sorguları netleştirme sistemi.
+
+Örnek:
+    👤 "Şurada bir kaza olmuş neler var?"
+    🤖 "Hangi bölgeden bahsediyorsunuz efendim? Örneğin İstanbul, Ankara?"
+    👤 "Kadıköy"
+    🤖 "Kadıköy kaza haberleri arıyorum efendim..."
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict, Any
+from enum import Enum, auto
+
+
+# ─────────────────────────────────────────────────────────────────
+# Clarification Types
+# ─────────────────────────────────────────────────────────────────
+
+class ClarificationType(Enum):
+    """Netleştirme soru tipleri."""
+    LOCATION = auto()      # Nerede?
+    TIME = auto()          # Ne zaman?
+    SUBJECT = auto()       # Kim/Ne hakkında?
+    SPECIFICITY = auto()   # Hangisi?
+    CONFIRMATION = auto()  # Emin misiniz?
+
+
+# ─────────────────────────────────────────────────────────────────
+# Data Classes
+# ─────────────────────────────────────────────────────────────────
+
+@dataclass
+class ClarificationQuestion:
+    """Netleştirme sorusu."""
+    type: ClarificationType
+    question: str
+    examples: List[str]
+    slot_name: str
+    context: str = ""
+
+
+@dataclass
+class QueryAnalysis:
+    """Sorgu analiz sonucu."""
+    original_query: str
+    intent: str
+    needs_clarification: bool
+    missing_slots: List[str]
+    clarification_question: Optional[ClarificationQuestion]
+    confidence: float
+    vague_indicators: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ClarificationState:
+    """Netleştirme durumu (conversation state)."""
+    pending_question: Optional[ClarificationQuestion] = None
+    original_query: str = ""
+    original_intent: str = ""
+    collected_slots: Dict[str, str] = field(default_factory=dict)
+    clarification_count: int = 0
+    max_clarifications: int = 2
+
+
+# ─────────────────────────────────────────────────────────────────
+# Clarification Templates
+# ─────────────────────────────────────────────────────────────────
+
+CLARIFICATION_TEMPLATES = {
+    ClarificationType.LOCATION: {
+        "question": "Hangi {context} bahsediyorsunuz efendim?",
+        "question_alt": "Hangi bölge veya şehir efendim?",
+        "examples": ["İstanbul", "Ankara", "İzmir"],
+    },
+    ClarificationType.TIME: {
+        "question": "Ne zaman {context} efendim?",
+        "question_alt": "Hangi tarih veya zaman diliminden bahsediyorsunuz efendim?",
+        "examples": ["bugün", "dün", "bu hafta"],
+    },
+    ClarificationType.SUBJECT: {
+        "question": "{context} hakkında daha fazla bilgi verir misiniz efendim?",
+        "question_alt": "Konu hakkında biraz daha detay verebilir misiniz efendim?",
+        "examples": [],
+    },
+    ClarificationType.SPECIFICITY: {
+        "question": "Hangi {context} efendim?",
+        "question_alt": "Tam olarak hangisinden bahsediyorsunuz efendim?",
+        "examples": [],
+    },
+    ClarificationType.CONFIRMATION: {
+        "question": "{context} emin misiniz efendim?",
+        "question_alt": "Doğru anladım mı efendim?",
+        "examples": ["evet", "hayır"],
+    },
+}
+
+
+# ─────────────────────────────────────────────────────────────────
+# Vague Indicator Patterns
+# ─────────────────────────────────────────────────────────────────
+
+VAGUE_INDICATORS = {
+    "location": [
+        r"\b[sş]urada\b",
+        r"\borada\b", 
+        r"\bburada\b",
+        r"\bbir yerde\b",
+        r"\byak[ıi]nlarda\b",
+        r"\bcivarda\b",
+        r"\betrafta\b",
+        r"\bbir bölgede\b",
+        r"\b[sş]ehirde\b",  # without specifying which city
+    ],
+    "time": [
+        r"\bge[cç]enlerde\b",
+        r"\bbir ara\b",
+        r"\bbi zaman\b",
+        r"\byak[ıi]nda\b",
+        r"\bson zamanlarda\b",
+        r"\bbu aralar\b",
+        r"\bge[cç]en g[üu]n\b",
+        r"\bdaha [öo]nce\b",
+    ],
+    "subject": [
+        r"\bo [sş]ey\b",
+        r"\b[sş]u [sş]ey\b",
+        r"\bo konu\b",
+        r"\b[sş]u konu\b",
+        r"\bo olay\b",
+        r"\bbiri\b",
+        r"\bbir [sş]ey\b",
+        r"\bbahsetti[gğ]im\b",
+        r"\bbiliyorsun ya\b",
+    ],
+}
+
+
+# Slot to clarification type mapping
+SLOT_TO_TYPE = {
+    "location": ClarificationType.LOCATION,
+    "time": ClarificationType.TIME,
+    "topic": ClarificationType.SUBJECT,
+    "subject": ClarificationType.SUBJECT,
+    "destination": ClarificationType.LOCATION,
+    "source": ClarificationType.LOCATION,
+    "person": ClarificationType.SUBJECT,
+    "company": ClarificationType.SUBJECT,
+}
+
+
+# Context words for question generation
+CONTEXT_WORDS = {
+    "location": "bölgeden",
+    "time": "olduğunu düşünüyorsunuz",
+    "topic": "konudan",
+    "subject": "kişi veya kurumdan",
+    "destination": "yere gitmek istiyorsunuz",
+    "source": "kaynaktan",
+    "person": "kişiden",
+    "company": "şirketten",
+}
+
+
+# Required slots for certain intents
+INTENT_REQUIRED_SLOTS = {
+    "news_search": ["topic"],
+    "weather": ["location"],
+    "directions": ["destination"],
+    "event_search": ["location"],
+    "stock_price": ["company"],
+    "person_info": ["person"],
+}
+
+
+# ─────────────────────────────────────────────────────────────────
+# Query Clarifier
+# ─────────────────────────────────────────────────────────────────
+
+class QueryClarifier:
+    """Belirsiz sorguları netleştirme sistemi.
+    
+    Features:
+    - Belirsiz ifadeleri tespit et (şurada, orada, geçenlerde)
+    - Eksik slotları belirle
+    - Jarvis tarzı netleştirme sorusu oluştur
+    - Conversation state yönetimi
+    - En fazla 2 netleştirme sorusu (UX için)
+    
+    Usage:
+        clarifier = QueryClarifier()
+        
+        # Analyze query
+        analysis = clarifier.analyze_query("şurada kaza olmuş", "news_search")
+        
+        if analysis.needs_clarification:
+            # Ask question
+            print(analysis.clarification_question.question)
+            
+            # User responds
+            response = "Kadıköy"
+            
+            # Process response
+            clarifier.process_response(response)
+            
+            # Get enhanced query
+            enhanced = clarifier.get_enhanced_query()
+            # "kaza olmuş Kadıköy"
+    """
+    
+    def __init__(self, max_clarifications: int = 2):
+        """Initialize clarifier.
+        
+        Args:
+            max_clarifications: Max number of clarification questions (default 2)
+        """
+        self.max_clarifications = max_clarifications
+        self._state = ClarificationState(max_clarifications=max_clarifications)
+    
+    @property
+    def state(self) -> ClarificationState:
+        """Get current state."""
+        return self._state
+    
+    @property
+    def is_pending(self) -> bool:
+        """Check if there's a pending clarification."""
+        return self._state.pending_question is not None
+    
+    @property
+    def collected_slots(self) -> Dict[str, str]:
+        """Get collected slot values."""
+        return self._state.collected_slots.copy()
+    
+    def has_pending_question(self) -> bool:
+        """Check if there's a pending clarification question."""
+        return self._state.pending_question is not None
+    
+    def start_clarification(self, query: str, question: "ClarificationQuestion") -> None:
+        """Start clarification flow.
+        
+        Args:
+            query: Original user query
+            question: First clarification question to ask
+        """
+        self._state.original_query = query
+        self._state.pending_question = question
+        self._state.clarification_count = 1
+    
+    # ─────────────────────────────────────────────────────────────
+    # Main API
+    # ─────────────────────────────────────────────────────────────
+    
+    def analyze_query(self, query: str, intent: str = "") -> QueryAnalysis:
+        """Sorguyu analiz et, netleştirme gerekiyor mu?
+        
+        Args:
+            query: User query
+            intent: Detected intent (optional)
+            
+        Returns:
+            QueryAnalysis with needs_clarification flag
+        """
+        query_lower = query.lower()
+        
+        # Find vague indicators
+        vague_found = self._find_vague_indicators(query_lower)
+        
+        # Find missing required slots
+        missing_slots = self._find_missing_slots(query_lower, intent, vague_found)
+        
+        # Check if we've exceeded max clarifications
+        if self._state.clarification_count >= self.max_clarifications:
+            return QueryAnalysis(
+                original_query=query,
+                intent=intent,
+                needs_clarification=False,
+                missing_slots=[],
+                clarification_question=None,
+                confidence=0.7,  # Lower confidence but proceed anyway
+                vague_indicators=vague_found,
+            )
+        
+        # No missing slots = no clarification needed
+        if not missing_slots:
+            return QueryAnalysis(
+                original_query=query,
+                intent=intent,
+                needs_clarification=False,
+                missing_slots=[],
+                clarification_question=None,
+                confidence=1.0,
+                vague_indicators=vague_found,
+            )
+        
+        # Generate clarification question for first missing slot
+        slot = missing_slots[0]
+        question = self._generate_question(slot, query)
+        
+        # Store state
+        self._state.pending_question = question
+        self._state.original_query = query
+        self._state.original_intent = intent
+        
+        return QueryAnalysis(
+            original_query=query,
+            intent=intent,
+            needs_clarification=True,
+            missing_slots=missing_slots,
+            clarification_question=question,
+            confidence=0.5,
+            vague_indicators=vague_found,
+        )
+    
+    def process_response(self, response: str) -> Dict[str, str]:
+        """Netleştirme yanıtını işle.
+        
+        Args:
+            response: User's response to clarification question
+            
+        Returns:
+            Updated collected slots
+        """
+        if not self._state.pending_question:
+            return self._state.collected_slots.copy()
+        
+        slot_name = self._state.pending_question.slot_name
+        self._state.collected_slots[slot_name] = response.strip()
+        self._state.clarification_count += 1
+        self._state.pending_question = None
+        
+        return self._state.collected_slots.copy()
+    
+    def get_enhanced_query(self) -> str:
+        """Netleştirilmiş sorguyu döndür.
+        
+        Returns:
+            Original query enhanced with collected slot values
+        """
+        query = self._state.original_query
+        
+        # Remove vague indicators and add specific values
+        query = self._replace_vague_with_specific(query)
+        
+        return query.strip()
+    
+    def get_search_query(self) -> str:
+        """Get optimized search query.
+        
+        Returns:
+            Query optimized for search (combines topic + location etc.)
+        """
+        parts = []
+        
+        # Start with original query (cleaned)
+        base = self._clean_vague_indicators(self._state.original_query)
+        if base:
+            parts.append(base)
+        
+        # Add collected slots
+        for slot, value in self._state.collected_slots.items():
+            if value and value not in base.lower():
+                parts.append(value)
+        
+        return " ".join(parts).strip()
+    
+    def reset(self) -> None:
+        """Durumu sıfırla."""
+        self._state = ClarificationState(max_clarifications=self.max_clarifications)
+    
+    def needs_more_clarification(self) -> bool:
+        """Check if more clarification is needed.
+        
+        Returns:
+            True if we should ask another question
+        """
+        if self._state.clarification_count >= self.max_clarifications:
+            return False
+        
+        # Re-analyze with current state
+        enhanced = self.get_enhanced_query()
+        analysis = self.analyze_query(enhanced, self._state.original_intent)
+        
+        return analysis.needs_clarification
+    
+    # ─────────────────────────────────────────────────────────────
+    # Internal Methods
+    # ─────────────────────────────────────────────────────────────
+    
+    def _find_vague_indicators(self, query: str) -> List[str]:
+        """Find vague indicator words in query."""
+        found = []
+        
+        for category, patterns in VAGUE_INDICATORS.items():
+            for pattern in patterns:
+                if re.search(pattern, query, re.IGNORECASE):
+                    found.append(category)
+                    break  # One per category is enough
+        
+        return found
+    
+    def _find_missing_slots(
+        self, 
+        query: str, 
+        intent: str,
+        vague_found: List[str],
+    ) -> List[str]:
+        """Find missing required slots."""
+        missing = []
+        
+        # Add slots for vague indicators
+        for vague_type in vague_found:
+            if vague_type not in self._state.collected_slots:
+                missing.append(vague_type)
+        
+        # Check intent-specific required slots
+        required = INTENT_REQUIRED_SLOTS.get(intent, [])
+        for slot in required:
+            if slot not in self._state.collected_slots:
+                if not self._has_slot_value(query, slot):
+                    if slot not in missing:
+                        missing.append(slot)
+        
+        return missing
+    
+    def _has_slot_value(self, query: str, slot: str) -> bool:
+        """Check if query already has a value for the slot."""
+        query_lower = query.lower()
+        
+        if slot == "location":
+            # Check for city/region names
+            cities = [
+                "istanbul", "ankara", "izmir", "bursa", "antalya",
+                "adana", "konya", "gaziantep", "mersin", "diyarbakır",
+                "kadıköy", "beşiktaş", "üsküdar", "fatih", "beyoğlu",
+                "türkiye", "avrupa", "amerika", "asya",
+            ]
+            return any(city in query_lower for city in cities)
+        
+        if slot == "time":
+            # Check for time expressions
+            times = [
+                "bugün", "dün", "yarın", "bu hafta", "geçen hafta",
+                "bu ay", "geçen ay", "bu yıl", "geçen yıl",
+                "sabah", "öğlen", "akşam", "gece",
+                r"\d{1,2}[:/]\d{2}",  # Time pattern
+                r"\d{1,2}\s+(ocak|şubat|mart|nisan|mayıs|haziran|temmuz|ağustos|eylül|ekim|kasım|aralık)",
+            ]
+            for t in times:
+                if re.search(t, query_lower):
+                    return True
+            return False
+        
+        if slot == "company":
+            # Check for company names
+            companies = [
+                "tesla", "apple", "google", "microsoft", "amazon",
+                "facebook", "meta", "netflix", "twitter", "x",
+                "turkcell", "garanti", "akbank", "işbank",
+            ]
+            return any(c in query_lower for c in companies)
+        
+        # Default: assume slot is missing
+        return False
+    
+    def _generate_question(self, slot: str, context: str) -> ClarificationQuestion:
+        """Generate clarification question for slot."""
+        ctype = SLOT_TO_TYPE.get(slot, ClarificationType.SPECIFICITY)
+        template = CLARIFICATION_TEMPLATES.get(ctype, CLARIFICATION_TEMPLATES[ClarificationType.SPECIFICITY])
+        
+        context_word = CONTEXT_WORDS.get(slot, "")
+        
+        # Format question
+        if context_word:
+            question = template["question"].format(context=context_word)
+        else:
+            question = template.get("question_alt", template["question"])
+        
+        # Add examples if available
+        examples = template.get("examples", [])
+        
+        return ClarificationQuestion(
+            type=ctype,
+            question=question,
+            examples=examples,
+            slot_name=slot,
+            context=context,
+        )
+    
+    def _replace_vague_with_specific(self, query: str) -> str:
+        """Replace vague indicators with specific values."""
+        result = query
+        
+        for slot, value in self._state.collected_slots.items():
+            if slot == "location":
+                # Replace location-related vague words
+                for pattern in VAGUE_INDICATORS.get("location", []):
+                    result = re.sub(pattern, value, result, flags=re.IGNORECASE)
+            elif slot == "time":
+                for pattern in VAGUE_INDICATORS.get("time", []):
+                    result = re.sub(pattern, value, result, flags=re.IGNORECASE)
+            elif slot in ("topic", "subject"):
+                for pattern in VAGUE_INDICATORS.get("subject", []):
+                    result = re.sub(pattern, value, result, flags=re.IGNORECASE)
+        
+        return result
+    
+    def _clean_vague_indicators(self, query: str) -> str:
+        """Remove vague indicators from query."""
+        result = query
+        
+        for patterns in VAGUE_INDICATORS.values():
+            for pattern in patterns:
+                result = re.sub(pattern, "", result, flags=re.IGNORECASE)
+        
+        # Clean up extra spaces
+        result = re.sub(r"\s+", " ", result).strip()
+        
+        return result
+
+
+# ─────────────────────────────────────────────────────────────────
+# Helper Functions
+# ─────────────────────────────────────────────────────────────────
+
+def format_clarification_response(question: ClarificationQuestion) -> str:
+    """Format clarification question for Jarvis response.
+    
+    Args:
+        question: ClarificationQuestion to format
+        
+    Returns:
+        Formatted string with examples
+    """
+    response = question.question
+    
+    if question.examples:
+        examples_str = ", ".join(question.examples[:3])
+        response += f" Örneğin {examples_str}?"
+    
+    return response
+
+
+def is_clarification_response(text: str, pending_question: Optional[ClarificationQuestion]) -> bool:
+    """Check if text is a response to a clarification question.
+    
+    Args:
+        text: User input
+        pending_question: Currently pending question
+        
+    Returns:
+        True if this looks like a clarification response
+    """
+    if not pending_question:
+        return False
+    
+    # Short responses are likely clarification answers
+    if len(text.split()) <= 3:
+        return True
+    
+    # Check if it matches expected examples
+    text_lower = text.lower().strip()
+    for example in pending_question.examples:
+        if example.lower() in text_lower:
+            return True
+    
+    return False
+
+
+# ─────────────────────────────────────────────────────────────────
+# Mock Clarifier for Testing
+# ─────────────────────────────────────────────────────────────────
+
+class MockQueryClarifier:
+    """Mock clarifier for testing."""
+    
+    def __init__(self):
+        self._analyses: List[QueryAnalysis] = []
+        self._responses: List[str] = []
+        self._is_pending = False
+        self._collected_slots: Dict[str, str] = {}
+        self._pending_slot: Optional[str] = None
+        self._needs_clarification = False
+        self._clarification_type = ClarificationType.LOCATION
+    
+    def add_mock_analysis(
+        self,
+        query: str,
+        needs_clarification: bool,
+        missing_slot: str = "",
+        question: str = "",
+    ) -> None:
+        """Add a mock analysis result."""
+        cq = None
+        if needs_clarification and missing_slot:
+            cq = ClarificationQuestion(
+                type=ClarificationType.LOCATION,
+                question=question or f"Hangi {missing_slot} efendim?",
+                examples=["örnek1", "örnek2"],
+                slot_name=missing_slot,
+            )
+        
+        analysis = QueryAnalysis(
+            original_query=query,
+            intent="test",
+            needs_clarification=needs_clarification,
+            missing_slots=[missing_slot] if missing_slot else [],
+            clarification_question=cq,
+            confidence=0.5 if needs_clarification else 1.0,
+        )
+        self._analyses.append(analysis)
+        self._is_pending = needs_clarification
+    
+    def set_pending_response(self, slot: str, search_query: str) -> None:
+        """Set pending response for testing."""
+        self._pending_slot = slot
+        self._is_pending = True
+    
+    def get_pending_slot(self) -> Optional[str]:
+        """Get pending slot name."""
+        return self._pending_slot
+    
+    def set_needs_clarification(
+        self,
+        needs: bool,
+        clarification_type: ClarificationType = ClarificationType.LOCATION,
+    ) -> None:
+        """Set whether clarification is needed."""
+        self._needs_clarification = needs
+        self._clarification_type = clarification_type
+    
+    def analyze_query(self, query: str, intent: str = "") -> QueryAnalysis:
+        if self._analyses:
+            return self._analyses.pop(0)
+        
+        cq = None
+        if self._needs_clarification:
+            cq = ClarificationQuestion(
+                type=self._clarification_type,
+                question="Hangi bölgeden bahsediyorsunuz efendim?",
+                examples=["İstanbul", "Ankara"],
+                slot_name="location",
+            )
+        
+        return QueryAnalysis(
+            original_query=query,
+            intent=intent,
+            needs_clarification=self._needs_clarification,
+            missing_slots=["location"] if self._needs_clarification else [],
+            clarification_question=cq,
+            confidence=0.5 if self._needs_clarification else 1.0,
+        )
+    
+    def process_response(self, response: str) -> Dict[str, str]:
+        self._responses.append(response)
+        self._is_pending = False
+        self._collected_slots["location"] = response
+        return self._collected_slots.copy()
+    
+    @property
+    def is_pending(self) -> bool:
+        return self._is_pending
+    
+    @property
+    def collected_slots(self) -> Dict[str, str]:
+        return self._collected_slots.copy()
+    
+    def reset(self) -> None:
+        self._analyses.clear()
+        self._responses.clear()
+        self._is_pending = False
+        self._collected_slots.clear()
+        self._pending_slot = None
+        self._needs_clarification = False

--- a/src/bantz/router/query_expander.py
+++ b/src/bantz/router/query_expander.py
@@ -1,0 +1,385 @@
+"""Query Expander - LLM ile sorgu genişletme (Issue #21).
+
+Sorguları bağlama göre genişletir ve ilgili sorular önerir.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Dict, Any, TYPE_CHECKING
+from dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from bantz.llm.ollama_client import OllamaClient
+
+
+@dataclass
+class ExpandedQuery:
+    """Genişletilmiş sorgu sonucu."""
+    original: str
+    expanded: str
+    additions: List[str]
+    confidence: float
+
+
+@dataclass
+class QuerySuggestion:
+    """Sorgu önerisi."""
+    query: str
+    reason: str
+    relevance: float
+
+
+class QueryExpander:
+    """LLM ile sorgu genişletme.
+    
+    Features:
+    - Sorguyu bağlama göre genişlet
+    - İlgili sorgular öner
+    - Arama optimizasyonu
+    
+    Usage:
+        expander = QueryExpander(llm_client)
+        
+        # Expand query
+        expanded = await expander.expand_query(
+            "kaza haberleri",
+            context={"location": "Kadıköy", "time": "bugün"}
+        )
+        # Result: "Kadıköy kaza haberleri bugün"
+        
+        # Get suggestions
+        suggestions = await expander.suggest_related("deprem haberleri")
+        # ["deprem son dakika", "deprem yardım", "deprem ölü sayısı"]
+    """
+    
+    EXPAND_PROMPT = """Aşağıdaki arama sorgusunu daha spesifik hale getir.
+Ekstra bilgi ekle ama anlamını değiştirme. Türkçe yaz.
+
+Orijinal sorgu: {query}
+Konum: {location}
+Zaman: {time}
+Ek bilgi: {extra}
+
+Genişletilmiş sorgu (tek satır, sadece sorgu):"""
+
+    SUGGEST_PROMPT = """Aşağıdaki sorguyla ilgili 3 alternatif arama öner.
+Her satırda bir öneri olsun. Türkçe yaz.
+
+Sorgu: {query}
+
+Öneriler:"""
+
+    OPTIMIZE_PROMPT = """Aşağıdaki arama sorgusunu arama motoru için optimize et.
+Gereksiz kelimeleri çıkar, anahtar kelimeleri koru. Türkçe yaz.
+
+Sorgu: {query}
+
+Optimize edilmiş sorgu (tek satır):"""
+
+    def __init__(self, llm_client: Optional["OllamaClient"] = None):
+        """Initialize expander.
+        
+        Args:
+            llm_client: OllamaClient instance (optional)
+        """
+        self._llm = llm_client
+    
+    @property
+    def has_llm(self) -> bool:
+        """Check if LLM is available."""
+        return self._llm is not None
+    
+    # ─────────────────────────────────────────────────────────────
+    # Sync Methods (no LLM)
+    # ─────────────────────────────────────────────────────────────
+    
+    def expand_simple(self, query: str, context: Dict[str, str]) -> str:
+        """Simple query expansion without LLM.
+        
+        Args:
+            query: Original query
+            context: Context dict with location, time, etc.
+            
+        Returns:
+            Expanded query string
+        """
+        parts = [query]
+        
+        # Add location if provided and not already in query
+        location = context.get("location", "")
+        if location and location.lower() not in query.lower():
+            parts.append(location)
+        
+        # Add time if provided and not already in query
+        time = context.get("time", "")
+        if time and time.lower() not in query.lower():
+            parts.append(time)
+        
+        return " ".join(parts).strip()
+    
+    def suggest_simple(self, query: str) -> List[str]:
+        """Simple query suggestions without LLM.
+        
+        Args:
+            query: Original query
+            
+        Returns:
+            List of related query suggestions
+        """
+        suggestions = []
+        
+        # Add "son dakika" variant
+        if "son dakika" not in query.lower():
+            suggestions.append(f"{query} son dakika")
+        
+        # Add "detay" variant
+        suggestions.append(f"{query} detay")
+        
+        # Add "neden" variant
+        suggestions.append(f"{query} neden")
+        
+        return suggestions[:3]
+    
+    def optimize_simple(self, query: str) -> str:
+        """Simple query optimization without LLM.
+        
+        Removes filler words and optimizes for search.
+        
+        Args:
+            query: Original query
+            
+        Returns:
+            Optimized query
+        """
+        # Filler words to remove
+        fillers = [
+            "bir", "bu", "şu", "o", "bana", "bize", "lütfen",
+            "acaba", "ya", "yani", "hani", "işte", "aslında",
+            "neydi", "neymiş", "miydi", "midir", "mı", "mi",
+            "haberlere", "haberlerine", "bak", "bakabilir misin",
+            "göster", "gösterir misin", "ara", "arabilir misin",
+            "ne var", "neler var", "neler olmuş",
+        ]
+        
+        result = query.lower()
+        
+        for filler in fillers:
+            # Word boundary replacement
+            result = result.replace(f" {filler} ", " ")
+            result = result.replace(f" {filler}", "")
+            if result.startswith(f"{filler} "):
+                result = result[len(filler) + 1:]
+        
+        # Clean up extra spaces
+        result = " ".join(result.split())
+        
+        return result.strip()
+    
+    # ─────────────────────────────────────────────────────────────
+    # Async Methods (with LLM)
+    # ─────────────────────────────────────────────────────────────
+    
+    async def expand_query(
+        self,
+        query: str,
+        context: Optional[Dict[str, str]] = None,
+    ) -> ExpandedQuery:
+        """Sorguyu bağlama göre genişlet.
+        
+        Args:
+            query: Original query
+            context: Context dict with location, time, etc.
+            
+        Returns:
+            ExpandedQuery with expanded string
+        """
+        context = context or {}
+        
+        # Fallback to simple expansion if no LLM
+        if not self._llm:
+            expanded = self.expand_simple(query, context)
+            return ExpandedQuery(
+                original=query,
+                expanded=expanded,
+                additions=[v for v in context.values() if v],
+                confidence=0.8,
+            )
+        
+        # Use LLM for expansion
+        prompt = self.EXPAND_PROMPT.format(
+            query=query,
+            location=context.get("location", "belirtilmedi"),
+            time=context.get("time", "belirtilmedi"),
+            extra=context.get("extra", "yok"),
+        )
+        
+        try:
+            from bantz.llm.ollama_client import LLMMessage
+            
+            response = self._llm.chat(
+                [LLMMessage(role="user", content=prompt)],
+                max_tokens=50,
+                temperature=0.3,
+            )
+            
+            expanded = response.strip()
+            
+            # Find what was added
+            additions = []
+            for word in expanded.split():
+                if word.lower() not in query.lower():
+                    additions.append(word)
+            
+            return ExpandedQuery(
+                original=query,
+                expanded=expanded,
+                additions=additions,
+                confidence=0.9,
+            )
+            
+        except Exception:
+            # Fallback to simple
+            expanded = self.expand_simple(query, context)
+            return ExpandedQuery(
+                original=query,
+                expanded=expanded,
+                additions=[v for v in context.values() if v],
+                confidence=0.7,
+            )
+    
+    async def suggest_related(self, query: str, limit: int = 3) -> List[QuerySuggestion]:
+        """İlgili sorgular öner.
+        
+        Args:
+            query: Original query
+            limit: Max suggestions
+            
+        Returns:
+            List of QuerySuggestion
+        """
+        # Fallback to simple suggestions if no LLM
+        if not self._llm:
+            simple = self.suggest_simple(query)
+            return [
+                QuerySuggestion(query=s, reason="ilgili arama", relevance=0.7)
+                for s in simple[:limit]
+            ]
+        
+        prompt = self.SUGGEST_PROMPT.format(query=query)
+        
+        try:
+            from bantz.llm.ollama_client import LLMMessage
+            
+            response = self._llm.chat(
+                [LLMMessage(role="user", content=prompt)],
+                max_tokens=100,
+                temperature=0.5,
+            )
+            
+            lines = [
+                line.strip().lstrip("1234567890.-) ")
+                for line in response.split("\n")
+                if line.strip()
+            ]
+            
+            suggestions = []
+            for i, line in enumerate(lines[:limit]):
+                suggestions.append(QuerySuggestion(
+                    query=line,
+                    reason="LLM önerisi",
+                    relevance=0.9 - (i * 0.1),
+                ))
+            
+            return suggestions
+            
+        except Exception:
+            simple = self.suggest_simple(query)
+            return [
+                QuerySuggestion(query=s, reason="ilgili arama", relevance=0.6)
+                for s in simple[:limit]
+            ]
+    
+    async def optimize(self, query: str) -> str:
+        """Sorguyu arama için optimize et.
+        
+        Args:
+            query: Original query
+            
+        Returns:
+            Optimized query string
+        """
+        if not self._llm:
+            return self.optimize_simple(query)
+        
+        prompt = self.OPTIMIZE_PROMPT.format(query=query)
+        
+        try:
+            from bantz.llm.ollama_client import LLMMessage
+            
+            response = self._llm.chat(
+                [LLMMessage(role="user", content=prompt)],
+                max_tokens=50,
+                temperature=0.2,
+            )
+            
+            return response.strip()
+            
+        except Exception:
+            return self.optimize_simple(query)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Mock Expander for Testing
+# ─────────────────────────────────────────────────────────────────
+
+class MockQueryExpander:
+    """Mock expander for testing without LLM."""
+    
+    def __init__(self):
+        self._expand_results: Dict[str, str] = {}
+        self._suggestions: List[str] = ["öneri 1", "öneri 2", "öneri 3"]
+    
+    def set_expand_result(self, query: str, expanded: str) -> None:
+        """Set mock expand result."""
+        self._expand_results[query] = expanded
+    
+    def set_suggestions(self, suggestions: List[str]) -> None:
+        """Set mock suggestions."""
+        self._suggestions = suggestions
+    
+    def expand_simple(self, query: str, context: Dict[str, str]) -> str:
+        if query in self._expand_results:
+            return self._expand_results[query]
+        
+        parts = [query]
+        if context.get("location"):
+            parts.append(context["location"])
+        return " ".join(parts)
+    
+    def suggest_simple(self, query: str) -> List[str]:
+        return self._suggestions[:3]
+    
+    def optimize_simple(self, query: str) -> str:
+        return query.strip()
+    
+    async def expand_query(
+        self,
+        query: str,
+        context: Optional[Dict[str, str]] = None,
+    ) -> ExpandedQuery:
+        context = context or {}
+        expanded = self.expand_simple(query, context)
+        return ExpandedQuery(
+            original=query,
+            expanded=expanded,
+            additions=[],
+            confidence=1.0,
+        )
+    
+    async def suggest_related(self, query: str, limit: int = 3) -> List[QuerySuggestion]:
+        return [
+            QuerySuggestion(query=s, reason="mock", relevance=0.8)
+            for s in self._suggestions[:limit]
+        ]
+    
+    async def optimize(self, query: str) -> str:
+        return self.optimize_simple(query)

--- a/src/bantz/router/types.py
+++ b/src/bantz/router/types.py
@@ -94,6 +94,9 @@ Intent = Literal[
     # Overlay control intents
     "overlay_move",
     "overlay_hide",
+    # Query clarification intents (Issue #21)
+    "vague_search",           # Belirsiz arama: "şurada kaza olmuş"
+    "clarification_response", # Clarification yanıtı
     "unknown",
 ]
 

--- a/tests/test_clarifier.py
+++ b/tests/test_clarifier.py
@@ -1,0 +1,498 @@
+"""Tests for Query Clarification System (Issue #21)."""
+from __future__ import annotations
+
+import pytest
+
+from bantz.router.clarifier import (
+    QueryClarifier,
+    QueryAnalysis,
+    ClarificationType,
+    ClarificationQuestion,
+    ClarificationState,
+    MockQueryClarifier,
+)
+from bantz.router.query_expander import (
+    QueryExpander,
+    ExpandedQuery,
+    QuerySuggestion,
+    MockQueryExpander,
+)
+from bantz.router.nlu import parse_intent
+
+
+# ─────────────────────────────────────────────────────────────────
+# QueryClarifier Tests
+# ─────────────────────────────────────────────────────────────────
+
+class TestQueryClarifierBasics:
+    """Basic QueryClarifier tests."""
+    
+    def test_init(self):
+        """Test clarifier initialization."""
+        clarifier = QueryClarifier()
+        assert clarifier.max_clarifications == 2
+        assert not clarifier.is_pending
+        assert clarifier.collected_slots == {}
+    
+    def test_init_custom_max(self):
+        """Test clarifier with custom max clarifications."""
+        clarifier = QueryClarifier(max_clarifications=3)
+        assert clarifier.max_clarifications == 3
+    
+    def test_has_pending_question_initial(self):
+        """Test has_pending_question returns False initially."""
+        clarifier = QueryClarifier()
+        assert not clarifier.has_pending_question()
+    
+    def test_reset(self):
+        """Test reset clears state."""
+        clarifier = QueryClarifier()
+        clarifier._state.original_query = "test"
+        clarifier._state.clarification_count = 1
+        
+        clarifier.reset()
+        
+        assert clarifier._state.original_query == ""
+        assert clarifier._state.clarification_count == 0
+
+
+class TestVagueIndicatorDetection:
+    """Tests for detecting vague indicators in queries."""
+    
+    def test_detect_vague_location_surada(self):
+        """Test 'şurada' triggers clarification."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("şurada kaza olmuş", "news_briefing")
+        
+        assert analysis.needs_clarification
+        assert "location" in analysis.vague_indicators or len(analysis.missing_slots) > 0
+    
+    def test_detect_vague_location_orada(self):
+        """Test 'orada' triggers clarification."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("orada yangın çıkmış", "news_briefing")
+        
+        assert analysis.needs_clarification
+    
+    def test_detect_vague_time_gecenlerde(self):
+        """Test 'geçenlerde' triggers clarification."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("geçenlerde bir olay olmuştu", "news_briefing")
+        
+        assert analysis.needs_clarification
+    
+    def test_specific_location_no_clarification(self):
+        """Test specific location doesn't need clarification."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("Kadıköy'de kaza olmuş", "news_briefing")
+        
+        # Should not need clarification if location is specific
+        assert not analysis.needs_clarification or "location" not in analysis.missing_slots
+    
+    def test_specific_query_no_clarification(self):
+        """Test fully specific query doesn't need clarification."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("bugün İstanbul'da deprem mi oldu", "news_briefing")
+        
+        # Fully specific - no clarification needed
+        assert not analysis.needs_clarification
+
+
+class TestClarificationFlow:
+    """Tests for the clarification flow."""
+    
+    def test_start_clarification(self):
+        """Test starting clarification flow."""
+        clarifier = QueryClarifier()
+        question = ClarificationQuestion(
+            type=ClarificationType.LOCATION,
+            question="Hangi bölgeden bahsediyorsunuz efendim?",
+            examples=["Kadıköy", "Beşiktaş"],
+            slot_name="location",
+        )
+        
+        clarifier.start_clarification("şurada kaza olmuş", question)
+        
+        assert clarifier.has_pending_question()
+        assert clarifier._state.original_query == "şurada kaza olmuş"
+        assert clarifier._state.clarification_count == 1
+    
+    def test_process_response(self):
+        """Test processing user response to clarification."""
+        clarifier = QueryClarifier()
+        question = ClarificationQuestion(
+            type=ClarificationType.LOCATION,
+            question="Hangi bölgeden bahsediyorsunuz efendim?",
+            examples=["Kadıköy", "Beşiktaş"],
+            slot_name="location",
+        )
+        
+        clarifier.start_clarification("şurada kaza olmuş", question)
+        collected = clarifier.process_response("Kadıköy")
+        
+        assert collected["location"] == "Kadıköy"
+        assert not clarifier.has_pending_question()
+    
+    def test_get_search_query(self):
+        """Test getting search query after clarification."""
+        clarifier = QueryClarifier()
+        question = ClarificationQuestion(
+            type=ClarificationType.LOCATION,
+            question="Hangi bölgeden bahsediyorsunuz efendim?",
+            examples=["Kadıköy", "Beşiktaş"],
+            slot_name="location",
+        )
+        
+        clarifier.start_clarification("şurada kaza olmuş", question)
+        clarifier.process_response("Kadıköy")
+        
+        search_query = clarifier.get_search_query()
+        
+        # Should contain both the event and location
+        assert "kaza" in search_query.lower()
+        assert "kadıköy" in search_query.lower()
+    
+    def test_max_clarifications_limit(self):
+        """Test max clarifications limit is respected."""
+        clarifier = QueryClarifier(max_clarifications=2)
+        
+        # First clarification
+        question1 = ClarificationQuestion(
+            type=ClarificationType.LOCATION,
+            question="Hangi bölge?",
+            examples=[],
+            slot_name="location",
+        )
+        clarifier.start_clarification("orada birşey olmuş geçenlerde", question1)
+        clarifier.process_response("Ankara")
+        
+        # Second clarification
+        question2 = ClarificationQuestion(
+            type=ClarificationType.TIME,
+            question="Ne zaman?",
+            examples=[],
+            slot_name="time",
+        )
+        clarifier._state.pending_question = question2
+        clarifier._state.clarification_count = 2
+        clarifier.process_response("dün")
+        
+        # Third analysis - should not need more clarification
+        analysis = clarifier.analyze_query("birşey olmuş", "news_briefing")
+        assert not analysis.needs_clarification
+
+
+class TestClarificationQuestionGeneration:
+    """Tests for clarification question generation."""
+    
+    def test_location_question_jarvis_style(self):
+        """Test location question is in Jarvis style with 'efendim'."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("şurada kaza var", "news_briefing")
+        
+        if analysis.needs_clarification and analysis.clarification_question:
+            question = analysis.clarification_question.question
+            assert "efendim" in question.lower()
+    
+    def test_question_has_examples(self):
+        """Test clarification question includes examples."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("orada yangın çıkmış", "news_briefing")
+        
+        if analysis.needs_clarification and analysis.clarification_question:
+            # Location questions should have example cities
+            assert len(analysis.clarification_question.examples) > 0
+
+
+# ─────────────────────────────────────────────────────────────────
+# QueryExpander Tests
+# ─────────────────────────────────────────────────────────────────
+
+class TestQueryExpanderBasics:
+    """Basic QueryExpander tests."""
+    
+    def test_init_without_llm(self):
+        """Test expander without LLM."""
+        expander = QueryExpander()
+        assert not expander.has_llm
+    
+    def test_expand_simple(self):
+        """Test simple expansion without LLM."""
+        expander = QueryExpander()
+        
+        result = expander.expand_simple(
+            "kaza haberleri",
+            {"location": "Kadıköy", "time": "bugün"}
+        )
+        
+        assert "kaza" in result
+        assert "Kadıköy" in result
+        assert "bugün" in result
+    
+    def test_expand_simple_no_duplicates(self):
+        """Test simple expansion doesn't duplicate existing terms."""
+        expander = QueryExpander()
+        
+        result = expander.expand_simple(
+            "Kadıköy kaza haberleri",
+            {"location": "Kadıköy"}
+        )
+        
+        # Should not have "Kadıköy" twice
+        assert result.count("Kadıköy") == 1
+    
+    def test_suggest_simple(self):
+        """Test simple suggestions."""
+        expander = QueryExpander()
+        
+        suggestions = expander.suggest_simple("deprem haberleri")
+        
+        assert len(suggestions) <= 3
+        assert any("son dakika" in s for s in suggestions)
+    
+    def test_optimize_simple_removes_fillers(self):
+        """Test optimization removes filler words."""
+        expander = QueryExpander()
+        
+        result = expander.optimize_simple("bana bir kaza haberlere bak lütfen")
+        
+        # Filler words should be removed
+        assert "bana" not in result
+        assert "lütfen" not in result
+        assert "kaza" in result
+
+
+class TestQueryExpanderAsync:
+    """Async QueryExpander tests."""
+    
+    @pytest.mark.asyncio
+    async def test_expand_query_without_llm(self):
+        """Test async expansion falls back to simple without LLM."""
+        expander = QueryExpander()
+        
+        result = await expander.expand_query(
+            "kaza",
+            context={"location": "İstanbul"}
+        )
+        
+        assert isinstance(result, ExpandedQuery)
+        assert result.original == "kaza"
+        assert "İstanbul" in result.expanded
+    
+    @pytest.mark.asyncio
+    async def test_suggest_related_without_llm(self):
+        """Test async suggestions falls back to simple without LLM."""
+        expander = QueryExpander()
+        
+        suggestions = await expander.suggest_related("yangın haberleri")
+        
+        assert len(suggestions) <= 3
+        assert all(isinstance(s, QuerySuggestion) for s in suggestions)
+    
+    @pytest.mark.asyncio
+    async def test_optimize_without_llm(self):
+        """Test async optimize falls back to simple without LLM."""
+        expander = QueryExpander()
+        
+        result = await expander.optimize("bana kaza haberleri göster lütfen")
+        
+        assert "kaza" in result
+        assert "lütfen" not in result
+
+
+# ─────────────────────────────────────────────────────────────────
+# Mock Tests
+# ─────────────────────────────────────────────────────────────────
+
+class TestMockQueryClarifier:
+    """Tests for MockQueryClarifier."""
+    
+    def test_mock_set_pending(self):
+        """Test mock can set pending state."""
+        mock = MockQueryClarifier()
+        
+        mock.set_pending_response("location", "Ankara kaza haberleri")
+        
+        assert mock.get_pending_slot() == "location"
+    
+    def test_mock_analyze(self):
+        """Test mock analyze returns configured result."""
+        mock = MockQueryClarifier()
+        mock.set_needs_clarification(True, ClarificationType.LOCATION)
+        
+        analysis = mock.analyze_query("test", "intent")
+        
+        assert analysis.needs_clarification
+
+
+class TestMockQueryExpander:
+    """Tests for MockQueryExpander."""
+    
+    def test_mock_set_expand_result(self):
+        """Test mock can set expand result."""
+        mock = MockQueryExpander()
+        mock.set_expand_result("kaza", "Kadıköy kaza son dakika")
+        
+        result = mock.expand_simple("kaza", {})
+        
+        assert result == "Kadıköy kaza son dakika"
+    
+    def test_mock_set_suggestions(self):
+        """Test mock can set suggestions."""
+        mock = MockQueryExpander()
+        mock.set_suggestions(["test1", "test2"])
+        
+        result = mock.suggest_simple("query")
+        
+        assert result == ["test1", "test2"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# NLU Vague Pattern Tests
+# ─────────────────────────────────────────────────────────────────
+
+class TestNLUVaguePatterns:
+    """Tests for NLU vague pattern detection."""
+    
+    def test_vague_location_with_event(self):
+        """Test vague location with event word triggers vague_search."""
+        parsed = parse_intent("şurada kaza olmuş")
+        assert parsed.intent == "vague_search"
+        assert parsed.slots.get("has_vague_location") is True
+    
+    def test_vague_time_with_event(self):
+        """Test vague time with event word triggers vague_search."""
+        parsed = parse_intent("geçenlerde bir olay olmuş")
+        assert parsed.intent == "vague_search"
+        assert parsed.slots.get("has_vague_time") is True
+    
+    def test_orada_with_event(self):
+        """Test 'orada' with event triggers vague_search."""
+        parsed = parse_intent("orada yangın çıkmış")
+        assert parsed.intent == "vague_search"
+    
+    def test_specific_location_no_vague(self):
+        """Test specific location doesn't trigger vague_search."""
+        parsed = parse_intent("İstanbul'da kaza olmuş")
+        # Should be regular news_briefing or google_search, not vague_search
+        assert parsed.intent != "vague_search" or not parsed.slots.get("has_vague_location")
+    
+    def test_no_event_no_vague(self):
+        """Test vague indicator without event word doesn't trigger."""
+        parsed = parse_intent("şurada güzel bir cafe var")
+        # No event word, shouldn't be vague_search
+        assert parsed.intent != "vague_search"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Integration Tests
+# ─────────────────────────────────────────────────────────────────
+
+class TestClarificationIntegration:
+    """Integration tests for the full clarification flow."""
+    
+    def test_full_flow_location_clarification(self):
+        """Test full flow: vague query -> clarification -> search."""
+        clarifier = QueryClarifier()
+        
+        # Step 1: Analyze vague query
+        analysis = clarifier.analyze_query("şurada kaza olmuş", "news_briefing")
+        assert analysis.needs_clarification
+        
+        # Step 2: Start clarification
+        if analysis.clarification_question:
+            clarifier.start_clarification("şurada kaza olmuş", analysis.clarification_question)
+        
+        # Step 3: User responds
+        clarifier.process_response("Kadıköy")
+        
+        # Step 4: Get search query
+        search_query = clarifier.get_search_query()
+        
+        assert "kaza" in search_query.lower()
+        assert "kadıköy" in search_query.lower()
+    
+    def test_flow_with_multiple_clarifications(self):
+        """Test flow with multiple clarification questions."""
+        clarifier = QueryClarifier(max_clarifications=2)
+        
+        # Step 1: First vague query (location + time vague)
+        q1 = ClarificationQuestion(
+            type=ClarificationType.LOCATION,
+            question="Hangi bölge efendim?",
+            examples=["Kadıköy"],
+            slot_name="location",
+        )
+        clarifier.start_clarification("orada geçenlerde birşey olmuş", q1)
+        clarifier.process_response("Beşiktaş")
+        
+        # Step 2: Second clarification (time)
+        q2 = ClarificationQuestion(
+            type=ClarificationType.TIME,
+            question="Ne zaman efendim?",
+            examples=["bugün"],
+            slot_name="time",
+        )
+        clarifier._state.pending_question = q2
+        clarifier.process_response("dün")
+        
+        # Step 3: Get combined search
+        search_query = clarifier.get_search_query()
+        
+        assert "beşiktaş" in search_query.lower()
+        assert "dün" in search_query.lower()
+
+
+# ─────────────────────────────────────────────────────────────────
+# Edge Cases
+# ─────────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    """Edge case tests."""
+    
+    def test_empty_query(self):
+        """Test empty query handling."""
+        clarifier = QueryClarifier()
+        analysis = clarifier.analyze_query("", "news_briefing")
+        
+        # Empty query shouldn't crash
+        assert analysis is not None
+    
+    def test_reset_mid_flow(self):
+        """Test reset during clarification flow."""
+        clarifier = QueryClarifier()
+        
+        question = ClarificationQuestion(
+            type=ClarificationType.LOCATION,
+            question="Hangi bölge?",
+            examples=[],
+            slot_name="location",
+        )
+        clarifier.start_clarification("test query", question)
+        
+        # Reset mid-flow
+        clarifier.reset()
+        
+        assert not clarifier.has_pending_question()
+        assert clarifier._state.original_query == ""
+    
+    def test_process_response_no_pending(self):
+        """Test process_response when no pending question."""
+        clarifier = QueryClarifier()
+        
+        result = clarifier.process_response("random response")
+        
+        # Should return empty slots, not crash
+        assert result == {}
+    
+    def test_unicode_in_query(self):
+        """Test Turkish unicode characters handled correctly."""
+        clarifier = QueryClarifier()
+        
+        analysis = clarifier.analyze_query(
+            "Şımarık Öğüt Çiğköfte Üstü İçin",
+            "news_briefing"
+        )
+        
+        # Should not crash with Turkish characters
+        assert analysis is not None


### PR DESCRIPTION
## Summary
Implements Query Clarification System for Issue #21.

When users give vague queries like 'şurada kaza olmuş' (there was an accident there), Bantz now asks clarifying questions in Jarvis style: 'Hangi bölgeden bahsediyorsunuz efendim?' (Which region are you referring to, sir?)

## What's New

### QueryClarifier (src/bantz/router/clarifier.py)
- Detects vague indicators: şurada, orada, burada, geçenlerde, etc.
- ClarificationType enum: LOCATION, TIME, SUBJECT, SPECIFICITY, CONFIRMATION
- ClarificationQuestion with Jarvis-style templates
- ClarificationState for conversation tracking
- Max 2 clarifications per conversation (UX)

### QueryExpander (src/bantz/router/query_expander.py)
- LLM-based query expansion with fallback to simple mode
- expand_query(): Add context (location, time) to query
- suggest_related(): Generate related search suggestions
- optimize(): Remove filler words, optimize for search

### NLU Patterns (src/bantz/router/nlu.py)
- vague_search intent detection
- Pattern matching for Turkish vague indicators

### Router Integration (src/bantz/router/engine.py)
- Clarification flow in handle()
- Pending question state management
- Seamless transition to news_briefing after clarification

## Example Flow
```
User: 'şurada kaza olmuş'
Bantz: 'Hangi bölgeden bahsediyorsunuz efendim?'
User: 'Kadıköy'
Bantz: [searches 'Kadıköy kaza haberleri']
```

## Tests
- 38 new tests in tests/test_clarifier.py
- 1211 total tests passing

## Files Changed
- src/bantz/router/clarifier.py (new, ~670 lines)
- src/bantz/router/query_expander.py (new, ~310 lines)
- src/bantz/router/engine.py (modified, +65 lines)
- src/bantz/router/nlu.py (modified, +40 lines)
- src/bantz/router/types.py (modified, +2 intents)
- src/bantz/router/__init__.py (updated exports)
- tests/test_clarifier.py (new, ~420 lines)

Closes #21