### PR TITLE
feat(v2-3): Cite-first research pipeline - sources + contradictions + confidence

### DIFF
--- a/src/bantz/research/__init__.py
+++ b/src/bantz/research/__init__.py
@@ -1,0 +1,50 @@
+"""
+Research Pipeline Module (Issue #33 - V2-3).
+
+Cite-first research pipeline with source collection,
+contradiction detection, and confidence scoring.
+
+Components:
+- SourceCollector: Collect and extract sources
+- SourceRanker: Rank sources by reliability
+- ContradictionDetector: Detect conflicting claims
+- ConfidenceScorer: Calculate confidence scores
+- ResearchOrchestrator: Full pipeline orchestration
+"""
+
+from bantz.research.source_collector import (
+    Source,
+    SourceCollector,
+)
+from bantz.research.source_ranker import (
+    SourceRanker,
+)
+from bantz.research.contradiction import (
+    ContradictionResult,
+    ContradictionDetector,
+)
+from bantz.research.confidence import (
+    ConfidenceResult,
+    ConfidenceScorer,
+)
+from bantz.research.orchestrator import (
+    ResearchResult,
+    ResearchOrchestrator,
+)
+
+__all__ = [
+    # Source Collection
+    "Source",
+    "SourceCollector",
+    # Ranking
+    "SourceRanker",
+    # Contradiction Detection
+    "ContradictionResult",
+    "ContradictionDetector",
+    # Confidence Scoring
+    "ConfidenceResult",
+    "ConfidenceScorer",
+    # Orchestration
+    "ResearchResult",
+    "ResearchOrchestrator",
+]

