### PR TITLE
[LLM-First] ToolRegistry -> deterministic JSON schema catalog

### DIFF
--- a/src/bantz/agent/tools.py
+++ b/src/bantz/agent/tools.py
@@ -1,10 +1,39 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Literal
 
 
 JsonSchema = dict[str, Any]
+
+RiskLevel = Literal["LOW", "MED", "HIGH"]
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Standard tool spec for LLM prompting (Issue #85)."""
+
+    name: str
+    description: str
+    args_schema: JsonSchema
+    returns_schema: Optional[JsonSchema] = None
+    risk_level: RiskLevel = "LOW"
+    requires_confirmation: bool = False
+    examples: Optional[list[dict[str, Any]]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "args_schema": self.args_schema,
+            "risk_level": self.risk_level,
+            "requires_confirmation": bool(self.requires_confirmation),
+        }
+        if self.returns_schema is not None:
+            out["returns_schema"] = self.returns_schema
+        if self.examples is not None:
+            out["examples"] = self.examples
+        return out
 
 
 @dataclass(frozen=True)
@@ -17,6 +46,9 @@ class Tool:
     name: str
     description: str
     parameters: JsonSchema
+    returns_schema: Optional[JsonSchema] = None
+    risk_level: Optional[RiskLevel] = None
+    examples: Optional[list[dict[str, Any]]] = None
     function: Optional[Callable[..., Any]] = None
     requires_confirmation: bool = False
 
@@ -36,15 +68,74 @@ class ToolRegistry:
 
     def as_schema(self) -> list[dict[str, Any]]:
         """Return a JSON-serializable schema list for prompting."""
+        # Backward-compatible legacy schema (kept for existing prompts/callers).
         return [
             {
-                "name": t.name,
-                "description": t.description,
-                "parameters": t.parameters,
-                "requires_confirmation": bool(t.requires_confirmation),
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+                "requires_confirmation": bool(tool.requires_confirmation),
             }
-            for t in self._tools.values()
+            for tool in (self._tools[name] for name in self.names())
         ]
+
+    def as_llm_catalog(
+        self, *, format: Literal["short", "long"] = "short"
+    ) -> list[dict[str, Any]]:
+        """Export a deterministic tool catalog for LLM use (Issue #85).
+
+        - `format="short"`: token-budget friendly, minimized schemas.
+        - `format="long"`: full schemas + optional examples/returns.
+        """
+
+        catalog: list[dict[str, Any]] = []
+        for name in self.names():
+            tool = self._tools[name]
+
+            risk_level: RiskLevel
+            if tool.risk_level is not None:
+                risk_level = tool.risk_level
+            else:
+                risk_level = "HIGH" if tool.requires_confirmation else "LOW"
+
+            args_schema = _normalize_schema(tool.parameters or {})
+            returns_schema = (
+                _normalize_schema(tool.returns_schema) if tool.returns_schema else None
+            )
+
+            if format == "short":
+                args_schema = _minimize_schema(args_schema)
+                if returns_schema is not None:
+                    returns_schema = _minimize_schema(returns_schema)
+
+            spec = ToolSpec(
+                name=tool.name,
+                description=tool.description,
+                args_schema=args_schema,
+                returns_schema=returns_schema,
+                risk_level=risk_level,
+                requires_confirmation=bool(tool.requires_confirmation),
+                examples=tool.examples if (format == "long") else None,
+            )
+            catalog.append(_normalize_schema(spec.to_dict()))
+
+        return catalog
+
+    def as_json_schema(
+        self, *, format: Literal["short", "long"] = "short"
+    ) -> dict[str, Any]:
+        """Return a JSON-serializable catalog envelope.
+
+        Note: This is not a JSONSchema meta-schema; it's a stable JSON object
+        containing `tools` with per-tool JSON Schemas.
+        """
+
+        return {
+            "type": "tool_catalog",
+            "version": 1,
+            "format": format,
+            "tools": self.as_llm_catalog(format=format),
+        }
 
     def validate_call(self, name: str, params: dict[str, Any]) -> tuple[bool, str]:
         tool = self.get(name)
@@ -74,3 +165,68 @@ class ToolRegistry:
                 return False, f"bad_type:{key}:expected_boolean"
 
         return True, "ok"
+
+
+def _normalize_schema(schema: Any) -> Any:
+    """Normalize JSON-ish objects for deterministic output.
+
+    - Sort dict keys recursively.
+    - For common schema lists like `required`, sort items.
+    """
+
+    if schema is None:
+        return None
+
+    if isinstance(schema, dict):
+        out: dict[str, Any] = {}
+        for key in sorted(schema.keys(), key=lambda k: str(k)):
+            value = schema[key]
+            if key == "required" and isinstance(value, list):
+                out[key] = sorted([str(v) for v in value])
+                continue
+            out[str(key)] = _normalize_schema(value)
+        return out
+
+    if isinstance(schema, list):
+        return [_normalize_schema(v) for v in schema]
+
+    return schema
+
+
+def _minimize_schema(schema: Any) -> Any:
+    """Minimize a JSON Schema object for token budget.
+
+    Keeps structural fields needed for reliable tool calling.
+    """
+
+    if not isinstance(schema, dict):
+        return schema
+
+    keep_keys = {
+        "type",
+        "properties",
+        "required",
+        "items",
+        "enum",
+        "oneOf",
+        "anyOf",
+        "allOf",
+        "additionalProperties",
+    }
+    minimized: dict[str, Any] = {k: v for k, v in schema.items() if k in keep_keys}
+
+    if "properties" in minimized and isinstance(minimized["properties"], dict):
+        props = minimized["properties"]
+        new_props: dict[str, Any] = {}
+        for k in sorted(props.keys(), key=lambda x: str(x)):
+            new_props[str(k)] = _minimize_schema(props[k])
+        minimized["properties"] = new_props
+
+    if "items" in minimized:
+        minimized["items"] = _minimize_schema(minimized["items"])
+
+    for key in ("oneOf", "anyOf", "allOf"):
+        if key in minimized and isinstance(minimized[key], list):
+            minimized[key] = [_minimize_schema(v) for v in minimized[key]]
+
+    return _normalize_schema(minimized)

--- a/src/bantz/brain/brain_loop.py
+++ b/src/bantz/brain/brain_loop.py
@@ -240,7 +240,7 @@ class BrainLoop:
                     "CALL_TOOL": {"name": "tool_name", "params": {}},
                     "FAIL": {"error": "..."},
                 },
