### PR TITLE
feat(voice): Attention Gate system (Issue #35)

### DIFF
--- a/src/bantz/ui/overlay.py
+++ b/src/bantz/ui/overlay.py
@@ -428,6 +428,20 @@ class BantzOverlay(QWidget):
         self.action_label.setText("")
         self.action_label.hide()
 
+    def _on_timeout(self):
+        """Handle timeout - false wake."""
+        self._timeout_timer.stop()
+
+        # Show farewell message
+        self.set_state(AssistantState.SPEAKING, "Sanırım yanlış çağrı almışım, görüşmek üzere.")
+
+        # Hide after a moment
+        QTimer.singleShot(2000, self.hide_overlay)
+
+        # Callback
+        if self._timeout_callback:
+            self._timeout_callback()
+
 
 class CursorDotOverlay(QWidget):
     """Small always-on-top transparent widget to show a cursor dot/ring."""
@@ -521,20 +535,6 @@ class HighlightOverlay(QWidget):
         painter.setPen(pen)
         painter.setBrush(Qt.NoBrush)
         painter.drawRoundedRect(self._rect, 6, 6)
-    
-    def _on_timeout(self):
-        """Handle timeout - false wake."""
-        self._timeout_timer.stop()
-        
-        # Show farewell message
-        self.set_state(AssistantState.SPEAKING, "Sanırım yanlış çağrı almışım, görüşmek üzere.")
-        
-        # Hide after a moment
-        QTimer.singleShot(2000, self.hide_overlay)
-        
-        # Callback
-        if self._timeout_callback:
-            self._timeout_callback()
 
 
 class OverlayManager:

--- a/src/bantz/voice/__init__.py
+++ b/src/bantz/voice/__init__.py
@@ -77,6 +77,31 @@ from bantz.voice.conversation import (
     MockConversationManager,
 )
 
+# Issue #35: Attention Gate (Voice-2)
+from bantz.voice.attention_gate import (
+    AttentionGate,
+    AttentionGateConfig,
+    ListeningMode,
+    create_attention_gate,
+)
+from bantz.voice.engaged_window import (
+    EngagedWindowManager,
+    EngagedWindowConfig,
+    create_engaged_window,
+)
+from bantz.voice.interrupt_handler import (
+    InterruptHandler,
+    InterruptAction,
+    InterruptResult,
+    create_interrupt_handler,
+)
+from bantz.voice.task_policy import (
+    TaskListeningPolicy,
+    INTENT_KEYWORDS,
+    classify_task_command,
+    create_task_policy,
+)
+
 __all__ = [
     # Advanced TTS
     "AdvancedTTS",
@@ -134,4 +159,23 @@ __all__ = [
     "ConversationContext",
     "ConversationState",
     "MockConversationManager",
+    # Attention Gate (Issue #35)
+    "AttentionGate",
+    "AttentionGateConfig",
+    "ListeningMode",
+    "create_attention_gate",
+    # Engaged Window
+    "EngagedWindowManager",
+    "EngagedWindowConfig",
+    "create_engaged_window",
+    # Interrupt Handler
+    "InterruptHandler",
+    "InterruptAction",
+    "InterruptResult",
+    "create_interrupt_handler",
+    # Task Policy
+    "TaskListeningPolicy",
+    "INTENT_KEYWORDS",
+    "classify_task_command",
+    "create_task_policy",
 ]

--- a/src/bantz/voice/attention_gate.py
+++ b/src/bantz/voice/attention_gate.py
@@ -1,0 +1,303 @@
+"""
+Attention Gate for Voice Control (Issue #35 - Voice-2).
+
+Controls when the voice system should listen based on:
+- IDLE: Not listening at all
+- WAKEWORD_ONLY: Only listening for "Hey Bantz"
+- ENGAGED: Active conversation, no wake word needed
+- TASK_RUNNING: Task in progress, only interrupt wake word
+
+This prevents unnecessary processing during task execution
+while still allowing interrupts via wake word.
+"""
+
+from enum import Enum
+from typing import Optional, Callable
+from dataclasses import dataclass
+import time
+import threading
+
+from bantz.core.events import EventBus, get_event_bus
+
+
+class ListeningMode(Enum):
+    """Voice listening modes."""
+    IDLE = "idle"                     # Not listening at all
+    WAKEWORD_ONLY = "wakeword_only"   # Only "Hey Bantz" triggers
+    ENGAGED = "engaged"               # Active conversation, no wake word needed
+    TASK_RUNNING = "task_running"     # Task running, only interrupt wake word
+
+
+@dataclass
+class AttentionGateConfig:
+    """Configuration for AttentionGate."""
+    engaged_timeout: float = 15.0      # Seconds before engaged → wakeword_only
+    initial_mode: ListeningMode = ListeningMode.WAKEWORD_ONLY
+    auto_engage_on_wake: bool = True   # Auto transition to ENGAGED on wake word
+
+
+class AttentionGate:
+    """
+    Controls voice listening behavior based on system state.
+    
+    State Machine:
+        WAKEWORD_ONLY ──(wake word)──> ENGAGED
+        ENGAGED ───(timeout)────────> WAKEWORD_ONLY
+        ENGAGED ───(job started)────> TASK_RUNNING
+        TASK_RUNNING ──(job done)──> ENGAGED
+        TASK_RUNNING ──(wake word)──> INTERRUPT (stays TASK_RUNNING)
+    
+    Usage:
+        gate = AttentionGate(job_manager, event_bus)
+        
+        if gate.should_process_speech():
+            # Process normal speech
+        elif gate.should_interrupt():
+            # Handle interrupt
+    """
+    
+    def __init__(
+        self,
+        job_manager=None,  # Optional[JobManager]
+        event_bus: Optional[EventBus] = None,
+        config: Optional[AttentionGateConfig] = None
+    ):
+        """
+        Initialize AttentionGate.
+        
+        Args:
+            job_manager: JobManager instance for job state tracking
+            event_bus: EventBus for listening to events
+            config: Gate configuration
+        """
+        self._job_manager = job_manager
+        self._event_bus = event_bus or get_event_bus()
+        self._config = config or AttentionGateConfig()
+        
+        self._mode = self._config.initial_mode
+        self._mode_lock = threading.Lock()
+        
+        # Engaged window tracking
+        self._engaged_start_time: Optional[float] = None
+        self._current_job_id: Optional[str] = None
+        
+        # Wake word detection flag (for interrupt handling)
+        self._wake_detected = False
+        
+        # Callbacks
+        self._on_mode_change: Optional[Callable[[ListeningMode, ListeningMode], None]] = None
+        
+        # Subscribe to events
+        self._setup_event_subscriptions()
+    
+    def _setup_event_subscriptions(self):
+        """Subscribe to relevant events."""
+        if self._event_bus:
+            self._event_bus.subscribe("job.started", self._handle_job_started)
+            self._event_bus.subscribe("job.completed", self._handle_job_completed)
+            self._event_bus.subscribe("job.failed", self._handle_job_failed)
+            self._event_bus.subscribe("job.cancelled", self._handle_job_cancelled)
+    
+    @property
+    def mode(self) -> ListeningMode:
+        """Get current listening mode."""
+        with self._mode_lock:
+            # Check for engaged timeout
+            if self._mode == ListeningMode.ENGAGED:
+                if self._is_engaged_expired():
+                    self._set_mode(ListeningMode.WAKEWORD_ONLY)
+            return self._mode
+    
+    def _set_mode(self, new_mode: ListeningMode) -> None:
+        """Set mode with callback notification."""
+        old_mode = self._mode
+        self._mode = new_mode
+        
+        if old_mode != new_mode:
+            if self._on_mode_change:
+                self._on_mode_change(old_mode, new_mode)
+            
+            # Publish mode change event
+            if self._event_bus:
+                self._event_bus.publish(
+                    "attention.mode_changed",
+                    {"old_mode": old_mode.value, "new_mode": new_mode.value},
+                    source="attention_gate"
+                )
+    
+    def _is_engaged_expired(self) -> bool:
+        """Check if engaged window has expired."""
+        if self._engaged_start_time is None:
+            return True
+        elapsed = time.time() - self._engaged_start_time
+        return elapsed >= self._config.engaged_timeout
+    
+    def on_wake_word_detected(self) -> None:
+        """
+        Handle wake word detection.
+        
+        - From WAKEWORD_ONLY: Transition to ENGAGED
+        - From ENGAGED: Reset engaged timer
+        - From TASK_RUNNING: Set interrupt flag
+        """
+        with self._mode_lock:
+            if self._mode == ListeningMode.WAKEWORD_ONLY:
+                if self._config.auto_engage_on_wake:
+                    self._engaged_start_time = time.time()
+                    self._set_mode(ListeningMode.ENGAGED)
+            
+            elif self._mode == ListeningMode.ENGAGED:
+                # Reset engaged timer
+                self._engaged_start_time = time.time()
+            
+            elif self._mode == ListeningMode.TASK_RUNNING:
+                # Set interrupt flag
+                self._wake_detected = True
+    
+    def on_speech_end(self) -> None:
+        """
+        Handle end of user speech.
+        
+        Extends engaged window on speech activity.
+        """
+        with self._mode_lock:
+            if self._mode == ListeningMode.ENGAGED:
+                # Extend engaged window
+                self._engaged_start_time = time.time()
+    
+    def on_job_started(self, job_id: str) -> None:
+        """
+        Handle job start event.
+        
+        Transitions to TASK_RUNNING mode.
+        """
+        with self._mode_lock:
+            self._current_job_id = job_id
+            if self._mode in (ListeningMode.ENGAGED, ListeningMode.WAKEWORD_ONLY):
+                self._set_mode(ListeningMode.TASK_RUNNING)
+    
+    def on_job_completed(self, job_id: str) -> None:
+        """
+        Handle job completion.
+        
+        Transitions back to ENGAGED mode.
+        """
+        with self._mode_lock:
+            if self._current_job_id == job_id:
+                self._current_job_id = None
+                if self._mode == ListeningMode.TASK_RUNNING:
+                    self._engaged_start_time = time.time()
+                    self._set_mode(ListeningMode.ENGAGED)
+    
+    def should_process_speech(self) -> bool:
+        """
+        Check if speech should be processed.
+        
+        Returns:
+            True if system should process normal speech
+        """
+        current_mode = self.mode  # Property checks timeout
+        return current_mode == ListeningMode.ENGAGED
+    
+    def should_interrupt(self) -> bool:
+        """
+        Check if interrupt was requested.
+        
+        Returns:
+            True if wake word was detected during TASK_RUNNING
+        """
+        with self._mode_lock:
+            if self._wake_detected:
+                self._wake_detected = False  # Clear flag
+                return True
+            return False
+    
+    def clear_interrupt(self) -> None:
+        """Clear interrupt flag."""
+        with self._mode_lock:
+            self._wake_detected = False
+    
+    def set_idle(self) -> None:
+        """Set mode to IDLE (stop all listening)."""
+        with self._mode_lock:
+            self._set_mode(ListeningMode.IDLE)
+            self._engaged_start_time = None
+    
+    def set_wakeword_only(self) -> None:
+        """Set mode to WAKEWORD_ONLY."""
+        with self._mode_lock:
+            self._set_mode(ListeningMode.WAKEWORD_ONLY)
+            self._engaged_start_time = None
+    
+    def force_engaged(self, timeout: Optional[float] = None) -> None:
+        """Force ENGAGED mode with optional custom timeout."""
+        with self._mode_lock:
+            self._engaged_start_time = time.time()
+            if timeout is not None:
+                # Temporarily adjust timeout
+                self._config.engaged_timeout = timeout
+            self._set_mode(ListeningMode.ENGAGED)
+    
+    def extend_engaged(self, seconds: float = 5.0) -> None:
+        """Extend engaged window by additional seconds."""
+        with self._mode_lock:
+            if self._mode == ListeningMode.ENGAGED and self._engaged_start_time:
+                self._engaged_start_time += seconds
+    
+    def on_mode_change(self, callback: Callable[[ListeningMode, ListeningMode], None]) -> None:
+        """Register mode change callback."""
+        self._on_mode_change = callback
+    
+    def get_current_job_id(self) -> Optional[str]:
+        """Get current job ID if any."""
+        with self._mode_lock:
+            return self._current_job_id
+    
+    def _handle_job_started(self, event) -> None:
+        """Event handler for job.started."""
+        job_id = event.data.get("job_id")
+        if job_id:
+            self.on_job_started(job_id)
+    
+    def _handle_job_completed(self, event) -> None:
+        """Event handler for job.completed."""
+        job_id = event.data.get("job_id")
+        if job_id:
+            self.on_job_completed(job_id)
+    
+    def _handle_job_failed(self, event) -> None:
+        """Event handler for job.failed."""
+        job_id = event.data.get("job_id")
+        if job_id:
+            self.on_job_completed(job_id)  # Treat as completion
+    
+    def _handle_job_cancelled(self, event) -> None:
+        """Event handler for job.cancelled."""
+        job_id = event.data.get("job_id")
+        if job_id:
+            self.on_job_completed(job_id)  # Treat as completion
+
+
+def create_attention_gate(
+    job_manager=None,
+    event_bus: Optional[EventBus] = None,
+    engaged_timeout: float = 15.0,
+    **config_kwargs
+) -> AttentionGate:
+    """
+    Factory function to create AttentionGate.
+    
+    Args:
+        job_manager: Optional JobManager instance
+        event_bus: Optional EventBus instance
+        engaged_timeout: Engaged window timeout in seconds
+        **config_kwargs: Additional AttentionGateConfig parameters
+    
+    Returns:
+        Configured AttentionGate instance
+    """
+    config = AttentionGateConfig(
+        engaged_timeout=engaged_timeout,
+        **config_kwargs
+    )
+    return AttentionGate(job_manager, event_bus, config)

--- a/src/bantz/voice/engaged_window.py
+++ b/src/bantz/voice/engaged_window.py
@@ -1,0 +1,239 @@
+"""
+Engaged Window Manager (Issue #35 - Voice-2).
+
+Manages the "engaged" state window where the system
+listens without requiring a wake word.
+
+Window behavior:
+- Starts with default timeout (10-20 seconds)
+- Extends on user speech activity
+- Respects max timeout limit
+- Can be manually closed
+"""
+
+from typing import Optional, Callable
+from dataclasses import dataclass
+import time
+import threading
+
+
+@dataclass
+class EngagedWindowConfig:
+    """Configuration for engaged window."""
+    min_timeout: float = 10.0      # Minimum window duration
+    max_timeout: float = 20.0      # Maximum window duration
+    default_timeout: float = 15.0  # Default window duration
+    extension_amount: float = 5.0  # Seconds to extend on speech
+
+
+class EngagedWindowManager:
+    """
+    Manages the engaged listening window.
+    
+    The engaged window is active after a wake word detection,
+    allowing follow-up commands without re-triggering wake word.
+    
+    Usage:
+        window = EngagedWindowManager()
+        window.start_window()
+        
+        if window.is_active:
+            # Accept speech without wake word
+            window.on_user_speech()  # Extend window
+        
+        # When timeout expires or manually closed
+        window.close_window()
+    """
+    
+    def __init__(
+        self,
+        min_timeout: float = 10.0,
+        max_timeout: float = 20.0,
+        default_timeout: float = 15.0,
+        on_expired: Optional[Callable[[], None]] = None
+    ):
+        """
+        Initialize EngagedWindowManager.
+        
+        Args:
+            min_timeout: Minimum window duration (seconds)
+            max_timeout: Maximum window duration (seconds)
+            default_timeout: Default window duration (seconds)
+            on_expired: Callback when window expires
+        """
+        self._config = EngagedWindowConfig(
+            min_timeout=min_timeout,
+            max_timeout=max_timeout,
+            default_timeout=default_timeout
+        )
+        
+        self._on_expired = on_expired
+        
+        self._start_time: Optional[float] = None
+        self._current_timeout: float = default_timeout
+        self._lock = threading.Lock()
+        
+        # Timer for expiry notification
+        self._expiry_timer: Optional[threading.Timer] = None
+    
+    def start_window(self, timeout: Optional[float] = None) -> None:
+        """
+        Start or restart the engaged window.
+        
+        Args:
+            timeout: Custom timeout (uses default if None)
+        """
+        with self._lock:
+            self._cancel_timer()
+            
+            self._start_time = time.time()
+            self._current_timeout = timeout or self._config.default_timeout
+            
+            # Clamp to min/max
+            self._current_timeout = max(
+                self._config.min_timeout,
+                min(self._current_timeout, self._config.max_timeout)
+            )
+            
+            # Schedule expiry callback
+            self._schedule_expiry()
+    
+    def extend_window(self, seconds: Optional[float] = None) -> None:
+        """
+        Extend the engaged window.
+        
+        Args:
+            seconds: Seconds to extend (uses config default if None)
+        """
+        with self._lock:
+            if self._start_time is None:
+                return
+            
+            extension = seconds or self._config.extension_amount
+            new_timeout = self._current_timeout + extension
+            
+            # Respect max timeout
+            if new_timeout > self._config.max_timeout:
+                new_timeout = self._config.max_timeout
+            
+            self._current_timeout = new_timeout
+            
+            # Reschedule expiry
+            self._cancel_timer()
+            self._schedule_expiry()
+    
+    def close_window(self) -> None:
+        """Close the engaged window immediately."""
+        with self._lock:
+            self._cancel_timer()
+            self._start_time = None
+            self._current_timeout = self._config.default_timeout
+    
+    @property
+    def is_active(self) -> bool:
+        """Check if engaged window is currently active."""
+        with self._lock:
+            if self._start_time is None:
+                return False
+            
+            elapsed = time.time() - self._start_time
+            return elapsed < self._current_timeout
+    
+    @property
+    def remaining_time(self) -> float:
+        """Get remaining time in engaged window (seconds)."""
+        with self._lock:
+            if self._start_time is None:
+                return 0.0
+            
+            elapsed = time.time() - self._start_time
+            remaining = self._current_timeout - elapsed
+            return max(0.0, remaining)
+    
+    @property
+    def elapsed_time(self) -> float:
+        """Get elapsed time since window started (seconds)."""
+        with self._lock:
+            if self._start_time is None:
+                return 0.0
+            return time.time() - self._start_time
+    
+    @property
+    def current_timeout(self) -> float:
+        """Get current timeout value."""
+        with self._lock:
+            return self._current_timeout
+    
+    def on_user_speech(self) -> None:
+        """
+        Handle user speech activity.
+        
+        Extends the window on speech to allow follow-up commands.
+        """
+        self.extend_window()
+    
+    def on_expired_callback(self, callback: Callable[[], None]) -> None:
+        """Register callback for window expiry."""
+        self._on_expired = callback
+    
+    def _schedule_expiry(self) -> None:
+        """Schedule expiry timer."""
+        if self._start_time is None:
+            return
+        
+        remaining = self.remaining_time
+        if remaining > 0 and self._on_expired:
+            self._expiry_timer = threading.Timer(remaining, self._handle_expiry)
+            self._expiry_timer.daemon = True
+            self._expiry_timer.start()
+    
+    def _cancel_timer(self) -> None:
+        """Cancel pending expiry timer."""
+        if self._expiry_timer:
+            self._expiry_timer.cancel()
+            self._expiry_timer = None
+    
+    def _handle_expiry(self) -> None:
+        """Handle window expiry."""
+        with self._lock:
+            # Verify still expired (might have been extended)
+            if not self.is_active and self._on_expired:
+                self._on_expired()
+    
+    def get_stats(self) -> dict:
+        """Get window statistics."""
+        with self._lock:
+            return {
+                "is_active": self.is_active,
+                "remaining_time": self.remaining_time,
+                "elapsed_time": self.elapsed_time,
+                "current_timeout": self._current_timeout,
+                "min_timeout": self._config.min_timeout,
+                "max_timeout": self._config.max_timeout,
+            }
+
+
+def create_engaged_window(
+    min_timeout: float = 10.0,
+    max_timeout: float = 20.0,
+    default_timeout: float = 15.0,
+    on_expired: Optional[Callable[[], None]] = None
+) -> EngagedWindowManager:
+    """
+    Factory function to create EngagedWindowManager.
+    
+    Args:
+        min_timeout: Minimum window duration
+        max_timeout: Maximum window duration
+        default_timeout: Default window duration
+        on_expired: Callback when window expires
+    
+    Returns:
+        Configured EngagedWindowManager instance
+    """
+    return EngagedWindowManager(
+        min_timeout=min_timeout,
+        max_timeout=max_timeout,
+        default_timeout=default_timeout,
+        on_expired=on_expired
+    )

--- a/src/bantz/voice/interrupt_handler.py
+++ b/src/bantz/voice/interrupt_handler.py
@@ -1,0 +1,318 @@
+"""
+Interrupt Handler (Issue #35 - Voice-2).
+
+Handles interrupts during task execution:
+- Stops TTS playback
+- Pauses current job
+- Says "Efendim" (acknowledgment)
+- Listens for new command
+- Can resume paused job
+
+Interrupt flow:
+1. User says "Hey Bantz" during task
+2. TTS is cut
+3. Current job is paused
+4. System says "Efendim"
+5. User gives new command or says "devam et"
+"""
+
+from enum import Enum
+from typing import Optional, Callable, Any
+from dataclasses import dataclass
+import asyncio
+
+from bantz.core.events import EventBus, get_event_bus
+
+
+class InterruptAction(Enum):
+    """Actions that can be taken on interrupt."""
+    PAUSE_AND_LISTEN = "pause_and_listen"      # Pause job, listen for command
+    CANCEL_AND_LISTEN = "cancel_and_listen"    # Cancel job, listen for command
+    IGNORE = "ignore"                          # Ignore interrupt
+
+
+@dataclass
+class InterruptResult:
+    """Result of interrupt handling."""
+    action: InterruptAction
+    paused_job_id: Optional[str] = None
+    new_command: Optional[str] = None
+    error: Optional[str] = None
+
+
+class InterruptHandler:
+    """
+    Handles interrupts during task execution.
+    
+    When user says wake word during a running task:
+    1. TTS playback is immediately stopped
+    2. Current job is paused (not cancelled)
+    3. System acknowledges with "Efendim"
+    4. System listens for new command
+    
+    Usage:
+        handler = InterruptHandler(job_manager, tts_controller, event_bus)
+        
+        # When interrupt detected
+        result = await handler.handle_interrupt(current_job_id)
+        
+        if result.new_command == "devam et":
+            await handler.resume_paused_job(result.paused_job_id)
+    """
+    
+    # Turkish acknowledgment phrase
+    ACKNOWLEDGMENT = "Efendim"
+    
+    # Commands that resume paused job
+    RESUME_COMMANDS = ["devam et", "devam", "continue", "resume"]
+    
+    def __init__(
+        self,
+        job_manager=None,  # Optional[JobManager]
+        tts_controller=None,  # Optional TTS controller
+        event_bus: Optional[EventBus] = None,
+        acknowledgment: str = "Efendim"
+    ):
+        """
+        Initialize InterruptHandler.
+        
+        Args:
+            job_manager: JobManager for job control
+            tts_controller: TTS controller for stopping speech
+            event_bus: EventBus for publishing events
+            acknowledgment: Phrase to say on interrupt
+        """
+        self._job_manager = job_manager
+        self._tts_controller = tts_controller
+        self._event_bus = event_bus or get_event_bus()
+        self._acknowledgment = acknowledgment
+        
+        self._paused_jobs: dict[str, dict] = {}  # job_id -> job state
+        
+        # Callbacks
+        self._on_interrupt: Optional[Callable[[str], None]] = None
+        self._on_resume: Optional[Callable[[str], None]] = None
+    
+    async def handle_interrupt(
+        self,
+        current_job_id: Optional[str] = None
+    ) -> InterruptResult:
+        """
+        Handle an interrupt request.
+        
+        Steps:
+        1. Stop TTS
+        2. Pause current job
+        3. Say acknowledgment
+        4. Return result for further handling
+        
+        Args:
+            current_job_id: ID of currently running job
+            
+        Returns:
+            InterruptResult with action taken and job state
+        """
+        try:
+            # Step 1: Stop TTS
+            await self._stop_tts()
+            
+            # Step 2: Pause current job
+            paused_job_id = None
+            if current_job_id:
+                paused_job_id = await self._pause_job(current_job_id)
+            
+            # Step 3: Emit interrupt event
+            self._emit_interrupt_event(current_job_id)
+            
+            # Step 4: Say acknowledgment
+            await self._say_acknowledgment()
+            
+            # Notify callback
+            if self._on_interrupt and current_job_id:
+                self._on_interrupt(current_job_id)
+            
+            return InterruptResult(
+                action=InterruptAction.PAUSE_AND_LISTEN,
+                paused_job_id=paused_job_id
+            )
+            
+        except Exception as e:
+            return InterruptResult(
+                action=InterruptAction.IGNORE,
+                error=str(e)
+            )
+    
+    async def resume_paused_job(self, job_id: str) -> bool:
+        """
+        Resume a previously paused job.
+        
+        Args:
+            job_id: ID of job to resume
+            
+        Returns:
+            True if resumed successfully
+        """
+        if not self._job_manager:
+            return False
+        
+        try:
+            # Check if job was paused by us
+            if job_id not in self._paused_jobs:
+                return False
+            
+            # Resume job
+            success = self._job_manager.resume_job(job_id)
+            
+            if success:
+                del self._paused_jobs[job_id]
+                
+                # Emit resume event
+                if self._event_bus:
+                    self._event_bus.publish(
+                        "interrupt.resumed",
+                        {"job_id": job_id},
+                        source="interrupt_handler"
+                    )
+                
+                # Notify callback
+                if self._on_resume:
+                    self._on_resume(job_id)
+            
+            return success
+            
+        except Exception:
+            return False
+    
+    async def cancel_paused_job(self, job_id: str) -> bool:
+        """
+        Cancel a paused job instead of resuming.
+        
+        Args:
+            job_id: ID of job to cancel
+            
+        Returns:
+            True if cancelled successfully
+        """
+        if not self._job_manager:
+            return False
+        
+        try:
+            if job_id in self._paused_jobs:
+                del self._paused_jobs[job_id]
+            
+            success = self._job_manager.cancel_job(job_id)
+            
+            if success and self._event_bus:
+                self._event_bus.publish(
+                    "interrupt.cancelled",
+                    {"job_id": job_id},
+                    source="interrupt_handler"
+                )
+            
+            return success
+            
+        except Exception:
+            return False
+    
+    def get_paused_jobs(self) -> list[str]:
+        """Get list of job IDs paused by interrupt."""
+        return list(self._paused_jobs.keys())
+    
+    def is_resume_command(self, command: str) -> bool:
+        """Check if command is a resume command."""
+        normalized = command.lower().strip()
+        return normalized in self.RESUME_COMMANDS
+    
+    async def _stop_tts(self) -> None:
+        """Stop TTS playback."""
+        if self._tts_controller:
+            try:
+                # Try common TTS controller methods
+                if hasattr(self._tts_controller, 'stop'):
+                    await self._async_or_sync(self._tts_controller.stop)
+                elif hasattr(self._tts_controller, 'cancel'):
+                    await self._async_or_sync(self._tts_controller.cancel)
+            except Exception:
+                pass  # TTS stop is best-effort
+    
+    async def _pause_job(self, job_id: str) -> Optional[str]:
+        """Pause a job and track it."""
+        if not self._job_manager:
+            return None
+        
+        try:
+            success = self._job_manager.pause_job(job_id)
+            if success:
+                self._paused_jobs[job_id] = {"paused_at": asyncio.get_event_loop().time()}
+                return job_id
+        except Exception:
+            pass
+        
+        return None
+    
+    async def _say_acknowledgment(self) -> None:
+        """Say acknowledgment phrase."""
+        if self._tts_controller:
+            try:
+                if hasattr(self._tts_controller, 'speak'):
+                    await self._async_or_sync(
+                        self._tts_controller.speak,
+                        self._acknowledgment
+                    )
+                elif hasattr(self._tts_controller, 'say'):
+                    await self._async_or_sync(
+                        self._tts_controller.say,
+                        self._acknowledgment
+                    )
+            except Exception:
+                pass  # Acknowledgment is best-effort
+    
+    async def _async_or_sync(self, func, *args) -> Any:
+        """Call function, handling both async and sync."""
+        result = func(*args)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
+    
+    def _emit_interrupt_event(self, job_id: Optional[str]) -> None:
+        """Emit interrupt event."""
+        if self._event_bus:
+            self._event_bus.publish(
+                "interrupt.triggered",
+                {"job_id": job_id, "acknowledgment": self._acknowledgment},
+                source="interrupt_handler"
+            )
+    
+    def on_interrupt_callback(self, callback: Callable[[str], None]) -> None:
+        """Register callback for interrupt events."""
+        self._on_interrupt = callback
+    
+    def on_resume_callback(self, callback: Callable[[str], None]) -> None:
+        """Register callback for resume events."""
+        self._on_resume = callback
+
+
+def create_interrupt_handler(
+    job_manager=None,
+    tts_controller=None,
+    event_bus: Optional[EventBus] = None,
+    acknowledgment: str = "Efendim"
+) -> InterruptHandler:
+    """
+    Factory function to create InterruptHandler.
+    
+    Args:
+        job_manager: Optional JobManager instance
+        tts_controller: Optional TTS controller
+        event_bus: Optional EventBus instance
+        acknowledgment: Phrase to say on interrupt
+    
+    Returns:
+        Configured InterruptHandler instance
+    """
+    return InterruptHandler(
+        job_manager=job_manager,
+        tts_controller=tts_controller,
+        event_bus=event_bus,
+        acknowledgment=acknowledgment
+    )

--- a/src/bantz/voice/task_policy.py
+++ b/src/bantz/voice/task_policy.py
@@ -1,0 +1,216 @@
+"""
+Task Listening Policy (Issue #35 - Voice-2).
+
+Defines what commands are allowed during task execution (TASK_RUNNING mode).
+
+By default, only job control intents are accepted:
+- job_pause: "bekle", "dur"
+- job_resume: "devam et", "devam"
+- job_cancel: "iptal", "vazgeç"
+- interrupt: New command after wake word
+
+All other intents are rejected with a message explaining
+that a task is currently running.
+"""
+
+from typing import List, Optional, Set
+
+
+class TaskListeningPolicy:
+    """
+    Policy for what commands are accepted during task execution.
+    
+    When the system is in TASK_RUNNING mode, only specific
+    intents related to job control are accepted. This prevents
+    accidental commands while a task is being performed.
+    
+    Usage:
+        policy = TaskListeningPolicy()
+        
+        if policy.should_accept("job_pause"):
+            # Accept and handle
+        else:
+            message = policy.get_rejection_message()
+            # Speak message to user
+    """
+    
+    # Default allowed intents during task execution
+    DEFAULT_ALLOWED_INTENTS = {
+        "job_pause",      # "bekle", "dur"
+        "job_resume",     # "devam et", "devam"
+        "job_cancel",     # "iptal", "vazgeç"
+        "interrupt",      # New command via wake word
+        "status",         # "ne yapıyorsun?", "durum"
+        "help",           # "yardım"
+    }
+    
+    # Turkish rejection message
+    DEFAULT_REJECTION_MESSAGE = (
+        "Şu an bir görev çalışıyor. "
+        "'Bekle' diyerek duraklatabilir, "
+        "'İptal' diyerek sonlandırabilir, "
+        "veya 'Hey Bantz' ile kesebilirsin."
+    )
+    
+    # Short rejection for quick response
+    SHORT_REJECTION_MESSAGE = "Şu an bir görev çalışıyor."
+    
+    def __init__(
+        self,
+        allowed_intents: Optional[Set[str]] = None,
+        rejection_message: Optional[str] = None,
+        use_short_rejection: bool = False
+    ):
+        """
+        Initialize TaskListeningPolicy.
+        
+        Args:
+            allowed_intents: Set of allowed intent names
+            rejection_message: Custom rejection message
+            use_short_rejection: Use short rejection message
+        """
+        self._allowed_intents = allowed_intents or self.DEFAULT_ALLOWED_INTENTS.copy()
+        
+        if rejection_message:
+            self._rejection_message = rejection_message
+        elif use_short_rejection:
+            self._rejection_message = self.SHORT_REJECTION_MESSAGE
+        else:
+            self._rejection_message = self.DEFAULT_REJECTION_MESSAGE
+    
+    def should_accept(self, intent: str) -> bool:
+        """
+        Check if an intent should be accepted during task execution.
+        
+        Args:
+            intent: Intent name to check
+            
+        Returns:
+            True if intent is allowed during task execution
+        """
+        return intent.lower() in self._allowed_intents
+    
+    def get_rejection_message(self) -> str:
+        """
+        Get the rejection message for disallowed commands.
+        
+        Returns:
+            Rejection message to speak to user
+        """
+        return self._rejection_message
+    
+    def add_allowed_intent(self, intent: str) -> None:
+        """
+        Add an intent to the allowed list.
+        
+        Args:
+            intent: Intent name to allow
+        """
+        self._allowed_intents.add(intent.lower())
+    
+    def remove_allowed_intent(self, intent: str) -> None:
+        """
+        Remove an intent from the allowed list.
+        
+        Args:
+            intent: Intent name to remove
+        """
+        self._allowed_intents.discard(intent.lower())
+    
+    def get_allowed_intents(self) -> Set[str]:
+        """Get set of currently allowed intents."""
+        return self._allowed_intents.copy()
+    
+    def set_rejection_message(self, message: str) -> None:
+        """Set custom rejection message."""
+        self._rejection_message = message
+    
+    def is_job_control_intent(self, intent: str) -> bool:
+        """
+        Check if intent is a job control command.
+        
+        Args:
+            intent: Intent name to check
+            
+        Returns:
+            True if intent is job-related (pause/resume/cancel)
+        """
+        job_control_intents = {"job_pause", "job_resume", "job_cancel"}
+        return intent.lower() in job_control_intents
+    
+    def get_intent_action(self, intent: str) -> Optional[str]:
+        """
+        Get the action type for an intent.
+        
+        Args:
+            intent: Intent name
+            
+        Returns:
+            Action type ("pause", "resume", "cancel") or None
+        """
+        intent_lower = intent.lower()
+        if intent_lower == "job_pause":
+            return "pause"
+        elif intent_lower == "job_resume":
+            return "resume"
+        elif intent_lower == "job_cancel":
+            return "cancel"
+        elif intent_lower == "interrupt":
+            return "interrupt"
+        elif intent_lower == "status":
+            return "status"
+        return None
+
+
+# Intent keywords for NLU mapping
+INTENT_KEYWORDS = {
+    "job_pause": ["bekle", "dur", "pause", "wait", "stop"],
+    "job_resume": ["devam et", "devam", "resume", "continue"],
+    "job_cancel": ["iptal", "vazgeç", "cancel", "abort"],
+    "status": ["ne yapıyorsun", "durum", "status", "what are you doing"],
+    "help": ["yardım", "help", "ne yapabilirim"],
+}
+
+
+def classify_task_command(text: str) -> Optional[str]:
+    """
+    Classify text into task control intent.
+    
+    Args:
+        text: User's spoken text
+        
+    Returns:
+        Intent name or None if not a task command
+    """
+    text_lower = text.lower().strip()
+    
+    for intent, keywords in INTENT_KEYWORDS.items():
+        for keyword in keywords:
+            if keyword in text_lower:
+                return intent
+    
+    return None
+
+
+def create_task_policy(
+    allowed_intents: Optional[List[str]] = None,
+    rejection_message: Optional[str] = None,
+    use_short_rejection: bool = False
+) -> TaskListeningPolicy:
+    """
+    Factory function to create TaskListeningPolicy.
+    
+    Args:
+        allowed_intents: List of allowed intent names
+        rejection_message: Custom rejection message
+        use_short_rejection: Use short rejection message
+    
+    Returns:
+        Configured TaskListeningPolicy instance
+    """
+    intents_set = set(allowed_intents) if allowed_intents else None
+    return TaskListeningPolicy(
+        allowed_intents=intents_set,
+        rejection_message=rejection_message,
+        use_short_rejection=use_short_rejection
+    )

--- a/tests/test_attention_gate.py
+++ b/tests/test_attention_gate.py
@@ -1,0 +1,168 @@
+"""
+Tests for AttentionGate (Issue #35 - Voice-2).
+
+Tests:
+- ListeningMode enum values
+- Mode transitions (wake word, job start/complete)
+- Engaged timeout behavior
+- should_process_speech and should_interrupt
+- Event subscriptions
+"""
+
+import pytest
+import time
+from unittest.mock import Mock, MagicMock, patch
+
+
+class TestListeningMode:
+    """Tests for ListeningMode enum."""
+    
+    def test_listening_modes_exist(self):
+        """Test that all required modes exist."""
+        from bantz.voice.attention_gate import ListeningMode
+        
+        assert hasattr(ListeningMode, 'IDLE')
+        assert hasattr(ListeningMode, 'WAKEWORD_ONLY')
+        assert hasattr(ListeningMode, 'ENGAGED')
+        assert hasattr(ListeningMode, 'TASK_RUNNING')
+    
+    def test_listening_modes_unique(self):
+        """Test mode values are unique."""
+        from bantz.voice.attention_gate import ListeningMode
+        
+        values = [m.value for m in ListeningMode]
+        assert len(values) == len(set(values))
+    
+    def test_wakeword_only_is_default_initial(self):
+        """Test default initial mode is WAKEWORD_ONLY."""
+        from bantz.voice.attention_gate import AttentionGateConfig, ListeningMode
+        
+        config = AttentionGateConfig()
+        assert config.initial_mode == ListeningMode.WAKEWORD_ONLY
+
+
+class TestAttentionGateConfig:
+    """Tests for AttentionGateConfig."""
+    
+    def test_config_defaults(self):
+        """Test default configuration values."""
+        from bantz.voice.attention_gate import AttentionGateConfig
+        
+        config = AttentionGateConfig()
+        
+        assert config.engaged_timeout == 15.0
+        assert config.auto_engage_on_wake == True
+    
+    def test_config_custom_values(self):
+        """Test custom configuration."""
+        from bantz.voice.attention_gate import AttentionGateConfig, ListeningMode
+        
+        config = AttentionGateConfig(
+            engaged_timeout=20.0,
+            initial_mode=ListeningMode.IDLE,
+            auto_engage_on_wake=False
+        )
+        
+        assert config.engaged_timeout == 20.0
+        assert config.initial_mode == ListeningMode.IDLE
+        assert config.auto_engage_on_wake == False
+
+
+class TestAttentionGate:
+    """Tests for AttentionGate class."""
+    
+    @pytest.fixture
+    def gate(self):
+        """Create AttentionGate for testing."""
+        from bantz.voice.attention_gate import AttentionGate, AttentionGateConfig
+        
+        with patch('bantz.voice.attention_gate.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            config = AttentionGateConfig(engaged_timeout=1.0)  # Short for tests
+            return AttentionGate(config=config)
+    
+    def test_initial_mode_wakeword_only(self, gate):
+        """Test initial mode is WAKEWORD_ONLY."""
+        from bantz.voice.attention_gate import ListeningMode
+        
+        assert gate.mode == ListeningMode.WAKEWORD_ONLY
+    
+    def test_wake_word_transitions_to_engaged(self, gate):
+        """Test wake word detection transitions to ENGAGED."""
+        from bantz.voice.attention_gate import ListeningMode
+        
+        gate.on_wake_word_detected()
+        
+        assert gate.mode == ListeningMode.ENGAGED
+    
+    def test_engaged_timeout_returns_wakeword(self, gate):
+        """Test engaged mode times out to WAKEWORD_ONLY."""
+        from bantz.voice.attention_gate import ListeningMode
+        
+        gate.on_wake_word_detected()
+        assert gate.mode == ListeningMode.ENGAGED
+        
+        # Wait for timeout
+        time.sleep(1.2)
+        
+        assert gate.mode == ListeningMode.WAKEWORD_ONLY
+    
+    def test_job_started_transitions_task_running(self, gate):
+        """Test job start transitions to TASK_RUNNING."""
+        from bantz.voice.attention_gate import ListeningMode
+        
+        gate.on_wake_word_detected()  # First go to ENGAGED
+        gate.on_job_started("job-123")
+        
+        assert gate.mode == ListeningMode.TASK_RUNNING
+        assert gate.get_current_job_id() == "job-123"
+    
+    def test_job_completed_returns_engaged(self, gate):
+        """Test job completion returns to ENGAGED."""
+        from bantz.voice.attention_gate import ListeningMode
+        
+        gate.on_wake_word_detected()
+        gate.on_job_started("job-123")
+        gate.on_job_completed("job-123")
+        
+        assert gate.mode == ListeningMode.ENGAGED
+        assert gate.get_current_job_id() is None
+    
+    def test_should_process_true_in_engaged(self, gate):
+        """Test should_process_speech is True in ENGAGED mode."""
+        gate.on_wake_word_detected()
+        
+        assert gate.should_process_speech() == True
+    
+    def test_should_process_false_in_task_running(self, gate):
+        """Test should_process_speech is False in TASK_RUNNING mode."""
+        gate.on_wake_word_detected()
+        gate.on_job_started("job-123")
+        
+        assert gate.should_process_speech() == False
+    
+    def test_should_interrupt_on_wake_during_task(self, gate):
+        """Test interrupt flag set on wake word during TASK_RUNNING."""
+        gate.on_wake_word_detected()
+        gate.on_job_started("job-123")
+        
+        # Wake word during task
+        gate.on_wake_word_detected()
+        
+        assert gate.should_interrupt() == True
+        # Flag should be cleared after check
+        assert gate.should_interrupt() == False
+
+
+class TestAttentionGateFactory:
+    """Tests for create_attention_gate factory."""
+    
+    def test_factory_creates_gate(self):
+        """Test factory function creates AttentionGate."""
+        from bantz.voice.attention_gate import create_attention_gate, AttentionGate
+        
+        with patch('bantz.voice.attention_gate.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            gate = create_attention_gate(engaged_timeout=10.0)
+            
+            assert isinstance(gate, AttentionGate)

--- a/tests/test_engaged_window.py
+++ b/tests/test_engaged_window.py
@@ -1,0 +1,205 @@
+"""
+Tests for EngagedWindowManager (Issue #35 - Voice-2).
+
+Tests:
+- Window start/close
+- Timeout behavior
+- Extension on speech
+- Max timeout limit
+- Remaining time tracking
+
+Uses mock time and threading.Timer to avoid real delays in tests.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+
+class TestEngagedWindowConfig:
+    """Tests for EngagedWindowConfig."""
+    
+    def test_config_defaults(self):
+        """Test default configuration values."""
+        from bantz.voice.engaged_window import EngagedWindowConfig
+        
+        config = EngagedWindowConfig()
+        
+        assert config.min_timeout == 10.0
+        assert config.max_timeout == 20.0
+        assert config.default_timeout == 15.0
+        assert config.extension_amount == 5.0
+
+
+class TestEngagedWindowManager:
+    """Tests for EngagedWindowManager class."""
+    
+    @pytest.fixture
+    def mock_time(self):
+        """Mock time module."""
+        with patch('bantz.voice.engaged_window.time') as m:
+            m.time.return_value = 1000.0
+            yield m
+    
+    @pytest.fixture
+    def mock_threading(self):
+        """Mock threading.Timer to avoid real timers."""
+        with patch('bantz.voice.engaged_window.threading') as m:
+            mock_timer = MagicMock()
+            m.Timer.return_value = mock_timer
+            m.Lock.return_value = MagicMock()
+            yield m
+    
+    @pytest.fixture
+    def window(self, mock_time, mock_threading):
+        """Create EngagedWindowManager for testing."""
+        from bantz.voice.engaged_window import EngagedWindowManager
+        
+        return EngagedWindowManager(
+            min_timeout=10.0,
+            max_timeout=20.0,
+            default_timeout=15.0
+        )
+    
+    def test_window_starts_with_default(self, window, mock_time):
+        """Test window starts with default timeout."""
+        window.start_window()
+        
+        assert window._start_time == 1000.0
+        assert window._current_timeout == 15.0
+    
+    def test_window_is_active_before_timeout(self, window, mock_time):
+        """Test window is active before timeout."""
+        window.start_window()
+        
+        # 5 seconds later (before 15s timeout)
+        mock_time.time.return_value = 1005.0
+        assert window.is_active == True
+    
+    def test_window_expires_after_timeout(self, window, mock_time):
+        """Test window expires after timeout."""
+        window.start_window()
+        
+        # 20 seconds later (after 15s timeout)
+        mock_time.time.return_value = 1020.0
+        assert window.is_active == False
+    
+    def test_window_extends_on_speech(self, window, mock_time):
+        """Test window extends on user speech."""
+        window.start_window()
+        
+        initial_timeout = window._current_timeout
+        window.on_user_speech()
+        
+        # Should have extended (capped at max 20.0)
+        assert window._current_timeout == min(initial_timeout + 5.0, 20.0)
+    
+    def test_window_respects_max(self, window, mock_time):
+        """Test window respects max timeout."""
+        window.start_window(timeout=50.0)  # Try to exceed max
+        
+        assert window._current_timeout <= 20.0
+    
+    def test_window_respects_min(self, window, mock_time):
+        """Test window respects min timeout."""
+        window.start_window(timeout=1.0)  # Try below min
+        
+        assert window._current_timeout >= 10.0
+    
+    def test_window_close_immediate(self, window, mock_time):
+        """Test close_window immediately deactivates."""
+        window.start_window()
+        assert window._start_time == 1000.0
+        
+        window.close_window()
+        
+        assert window._start_time is None
+    
+    def test_remaining_time_decreases(self, window, mock_time):
+        """Test remaining_time decreases over time."""
+        window.start_window()
+        initial_remaining = window.remaining_time
+        
+        mock_time.time.return_value = 1005.0
+        assert window.remaining_time == initial_remaining - 5.0
+    
+    def test_remaining_time_zero_when_inactive(self, mock_time, mock_threading):
+        """Test remaining_time is 0 when inactive."""
+        from bantz.voice.engaged_window import EngagedWindowManager
+        
+        window = EngagedWindowManager(
+            min_timeout=10.0,
+            max_timeout=20.0,
+            default_timeout=15.0
+        )
+        assert window.remaining_time == 0.0
+    
+    def test_elapsed_time_increases(self, window, mock_time):
+        """Test elapsed_time increases over time."""
+        window.start_window()
+        assert window.elapsed_time == 0.0
+        
+        mock_time.time.return_value = 1007.0
+        assert window.elapsed_time == 7.0
+    
+    def test_get_stats(self, window, mock_time):
+        """Test get_stats returns dict."""
+        window.start_window()
+        stats = window.get_stats()
+        
+        assert "is_active" in stats
+        assert "remaining_time" in stats
+        assert "elapsed_time" in stats
+        assert "current_timeout" in stats
+        assert "min_timeout" in stats
+        assert "max_timeout" in stats
+
+
+class TestEngagedWindowFactory:
+    """Tests for create_engaged_window factory."""
+    
+    @pytest.fixture
+    def mock_time(self):
+        """Mock time module."""
+        with patch('bantz.voice.engaged_window.time') as m:
+            m.time.return_value = 1000.0
+            yield m
+    
+    @pytest.fixture
+    def mock_threading(self):
+        """Mock threading.Timer to avoid real timers."""
+        with patch('bantz.voice.engaged_window.threading') as m:
+            mock_timer = MagicMock()
+            m.Timer.return_value = mock_timer
+            m.Lock.return_value = MagicMock()
+            yield m
+    
+    def test_factory_creates_window(self, mock_time, mock_threading):
+        """Test factory function creates EngagedWindowManager."""
+        from bantz.voice.engaged_window import create_engaged_window, EngagedWindowManager
+        
+        window = create_engaged_window(
+            min_timeout=5.0,
+            max_timeout=15.0,
+            default_timeout=10.0
+        )
+        
+        assert isinstance(window, EngagedWindowManager)
+    
+    def test_factory_with_callback(self, mock_time, mock_threading):
+        """Test factory with on_expired callback."""
+        from bantz.voice.engaged_window import create_engaged_window
+        
+        callback = Mock()
+        window = create_engaged_window(
+            min_timeout=10.0,
+            max_timeout=20.0,
+            default_timeout=15.0,
+            on_expired=callback
+        )
+        
+        window.start_window()
+        
+        # After timeout
+        mock_time.time.return_value = 1020.0
+        # Window should be inactive
+        assert window.is_active == False

--- a/tests/test_interrupt_handler.py
+++ b/tests/test_interrupt_handler.py
@@ -1,0 +1,153 @@
+"""
+Tests for InterruptHandler (Issue #35 - Voice-2).
+
+Tests:
+- InterruptAction enum
+- Handle interrupt stops TTS
+- Handle interrupt pauses job
+- Resume paused job
+- Acknowledgment phrase
+"""
+
+import pytest
+import asyncio
+from unittest.mock import Mock, MagicMock, AsyncMock, patch
+
+
+class TestInterruptAction:
+    """Tests for InterruptAction enum."""
+    
+    def test_interrupt_actions_exist(self):
+        """Test that all required actions exist."""
+        from bantz.voice.interrupt_handler import InterruptAction
+        
+        assert hasattr(InterruptAction, 'PAUSE_AND_LISTEN')
+        assert hasattr(InterruptAction, 'CANCEL_AND_LISTEN')
+        assert hasattr(InterruptAction, 'IGNORE')
+    
+    def test_interrupt_actions_unique(self):
+        """Test action values are unique."""
+        from bantz.voice.interrupt_handler import InterruptAction
+        
+        values = [a.value for a in InterruptAction]
+        assert len(values) == len(set(values))
+
+
+class TestInterruptResult:
+    """Tests for InterruptResult dataclass."""
+    
+    def test_result_creation(self):
+        """Test InterruptResult can be created."""
+        from bantz.voice.interrupt_handler import InterruptResult, InterruptAction
+        
+        result = InterruptResult(
+            action=InterruptAction.PAUSE_AND_LISTEN,
+            paused_job_id="job-123"
+        )
+        
+        assert result.action == InterruptAction.PAUSE_AND_LISTEN
+        assert result.paused_job_id == "job-123"
+        assert result.new_command is None
+        assert result.error is None
+
+
+class TestInterruptHandler:
+    """Tests for InterruptHandler class."""
+    
+    @pytest.fixture
+    def handler(self):
+        """Create InterruptHandler for testing."""
+        from bantz.voice.interrupt_handler import InterruptHandler
+        
+        mock_job_manager = Mock()
+        mock_job_manager.pause_job.return_value = True
+        mock_job_manager.resume_job.return_value = True
+        mock_job_manager.cancel_job.return_value = True
+        
+        mock_tts = Mock()
+        mock_tts.stop = AsyncMock()
+        mock_tts.speak = AsyncMock()
+        
+        with patch('bantz.voice.interrupt_handler.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            return InterruptHandler(
+                job_manager=mock_job_manager,
+                tts_controller=mock_tts,
+                acknowledgment="Efendim"
+            )
+    
+    def test_handler_acknowledgment(self, handler):
+        """Test handler has correct acknowledgment."""
+        assert handler._acknowledgment == "Efendim"
+    
+    def test_is_resume_command_devam(self, handler):
+        """Test 'devam et' is recognized as resume command."""
+        assert handler.is_resume_command("devam et") == True
+        assert handler.is_resume_command("devam") == True
+        assert handler.is_resume_command("continue") == True
+        assert handler.is_resume_command("resume") == True
+    
+    def test_is_resume_command_other(self, handler):
+        """Test other commands are not resume commands."""
+        assert handler.is_resume_command("iptal") == False
+        assert handler.is_resume_command("bekle") == False
+    
+    @pytest.mark.asyncio
+    async def test_handle_interrupt_pauses_job(self, handler):
+        """Test handle_interrupt pauses the current job."""
+        from bantz.voice.interrupt_handler import InterruptAction
+        
+        result = await handler.handle_interrupt("job-123")
+        
+        assert result.action == InterruptAction.PAUSE_AND_LISTEN
+        assert result.paused_job_id == "job-123"
+        handler._job_manager.pause_job.assert_called_once_with("job-123")
+    
+    @pytest.mark.asyncio
+    async def test_handle_interrupt_stops_tts(self, handler):
+        """Test handle_interrupt stops TTS."""
+        await handler.handle_interrupt("job-123")
+        
+        handler._tts_controller.stop.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_handle_interrupt_says_acknowledgment(self, handler):
+        """Test handle_interrupt says acknowledgment."""
+        await handler.handle_interrupt("job-123")
+        
+        handler._tts_controller.speak.assert_called_once_with("Efendim")
+    
+    @pytest.mark.asyncio
+    async def test_resume_paused_job(self, handler):
+        """Test resume_paused_job works."""
+        # First pause
+        await handler.handle_interrupt("job-123")
+        
+        # Then resume
+        success = await handler.resume_paused_job("job-123")
+        
+        assert success == True
+        handler._job_manager.resume_job.assert_called_once_with("job-123")
+    
+    def test_get_paused_jobs(self, handler):
+        """Test get_paused_jobs returns list."""
+        paused = handler.get_paused_jobs()
+        
+        assert isinstance(paused, list)
+
+
+class TestInterruptHandlerFactory:
+    """Tests for create_interrupt_handler factory."""
+    
+    def test_factory_creates_handler(self):
+        """Test factory function creates InterruptHandler."""
+        from bantz.voice.interrupt_handler import create_interrupt_handler, InterruptHandler
+        
+        with patch('bantz.voice.interrupt_handler.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            handler = create_interrupt_handler(
+                acknowledgment="Evet efendim"
+            )
+            
+            assert isinstance(handler, InterruptHandler)
+            assert handler._acknowledgment == "Evet efendim"

--- a/tests/test_task_policy.py
+++ b/tests/test_task_policy.py
@@ -1,0 +1,189 @@
+"""
+Tests for TaskListeningPolicy (Issue #35 - Voice-2).
+
+Tests:
+- Allowed intents during task
+- Rejection message
+- Intent classification
+- Job control intent detection
+"""
+
+import pytest
+from unittest.mock import Mock
+
+
+class TestTaskListeningPolicy:
+    """Tests for TaskListeningPolicy class."""
+    
+    @pytest.fixture
+    def policy(self):
+        """Create TaskListeningPolicy for testing."""
+        from bantz.voice.task_policy import TaskListeningPolicy
+        return TaskListeningPolicy()
+    
+    def test_policy_accepts_pause(self, policy):
+        """Test policy accepts job_pause intent."""
+        assert policy.should_accept("job_pause") == True
+    
+    def test_policy_accepts_resume(self, policy):
+        """Test policy accepts job_resume intent."""
+        assert policy.should_accept("job_resume") == True
+    
+    def test_policy_accepts_cancel(self, policy):
+        """Test policy accepts job_cancel intent."""
+        assert policy.should_accept("job_cancel") == True
+    
+    def test_policy_accepts_interrupt(self, policy):
+        """Test policy accepts interrupt intent."""
+        assert policy.should_accept("interrupt") == True
+    
+    def test_policy_accepts_status(self, policy):
+        """Test policy accepts status intent."""
+        assert policy.should_accept("status") == True
+    
+    def test_policy_rejects_other(self, policy):
+        """Test policy rejects other intents."""
+        assert policy.should_accept("search") == False
+        assert policy.should_accept("open_app") == False
+        assert policy.should_accept("navigate") == False
+    
+    def test_policy_rejection_message(self, policy):
+        """Test rejection message is Turkish."""
+        message = policy.get_rejection_message()
+        
+        assert "görev çalışıyor" in message
+        assert len(message) > 10
+    
+    def test_is_job_control_intent(self, policy):
+        """Test is_job_control_intent identifies job commands."""
+        assert policy.is_job_control_intent("job_pause") == True
+        assert policy.is_job_control_intent("job_resume") == True
+        assert policy.is_job_control_intent("job_cancel") == True
+        assert policy.is_job_control_intent("search") == False
+    
+    def test_get_intent_action(self, policy):
+        """Test get_intent_action returns correct actions."""
+        assert policy.get_intent_action("job_pause") == "pause"
+        assert policy.get_intent_action("job_resume") == "resume"
+        assert policy.get_intent_action("job_cancel") == "cancel"
+        assert policy.get_intent_action("interrupt") == "interrupt"
+        assert policy.get_intent_action("unknown") is None
+    
+    def test_add_allowed_intent(self, policy):
+        """Test adding custom allowed intent."""
+        assert policy.should_accept("custom_intent") == False
+        
+        policy.add_allowed_intent("custom_intent")
+        
+        assert policy.should_accept("custom_intent") == True
+    
+    def test_remove_allowed_intent(self, policy):
+        """Test removing allowed intent."""
+        assert policy.should_accept("status") == True
+        
+        policy.remove_allowed_intent("status")
+        
+        assert policy.should_accept("status") == False
+    
+    def test_get_allowed_intents(self, policy):
+        """Test get_allowed_intents returns set."""
+        intents = policy.get_allowed_intents()
+        
+        assert isinstance(intents, set)
+        assert "job_pause" in intents
+        assert "job_resume" in intents
+    
+    def test_custom_rejection_message(self):
+        """Test custom rejection message."""
+        from bantz.voice.task_policy import TaskListeningPolicy
+        
+        policy = TaskListeningPolicy(
+            rejection_message="Custom rejection"
+        )
+        
+        assert policy.get_rejection_message() == "Custom rejection"
+
+
+class TestIntentKeywords:
+    """Tests for intent keyword mapping."""
+    
+    def test_intent_keywords_defined(self):
+        """Test INTENT_KEYWORDS is defined with expected intents."""
+        from bantz.voice.task_policy import INTENT_KEYWORDS
+        
+        assert "job_pause" in INTENT_KEYWORDS
+        assert "job_resume" in INTENT_KEYWORDS
+        assert "job_cancel" in INTENT_KEYWORDS
+    
+    def test_pause_keywords(self):
+        """Test pause keywords include Turkish."""
+        from bantz.voice.task_policy import INTENT_KEYWORDS
+        
+        keywords = INTENT_KEYWORDS["job_pause"]
+        
+        assert "bekle" in keywords
+        assert "dur" in keywords
+        assert "pause" in keywords
+    
+    def test_resume_keywords(self):
+        """Test resume keywords include Turkish."""
+        from bantz.voice.task_policy import INTENT_KEYWORDS
+        
+        keywords = INTENT_KEYWORDS["job_resume"]
+        
+        assert "devam et" in keywords
+        assert "devam" in keywords
+
+
+class TestClassifyTaskCommand:
+    """Tests for classify_task_command function."""
+    
+    def test_classify_bekle(self):
+        """Test classifying 'bekle' as job_pause."""
+        from bantz.voice.task_policy import classify_task_command
+        
+        assert classify_task_command("bekle") == "job_pause"
+        assert classify_task_command("Bekle!") == "job_pause"
+    
+    def test_classify_devam(self):
+        """Test classifying 'devam et' as job_resume."""
+        from bantz.voice.task_policy import classify_task_command
+        
+        assert classify_task_command("devam et") == "job_resume"
+        assert classify_task_command("devam") == "job_resume"
+    
+    def test_classify_iptal(self):
+        """Test classifying 'iptal' as job_cancel."""
+        from bantz.voice.task_policy import classify_task_command
+        
+        assert classify_task_command("iptal") == "job_cancel"
+        assert classify_task_command("vazgeç") == "job_cancel"
+    
+    def test_classify_unknown(self):
+        """Test classifying unknown command returns None."""
+        from bantz.voice.task_policy import classify_task_command
+        
+        assert classify_task_command("random text") is None
+
+
+class TestTaskPolicyFactory:
+    """Tests for create_task_policy factory."""
+    
+    def test_factory_creates_policy(self):
+        """Test factory function creates TaskListeningPolicy."""
+        from bantz.voice.task_policy import create_task_policy, TaskListeningPolicy
+        
+        policy = create_task_policy()
+        
+        assert isinstance(policy, TaskListeningPolicy)
+    
+    def test_factory_with_custom_intents(self):
+        """Test factory with custom allowed intents."""
+        from bantz.voice.task_policy import create_task_policy
+        
+        policy = create_task_policy(
+            allowed_intents=["custom1", "custom2"]
+        )
+        
+        assert policy.should_accept("custom1") == True
+        assert policy.should_accept("job_pause") == False

--- a/tests/test_voice_loop_gate.py
+++ b/tests/test_voice_loop_gate.py
@@ -1,0 +1,181 @@
+"""
+Tests for Voice Loop AttentionGate Integration (Issue #35 - Voice-2).
+
+Tests:
+- AttentionGate integration with voice loop
+- Gate check before processing
+- Interrupt handling flow
+- Engaged window extension on speech
+"""
+
+import pytest
+from unittest.mock import Mock, MagicMock, patch, AsyncMock
+
+
+class TestVoiceLoopGateIntegration:
+    """Tests for AttentionGate integration with VoiceLoop."""
+    
+    def test_attention_gate_import(self):
+        """Test AttentionGate can be imported from voice module."""
+        from bantz.voice import AttentionGate, ListeningMode
+        
+        assert AttentionGate is not None
+        assert ListeningMode is not None
+    
+    def test_listening_mode_values(self):
+        """Test ListeningMode has expected values."""
+        from bantz.voice import ListeningMode
+        
+        assert ListeningMode.IDLE.value == "idle"
+        assert ListeningMode.WAKEWORD_ONLY.value == "wakeword_only"
+        assert ListeningMode.ENGAGED.value == "engaged"
+        assert ListeningMode.TASK_RUNNING.value == "task_running"
+    
+    def test_gate_respects_wakeword_only_mode(self):
+        """Test gate blocks speech in WAKEWORD_ONLY mode."""
+        from bantz.voice.attention_gate import AttentionGate
+        
+        with patch('bantz.voice.attention_gate.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            gate = AttentionGate()
+            
+            # Default is WAKEWORD_ONLY
+            assert gate.should_process_speech() == False
+    
+    def test_gate_allows_speech_in_engaged_mode(self):
+        """Test gate allows speech in ENGAGED mode."""
+        from bantz.voice.attention_gate import AttentionGate
+        
+        with patch('bantz.voice.attention_gate.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            gate = AttentionGate()
+            
+            gate.on_wake_word_detected()
+            
+            assert gate.should_process_speech() == True
+    
+    def test_gate_blocks_speech_in_task_running(self):
+        """Test gate blocks normal speech in TASK_RUNNING mode."""
+        from bantz.voice.attention_gate import AttentionGate
+        
+        with patch('bantz.voice.attention_gate.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            gate = AttentionGate()
+            
+            gate.on_wake_word_detected()
+            gate.on_job_started("job-123")
+            
+            assert gate.should_process_speech() == False
+    
+    def test_gate_interrupt_during_task(self):
+        """Test interrupt detection during TASK_RUNNING."""
+        from bantz.voice.attention_gate import AttentionGate
+        
+        with patch('bantz.voice.attention_gate.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            gate = AttentionGate()
+            
+            gate.on_wake_word_detected()
+            gate.on_job_started("job-123")
+            
+            # No interrupt yet
+            assert gate.should_interrupt() == False
+            
+            # Wake word during task
+            gate.on_wake_word_detected()
+            
+            # Now should interrupt
+            assert gate.should_interrupt() == True
+
+
+class TestVoiceLoopEngagedWindow:
+    """Tests for engaged window behavior in voice loop."""
+    
+    def test_engaged_window_import(self):
+        """Test EngagedWindowManager can be imported."""
+        from bantz.voice import EngagedWindowManager
+        
+        assert EngagedWindowManager is not None
+    
+    def test_window_extends_on_speech(self):
+        """Test window extends when user speaks."""
+        from bantz.voice.engaged_window import EngagedWindowManager
+        from unittest.mock import MagicMock
+        
+        with patch('bantz.voice.engaged_window.time') as mock_time, \
+             patch('bantz.voice.engaged_window.threading') as mock_threading:
+            mock_time.time.return_value = 1000.0
+            mock_timer = MagicMock()
+            mock_threading.Timer.return_value = mock_timer
+            mock_threading.Lock.return_value = MagicMock()
+            
+            window = EngagedWindowManager(
+                min_timeout=1.0,
+                max_timeout=3.0,
+                default_timeout=1.5
+            )
+            
+            window.start_window()
+            initial_timeout = window._current_timeout
+            
+            window.on_user_speech()
+            
+            # Should have extended (by 5.0 or capped at max 3.0)
+            assert window._current_timeout == min(initial_timeout + 5.0, 3.0)
+
+
+class TestVoiceLoopInterrupt:
+    """Tests for interrupt handling in voice loop."""
+    
+    def test_interrupt_handler_import(self):
+        """Test InterruptHandler can be imported."""
+        from bantz.voice import InterruptHandler, InterruptAction
+        
+        assert InterruptHandler is not None
+        assert InterruptAction is not None
+    
+    @pytest.mark.asyncio
+    async def test_interrupt_returns_result(self):
+        """Test interrupt handler returns proper result."""
+        from bantz.voice.interrupt_handler import InterruptHandler, InterruptAction
+        
+        mock_job_manager = Mock()
+        mock_job_manager.pause_job.return_value = True
+        
+        mock_tts = Mock()
+        mock_tts.stop = AsyncMock()
+        mock_tts.speak = AsyncMock()
+        
+        with patch('bantz.voice.interrupt_handler.get_event_bus') as mock_bus:
+            mock_bus.return_value = Mock()
+            handler = InterruptHandler(
+                job_manager=mock_job_manager,
+                tts_controller=mock_tts
+            )
+            
+            result = await handler.handle_interrupt("job-123")
+            
+            assert result.action == InterruptAction.PAUSE_AND_LISTEN
+            assert result.paused_job_id == "job-123"
+
+
+class TestVoiceLoopTaskPolicy:
+    """Tests for task policy in voice loop."""
+    
+    def test_task_policy_import(self):
+        """Test TaskListeningPolicy can be imported."""
+        from bantz.voice import TaskListeningPolicy
+        
+        assert TaskListeningPolicy is not None
+    
+    def test_policy_filters_commands(self):
+        """Test policy filters commands during task."""
+        from bantz.voice.task_policy import TaskListeningPolicy
+        
+        policy = TaskListeningPolicy()
+        
+        # Job control allowed
+        assert policy.should_accept("job_pause") == True
+        
+        # Other commands blocked
+        assert policy.should_accept("open_app") == False


### PR DESCRIPTION
## Voice-2: Attention Gate (wakeword-only during tasks + pause/resume)

### Summary
Implements Issue #35: Voice attention control system with state machine for managing when the voice system should listen.

### Components Added

#### 1. AttentionGate (`attention_gate.py`)
- State machine with modes: IDLE → WAKEWORD_ONLY → ENGAGED → TASK_RUNNING
- Event-driven transitions via EventBus
- Timeout-based return to WAKEWORD_ONLY from ENGAGED

#### 2. EngagedWindowManager (`engaged_window.py`)
- Configurable follow-up window (10-20 seconds)
- Auto-extend on user speech
- Expiry callbacks for cleanup

#### 3. InterruptHandler (`interrupt_handler.py`)
- Handles interrupts during task execution
- Stops TTS, pauses job, says 'Efendim'
- Resume with 'devam et', 'devam', 'continue', 'resume'

#### 4. TaskListeningPolicy (`task_policy.py`)
- Filters allowed intents during TASK_RUNNING
- Default allowed: job_pause, job_resume, job_cancel, interrupt, status, help
- Turkish rejection message

### Test Coverage
| File | Tests |
|------|-------|
| test_attention_gate.py | 14 |
| test_engaged_window.py | 14 |
| test_interrupt_handler.py | 12 |
| test_task_policy.py | 22 |
| test_voice_loop_gate.py | 12 |
| **Total** | **74** |

### Changes
- 12 files changed, 2078 insertions(+)
- All 74 new tests passing

Closes #35