--- a/src/bantz/research/confidence.py
+++ b/src/bantz/research/confidence.py
@@ -1,0 +1,304 @@
+"""
+Confidence Scorer (Issue #33 - V2-3).
+
+Calculates confidence scores for research results
+based on multiple factors.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Optional
+
+from bantz.research.source_collector import Source
+from bantz.research.contradiction import ContradictionResult
+
+
+@dataclass
+class ConfidenceResult:
+    """
+    Result of confidence scoring.
+    
+    Attributes:
+        score: Overall confidence score (0.0 - 1.0)
+        level: Confidence level ("low", "medium", "high")
+        factors: Individual factor contributions
+        explanation: Human-readable explanation
+    """
+    score: float
+    level: str  # "low", "medium", "high"
+    factors: dict[str, float] = field(default_factory=dict)
+    explanation: str = ""
+
+
+class ConfidenceScorer:
+    """
+    Calculates confidence scores for research results.
+    
+    Combines multiple factors:
+    - Source count
+    - Source reliability
+    - Recency
+    - Agreement between sources
+    - Topic coverage
+    """
+    
+    # Factor weights (must sum to 1.0)
+    WEIGHTS: dict[str, float] = {
+        "source_count": 0.20,      # More sources = higher confidence
+        "source_reliability": 0.25, # Higher reliability = higher confidence
+        "recency": 0.15,           # More recent = higher confidence
+        "agreement": 0.25,         # More agreement = higher confidence
+        "coverage": 0.15,          # Better coverage = higher confidence
+    }
+    
+    # Confidence level thresholds
+    LEVEL_THRESHOLDS = {
+        "low": 0.4,     # score < 0.4
+        "medium": 0.7,  # 0.4 <= score < 0.7
+        "high": 1.0,    # score >= 0.7
+    }
+    
+    # Source count scoring
+    MIN_SOURCES_FOR_CONFIDENCE = 2
+    OPTIMAL_SOURCE_COUNT = 5
+    
+    def __init__(self, reference_date: Optional[datetime] = None):
+        """
+        Initialize ConfidenceScorer.
+        
+        Args:
+            reference_date: Date to use for recency calculations.
+                           Defaults to now.
+        """
+        self.reference_date = reference_date or datetime.now()
+    
+    def score(
+        self,
+        sources: list[Source],
+        contradiction: ContradictionResult
+    ) -> ConfidenceResult:
+        """
+        Calculate confidence score for research results.
+        
+        Args:
+            sources: List of sources used
+            contradiction: Contradiction detection result
+        
+        Returns:
+            ConfidenceResult with overall score and breakdown
+        """
+        factors: dict[str, float] = {}
+        
+        # Factor 1: Source count
+        factors["source_count"] = self._score_source_count(sources)
+        
+        # Factor 2: Source reliability
+        factors["source_reliability"] = self._score_source_reliability(sources)
+        
+        # Factor 3: Recency
+        factors["recency"] = self._score_recency(sources)
+        
+        # Factor 4: Agreement
+        factors["agreement"] = self._score_agreement(contradiction)
+        
+        # Factor 5: Coverage (based on content type diversity)
+        factors["coverage"] = self._score_coverage(sources)
+        
+        # Calculate weighted score
+        total_score = sum(
+            factors[key] * self.WEIGHTS[key]
+            for key in self.WEIGHTS
+        )
+        
+        # Clamp to 0.0 - 1.0
+        total_score = max(0.0, min(1.0, total_score))
+        
+        # Determine level
+        level = self._determine_level(total_score)
+        
+        # Generate explanation
+        explanation = self._generate_explanation(factors, total_score, level)
+        
+        return ConfidenceResult(
+            score=total_score,
+            level=level,
+            factors=factors,
+            explanation=explanation
+        )
+    
+    def _score_source_count(self, sources: list[Source]) -> float:
+        """
+        Score based on number of sources.
+        
+        - 0 sources: 0.0
+        - 1 source: 0.3 (single source penalty)
+        - 2-5 sources: Linear scale to 1.0
+        - 5+ sources: 1.0 (optimal)
+        """
+        count = len(sources)
+        
+        if count == 0:
+            return 0.0
+        elif count == 1:
+            return 0.3  # Single source penalty
+        elif count >= self.OPTIMAL_SOURCE_COUNT:
+            return 1.0
+        else:
+            # Linear scale from 2 to OPTIMAL
+            return 0.3 + 0.7 * (count - 1) / (self.OPTIMAL_SOURCE_COUNT - 1)
+    
+    def _score_source_reliability(self, sources: list[Source]) -> float:
+        """
+        Score based on average source reliability.
+        
+        Returns weighted average of reliability scores,
+        with higher-reliability sources weighted more.
+        """
+        if not sources:
+            return 0.0
+        
+        # Use reliability scores from sources
+        scores = [s.reliability_score for s in sources if s.reliability_score > 0]
+        
+        if not scores:
+            return 0.5  # Default if no scores available
+        
+        # Weighted average favoring higher scores
+        total = sum(scores)
+        count = len(scores)
+        
+        # Simple average
+        avg = total / count
+        
+        # Boost for having multiple reliable sources
+        if count >= 3 and avg >= 0.7:
+            avg = min(1.0, avg * 1.1)
+        
+        return avg
+    
+    def _score_recency(self, sources: list[Source]) -> float:
+        """
+        Score based on source recency.
+        
+        - Sources within 7 days: 1.0
+        - Sources within 30 days: 0.7
+        - Sources within 90 days: 0.5
+        - Older sources: 0.3
+        - No dates: 0.5 (neutral)
+        """
+        if not sources:
+            return 0.5
+        
+        dated_sources = [s for s in sources if s.date is not None]
+        
+        if not dated_sources:
+            return 0.5  # No date info available
+        
+        # Find most recent source
+        most_recent = max(dated_sources, key=lambda s: s.date)
+        delta = self.reference_date - most_recent.date
+        days_old = delta.days
+        
+        if days_old < 0:
+            return 1.0  # Future date (unusual but handle it)
+        elif days_old <= 7:
+            return 1.0
+        elif days_old <= 30:
+            return 0.7
+        elif days_old <= 90:
+            return 0.5
+        else:
+            return 0.3
+    
+    def _score_agreement(self, contradiction: ContradictionResult) -> float:
+        """
+        Score based on source agreement.
+        
+        Uses agreement_score from ContradictionResult.
+        Penalty for contradictions.
+        """
+        # Direct mapping from agreement score
+        base_score = contradiction.agreement_score
+        
+        # Additional penalty for having contradictions
+        if contradiction.has_contradiction:
+            penalty = len(contradiction.conflicting_claims) * 0.1
+            base_score = max(0.0, base_score - penalty)
+        
+        return base_score
+    
+    def _score_coverage(self, sources: list[Source]) -> float:
+        """
+        Score based on content type diversity.
+        
+        Higher score for diverse source types (news, academic, etc.)
+        """
+        if not sources:
+            return 0.0
+        
+        # Count unique content types
+        content_types = set(s.content_type for s in sources)
+        
+        # Score based on diversity
+        type_count = len(content_types)
+        
+        if type_count == 1:
+            return 0.5
+        elif type_count == 2:
+            return 0.7
+        elif type_count == 3:
+            return 0.9
+        else:
+            return 1.0
+    
+    def _determine_level(self, score: float) -> str:
+        """Determine confidence level from score."""
+        if score < self.LEVEL_THRESHOLDS["low"]:
+            return "low"
+        elif score < self.LEVEL_THRESHOLDS["medium"]:
+            return "medium"
+        else:
+            return "high"
+    
+    def _generate_explanation(
+        self,
+        factors: dict[str, float],
+        total_score: float,
+        level: str
+    ) -> str:
+        """Generate human-readable explanation."""
+        explanations = []
+        
+        # Source count
+        count_score = factors.get("source_count", 0)
+        if count_score < 0.4:
+            explanations.append("Limited sources found")
+        elif count_score >= 0.8:
+            explanations.append("Multiple sources confirm")
+        
+        # Reliability
+        rel_score = factors.get("source_reliability", 0)
+        if rel_score < 0.5:
+            explanations.append("source quality is mixed")
+        elif rel_score >= 0.8:
+            explanations.append("sources are highly reliable")
+        
+        # Agreement
+        agree_score = factors.get("agreement", 0)
+        if agree_score < 0.5:
+            explanations.append("sources show conflicting information")
+        elif agree_score >= 0.8:
+            explanations.append("sources are in agreement")
+        
+        # Recency
+        rec_score = factors.get("recency", 0)
+        if rec_score < 0.5:
+            explanations.append("information may be outdated")
+        elif rec_score >= 0.8:
+            explanations.append("information is recent")
+        
+        if not explanations:
+            return f"Confidence level: {level} ({total_score:.1%})"
+        
+        main = ". ".join(explanations)
+        return f"{main}. Confidence: {level} ({total_score:.1%})"

--- a/src/bantz/research/contradiction.py
+++ b/src/bantz/research/contradiction.py
@@ -1,0 +1,286 @@
+"""
+Contradiction Detector (Issue #33 - V2-3).
+
+Detects conflicting claims between sources using
+text similarity and semantic analysis.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+from bantz.research.source_collector import Source
+
+
+@dataclass
+class ContradictionResult:
+    """
+    Result of contradiction detection.
+    
+    Attributes:
+        has_contradiction: True if contradictions found
+        conflicting_claims: List of (source1, source2, description) tuples
+        agreement_score: 0.0 = total conflict, 1.0 = total agreement
+    """
+    has_contradiction: bool
+    conflicting_claims: list[tuple[Source, Source, str]] = field(default_factory=list)
+    agreement_score: float = 1.0  # Default to full agreement
+
+
+class ContradictionDetector:
+    """
+    Detects contradictions between sources.
+    
+    Uses text analysis to identify conflicting claims
+    and calculates overall agreement scores.
+    """
+    
+    # Negation words that indicate potential contradiction
+    NEGATION_WORDS = {
+        "not", "no", "never", "neither", "none", "nobody",
+        "nothing", "nowhere", "hardly", "barely", "scarcely",
+        "doesn't", "don't", "didn't", "won't", "wouldn't",
+        "couldn't", "shouldn't", "isn't", "aren't", "wasn't",
+        "weren't", "hasn't", "haven't", "hadn't", "cannot",
+        "denied", "denies", "rejected", "false", "untrue",
+        "incorrect", "wrong", "inaccurate", "misleading",
+    }
+    
+    # Contradiction indicator phrases
+    CONTRADICTION_PHRASES = [
+        ("confirmed", "denied"),
+        ("true", "false"),
+        ("correct", "incorrect"),
+        ("accurate", "inaccurate"),
+        ("increased", "decreased"),
+        ("rising", "falling"),
+        ("up", "down"),
+        ("yes", "no"),
+        ("success", "failure"),
+        ("approved", "rejected"),
+        ("support", "oppose"),
+        ("agree", "disagree"),
+        ("accept", "reject"),
+        ("win", "lose"),
+        ("alive", "dead"),
+    ]
+    
+    # Similarity threshold for claim matching
+    SIMILARITY_THRESHOLD = 0.6
+    
+    def __init__(self, llm_client=None):
+        """
+        Initialize ContradictionDetector.
+        
+        Args:
+            llm_client: Optional LLM client for semantic analysis.
+                       If not provided, uses heuristic methods.
+        """
+        self.llm_client = llm_client
+    
+    def detect(
+        self,
+        sources: list[Source],
+        summaries: list[str]
+    ) -> ContradictionResult:
+        """
+        Detect contradictions between sources.
+        
+        Analyzes summaries from sources to find conflicting claims.
+        
+        Args:
+            sources: List of sources
+            summaries: Corresponding summaries for each source
+        
+        Returns:
+            ContradictionResult with detection results
+        """
+        if len(sources) < 2 or len(summaries) < 2:
+            return ContradictionResult(
+                has_contradiction=False,
+                conflicting_claims=[],
+                agreement_score=1.0
+            )
+        
+        # Ensure sources and summaries match in length
+        min_len = min(len(sources), len(summaries))
+        sources = sources[:min_len]
+        summaries = summaries[:min_len]
+        
+        # Extract key claims from each summary
+        source_claims: list[tuple[Source, list[str]]] = []
+        for source, summary in zip(sources, summaries):
+            claims = self.extract_key_claims(summary)
+            source_claims.append((source, claims))
+        
+        # Compare claims pairwise
+        conflicting_claims: list[tuple[Source, Source, str]] = []
+        total_comparisons = 0
+        agreements = 0
+        
+        for i in range(len(source_claims)):
+            for j in range(i + 1, len(source_claims)):
+                source1, claims1 = source_claims[i]
+                source2, claims2 = source_claims[j]
+                
+                # Compare claims
+                for claim1 in claims1:
+                    for claim2 in claims2:
+                        total_comparisons += 1
+                        similarity = self.compare_claims(claim1, claim2)
+                        
+                        # Check for contradiction
+                        if self._is_contradiction(claim1, claim2, similarity):
+                            description = f"'{claim1}' vs '{claim2}'"
+                            conflicting_claims.append(
+                                (source1, source2, description)
+                            )
+                        elif similarity > self.SIMILARITY_THRESHOLD:
+                            agreements += 1
+        
+        # Calculate agreement score
+        if total_comparisons > 0:
+            contradiction_count = len(conflicting_claims)
+            agreement_ratio = (total_comparisons - contradiction_count) / total_comparisons
+            agreement_score = max(0.0, min(1.0, agreement_ratio))
+        else:
+            agreement_score = 1.0
+        
+        return ContradictionResult(
+            has_contradiction=len(conflicting_claims) > 0,
+            conflicting_claims=conflicting_claims,
+            agreement_score=agreement_score
+        )
+    
+    def compare_claims(self, claim1: str, claim2: str) -> float:
+        """
+        Compare two claims for similarity.
+        
+        Uses word overlap and semantic heuristics.
+        
+        Args:
+            claim1: First claim text
+            claim2: Second claim text
+        
+        Returns:
+            Similarity score between 0.0 and 1.0
+        """
+        # Normalize claims
+        words1 = set(self._normalize_text(claim1).split())
+        words2 = set(self._normalize_text(claim2).split())
+        
+        # Remove stopwords
+        stopwords = {
+            "the", "a", "an", "is", "are", "was", "were", "be", "been",
+            "being", "have", "has", "had", "do", "does", "did", "will",
+            "would", "could", "should", "may", "might", "must", "shall",
+            "to", "of", "in", "for", "on", "with", "at", "by", "from",
+            "as", "into", "through", "during", "before", "after", "above",
+            "below", "between", "under", "again", "further", "then", "once",
+            "that", "this", "these", "those", "it", "its", "and", "but",
+            "or", "nor", "so", "yet", "both", "each", "few", "more", "most",
+        }
+        words1 = words1 - stopwords
+        words2 = words2 - stopwords
+        
+        if not words1 or not words2:
+            return 0.0
+        
+        # Jaccard similarity
+        intersection = words1 & words2
+        union = words1 | words2
+        
+        return len(intersection) / len(union) if union else 0.0
+    
+    def extract_key_claims(self, text: str) -> list[str]:
+        """
+        Extract key claims from text.
+        
+        Splits text into sentences and extracts claims
+        that contain factual assertions.
+        
+        Args:
+            text: Text to extract claims from
+        
+        Returns:
+            List of claim strings
+        """
+        if not text:
+            return []
+        
+        # Split into sentences
+        sentences = re.split(r'[.!?]+', text)
+        
+        claims = []
+        for sentence in sentences:
+            sentence = sentence.strip()
+            
+            # Skip short sentences
+            if len(sentence.split()) < 3:
+                continue
+            
+            # Skip questions
+            if sentence.endswith("?"):
+                continue
+            
+            # Check for factual indicators
+            if self._is_factual_claim(sentence):
+                claims.append(sentence)
+        
+        return claims
+    
+    def _is_factual_claim(self, sentence: str) -> bool:
+        """Check if sentence contains a factual claim."""
+        lower = sentence.lower()
+        
+        # Look for factual indicators
+        factual_indicators = [
+            "is", "are", "was", "were", "has", "have", "had",
+            "will", "confirmed", "announced", "reported", "said",
+            "stated", "according", "showed", "revealed", "found",
+            "discovered", "proved", "demonstrated", "indicates",
+            "percent", "%", "million", "billion", "thousand",
+        ]
+        
+        return any(ind in lower for ind in factual_indicators)
+    
+    def _is_contradiction(
+        self,
+        claim1: str,
+        claim2: str,
+        similarity: float
+    ) -> bool:
+        """
+        Check if two claims contradict each other.
+        
+        Looks for negation patterns and opposing terms.
+        """
+        lower1 = claim1.lower()
+        lower2 = claim2.lower()
+        
+        # Check for negation asymmetry
+        neg1 = any(neg in lower1 for neg in self.NEGATION_WORDS)
+        neg2 = any(neg in lower2 for neg in self.NEGATION_WORDS)
+        
+        # If similar topics but different negation, likely contradiction
+        if similarity > 0.3 and neg1 != neg2:
+            return True
+        
+        # Check for opposing terms
+        for term1, term2 in self.CONTRADICTION_PHRASES:
+            if term1 in lower1 and term2 in lower2:
+                return True
+            if term2 in lower1 and term1 in lower2:
+                return True
+        
+        return False
+    
+    def _normalize_text(self, text: str) -> str:
+        """Normalize text for comparison."""
+        # Lowercase
+        text = text.lower()
+        # Remove punctuation
+        text = re.sub(r'[^\w\s]', ' ', text)
+        # Normalize whitespace
+        text = ' '.join(text.split())
+        return text

--- a/src/bantz/research/orchestrator.py
+++ b/src/bantz/research/orchestrator.py
@@ -1,0 +1,290 @@
+"""
+Research Orchestrator (Issue #33 - V2-3).
+
+Orchestrates the full cite-first research pipeline:
+1. Collect sources
+2. Rank by reliability
+3. Detect contradictions
+4. Calculate confidence
+5. Generate summary
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from bantz.research.source_collector import Source, SourceCollector
+from bantz.research.source_ranker import SourceRanker
+from bantz.research.contradiction import ContradictionResult, ContradictionDetector
+from bantz.research.confidence import ConfidenceResult, ConfidenceScorer
+from bantz.core.events import EventBus, EventType
+
+
+@dataclass
+class ResearchResult:
+    """
+    Complete research result.
+    
+    Attributes:
+        query: Original search query
+        sources: Ranked sources used
+        summary: Generated summary
+        confidence: Confidence scoring result
+        contradiction: Contradiction detection result
+        duration_ms: Total research duration in milliseconds
+    """
+    query: str
+    sources: list[Source] = field(default_factory=list)
+    summary: str = ""
+    confidence: Optional[ConfidenceResult] = None
+    contradiction: Optional[ContradictionResult] = None
+    duration_ms: float = 0.0
+
+
+class ResearchOrchestrator:
+    """
+    Orchestrates the full research pipeline.
+    
+    Combines source collection, ranking, contradiction detection,
+    and confidence scoring into a single pipeline.
+    """
+    
+    # Configuration
+    MIN_SOURCES: int = 2
+    MAX_SOURCES: int = 10
+    QUALITY_THRESHOLD: float = 0.3
+    
+    def __init__(
+        self,
+        collector: SourceCollector,
+        ranker: SourceRanker,
+        contradiction_detector: ContradictionDetector,
+        confidence_scorer: ConfidenceScorer,
+        event_bus: Optional[EventBus] = None,
+        summarizer=None
+    ):
+        """
+        Initialize ResearchOrchestrator.
+        
+        Args:
+            collector: Source collector for gathering sources
+            ranker: Source ranker for reliability scoring
+            contradiction_detector: For finding conflicting claims
+            confidence_scorer: For calculating confidence
+            event_bus: Optional event bus for publishing events
+            summarizer: Optional summarizer for generating summaries
+        """
+        self.collector = collector
+        self.ranker = ranker
+        self.contradiction_detector = contradiction_detector
+        self.confidence_scorer = confidence_scorer
+        self.event_bus = event_bus
+        self.summarizer = summarizer
+    
+    async def research(self, query: str) -> ResearchResult:
+        """
+        Execute full research pipeline.
+        
+        Pipeline steps:
+        1. Collect sources from search
+        2. Rank sources by reliability
+        3. Filter low-quality sources
+        4. Extract summaries from sources
+        5. Detect contradictions
+        6. Calculate confidence
+        7. Generate final summary
+        
+        Args:
+            query: Research query
+        
+        Returns:
+            ResearchResult with all findings
+        """
+        start_time = time.time()
+        
+        # Step 1: Collect sources
+        self._emit_event(EventType.PROGRESS, {
+            "step": "collecting",
+            "message": f"Searching for: {query}"
+        })
+        
+        sources = await self.collector.collect(
+            query=query,
+            max_sources=self.MAX_SOURCES
+        )
+        
+        self._emit_event(EventType.FOUND, {
+            "step": "sources_found",
+            "count": len(sources),
+            "query": query
+        })
+        
+        # Step 2: Rank sources by reliability
+        self._emit_event(EventType.PROGRESS, {
+            "step": "ranking",
+            "message": "Ranking sources by reliability"
+        })
+        
+        ranked_sources = self.ranker.rank(sources)
+        
+        # Step 3: Filter low-quality sources
+        filtered_sources = self.ranker.filter_low_quality(
+            ranked_sources,
+            threshold=self.QUALITY_THRESHOLD
+        )
+        
+        # Ensure minimum sources
+        if len(filtered_sources) < self.MIN_SOURCES and len(ranked_sources) >= self.MIN_SOURCES:
+            # Use top ranked sources if filtering is too aggressive
+            filtered_sources = ranked_sources[:self.MIN_SOURCES]
+        
+        # Step 4: Extract summaries (use snippets for now)
+        summaries = [s.snippet for s in filtered_sources if s.snippet]
+        
+        # Step 5: Detect contradictions
+        self._emit_event(EventType.PROGRESS, {
+            "step": "analyzing",
+            "message": "Analyzing for contradictions"
+        })
+        
+        contradiction = self.contradiction_detector.detect(
+            sources=filtered_sources,
+            summaries=summaries
+        )
+        
+        # Step 6: Calculate confidence
+        confidence = self.confidence_scorer.score(
+            sources=filtered_sources,
+            contradiction=contradiction
+        )
+        
+        # Step 7: Generate summary
+        self._emit_event(EventType.PROGRESS, {
+            "step": "summarizing",
+            "message": "Generating summary"
+        })
+        
+        summary = await self._generate_summary(
+            query=query,
+            sources=filtered_sources,
+            contradiction=contradiction,
+            confidence=confidence
+        )
+        
+        # Calculate duration
+        duration_ms = (time.time() - start_time) * 1000
+        
+        # Create result
+        result = ResearchResult(
+            query=query,
+            sources=filtered_sources,
+            summary=summary,
+            confidence=confidence,
+            contradiction=contradiction,
+            duration_ms=duration_ms
+        )
+        
+        # Emit result event
+        self._emit_event(EventType.RESULT, {
+            "step": "complete",
+            "query": query,
+            "source_count": len(filtered_sources),
+            "confidence_level": confidence.level,
+            "has_contradictions": contradiction.has_contradiction,
+            "duration_ms": duration_ms
+        })
+        
+        return result
+    
+    async def _generate_summary(
+        self,
+        query: str,
+        sources: list[Source],
+        contradiction: ContradictionResult,
+        confidence: ConfidenceResult
+    ) -> str:
+        """
+        Generate research summary.
+        
+        If a summarizer is provided, uses it.
+        Otherwise, generates a basic summary from snippets.
+        """
+        if self.summarizer:
+            # Use provided summarizer
+            try:
+                return await self.summarizer.summarize(
+                    query=query,
+                    sources=sources,
+                    contradiction=contradiction
+                )
+            except Exception:
+                pass  # Fall through to basic summary
+        
+        # Basic summary from snippets
+        if not sources:
+            return f"No reliable sources found for: {query}"
+        
+        # Combine top snippets
+        top_sources = sources[:3]
+        snippets = []
+        
+        for source in top_sources:
+            if source.snippet:
+                snippets.append(f"• {source.snippet}")
+        
+        if not snippets:
+            return f"Found {len(sources)} sources but no summaries available."
+        
+        summary_parts = [
+            f"Research results for: {query}",
+            "",
+            "Key findings:",
+            *snippets,
+        ]
+        
+        # Add confidence note
+        summary_parts.append("")
+        summary_parts.append(confidence.explanation)
+        
+        # Add contradiction warning if needed
+        if contradiction.has_contradiction:
+            summary_parts.append("")
+            summary_parts.append(
+                f"⚠️ Note: {len(contradiction.conflicting_claims)} "
+                f"conflicting claims detected between sources."
+            )
+        
+        return "\n".join(summary_parts)
+    
+    def _emit_event(self, event_type: EventType, data: dict) -> None:
+        """Emit event to event bus if available."""
+        if self.event_bus:
+            self.event_bus.publish(
+                event_type=event_type.value,
+                data=data,
+                source="research_orchestrator"
+            )
+
+
+# Factory function for creating orchestrator with defaults
+def create_research_orchestrator(
+    event_bus: Optional[EventBus] = None,
+    search_tool=None
+) -> ResearchOrchestrator:
+    """
+    Create a ResearchOrchestrator with default components.
+    
+    Args:
+        event_bus: Optional event bus for events
+        search_tool: Optional search tool for source collection
+    
+    Returns:
+        Configured ResearchOrchestrator
+    """
+    return ResearchOrchestrator(
+        collector=SourceCollector(search_tool=search_tool),
+        ranker=SourceRanker(),
+        contradiction_detector=ContradictionDetector(),
+        confidence_scorer=ConfidenceScorer(),
+        event_bus=event_bus
+    )

--- a/src/bantz/research/source_collector.py
+++ b/src/bantz/research/source_collector.py
@@ -1,0 +1,291 @@
+"""
+Source Collector (Issue #33 - V2-3).
+
+Collects and extracts sources from web searches for the
+cite-first research pipeline.
+"""
+
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+from urllib.parse import urlparse
+
+
+@dataclass
+class Source:
+    """
+    Represents a research source with metadata.
+    
+    Attributes:
+        url: Full URL of the source
+        title: Title of the article/page
+        snippet: Short excerpt or description
+        date: Publication date if available
+        domain: Extracted domain (e.g., "reuters.com")
+        reliability_score: 0.0-1.0 reliability rating
+        content_type: Type of content (article, news, academic, social)
+    """
+    url: str
+    title: str
+    snippet: str
+    date: Optional[datetime] = None
+    domain: str = ""
+    reliability_score: float = 0.0
+    content_type: str = "article"  # article, news, academic, social
+    
+    def __post_init__(self):
+        """Extract domain from URL if not provided."""
+        if not self.domain and self.url:
+            self.domain = self._extract_domain(self.url)
+    
+    def _extract_domain(self, url: str) -> str:
+        """Extract domain from URL."""
+        try:
+            parsed = urlparse(url)
+            domain = parsed.netloc
+            # Remove www. prefix
+            if domain.startswith("www."):
+                domain = domain[4:]
+            return domain
+        except Exception:
+            return ""
+
+
+# Common date patterns for parsing
+DATE_PATTERNS = [
+    # ISO format
+    (r"(\d{4}-\d{2}-\d{2})", "%Y-%m-%d"),
+    # US format
+    (r"(\d{1,2}/\d{1,2}/\d{4})", "%m/%d/%Y"),
+    # European format
+    (r"(\d{1,2}\.\d{1,2}\.\d{4})", "%d.%m.%Y"),
+    # Month name format
+    (r"(\w+ \d{1,2},? \d{4})", None),  # Special handling
+    # Relative dates handled separately
+]
+
+# Month name mapping for parsing
+MONTH_NAMES = {
+    "january": 1, "jan": 1,
+    "february": 2, "feb": 2,
+    "march": 3, "mar": 3,
+    "april": 4, "apr": 4,
+    "may": 5,
+    "june": 6, "jun": 6,
+    "july": 7, "jul": 7,
+    "august": 8, "aug": 8,
+    "september": 9, "sep": 9, "sept": 9,
+    "october": 10, "oct": 10,
+    "november": 11, "nov": 11,
+    "december": 12, "dec": 12,
+}
+
+
+class SourceCollector:
+    """
+    Collects sources from web searches.
+    
+    Uses web search tools to gather sources and extracts
+    metadata for each source.
+    """
+    
+    def __init__(self, search_tool=None):
+        """
+        Initialize SourceCollector.
+        
+        Args:
+            search_tool: Optional web search tool to use.
+                        If not provided, uses mock search for testing.
+        """
+        self.search_tool = search_tool
+    
+    async def collect(
+        self,
+        query: str,
+        max_sources: int = 10
+    ) -> list[Source]:
+        """
+        Collect sources for a query.
+        
+        Args:
+            query: Search query string
+            max_sources: Maximum number of sources to return
+        
+        Returns:
+            List of Source objects ordered by relevance
+        """
+        if self.search_tool:
+            # Use actual search tool
+            from bantz.agent.tool_base import ToolContext
+            context = ToolContext(job_id=f"collect-{int(time.time())}")
+            result = await self.search_tool.run(
+                {"query": query, "max_results": max_sources},
+                context
+            )
+            
+            if result.success and result.data:
+                raw_results = result.data.get("results", [])
+                sources = []
+                for r in raw_results[:max_sources]:
+                    source = Source(
+                        url=r.get("url", ""),
+                        title=r.get("title", ""),
+                        snippet=r.get("snippet", ""),
+                        date=self.parse_date(r.get("date", ""))
+                    )
+                    sources.append(source)
+                return sources
+        
+        # Mock search for testing - returns empty list
+        # Real implementation would use web search
+        return []
+    
+    async def extract_metadata(self, url: str) -> Source:
+        """
+        Extract metadata from a URL.
+        
+        Args:
+            url: URL to extract metadata from
+        
+        Returns:
+            Source object with extracted metadata
+        """
+        # Parse domain from URL
+        domain = ""
+        try:
+            parsed = urlparse(url)
+            domain = parsed.netloc
+            if domain.startswith("www."):
+                domain = domain[4:]
+        except Exception:
+            pass
+        
+        # Determine content type from domain
+        content_type = self._detect_content_type(domain)
+        
+        # Create source with basic info
+        source = Source(
+            url=url,
+            title="",  # Would be fetched
+            snippet="",  # Would be fetched
+            domain=domain,
+            content_type=content_type
+        )
+        
+        return source
+    
+    def parse_date(self, raw_date: str) -> Optional[datetime]:
+        """
+        Parse a date string into datetime.
+        
+        Handles multiple formats:
+        - ISO: 2024-01-15
+        - US: 01/15/2024, 1/15/2024
+        - European: 15.01.2024
+        - Text: January 15, 2024, Jan 15 2024
+        
+        Args:
+            raw_date: Raw date string
+        
+        Returns:
+            datetime if parseable, None otherwise
+        """
+        if not raw_date:
+            return None
+        
+        raw_date = raw_date.strip()
+        
+        # Try ISO format first (most common in APIs)
+        iso_match = re.search(r"(\d{4}-\d{2}-\d{2})", raw_date)
+        if iso_match:
+            try:
+                return datetime.strptime(iso_match.group(1), "%Y-%m-%d")
+            except ValueError:
+                pass
+        
+        # Try US format
+        us_match = re.search(r"(\d{1,2}/\d{1,2}/\d{4})", raw_date)
+        if us_match:
+            try:
+                return datetime.strptime(us_match.group(1), "%m/%d/%Y")
+            except ValueError:
+                pass
+        
+        # Try European format
+        eu_match = re.search(r"(\d{1,2}\.\d{1,2}\.\d{4})", raw_date)
+        if eu_match:
+            try:
+                return datetime.strptime(eu_match.group(1), "%d.%m.%Y")
+            except ValueError:
+                pass
+        
+        # Try text month format (e.g., "January 15, 2024")
+        text_match = re.search(
+            r"(\w+)\s+(\d{1,2}),?\s+(\d{4})",
+            raw_date,
+            re.IGNORECASE
+        )
+        if text_match:
+            month_str = text_match.group(1).lower()
+            day = int(text_match.group(2))
+            year = int(text_match.group(3))
+            
+            if month_str in MONTH_NAMES:
+                month = MONTH_NAMES[month_str]
+                try:
+                    return datetime(year, month, day)
+                except ValueError:
+                    pass
+        
+        # Try short format: "15 Jan 2024"
+        short_match = re.search(
+            r"(\d{1,2})\s+(\w+)\s+(\d{4})",
+            raw_date,
+            re.IGNORECASE
+        )
+        if short_match:
+            day = int(short_match.group(1))
+            month_str = short_match.group(2).lower()
+            year = int(short_match.group(3))
+            
+            if month_str in MONTH_NAMES:
+                month = MONTH_NAMES[month_str]
+                try:
+                    return datetime(year, month, day)
+                except ValueError:
+                    pass
+        
+        return None
+    
+    def _detect_content_type(self, domain: str) -> str:
+        """Detect content type from domain."""
+        domain_lower = domain.lower()
+        
+        # News domains
+        news_domains = [
+            "reuters.com", "bbc.com", "cnn.com", "nytimes.com",
+            "theguardian.com", "apnews.com", "bloomberg.com"
+        ]
+        if any(d in domain_lower for d in news_domains):
+            return "news"
+        
+        # Academic domains
+        academic_domains = [
+            "arxiv.org", "scholar.google", "pubmed", "doi.org",
+            ".edu", "researchgate.net", "nature.com", "science.org"
+        ]
+        if any(d in domain_lower for d in academic_domains):
+            return "academic"
+        
+        # Social media
+        social_domains = [
+            "twitter.com", "x.com", "facebook.com", "reddit.com",
+            "instagram.com", "tiktok.com", "youtube.com"
+        ]
+        if any(d in domain_lower for d in social_domains):
+            return "social"
+        
+        # Default to article
+        return "article"

--- a/src/bantz/research/source_ranker.py
+++ b/src/bantz/research/source_ranker.py
@@ -1,0 +1,221 @@
+"""
+Source Ranker (Issue #33 - V2-3).
+
+Ranks sources by reliability using domain reputation,
+recency, and content type heuristics.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from bantz.research.source_collector import Source
+
+
+class SourceRanker:
+    """
+    Ranks sources by reliability and quality.
+    
+    Uses domain reputation, recency, and content type
+    to calculate reliability scores.
+    """
+    
+    # Domain reliability scores (0.0 - 1.0)
+    DOMAIN_SCORES: dict[str, float] = {
+        # Tier 1: Wire services & major outlets (0.90-0.95)
+        "reuters.com": 0.95,
+        "apnews.com": 0.95,
+        "bbc.com": 0.90,
+        "bbc.co.uk": 0.90,
+        "nytimes.com": 0.90,
+        "theguardian.com": 0.88,
+        "washingtonpost.com": 0.88,
+        "economist.com": 0.90,
+        
+        # Tier 2: Quality news (0.80-0.89)
+        "cnn.com": 0.82,
+        "bloomberg.com": 0.85,
+        "ft.com": 0.88,
+        "wsj.com": 0.85,
+        "npr.org": 0.85,
+        "pbs.org": 0.85,
+        
+        # Tier 3: Reference & academic (0.75-0.85)
+        "wikipedia.org": 0.80,
+        "britannica.com": 0.85,
+        "arxiv.org": 0.85,
+        "nature.com": 0.90,
+        "science.org": 0.90,
+        "pubmed.ncbi.nlm.nih.gov": 0.90,
+        
+        # Tier 4: Tech & specialized (0.70-0.80)
+        "techcrunch.com": 0.75,
+        "wired.com": 0.78,
+        "arstechnica.com": 0.78,
+        "theverge.com": 0.72,
+        
+        # Tier 5: Social & user-generated (0.30-0.50)
+        "twitter.com": 0.40,
+        "x.com": 0.40,
+        "reddit.com": 0.45,
+        "facebook.com": 0.35,
+        "instagram.com": 0.30,
+        "tiktok.com": 0.30,
+        "youtube.com": 0.50,
+        
+        # Tier 6: Blogs & medium (0.40-0.60)
+        "medium.com": 0.50,
+        "substack.com": 0.55,
+        "blogspot.com": 0.40,
+        "wordpress.com": 0.40,
+    }
+    
+    # Default score for unknown domains
+    DEFAULT_DOMAIN_SCORE: float = 0.50
+    
+    # Content type score modifiers
+    CONTENT_TYPE_MODIFIERS: dict[str, float] = {
+        "academic": 0.10,   # Boost academic content
+        "news": 0.05,       # Slight boost for news
+        "article": 0.0,     # Neutral
+        "social": -0.15,    # Penalty for social media
+    }
+    
+    # Recency bonus configuration
+    RECENCY_BONUS_MAX: float = 0.10  # Max bonus for very recent
+    RECENCY_DECAY_DAYS: int = 30     # Days until no bonus
+    
+    def __init__(self, reference_date: Optional[datetime] = None):
+        """
+        Initialize SourceRanker.
+        
+        Args:
+            reference_date: Date to use for recency calculations.
+                           Defaults to now.
+        """
+        self.reference_date = reference_date or datetime.now()
+    
+    def rank(self, sources: list[Source]) -> list[Source]:
+        """
+        Rank sources by reliability score.
+        
+        Calculates reliability for each source and returns
+        them sorted in descending order (highest first).
+        
+        Args:
+            sources: List of sources to rank
+        
+        Returns:
+            Sources sorted by reliability (highest first)
+        """
+        # Calculate reliability for each source
+        for source in sources:
+            source.reliability_score = self.calculate_reliability(source)
+        
+        # Sort by reliability (descending)
+        return sorted(
+            sources,
+            key=lambda s: s.reliability_score,
+            reverse=True
+        )
+    
+    def calculate_reliability(self, source: Source) -> float:
+        """
+        Calculate reliability score for a source.
+        
+        Factors:
+        - Domain reputation (base score)
+        - Content type modifier
+        - Recency bonus
+        
+        Args:
+            source: Source to calculate reliability for
+        
+        Returns:
+            Reliability score between 0.0 and 1.0
+        """
+        # Base score from domain
+        domain = source.domain.lower()
+        base_score = self.DOMAIN_SCORES.get(domain, self.DEFAULT_DOMAIN_SCORE)
+        
+        # Content type modifier
+        content_modifier = self.CONTENT_TYPE_MODIFIERS.get(
+            source.content_type, 0.0
+        )
+        
+        # Recency bonus
+        recency_bonus = self._calculate_recency_bonus(source.date)
+        
+        # Combine scores
+        total_score = base_score + content_modifier + recency_bonus
+        
+        # Clamp to 0.0 - 1.0 range
+        return max(0.0, min(1.0, total_score))
+    
+    def filter_low_quality(
+        self,
+        sources: list[Source],
+        threshold: float = 0.3
+    ) -> list[Source]:
+        """
+        Filter out low quality sources.
+        
+        Args:
+            sources: List of sources to filter
+            threshold: Minimum reliability score (default 0.3)
+        
+        Returns:
+            Sources with reliability >= threshold
+        """
+        # Ensure scores are calculated
+        for source in sources:
+            if source.reliability_score == 0.0 and source.domain:
+                source.reliability_score = self.calculate_reliability(source)
+        
+        return [s for s in sources if s.reliability_score >= threshold]
+    
+    def _calculate_recency_bonus(self, date: Optional[datetime]) -> float:
+        """
+        Calculate recency bonus for a source.
+        
+        Sources within RECENCY_DECAY_DAYS get a linear bonus
+        up to RECENCY_BONUS_MAX for very recent content.
+        
+        Args:
+            date: Publication date of source
+        
+        Returns:
+            Recency bonus (0.0 to RECENCY_BONUS_MAX)
+        """
+        if not date:
+            return 0.0
+        
+        # Calculate days since publication
+        delta = self.reference_date - date
+        days_old = delta.days
+        
+        # Future dates get no bonus
+        if days_old < 0:
+            return 0.0
+        
+        # Calculate linear decay
+        if days_old >= self.RECENCY_DECAY_DAYS:
+            return 0.0
+        
+        # Linear interpolation: newer = higher bonus
+        decay_factor = 1.0 - (days_old / self.RECENCY_DECAY_DAYS)
+        return self.RECENCY_BONUS_MAX * decay_factor
+    
+    def get_domain_score(self, domain: str) -> float:
+        """
+        Get the base reliability score for a domain.
+        
+        Args:
+            domain: Domain name (e.g., "reuters.com")
+        
+        Returns:
+            Domain reliability score
+        """
+        return self.DOMAIN_SCORES.get(
+            domain.lower(),
+            self.DEFAULT_DOMAIN_SCORE
+        )

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,392 @@
+"""
+Tests for Confidence Scorer (Issue #33 - V2-3).
+
+Test Scenarios:
+- High confidence with multiple reliable sources
+- Low confidence with single source
+- Confidence reduced by contradictions
+- Factor weights sum correctly
+- Level thresholds: <0.4 low, 0.4-0.7 medium, >0.7 high
+"""
+
+import pytest
+from datetime import datetime, timedelta
+
+from bantz.research.source_collector import Source
+from bantz.research.contradiction import ContradictionResult
+from bantz.research.confidence import (
+    ConfidenceResult,
+    ConfidenceScorer,
+)
+
+
+class TestConfidenceResultDataclass:
+    """Test ConfidenceResult dataclass."""
+    
+    def test_result_required_fields(self):
+        """Result has required fields."""
+        result = ConfidenceResult(
+            score=0.75,
+            level="high",
+            factors={"source_count": 0.8},
+            explanation="Test explanation"
+        )
+        assert result.score == 0.75
+        assert result.level == "high"
+        assert "source_count" in result.factors
+        assert result.explanation == "Test explanation"
+    
+    def test_result_level_values(self):
+        """Level can be low, medium, or high."""
+        for level in ["low", "medium", "high"]:
+            result = ConfidenceResult(score=0.5, level=level)
+            assert result.level == level
+    
+    def test_result_factors_default(self):
+        """Factors defaults to empty dict."""
+        result = ConfidenceResult(score=0.5, level="medium")
+        assert result.factors == {}
+
+
+class TestConfidenceScorerWeights:
+    """Test weight configuration."""
+    
+    def test_weights_sum_to_one(self):
+        """Factor weights should sum to 1.0."""
+        total = sum(ConfidenceScorer.WEIGHTS.values())
+        assert abs(total - 1.0) < 0.001
+    
+    def test_all_weights_positive(self):
+        """All weights should be positive."""
+        for weight in ConfidenceScorer.WEIGHTS.values():
+            assert weight > 0
+    
+    def test_expected_factors_present(self):
+        """Expected factors are in weights."""
+        expected = ["source_count", "source_reliability", "recency", "agreement", "coverage"]
+        for factor in expected:
+            assert factor in ConfidenceScorer.WEIGHTS
+
+
+class TestConfidenceScorerLevels:
+    """Test confidence level determination."""
+    
+    @pytest.fixture
+    def scorer(self):
+        return ConfidenceScorer()
+    
+    def test_level_low_threshold(self, scorer):
+        """Score < 0.4 is low."""
+        level = scorer._determine_level(0.3)
+        assert level == "low"
+    
+    def test_level_medium_threshold(self, scorer):
+        """Score 0.4-0.7 is medium."""
+        level = scorer._determine_level(0.5)
+        assert level == "medium"
+    
+    def test_level_high_threshold(self, scorer):
+        """Score >= 0.7 is high."""
+        level = scorer._determine_level(0.8)
+        assert level == "high"
+    
+    def test_level_boundary_low_medium(self, scorer):
+        """Boundary at 0.4."""
+        assert scorer._determine_level(0.39) == "low"
+        assert scorer._determine_level(0.40) == "medium"
+    
+    def test_level_boundary_medium_high(self, scorer):
+        """Boundary at 0.7."""
+        assert scorer._determine_level(0.69) == "medium"
+        assert scorer._determine_level(0.70) == "high"
+
+
+class TestConfidenceScorerSourceCount:
+    """Test source count scoring."""
+    
+    @pytest.fixture
+    def scorer(self):
+        return ConfidenceScorer()
+    
+    def test_no_sources_zero_score(self, scorer):
+        """Zero sources gives zero score."""
+        score = scorer._score_source_count([])
+        assert score == 0.0
+    
+    def test_single_source_low_score(self, scorer):
+        """Single source gives low score (0.3)."""
+        sources = [Source(url="https://a.com", title="A", snippet="")]
+        score = scorer._score_source_count(sources)
+        assert score == 0.3
+    
+    def test_optimal_sources_full_score(self, scorer):
+        """Optimal source count gives full score."""
+        sources = [
+            Source(url=f"https://s{i}.com", title=f"S{i}", snippet="")
+            for i in range(scorer.OPTIMAL_SOURCE_COUNT)
+        ]
+        score = scorer._score_source_count(sources)
+        assert score == 1.0
+    
+    def test_sources_linear_scaling(self, scorer):
+        """Score scales linearly between 1 and optimal."""
+        sources_2 = [
+            Source(url=f"https://s{i}.com", title=f"S{i}", snippet="")
+            for i in range(2)
+        ]
+        sources_3 = [
+            Source(url=f"https://s{i}.com", title=f"S{i}", snippet="")
+            for i in range(3)
+        ]
+        
+        score_2 = scorer._score_source_count(sources_2)
+        score_3 = scorer._score_source_count(sources_3)
+        
+        assert score_3 > score_2
+
+
+class TestConfidenceScorerAgreement:
+    """Test agreement scoring."""
+    
+    @pytest.fixture
+    def scorer(self):
+        return ConfidenceScorer()
+    
+    def test_full_agreement_full_score(self, scorer):
+        """Full agreement gives full score."""
+        contradiction = ContradictionResult(
+            has_contradiction=False,
+            agreement_score=1.0
+        )
+        score = scorer._score_agreement(contradiction)
+        assert score == 1.0
+    
+    def test_contradiction_reduces_score(self, scorer):
+        """Contradiction reduces agreement score."""
+        source1 = Source(url="https://a.com", title="A", snippet="")
+        source2 = Source(url="https://b.com", title="B", snippet="")
+        
+        contradiction = ContradictionResult(
+            has_contradiction=True,
+            conflicting_claims=[(source1, source2, "conflict")],
+            agreement_score=0.7
+        )
+        score = scorer._score_agreement(contradiction)
+        
+        # Should be less than agreement_score due to penalty
+        assert score < 0.7
+    
+    def test_multiple_contradictions_more_penalty(self, scorer):
+        """Multiple contradictions reduce score more."""
+        source1 = Source(url="https://a.com", title="A", snippet="")
+        source2 = Source(url="https://b.com", title="B", snippet="")
+        
+        single = ContradictionResult(
+            has_contradiction=True,
+            conflicting_claims=[(source1, source2, "conflict")],
+            agreement_score=0.8
+        )
+        
+        multiple = ContradictionResult(
+            has_contradiction=True,
+            conflicting_claims=[
+                (source1, source2, "conflict1"),
+                (source1, source2, "conflict2"),
+                (source1, source2, "conflict3"),
+            ],
+            agreement_score=0.8
+        )
+        
+        score_single = scorer._score_agreement(single)
+        score_multiple = scorer._score_agreement(multiple)
+        
+        assert score_multiple < score_single
+
+
+class TestConfidenceScorerRecency:
+    """Test recency scoring."""
+    
+    def test_recent_sources_high_score(self):
+        """Sources within 7 days get high score."""
+        reference = datetime(2024, 1, 15)
+        scorer = ConfidenceScorer(reference_date=reference)
+        
+        sources = [
+            Source(
+                url="https://a.com",
+                title="A",
+                snippet="",
+                date=datetime(2024, 1, 14)  # 1 day ago
+            )
+        ]
+        score = scorer._score_recency(sources)
+        assert score == 1.0
+    
+    def test_month_old_sources_medium_score(self):
+        """Sources within 30 days get medium score."""
+        reference = datetime(2024, 1, 30)
+        scorer = ConfidenceScorer(reference_date=reference)
+        
+        sources = [
+            Source(
+                url="https://a.com",
+                title="A",
+                snippet="",
+                date=datetime(2024, 1, 10)  # ~20 days ago
+            )
+        ]
+        score = scorer._score_recency(sources)
+        assert score == 0.7
+    
+    def test_old_sources_low_score(self):
+        """Sources over 90 days get low score."""
+        reference = datetime(2024, 6, 1)
+        scorer = ConfidenceScorer(reference_date=reference)
+        
+        sources = [
+            Source(
+                url="https://a.com",
+                title="A",
+                snippet="",
+                date=datetime(2024, 1, 1)  # ~150 days ago
+            )
+        ]
+        score = scorer._score_recency(sources)
+        assert score == 0.3
+    
+    def test_no_dated_sources_neutral(self):
+        """Sources without dates get neutral score."""
+        scorer = ConfidenceScorer()
+        
+        sources = [
+            Source(url="https://a.com", title="A", snippet="")
+        ]
+        score = scorer._score_recency(sources)
+        assert score == 0.5
+
+
+class TestConfidenceScorerFullScore:
+    """Test full scoring method."""
+    
+    @pytest.fixture
+    def scorer(self):
+        return ConfidenceScorer(reference_date=datetime(2024, 1, 15))
+    
+    def test_high_confidence_reliable_sources(self, scorer):
+        """Multiple reliable sources give high confidence."""
+        sources = [
+            Source(
+                url="https://reuters.com/article",
+                title="Reuters",
+                snippet="",
+                reliability_score=0.95,
+                date=datetime(2024, 1, 14)
+            ),
+            Source(
+                url="https://bbc.com/news",
+                title="BBC",
+                snippet="",
+                reliability_score=0.90,
+                date=datetime(2024, 1, 14)
+            ),
+            Source(
+                url="https://nytimes.com/article",
+                title="NYT",
+                snippet="",
+                reliability_score=0.90,
+                date=datetime(2024, 1, 13),
+                content_type="news"
+            ),
+        ]
+        
+        contradiction = ContradictionResult(
+            has_contradiction=False,
+            agreement_score=1.0
+        )
+        
+        result = scorer.score(sources, contradiction)
+        
+        assert result.level == "high"
+        assert result.score >= 0.7
+    
+    def test_low_confidence_single_source(self, scorer):
+        """Single source gives low confidence."""
+        sources = [
+            Source(
+                url="https://randomblog.com",
+                title="Blog",
+                snippet="",
+                reliability_score=0.5
+            )
+        ]
+        
+        contradiction = ContradictionResult(
+            has_contradiction=False,
+            agreement_score=1.0
+        )
+        
+        result = scorer.score(sources, contradiction)
+        
+        # Single low-reliability source should have low confidence
+        assert result.score < 0.7
+    
+    def test_confidence_reduced_by_contradiction(self, scorer):
+        """Contradiction reduces confidence."""
+        sources = [
+            Source(
+                url="https://reuters.com/a",
+                title="Reuters A",
+                snippet="",
+                reliability_score=0.95,
+                date=datetime(2024, 1, 14)
+            ),
+            Source(
+                url="https://bbc.com/b",
+                title="BBC B",
+                snippet="",
+                reliability_score=0.90,
+                date=datetime(2024, 1, 14)
+            ),
+        ]
+        
+        # With contradiction
+        with_contradiction = ContradictionResult(
+            has_contradiction=True,
+            conflicting_claims=[(sources[0], sources[1], "conflict")],
+            agreement_score=0.5
+        )
+        
+        # Without contradiction
+        without_contradiction = ContradictionResult(
+            has_contradiction=False,
+            agreement_score=1.0
+        )
+        
+        score_with = scorer.score(sources, with_contradiction)
+        score_without = scorer.score(sources, without_contradiction)
+        
+        assert score_with.score < score_without.score
+    
+    def test_factors_all_present(self, scorer):
+        """All expected factors are in result."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet="", reliability_score=0.7)
+        ]
+        contradiction = ContradictionResult(has_contradiction=False, agreement_score=1.0)
+        
+        result = scorer.score(sources, contradiction)
+        
+        for factor in ConfidenceScorer.WEIGHTS:
+            assert factor in result.factors
+    
+    def test_explanation_generated(self, scorer):
+        """Explanation is generated."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet="", reliability_score=0.9)
+        ]
+        contradiction = ContradictionResult(has_contradiction=False, agreement_score=1.0)
+        
+        result = scorer.score(sources, contradiction)
+        
+        assert result.explanation != ""
+        assert len(result.explanation) > 10

--- a/tests/test_contradiction.py
+++ b/tests/test_contradiction.py
@@ -1,0 +1,263 @@
+"""
+Tests for Contradiction Detector (Issue #33 - V2-3).
+
+Test Scenarios:
+- No contradiction when sources agree
+- Contradiction detected when conflicting
+- Conflicting source pairs are listed
+- Agreement score in 0-1 range
+- Key claims extraction
+"""
+
+import pytest
+
+from bantz.research.source_collector import Source
+from bantz.research.contradiction import (
+    ContradictionResult,
+    ContradictionDetector,
+)
+
+
+class TestContradictionResultDataclass:
+    """Test ContradictionResult dataclass."""
+    
+    def test_result_no_contradiction(self):
+        """Result with no contradiction."""
+        result = ContradictionResult(
+            has_contradiction=False,
+            conflicting_claims=[],
+            agreement_score=1.0
+        )
+        assert result.has_contradiction is False
+        assert result.agreement_score == 1.0
+        assert len(result.conflicting_claims) == 0
+    
+    def test_result_with_contradiction(self):
+        """Result with contradiction."""
+        source1 = Source(url="https://a.com", title="A", snippet="")
+        source2 = Source(url="https://b.com", title="B", snippet="")
+        
+        result = ContradictionResult(
+            has_contradiction=True,
+            conflicting_claims=[(source1, source2, "claim vs claim")],
+            agreement_score=0.5
+        )
+        assert result.has_contradiction is True
+        assert len(result.conflicting_claims) == 1
+    
+    def test_result_agreement_score_range(self):
+        """Agreement score should be 0.0 to 1.0."""
+        result = ContradictionResult(
+            has_contradiction=False,
+            agreement_score=0.75
+        )
+        assert 0.0 <= result.agreement_score <= 1.0
+
+
+class TestContradictionDetectorCompareClaims:
+    """Test claim comparison."""
+    
+    @pytest.fixture
+    def detector(self):
+        return ContradictionDetector()
+    
+    def test_compare_identical_claims(self, detector):
+        """Identical claims have high similarity."""
+        claim = "The temperature is 20 degrees"
+        similarity = detector.compare_claims(claim, claim)
+        assert similarity == 1.0
+    
+    def test_compare_similar_claims(self, detector):
+        """Similar claims have moderate similarity."""
+        claim1 = "The temperature increased to 20 degrees"
+        claim2 = "The temperature rose to 20 degrees"
+        similarity = detector.compare_claims(claim1, claim2)
+        assert similarity > 0.3
+    
+    def test_compare_different_claims(self, detector):
+        """Different claims have low similarity."""
+        claim1 = "The economy is growing"
+        claim2 = "The weather is sunny today"
+        similarity = detector.compare_claims(claim1, claim2)
+        assert similarity < 0.5
+    
+    def test_compare_empty_claims(self, detector):
+        """Empty claims have zero similarity."""
+        similarity = detector.compare_claims("", "test")
+        assert similarity == 0.0
+
+
+class TestContradictionDetectorExtractClaims:
+    """Test key claim extraction."""
+    
+    @pytest.fixture
+    def detector(self):
+        return ContradictionDetector()
+    
+    def test_extract_claims_from_text(self, detector):
+        """Claims are extracted from text."""
+        text = "The company reported record profits. Sales increased by 20%. The CEO confirmed the expansion."
+        claims = detector.extract_key_claims(text)
+        assert len(claims) >= 2
+    
+    def test_extract_claims_filters_short(self, detector):
+        """Short sentences are filtered out."""
+        text = "Yes. No. Maybe. The company reported significant growth in Q4."
+        claims = detector.extract_key_claims(text)
+        # Only the longer sentence should be included
+        assert all(len(c.split()) >= 3 for c in claims)
+    
+    def test_extract_claims_empty_text(self, detector):
+        """Empty text returns empty list."""
+        claims = detector.extract_key_claims("")
+        assert claims == []
+    
+    def test_extract_claims_factual_content(self, detector):
+        """Factual statements are identified."""
+        text = "The study showed that exercise improves health. Researchers found a correlation."
+        claims = detector.extract_key_claims(text)
+        assert len(claims) >= 1
+
+
+class TestContradictionDetectorDetect:
+    """Test contradiction detection."""
+    
+    @pytest.fixture
+    def detector(self):
+        return ContradictionDetector()
+    
+    def test_detect_no_contradiction_agreement(self, detector):
+        """Sources in agreement show no contradiction."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet=""),
+            Source(url="https://b.com", title="B", snippet=""),
+        ]
+        summaries = [
+            "The company reported increased profits this quarter.",
+            "The company showed profit growth in the recent quarter.",
+        ]
+        
+        result = detector.detect(sources, summaries)
+        
+        # Should show agreement or minimal contradiction
+        assert result.agreement_score >= 0.5
+    
+    def test_detect_contradiction_negation(self, detector):
+        """Negation patterns indicate contradiction."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet=""),
+            Source(url="https://b.com", title="B", snippet=""),
+        ]
+        summaries = [
+            "The company confirmed the merger will proceed.",
+            "The company denied the merger will proceed.",
+        ]
+        
+        result = detector.detect(sources, summaries)
+        
+        assert result.has_contradiction is True
+        assert len(result.conflicting_claims) >= 1
+    
+    def test_detect_contradiction_opposites(self, detector):
+        """Opposite terms indicate contradiction."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet=""),
+            Source(url="https://b.com", title="B", snippet=""),
+        ]
+        summaries = [
+            "Stock prices are rising sharply today.",
+            "Stock prices are falling sharply today.",
+        ]
+        
+        result = detector.detect(sources, summaries)
+        
+        assert result.has_contradiction is True
+    
+    def test_detect_single_source_no_contradiction(self, detector):
+        """Single source cannot have contradiction."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet=""),
+        ]
+        summaries = [
+            "The company reported increased profits.",
+        ]
+        
+        result = detector.detect(sources, summaries)
+        
+        assert result.has_contradiction is False
+        assert result.agreement_score == 1.0
+    
+    def test_detect_empty_sources(self, detector):
+        """Empty sources return no contradiction."""
+        result = detector.detect([], [])
+        
+        assert result.has_contradiction is False
+        assert result.agreement_score == 1.0
+    
+    def test_detect_conflicting_pairs_listed(self, detector):
+        """Conflicting pairs are included in result."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet=""),
+            Source(url="https://b.com", title="B", snippet=""),
+        ]
+        summaries = [
+            "The CEO confirmed the deal is approved.",
+            "The CEO denied the deal is approved.",
+        ]
+        
+        result = detector.detect(sources, summaries)
+        
+        if result.has_contradiction:
+            assert len(result.conflicting_claims) >= 1
+            # Each claim is a tuple of (source1, source2, description)
+            for claim in result.conflicting_claims:
+                assert len(claim) == 3
+                assert isinstance(claim[0], Source)
+                assert isinstance(claim[1], Source)
+                assert isinstance(claim[2], str)
+    
+    def test_detect_agreement_score_range(self, detector):
+        """Agreement score is between 0 and 1."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet=""),
+            Source(url="https://b.com", title="B", snippet=""),
+        ]
+        summaries = [
+            "The economy is strong according to reports.",
+            "The economy is weak according to reports.",
+        ]
+        
+        result = detector.detect(sources, summaries)
+        
+        assert 0.0 <= result.agreement_score <= 1.0
+
+
+class TestContradictionDetectorNegation:
+    """Test negation word detection."""
+    
+    def test_negation_words_exist(self):
+        """Negation words set is populated."""
+        assert len(ContradictionDetector.NEGATION_WORDS) > 10
+    
+    def test_common_negations_included(self):
+        """Common negation words are in the set."""
+        negations = ContradictionDetector.NEGATION_WORDS
+        assert "not" in negations
+        assert "denied" in negations
+        assert "false" in negations
+
+
+class TestContradictionPhrases:
+    """Test contradiction phrase pairs."""
+    
+    def test_contradiction_phrases_exist(self):
+        """Contradiction phrase pairs are defined."""
+        assert len(ContradictionDetector.CONTRADICTION_PHRASES) > 5
+    
+    def test_common_pairs_included(self):
+        """Common opposing pairs are included."""
+        phrases = ContradictionDetector.CONTRADICTION_PHRASES
+        pair_strings = [(p[0], p[1]) for p in phrases]
+        
+        assert ("true", "false") in pair_strings
+        assert ("confirmed", "denied") in pair_strings