-                "tools": self._tools.as_schema(),
+                "tools": self._tools.as_llm_catalog(format="short"),
                 "policy_summary": _summarize_policy(policy),
                 "session_context": _shorten_jsonable(ctx, max_chars=1200),
                 "conversation_context": _short_conversation(

--- a/tests/test_tool_schema.py
+++ b/tests/test_tool_schema.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from bantz.agent.tools import Tool, ToolRegistry
+
+
+def test_tool_registry_llm_catalog_deterministic_and_formats():
+    tools = ToolRegistry()
+
+    # Register out-of-order to prove deterministic sorting by name.
+    tools.register(
+        Tool(
+            name="b_tool",
+            description="B tool",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "z": {
+                        "type": "string",
+                        "description": "should be stripped in short",
+                    },
+                    "a": {"type": "integer"},
+                },
+                "required": ["z", "a"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {"ok": {"type": "boolean"}},
+            },
+            examples=[{"call": {"z": "x", "a": 1}, "result": {"ok": True}}],
+            requires_confirmation=True,
+        )
+    )
+
+    tools.register(
+        Tool(
+            name="a_tool",
+            description="A tool",
+            parameters={
+                "type": "object",
+                "properties": {"b": {"type": "number"}, "a": {"type": "number"}},
+                "required": ["b", "a"],
+            },
+            risk_level="MED",
+        )
+    )
+
+    short = tools.as_llm_catalog(format="short")
+    long = tools.as_llm_catalog(format="long")
+
+    # Deterministic ordering
+    assert [t["name"] for t in short] == ["a_tool", "b_tool"]
+
+    # Stable required + properties ordering
+    assert short[0]["args_schema"]["required"] == ["a", "b"]
+    assert list(short[0]["args_schema"]["properties"].keys()) == ["a", "b"]
+
+    # Risk defaults and overrides
+    assert short[0]["risk_level"] == "MED"
+    assert short[1]["risk_level"] == "HIGH"  # inferred from requires_confirmation
+
+    # Short format strips examples and schema descriptions
+    assert "examples" not in short[1]
+    assert "description" not in short[1]["args_schema"]["properties"]["z"]
+
+    # Long format includes examples and returns_schema
+    assert "examples" in long[1]
+    assert "returns_schema" in long[1]
+
+    # Wrapper is stable and contains tools
+    envelope = tools.as_json_schema(format="short")
+    assert envelope["type"] == "tool_catalog"
+    assert envelope["version"] == 1
+    assert envelope["format"] == "short"
+    assert envelope["tools"] == short


### PR DESCRIPTION
Implements Issue #85: deterministic LLM-callable tool catalog export with short/long formats.

What changed:
- Add ToolSpec + risk/returns/examples fields to tool definitions.
- Add ToolRegistry.as_llm_catalog(format=short|long) and ToolRegistry.as_json_schema() with stable ordering + schema normalization/minimization.
- Update BrainLoop payload to use the short LLM catalog export.
- Add unit test: tests/test_tool_schema.py (2-tool registry -> expected stable schema).

Acceptance checklist:
- [x] Deterministic/stable schema output (unit test)
- [x] Short/long format supported (unit test)

Closes #85
