### PR TITLE
[Calendar MVP] Add calendar.find_free_slots

### DIFF
--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -491,4 +491,48 @@ def build_default_registry() -> ToolRegistry:
         )
     )
 
+    try:
+        from bantz.google.calendar import find_free_slots as google_calendar_find_free_slots
+    except Exception:  # pragma: no cover
+        google_calendar_find_free_slots = None
+
+    reg.register(
+        Tool(
+            name="calendar.find_free_slots",
+            description="Find free time slots between time_min and time_max for a given duration.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "time_min": {"type": "string", "description": "RFC3339 window start"},
+                    "time_max": {"type": "string", "description": "RFC3339 window end"},
+                    "duration_minutes": {"type": "integer", "description": "Required duration in minutes"},
+                    "suggestions": {"type": "integer", "description": "How many slots to return (default: 3)"},
+                    "calendar_id": {"type": "string", "description": "Calendar ID (default: primary)"},
+                },
+                "required": ["time_min", "time_max", "duration_minutes"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "slots": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "start": {"type": "string"},
+                                "end": {"type": "string"},
+                            },
+                            "required": ["start", "end"],
+                        },
+                    },
+                },
+                "required": ["ok", "slots"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_calendar_find_free_slots,
+        )
+    )
+
     return reg

--- a/tests/test_google_calendar_free_slots.py
+++ b/tests/test_google_calendar_free_slots.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from bantz.google import calendar as cal
+
+
+def test_compute_free_slots_no_events_returns_first_slot():
+    slots = cal._compute_free_slots(
+        events=[],
+        time_min="2026-01-28T18:00:00+03:00",
+        time_max="2026-01-28T22:00:00+03:00",
+        duration_minutes=60,
+        suggestions=3,
+    )
+    assert slots
+    assert slots[0]["start"].startswith("2026-01-28T18:00")
+
+
+def test_compute_free_slots_merges_overlaps_and_finds_gap():
+    events = [
+        {"start": "2026-01-28T18:00:00+03:00", "end": "2026-01-28T18:30:00+03:00"},
+        {"start": "2026-01-28T18:20:00+03:00", "end": "2026-01-28T19:00:00+03:00"},
+        {"start": "2026-01-28T20:00:00+03:00", "end": "2026-01-28T20:30:00+03:00"},
+    ]
+    slots = cal._compute_free_slots(
+        events=events,
+        time_min="2026-01-28T18:00:00+03:00",
+        time_max="2026-01-28T21:00:00+03:00",
+        duration_minutes=30,
+        suggestions=3,
+    )
+    # First free slot is 19:00-19:30
+    assert slots[0]["start"].startswith("2026-01-28T19:00")
+    assert slots[0]["end"].startswith("2026-01-28T19:30")
+
+
+def test_compute_free_slots_all_day_event_blocks_day():
+    events = [
+        {"start": "2026-01-28", "end": "2026-01-29"},
+    ]
+    slots = cal._compute_free_slots(
+        events=events,
+        time_min="2026-01-28T09:00:00+03:00",
+        time_max="2026-01-28T21:00:00+03:00",
+        duration_minutes=30,
+        suggestions=3,
+    )
+    assert slots == []


### PR DESCRIPTION
Adds calendar.find_free_slots (LOW) using list_events + gap extraction. Handles all-day events and overlapping intervals. Full suite: 2787 passed, 1 skipped.