--- a/tests/test_research_orchestrator.py
+++ b/tests/test_research_orchestrator.py
@@ -1,0 +1,376 @@
+"""
+Tests for Research Orchestrator (Issue #33 - V2-3).
+
+Test Scenarios:
+- Full pipeline execution
+- Events emitted (FOUND, PROGRESS, RESULT)
+- Minimum 2 sources target
+- Contradiction in result
+- Confidence in result
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bantz.research.source_collector import Source, SourceCollector
+from bantz.research.source_ranker import SourceRanker
+from bantz.research.contradiction import ContradictionResult, ContradictionDetector
+from bantz.research.confidence import ConfidenceResult, ConfidenceScorer
+from bantz.research.orchestrator import (
+    ResearchResult,
+    ResearchOrchestrator,
+    create_research_orchestrator,
+)
+from bantz.core.events import EventBus
+
+
+class TestResearchResultDataclass:
+    """Test ResearchResult dataclass."""
+    
+    def test_result_required_fields(self):
+        """Result has required query field."""
+        result = ResearchResult(query="test query")
+        assert result.query == "test query"
+    
+    def test_result_default_empty_sources(self):
+        """Sources defaults to empty list."""
+        result = ResearchResult(query="test")
+        assert result.sources == []
+    
+    def test_result_with_sources(self):
+        """Result can have sources."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet="Snippet A")
+        ]
+        result = ResearchResult(query="test", sources=sources)
+        assert len(result.sources) == 1
+    
+    def test_result_with_confidence(self):
+        """Result can have confidence."""
+        confidence = ConfidenceResult(score=0.8, level="high")
+        result = ResearchResult(query="test", confidence=confidence)
+        assert result.confidence.level == "high"
+    
+    def test_result_with_contradiction(self):
+        """Result can have contradiction."""
+        contradiction = ContradictionResult(has_contradiction=False, agreement_score=1.0)
+        result = ResearchResult(query="test", contradiction=contradiction)
+        assert result.contradiction.has_contradiction is False
+    
+    def test_result_duration(self):
+        """Result tracks duration."""
+        result = ResearchResult(query="test", duration_ms=150.5)
+        assert result.duration_ms == 150.5
+
+
+class TestResearchOrchestratorSetup:
+    """Test orchestrator setup."""
+    
+    def test_orchestrator_creation(self):
+        """Orchestrator can be created with components."""
+        orchestrator = ResearchOrchestrator(
+            collector=SourceCollector(),
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer()
+        )
+        assert orchestrator is not None
+    
+    def test_orchestrator_with_event_bus(self):
+        """Orchestrator accepts event bus."""
+        event_bus = EventBus()
+        orchestrator = ResearchOrchestrator(
+            collector=SourceCollector(),
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer(),
+            event_bus=event_bus
+        )
+        assert orchestrator.event_bus is event_bus
+
+
+class TestResearchOrchestratorPipeline:
+    """Test full pipeline execution."""
+    
+    @pytest.fixture
+    def mock_collector(self):
+        """Create mock collector with sample sources."""
+        collector = MagicMock(spec=SourceCollector)
+        collector.collect = AsyncMock(return_value=[
+            Source(
+                url="https://reuters.com/article",
+                title="Reuters Article",
+                snippet="This is a test snippet from Reuters.",
+                reliability_score=0.95
+            ),
+            Source(
+                url="https://bbc.com/news",
+                title="BBC News",
+                snippet="BBC reports similar findings.",
+                reliability_score=0.90
+            ),
+        ])
+        return collector
+    
+    @pytest.fixture
+    def orchestrator(self, mock_collector):
+        """Create orchestrator with mock collector."""
+        return ResearchOrchestrator(
+            collector=mock_collector,
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer()
+        )
+    
+    @pytest.mark.asyncio
+    async def test_pipeline_returns_result(self, orchestrator):
+        """Pipeline returns ResearchResult."""
+        result = await orchestrator.research("test query")
+        assert isinstance(result, ResearchResult)
+    
+    @pytest.mark.asyncio
+    async def test_pipeline_has_query(self, orchestrator):
+        """Result contains original query."""
+        result = await orchestrator.research("test query")
+        assert result.query == "test query"
+    
+    @pytest.mark.asyncio
+    async def test_pipeline_has_sources(self, orchestrator):
+        """Result contains sources."""
+        result = await orchestrator.research("test query")
+        assert len(result.sources) > 0
+    
+    @pytest.mark.asyncio
+    async def test_pipeline_has_confidence(self, orchestrator):
+        """Result contains confidence."""
+        result = await orchestrator.research("test query")
+        assert result.confidence is not None
+        assert hasattr(result.confidence, "score")
+        assert hasattr(result.confidence, "level")
+    
+    @pytest.mark.asyncio
+    async def test_pipeline_has_contradiction(self, orchestrator):
+        """Result contains contradiction info."""
+        result = await orchestrator.research("test query")
+        assert result.contradiction is not None
+        assert hasattr(result.contradiction, "has_contradiction")
+    
+    @pytest.mark.asyncio
+    async def test_pipeline_has_summary(self, orchestrator):
+        """Result contains summary."""
+        result = await orchestrator.research("test query")
+        assert result.summary != ""
+    
+    @pytest.mark.asyncio
+    async def test_pipeline_tracks_duration(self, orchestrator):
+        """Result tracks execution duration."""
+        result = await orchestrator.research("test query")
+        assert result.duration_ms > 0
+
+
+class TestResearchOrchestratorEvents:
+    """Test event emission."""
+    
+    @pytest.fixture
+    def mock_collector(self):
+        """Create mock collector."""
+        collector = MagicMock(spec=SourceCollector)
+        collector.collect = AsyncMock(return_value=[
+            Source(url="https://a.com", title="A", snippet="Test", reliability_score=0.8)
+        ])
+        return collector
+    
+    @pytest.mark.asyncio
+    async def test_emits_found_event(self, mock_collector):
+        """Pipeline emits FOUND event."""
+        event_bus = EventBus()
+        events = []
+        
+        def capture_event(event):
+            events.append(event)
+        
+        event_bus.subscribe("found", capture_event)
+        
+        orchestrator = ResearchOrchestrator(
+            collector=mock_collector,
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer(),
+            event_bus=event_bus
+        )
+        
+        await orchestrator.research("test")
+        
+        found_events = [e for e in events if e.event_type == "found"]
+        assert len(found_events) >= 1
+    
+    @pytest.mark.asyncio
+    async def test_emits_progress_events(self, mock_collector):
+        """Pipeline emits PROGRESS events."""
+        event_bus = EventBus()
+        events = []
+        
+        def capture_event(event):
+            events.append(event)
+        
+        event_bus.subscribe("progress", capture_event)
+        
+        orchestrator = ResearchOrchestrator(
+            collector=mock_collector,
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer(),
+            event_bus=event_bus
+        )
+        
+        await orchestrator.research("test")
+        
+        progress_events = [e for e in events if e.event_type == "progress"]
+        assert len(progress_events) >= 1
+    
+    @pytest.mark.asyncio
+    async def test_emits_result_event(self, mock_collector):
+        """Pipeline emits RESULT event."""
+        event_bus = EventBus()
+        events = []
+        
+        def capture_event(event):
+            events.append(event)
+        
+        event_bus.subscribe("result", capture_event)
+        
+        orchestrator = ResearchOrchestrator(
+            collector=mock_collector,
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer(),
+            event_bus=event_bus
+        )
+        
+        await orchestrator.research("test")
+        
+        result_events = [e for e in events if e.event_type == "result"]
+        assert len(result_events) >= 1
+
+
+class TestResearchOrchestratorMinSources:
+    """Test minimum sources behavior."""
+    
+    @pytest.mark.asyncio
+    async def test_min_sources_target(self):
+        """Orchestrator targets minimum 2 sources."""
+        collector = MagicMock(spec=SourceCollector)
+        collector.collect = AsyncMock(return_value=[
+            Source(url="https://a.com", title="A", snippet="Test", reliability_score=0.1),
+            Source(url="https://b.com", title="B", snippet="Test", reliability_score=0.1),
+            Source(url="https://c.com", title="C", snippet="Test", reliability_score=0.9),
+        ])
+        
+        orchestrator = ResearchOrchestrator(
+            collector=collector,
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer()
+        )
+        
+        result = await orchestrator.research("test")
+        
+        # Should have at least MIN_SOURCES even after filtering
+        assert len(result.sources) >= orchestrator.MIN_SOURCES
+
+
+class TestResearchOrchestratorContradictionInResult:
+    """Test contradiction detection integration."""
+    
+    @pytest.mark.asyncio
+    async def test_contradiction_in_result(self):
+        """Contradiction is included in result."""
+        collector = MagicMock(spec=SourceCollector)
+        collector.collect = AsyncMock(return_value=[
+            Source(
+                url="https://a.com",
+                title="A",
+                snippet="The company confirmed the merger.",
+                reliability_score=0.8
+            ),
+            Source(
+                url="https://b.com",
+                title="B",
+                snippet="The company denied the merger.",
+                reliability_score=0.8
+            ),
+        ])
+        
+        orchestrator = ResearchOrchestrator(
+            collector=collector,
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer()
+        )
+        
+        result = await orchestrator.research("merger news")
+        
+        # Contradiction should be detected
+        assert result.contradiction is not None
+        # Note: actual detection depends on snippet analysis
+
+
+class TestResearchOrchestratorConfidenceInResult:
+    """Test confidence scoring integration."""
+    
+    @pytest.mark.asyncio
+    async def test_confidence_in_result(self):
+        """Confidence is included in result."""
+        collector = MagicMock(spec=SourceCollector)
+        collector.collect = AsyncMock(return_value=[
+            Source(
+                url="https://reuters.com/article",
+                title="Reuters",
+                snippet="High quality source.",
+                reliability_score=0.95
+            ),
+            Source(
+                url="https://bbc.com/news",
+                title="BBC",
+                snippet="Another quality source.",
+                reliability_score=0.90
+            ),
+        ])
+        
+        orchestrator = ResearchOrchestrator(
+            collector=collector,
+            ranker=SourceRanker(),
+            contradiction_detector=ContradictionDetector(),
+            confidence_scorer=ConfidenceScorer()
+        )
+        
+        result = await orchestrator.research("test query")
+        
+        assert result.confidence is not None
+        assert result.confidence.score >= 0.0
+        assert result.confidence.score <= 1.0
+        assert result.confidence.level in ["low", "medium", "high"]
+
+
+class TestCreateResearchOrchestrator:
+    """Test factory function."""
+    
+    def test_creates_orchestrator(self):
+        """Factory creates orchestrator."""
+        orchestrator = create_research_orchestrator()
+        assert isinstance(orchestrator, ResearchOrchestrator)
+    
+    def test_creates_with_event_bus(self):
+        """Factory accepts event bus."""
+        event_bus = EventBus()
+        orchestrator = create_research_orchestrator(event_bus=event_bus)
+        assert orchestrator.event_bus is event_bus
+    
+    def test_creates_with_all_components(self):
+        """Factory creates all required components."""
+        orchestrator = create_research_orchestrator()
+        assert orchestrator.collector is not None
+        assert orchestrator.ranker is not None
+        assert orchestrator.contradiction_detector is not None
+        assert orchestrator.confidence_scorer is not None

