### PR TITLE
Calendar: human hours for free slots + dedupe

### DIFF
--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -507,6 +507,8 @@ def build_default_registry() -> ToolRegistry:
                     "time_max": {"type": "string", "description": "RFC3339 window end"},
                     "duration_minutes": {"type": "integer", "description": "Required duration in minutes"},
                     "suggestions": {"type": "integer", "description": "How many slots to return (default: 3)"},
+                    "preferred_start": {"type": "string", "description": "Preferred day start HH:MM (default: 07:30)"},
+                    "preferred_end": {"type": "string", "description": "Preferred day end HH:MM (default: 22:30; supports 24:00)"},
                     "calendar_id": {"type": "string", "description": "Calendar ID (default: primary)"},
                 },
                 "required": ["time_min", "time_max", "duration_minutes"],

--- a/tests/test_google_calendar_free_slots_human_hours.py
+++ b/tests/test_google_calendar_free_slots_human_hours.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from bantz.google import calendar as cal
+
+
+def test_compute_free_slots_human_hours_blocks_midnight_by_default():
+    slots = cal._compute_free_slots(
+        events=[],
+        time_min="2026-01-29T00:00:00+03:00",
+        time_max="2026-01-29T20:00:00+03:00",
+        duration_minutes=120,
+        suggestions=3,
+    )
+    assert slots
+    assert slots[0]["start"].startswith("2026-01-29T07:30")
+    assert slots[0]["end"].startswith("2026-01-29T09:30")
+
+
+def test_compute_free_slots_human_hours_respects_custom_preferred_window():
+    slots = cal._compute_free_slots(
+        events=[],
+        time_min="2026-01-29T00:00:00+03:00",
+        time_max="2026-01-29T20:00:00+03:00",
+        duration_minutes=60,
+        suggestions=3,
+        preferred_start="10:00",
+        preferred_end="12:00",
+    )
+    assert slots
+    assert slots[0]["start"].startswith("2026-01-29T10:00")
+    assert slots[0]["end"].startswith("2026-01-29T11:00")

--- a/tests/test_google_calendar_list_events_dedupe.py
+++ b/tests/test_google_calendar_list_events_dedupe.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from bantz.google import calendar as cal
+
+
+def test_dedupe_normalized_events_by_id_or_key():
+    events = [
+        {
+            "id": "evt-1",
+            "summary": "Bantz Test",
+            "start": "2026-01-28T18:00:00+03:00",
+            "end": "2026-01-28T19:00:00+03:00",
+        },
+        {
+            "id": "evt-1",
+            "summary": "Bantz Test",
+            "start": "2026-01-28T18:00:00+03:00",
+            "end": "2026-01-28T19:00:00+03:00",
+        },
+        {
+            "id": None,
+            "summary": "Bantz Key",
+            "start": "2026-01-28T20:00:00+03:00",
+            "end": "2026-01-28T20:30:00+03:00",
+        },
+        {
+            "id": None,
+            "summary": "Bantz Key",
+            "start": "2026-01-28T20:00:00+03:00",
+            "end": "2026-01-28T20:30:00+03:00",
+        },
+    ]
+
+    deduped = cal._dedupe_normalized_events(events)
+    assert len(deduped) == 2


### PR DESCRIPTION
P0 Jarvis calendar polish:

- Adds human-hours constraints to calendar.find_free_slots (default 07:30–22:30) via preferred_start/preferred_end params.
- Prevents midnight suggestions (e.g., 00:00–02:00) when searching tomorrow.
- Dedupes list_events output by id when present, else (start,end,summary).
- Updates scripts/demo_calendar_conversation.py to pass preferred_start/preferred_end.