--- a/tests/test_source_collector.py
+++ b/tests/test_source_collector.py
@@ -1,0 +1,245 @@
+"""
+Tests for Source Collector (Issue #33 - V2-3).
+
+Test Scenarios:
+- Source collection returns list
+- Source has required fields (URL, title)
+- Date parsing for various formats
+- Max sources limit
+- Domain extraction from URL
+"""
+
+import pytest
+from datetime import datetime
+
+from bantz.research.source_collector import (
+    Source,
+    SourceCollector,
+    MONTH_NAMES,
+)
+
+
+class TestSourceDataclass:
+    """Test Source dataclass."""
+    
+    def test_source_required_fields(self):
+        """Source requires url, title, snippet."""
+        source = Source(
+            url="https://example.com/article",
+            title="Test Article",
+            snippet="This is a test snippet"
+        )
+        assert source.url == "https://example.com/article"
+        assert source.title == "Test Article"
+        assert source.snippet == "This is a test snippet"
+    
+    def test_source_optional_date(self):
+        """Date is optional and defaults to None."""
+        source = Source(url="https://example.com", title="Test", snippet="")
+        assert source.date is None
+    
+    def test_source_with_date(self):
+        """Source can have a date."""
+        date = datetime(2024, 1, 15)
+        source = Source(
+            url="https://example.com",
+            title="Test",
+            snippet="",
+            date=date
+        )
+        assert source.date == date
+    
+    def test_source_domain_auto_extracted(self):
+        """Domain is auto-extracted from URL."""
+        source = Source(
+            url="https://www.reuters.com/article/test",
+            title="Test",
+            snippet=""
+        )
+        assert source.domain == "reuters.com"
+    
+    def test_source_domain_no_www(self):
+        """Domain extraction removes www prefix."""
+        source = Source(
+            url="https://bbc.com/news",
+            title="Test",
+            snippet=""
+        )
+        assert source.domain == "bbc.com"
+    
+    def test_source_domain_manual_override(self):
+        """Manually provided domain is preserved."""
+        source = Source(
+            url="https://example.com",
+            title="Test",
+            snippet="",
+            domain="custom.domain.com"
+        )
+        assert source.domain == "custom.domain.com"
+    
+    def test_source_reliability_default_zero(self):
+        """Reliability defaults to 0.0."""
+        source = Source(url="https://example.com", title="Test", snippet="")
+        assert source.reliability_score == 0.0
+    
+    def test_source_content_type_default(self):
+        """Content type defaults to article."""
+        source = Source(url="https://example.com", title="Test", snippet="")
+        assert source.content_type == "article"
+    
+    def test_source_content_types(self):
+        """Source can have different content types."""
+        for content_type in ["article", "news", "academic", "social"]:
+            source = Source(
+                url="https://example.com",
+                title="Test",
+                snippet="",
+                content_type=content_type
+            )
+            assert source.content_type == content_type
+
+
+class TestSourceCollectorDateParsing:
+    """Test date parsing functionality."""
+    
+    @pytest.fixture
+    def collector(self):
+        return SourceCollector()
+    
+    def test_parse_date_iso_format(self, collector):
+        """Parse ISO date format (YYYY-MM-DD)."""
+        result = collector.parse_date("2024-01-15")
+        assert result == datetime(2024, 1, 15)
+    
+    def test_parse_date_us_format(self, collector):
+        """Parse US date format (MM/DD/YYYY)."""
+        result = collector.parse_date("01/15/2024")
+        assert result == datetime(2024, 1, 15)
+    
+    def test_parse_date_european_format(self, collector):
+        """Parse European date format (DD.MM.YYYY)."""
+        result = collector.parse_date("15.01.2024")
+        assert result == datetime(2024, 1, 15)
+    
+    def test_parse_date_text_month_long(self, collector):
+        """Parse text month format (Month DD, YYYY)."""
+        result = collector.parse_date("January 15, 2024")
+        assert result == datetime(2024, 1, 15)
+    
+    def test_parse_date_text_month_short(self, collector):
+        """Parse short month format (Jan 15, 2024)."""
+        result = collector.parse_date("Jan 15, 2024")
+        assert result == datetime(2024, 1, 15)
+    
+    def test_parse_date_text_month_no_comma(self, collector):
+        """Parse text month without comma."""
+        result = collector.parse_date("January 15 2024")
+        assert result == datetime(2024, 1, 15)
+    
+    def test_parse_date_day_month_year(self, collector):
+        """Parse DD Mon YYYY format."""
+        result = collector.parse_date("15 Jan 2024")
+        assert result == datetime(2024, 1, 15)
+    
+    def test_parse_date_empty_returns_none(self, collector):
+        """Empty string returns None."""
+        result = collector.parse_date("")
+        assert result is None
+    
+    def test_parse_date_invalid_returns_none(self, collector):
+        """Invalid date returns None."""
+        result = collector.parse_date("not a date")
+        assert result is None
+    
+    def test_parse_date_all_months(self, collector):
+        """All month names are recognized."""
+        for month_name, month_num in MONTH_NAMES.items():
+            date_str = f"{month_name.capitalize()} 15, 2024"
+            result = collector.parse_date(date_str)
+            if result:  # Some variations may not match
+                assert result.month == month_num
+
+
+class TestSourceCollectorContentType:
+    """Test content type detection."""
+    
+    @pytest.fixture
+    def collector(self):
+        return SourceCollector()
+    
+    @pytest.mark.asyncio
+    async def test_detect_news_domain(self, collector):
+        """News domains are detected."""
+        source = await collector.extract_metadata("https://reuters.com/article/test")
+        assert source.content_type == "news"
+    
+    @pytest.mark.asyncio
+    async def test_detect_academic_domain(self, collector):
+        """Academic domains are detected."""
+        source = await collector.extract_metadata("https://arxiv.org/abs/1234")
+        assert source.content_type == "academic"
+    
+    @pytest.mark.asyncio
+    async def test_detect_social_domain(self, collector):
+        """Social media domains are detected."""
+        source = await collector.extract_metadata("https://twitter.com/user/status/123")
+        assert source.content_type == "social"
+    
+    @pytest.mark.asyncio
+    async def test_detect_default_article(self, collector):
+        """Unknown domains default to article."""
+        source = await collector.extract_metadata("https://randomblog.example.com/post")
+        assert source.content_type == "article"
+
+
+class TestSourceCollectorCollect:
+    """Test source collection."""
+    
+    @pytest.fixture
+    def collector(self):
+        return SourceCollector()
+    
+    @pytest.mark.asyncio
+    async def test_collect_returns_list(self, collector):
+        """Collect returns a list."""
+        result = await collector.collect("test query")
+        assert isinstance(result, list)
+    
+    @pytest.mark.asyncio
+    async def test_collect_empty_without_search_tool(self, collector):
+        """Without search tool, returns empty list."""
+        result = await collector.collect("test query")
+        assert result == []
+    
+    @pytest.mark.asyncio
+    async def test_collect_respects_max_sources(self, collector):
+        """Max sources parameter is respected."""
+        result = await collector.collect("test query", max_sources=5)
+        assert len(result) <= 5
+
+
+class TestSourceCollectorExtractMetadata:
+    """Test metadata extraction."""
+    
+    @pytest.fixture
+    def collector(self):
+        return SourceCollector()
+    
+    @pytest.mark.asyncio
+    async def test_extract_metadata_returns_source(self, collector):
+        """Extract metadata returns a Source object."""
+        result = await collector.extract_metadata("https://example.com/article")
+        assert isinstance(result, Source)
+    
+    @pytest.mark.asyncio
+    async def test_extract_metadata_has_domain(self, collector):
+        """Extracted source has domain."""
+        result = await collector.extract_metadata("https://www.bbc.com/news/article")
+        assert result.domain == "bbc.com"
+    
+    @pytest.mark.asyncio
+    async def test_extract_metadata_has_url(self, collector):
+        """Extracted source has original URL."""
+        url = "https://example.com/article"
+        result = await collector.extract_metadata(url)
+        assert result.url == url

--- a/tests/test_source_ranker.py
+++ b/tests/test_source_ranker.py
@@ -1,0 +1,276 @@
+"""
+Tests for Source Ranker (Issue #33 - V2-3).
+
+Test Scenarios:
+- Sources ranked by reliability (highest first)
+- Known domains get correct scores
+- Unknown domains get default score
+- Recency boost for new content
+- Low quality filtering
+"""
+
+import pytest
+from datetime import datetime, timedelta
+
+from bantz.research.source_collector import Source
+from bantz.research.source_ranker import SourceRanker
+
+
+class TestSourceRankerDomainScores:
+    """Test domain score lookup."""
+    
+    @pytest.fixture
+    def ranker(self):
+        return SourceRanker()
+    
+    def test_known_domain_reuters(self, ranker):
+        """Reuters has high reliability score."""
+        score = ranker.get_domain_score("reuters.com")
+        assert score == 0.95
+    
+    def test_known_domain_bbc(self, ranker):
+        """BBC has high reliability score."""
+        score = ranker.get_domain_score("bbc.com")
+        assert score == 0.90
+    
+    def test_known_domain_wikipedia(self, ranker):
+        """Wikipedia has moderate reliability score."""
+        score = ranker.get_domain_score("wikipedia.org")
+        assert score == 0.80
+    
+    def test_known_domain_twitter(self, ranker):
+        """Twitter has lower reliability score."""
+        score = ranker.get_domain_score("twitter.com")
+        assert score == 0.40
+    
+    def test_unknown_domain_default(self, ranker):
+        """Unknown domains get default score."""
+        score = ranker.get_domain_score("unknownsite.com")
+        assert score == ranker.DEFAULT_DOMAIN_SCORE
+    
+    def test_domain_case_insensitive(self, ranker):
+        """Domain lookup is case insensitive."""
+        score = ranker.get_domain_score("REUTERS.COM")
+        assert score == 0.95
+
+
+class TestSourceRankerCalculateReliability:
+    """Test reliability calculation."""
+    
+    @pytest.fixture
+    def ranker(self):
+        return SourceRanker(reference_date=datetime(2024, 1, 15))
+    
+    def test_reliability_from_domain(self, ranker):
+        """Reliability includes domain score."""
+        source = Source(
+            url="https://reuters.com/article",
+            title="Test",
+            snippet=""
+        )
+        score = ranker.calculate_reliability(source)
+        assert score >= 0.90  # Reuters base score
+    
+    def test_reliability_academic_boost(self, ranker):
+        """Academic content gets boost."""
+        source = Source(
+            url="https://unknownsite.com",
+            title="Test",
+            snippet="",
+            content_type="academic"
+        )
+        base = ranker.DEFAULT_DOMAIN_SCORE
+        score = ranker.calculate_reliability(source)
+        assert score > base  # Should be boosted
+    
+    def test_reliability_social_penalty(self, ranker):
+        """Social content gets penalty."""
+        source = Source(
+            url="https://unknownsite.com",
+            title="Test",
+            snippet="",
+            content_type="social"
+        )
+        base = ranker.DEFAULT_DOMAIN_SCORE
+        score = ranker.calculate_reliability(source)
+        assert score < base  # Should be penalized
+    
+    def test_reliability_recency_bonus(self, ranker):
+        """Recent content gets bonus."""
+        recent_date = datetime(2024, 1, 10)  # 5 days before reference
+        source = Source(
+            url="https://unknownsite.com",
+            title="Test",
+            snippet="",
+            date=recent_date
+        )
+        score_with_date = ranker.calculate_reliability(source)
+        
+        source_no_date = Source(
+            url="https://unknownsite.com",
+            title="Test",
+            snippet=""
+        )
+        score_no_date = ranker.calculate_reliability(source_no_date)
+        
+        assert score_with_date > score_no_date
+    
+    def test_reliability_clamped_to_1(self, ranker):
+        """Reliability score is clamped to 1.0."""
+        # Create a source with maximum bonuses
+        recent_date = datetime(2024, 1, 14)  # Very recent
+        source = Source(
+            url="https://nature.com/article",  # High score domain
+            title="Test",
+            snippet="",
+            date=recent_date,
+            content_type="academic"  # Bonus
+        )
+        score = ranker.calculate_reliability(source)
+        assert score <= 1.0
+    
+    def test_reliability_clamped_to_0(self, ranker):
+        """Reliability score is clamped to 0.0."""
+        # Create a source with maximum penalties
+        source = Source(
+            url="https://instagram.com/post",  # Low score domain
+            title="Test",
+            snippet="",
+            content_type="social"  # Penalty
+        )
+        score = ranker.calculate_reliability(source)
+        assert score >= 0.0
+
+
+class TestSourceRankerRecencyBonus:
+    """Test recency bonus calculation."""
+    
+    def test_recency_bonus_very_recent(self):
+        """Very recent sources get full bonus."""
+        reference = datetime(2024, 1, 15)
+        ranker = SourceRanker(reference_date=reference)
+        
+        recent_date = datetime(2024, 1, 14)  # 1 day ago
+        source = Source(url="https://example.com", title="", snippet="", date=recent_date)
+        
+        bonus = ranker._calculate_recency_bonus(source.date)
+        assert bonus > 0.08  # Near max bonus
+    
+    def test_recency_bonus_old_source(self):
+        """Old sources get no bonus."""
+        reference = datetime(2024, 1, 15)
+        ranker = SourceRanker(reference_date=reference)
+        
+        old_date = datetime(2023, 1, 1)  # Over a year ago
+        bonus = ranker._calculate_recency_bonus(old_date)
+        assert bonus == 0.0
+    
+    def test_recency_bonus_30_days(self):
+        """Sources at 30 days get no bonus."""
+        reference = datetime(2024, 1, 30)
+        ranker = SourceRanker(reference_date=reference)
+        
+        date = datetime(2024, 1, 1)  # ~30 days ago
+        bonus = ranker._calculate_recency_bonus(date)
+        # Should be at or near 0
+        assert bonus < 0.02
+    
+    def test_recency_bonus_no_date(self):
+        """No date means no bonus."""
+        ranker = SourceRanker()
+        bonus = ranker._calculate_recency_bonus(None)
+        assert bonus == 0.0
+
+
+class TestSourceRankerRank:
+    """Test source ranking."""
+    
+    @pytest.fixture
+    def ranker(self):
+        return SourceRanker()
+    
+    def test_rank_orders_by_reliability(self, ranker):
+        """Sources are ordered by reliability (highest first)."""
+        sources = [
+            Source(url="https://twitter.com/post", title="Twitter", snippet=""),
+            Source(url="https://reuters.com/article", title="Reuters", snippet=""),
+            Source(url="https://example.com/article", title="Unknown", snippet=""),
+        ]
+        
+        ranked = ranker.rank(sources)
+        
+        assert ranked[0].domain == "reuters.com"
+        assert ranked[-1].domain == "twitter.com"
+    
+    def test_rank_sets_reliability_scores(self, ranker):
+        """Ranking sets reliability scores on sources."""
+        sources = [
+            Source(url="https://bbc.com/news", title="BBC", snippet=""),
+        ]
+        
+        ranked = ranker.rank(sources)
+        
+        assert ranked[0].reliability_score > 0
+    
+    def test_rank_preserves_all_sources(self, ranker):
+        """Ranking preserves all input sources."""
+        sources = [
+            Source(url="https://a.com", title="A", snippet=""),
+            Source(url="https://b.com", title="B", snippet=""),
+            Source(url="https://c.com", title="C", snippet=""),
+        ]
+        
+        ranked = ranker.rank(sources)
+        
+        assert len(ranked) == len(sources)
+
+
+class TestSourceRankerFilterLowQuality:
+    """Test low quality filtering."""
+    
+    @pytest.fixture
+    def ranker(self):
+        return SourceRanker()
+    
+    def test_filter_removes_low_quality(self, ranker):
+        """Low quality sources are filtered out."""
+        sources = [
+            Source(url="https://reuters.com/article", title="Reuters", snippet=""),
+            Source(url="https://instagram.com/post", title="Instagram", snippet="", content_type="social"),
+        ]
+        
+        # First rank to set scores
+        ranked = ranker.rank(sources)
+        
+        # Filter with moderate threshold
+        filtered = ranker.filter_low_quality(ranked, threshold=0.3)
+        
+        # Instagram with social penalty should be filtered
+        domains = [s.domain for s in filtered]
+        assert "reuters.com" in domains
+    
+    def test_filter_keeps_high_quality(self, ranker):
+        """High quality sources pass filter."""
+        sources = [
+            Source(url="https://reuters.com/article", title="Reuters", snippet=""),
+            Source(url="https://bbc.com/news", title="BBC", snippet=""),
+        ]
+        
+        ranked = ranker.rank(sources)
+        filtered = ranker.filter_low_quality(ranked, threshold=0.5)
+        
+        assert len(filtered) == 2
+    
+    def test_filter_custom_threshold(self, ranker):
+        """Custom threshold is respected."""
+        sources = [
+            Source(url="https://reuters.com/article", title="Reuters", snippet=""),  # ~0.95
+            Source(url="https://medium.com/post", title="Medium", snippet=""),  # ~0.50
+        ]
+        
+        ranked = ranker.rank(sources)
+        
+        # High threshold should filter medium
+        filtered = ranker.filter_low_quality(ranked, threshold=0.8)
+        assert len(filtered) == 1
+        assert filtered[0].domain == "reuters.com"


### PR DESCRIPTION
## Issue #33 - V2-3 Cite-first Research Pipeline

### New Components

| Component | Description |
|-----------|-------------|
| **Source** | Dataclass with auto domain extraction, content type |
| **SourceCollector** | Collect sources, parse dates, detect content types |
| **SourceRanker** | Domain reliability scores, recency bonus, filtering |
| **ContradictionDetector** | Negation patterns, opposing terms detection |
| **ConfidenceScorer** | Weighted multi-factor scoring |
| **ResearchOrchestrator** | Full pipeline orchestration |

### Domain Reliability Tiers

| Tier | Score | Examples |
|------|-------|----------|
| 1 | 0.90-0.95 | Reuters, AP, BBC, NYT |
| 2 | 0.80-0.89 | CNN, Bloomberg, WSJ |
| 3 | 0.75-0.85 | Wikipedia, Nature, arXiv |
| 4 | 0.70-0.80 | TechCrunch, Wired |
| 5 | 0.30-0.50 | Twitter, Reddit, Instagram |

### Confidence Scoring Weights

```
source_count:      20%
source_reliability: 25%
recency:           15%
agreement:         25%
coverage:          15%
```

### Confidence Levels
- **Low**: score < 0.4
- **Medium**: 0.4 ≤ score < 0.7
- **High**: score ≥ 0.7

### Pipeline Flow
```
Query → Collect → Rank → Filter → Detect Contradictions → Score Confidence → Summarize
        ↓         ↓                ↓                      ↓
     PROGRESS   FOUND           analyze                 RESULT
```

### Tests: 124 passing
- test_source_collector.py: ~30 tests
- test_source_ranker.py: ~24 tests
- test_contradiction.py: ~22 tests
- test_confidence.py: ~24 tests
- test_research_orchestrator.py: ~24 tests

Closes #33