### PR TITLE
Fix calendar demo slot-filling and time parsing

### DIFF
--- a/scripts/demo_calendar_brainloop.py
+++ b/scripts/demo_calendar_brainloop.py
@@ -1,0 +1,681 @@
+from __future__ import annotations
+
+# ruff: noqa: E402
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+# Allow running directly from repo root without an editable install.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from bantz.agent.tools import Tool, ToolRegistry
+from bantz.agent.builtin_tools import build_default_registry
+from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+from bantz.brain.json_repair import RepairLLM, validate_or_repair_action
+from bantz.core.events import Event, EventBus, EventType
+from bantz.llm.ollama_client import LLMMessage, OllamaClient
+from bantz.policy.engine import PolicyEngine
+from bantz.policy.risk_map import RiskMap
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DemoConfig:
+    session_id: str
+    run: bool
+    calendar_id: Optional[str]
+    tz_name: str
+    d: date
+
+
+def _iso_now(tz_name: str) -> str:
+    try:
+        from zoneinfo import ZoneInfo
+
+        tz = ZoneInfo(tz_name)
+        return datetime.now(tz).replace(microsecond=0).isoformat()
+    except Exception:
+        return datetime.now().astimezone().replace(microsecond=0).isoformat()
+
+
+def _normalize_tr(text: str) -> str:
+    t = (text or "").lower()
+    return (
+        t.replace("ç", "c")
+        .replace("ğ", "g")
+        .replace("ı", "i")
+        .replace("ö", "o")
+        .replace("ş", "s")
+        .replace("ü", "u")
+    )
+
+
+def _detect_time_intent(user_text: str) -> Optional[str]:
+    """Return one of: evening|tomorrow|morning|today|None."""
+
+    t = _normalize_tr(user_text)
+    has_evening = "aksam" in t
+    has_tomorrow = "yarin" in t
+    has_morning = "sabah" in t
+    has_today = "bugun" in t
+
+    # Precedence: explicit "yarın akşam" should map to tomorrow window, not tonight.
+    if has_evening and has_tomorrow:
+        return "tomorrow"
+    if has_evening:
+        return "evening"
+    if has_tomorrow:
+        return "tomorrow"
+    if has_morning:
+        return "morning"
+    if has_today:
+        return "today"
+    return None
+
+
+def _mask_params(params: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in (params or {}).items():
+        if isinstance(v, str):
+            vv = v
+            if len(vv) > 120:
+                vv = vv[:119] + "…"
+            out[str(k)] = vv
+        else:
+            out[str(k)] = v
+    return out
+
+
+def _compute_windows(*, now_local: datetime, tzinfo: Any) -> dict[str, dict[str, str]]:
+    tomorrow = now_local.date() + timedelta(days=1)
+    midnight_local = datetime.combine(tomorrow, time(0, 0), tzinfo=tzinfo).replace(microsecond=0)
+
+    today_0730 = datetime.combine(now_local.date(), time(7, 30), tzinfo=tzinfo).replace(microsecond=0)
+    today_1130 = datetime.combine(now_local.date(), time(11, 30), tzinfo=tzinfo).replace(microsecond=0)
+    today_2230 = datetime.combine(now_local.date(), time(22, 30), tzinfo=tzinfo).replace(microsecond=0)
+
+    tomorrow_0730 = datetime.combine(tomorrow, time(7, 30), tzinfo=tzinfo).replace(microsecond=0)
+    tomorrow_1130 = datetime.combine(tomorrow, time(11, 30), tzinfo=tzinfo).replace(microsecond=0)
+    tomorrow_2230 = datetime.combine(tomorrow, time(22, 30), tzinfo=tzinfo).replace(microsecond=0)
+
+    # Avoid past/invalid ranges.
+    today_max = today_2230 if now_local < today_2230 else midnight_local
+
+    if now_local >= today_1130:
+        # It's already past today's morning; expose tomorrow-morning window instead.
+        morning_today_min = tomorrow_0730
+        morning_today_max = tomorrow_1130
+    else:
+        morning_today_min = max(now_local, today_0730)
+        morning_today_max = today_1130
+
+    return {
+        "evening_window": {"time_min": now_local.isoformat(), "time_max": midnight_local.isoformat()},
+        "tomorrow_window": {"time_min": tomorrow_0730.isoformat(), "time_max": tomorrow_2230.isoformat()},
+        "today_window": {"time_min": now_local.isoformat(), "time_max": today_max.isoformat()},
+        "morning_today_window": {"time_min": morning_today_min.isoformat(), "time_max": morning_today_max.isoformat()},
+        "morning_tomorrow_window": {"time_min": tomorrow_0730.isoformat(), "time_max": tomorrow_1130.isoformat()},
+    }
+
+
+def _override_time_params(
+    *,
+    tool_name: str,
+    params: dict[str, Any],
+    user_text: str,
+    session_context: dict[str, Any],
+    debug: bool,
+) -> dict[str, Any]:
+    """Deterministically override time_min/time_max for certain natural-language intents."""
+
+    intent = _detect_time_intent(user_text)
+    if debug:
+        print(f"[debug] intent: {intent or 'none'}", file=sys.stderr)
+
+    if tool_name not in {"calendar.list_events", "calendar.find_free_slots"}:
+        return params
+
+    if intent is None:
+        return params
+
+    windows = session_context or {}
+
+    chosen: Optional[dict[str, str]] = None
+    if intent == "evening":
+        chosen = windows.get("evening_window")
+    elif intent == "tomorrow":
+        chosen = windows.get("tomorrow_window")
+    elif intent == "today":
+        chosen = windows.get("today_window")
+    elif intent == "morning":
+        now_iso = str(windows.get("now_iso") or "")
+        # If it's already past today's morning, default to tomorrow morning.
+        chosen = windows.get("morning_today_window")
+        try:
+            now_dt = datetime.fromisoformat(now_iso.replace("Z", "+00:00")) if now_iso else None
+            if now_dt is not None:
+                today_1130 = windows.get("morning_today_window", {}).get("time_max")
+                if today_1130:
+                    max_dt = datetime.fromisoformat(str(today_1130).replace("Z", "+00:00"))
+                    if now_dt >= max_dt:
+                        chosen = windows.get("morning_tomorrow_window")
+        except Exception:
+            chosen = windows.get("morning_tomorrow_window")
+
+    if not isinstance(chosen, dict):
+        return params
+    tmin = chosen.get("time_min")
+    tmax = chosen.get("time_max")
+    if not isinstance(tmin, str) or not isinstance(tmax, str) or not tmin or not tmax:
+        return params
+
+    original = dict(params)
+    params = dict(params)
+    params["time_min"] = tmin
+    params["time_max"] = tmax
+
+    if tool_name == "calendar.find_free_slots":
+        # Provide human-hour defaults unless the LLM explicitly provided them.
+        params.setdefault("preferred_start", "07:30")
+        params.setdefault("preferred_end", "22:30")
+
+    if debug:
+        print(f"[debug] original params: {json.dumps(_mask_params(original), ensure_ascii=False)}", file=sys.stderr)
+        print(f"[debug] override time_min/time_max: {tmin} .. {tmax}", file=sys.stderr)
+
+    return params
+
+
+def _print_event_stream(ev: Event) -> None:
+    """Pretty, stable-ish event-stream lines for demos."""
+
+    t = str(ev.event_type)
+    data = ev.data or {}
+
+    # Keep output single-line and scannable.
+    if t == EventType.ACK.value:
+        text = str(data.get("text") or "")
+        if text:
+            print(f"ACK: {text}")
+        else:
+            print("ACK")
+        return
+
+    if t == EventType.PROGRESS.value:
+        msg = str(data.get("message") or "")
+        if msg:
+            print(f"PROGRESS: {msg}")
+        else:
+            print("PROGRESS")
+        return
+
+    if t == EventType.FOUND.value:
+        tool = (data.get("tool") or data.get("name") or "").strip()
+        print(f"FOUND: {tool}" if tool else "FOUND")
+        return
+
+    if t == EventType.QUESTION.value:
+        q = str(data.get("question") or "")
+        print(f"QUESTION: {q}" if q else "QUESTION")
+        return
+
+    if t == EventType.RESULT.value:
+        text = str(data.get("text") or data.get("summary") or "")
+        print(f"RESULT: {text}" if text else "RESULT")
+        return
+
+    if t == EventType.ERROR.value:
+        msg = str(data.get("message") or data.get("error") or "")
+        print(f"ERROR: {msg}" if msg else "ERROR")
+        return
+
+    # Fallback: JSON line.
+    print("EVENT", json.dumps(ev.to_dict(), ensure_ascii=False))
+
+
+class OllamaTextLLM(RepairLLM):
+    """Text-only Ollama client used by the JSON repair adapter."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        timeout_seconds: float,
+        temperature: float = 0.2,
+        max_tokens: int = 768,
+    ):
+        self._client = OllamaClient(
+            base_url=base_url,
+            model=model,
+            timeout_seconds=timeout_seconds,
+        )
+        self._temperature = float(temperature)
+        self._max_tokens = int(max_tokens)
+        self.calls = 0
+
+    @property
+    def base_url(self) -> str:
+        return self._client.base_url
+
+    @property
+    def model(self) -> str:
+        return self._client.model
+
+    def is_available(self) -> bool:
+        return self._client.is_available()
+
+    def complete_text(self, *, prompt: str) -> str:
+        self.calls += 1
+        messages = [
+            LLMMessage(
+                role="system",
+                content=(
+                    "Sadece tek bir JSON object döndür. "
+                    "Markdown/backtick/açıklama yazma. "
+                    "JSON dışı hiçbir şey üretme."
+                ),
+            ),
+            LLMMessage(role="user", content=prompt),
+        ]
+        return self._client.chat(
+            messages,
+            temperature=self._temperature,
+            max_tokens=self._max_tokens,
+        )
+
+
+class JarvisRepairingLLMAdapter:
+    """Adapter: free-form LLM -> strict BrainLoop JSON actions with repair.
+
+    This is intentionally verbose in prompting to make the demo feel 'Jarvis-like':
+    - Turkish
+    - time-awareness
+    - proposes options
+    - policy confirmation respected (BrainLoop+PolicyEngine handles gating)
+    """
+
+    def __init__(self, *, llm: RepairLLM, tools: ToolRegistry, max_attempts: int = 2):
+        self._llm = llm
+        self._tools = tools
+        self._max_attempts = max_attempts
+
+    def complete_json(self, *, messages: list[dict[str, str]], schema_hint: str) -> dict[str, Any]:
+        conversation_tail = "\n".join(
+            [
+                f"{m.get('role','')}: {m.get('content','')}"
+                for m in messages[-8:]
+                if isinstance(m, dict)
+            ]
+        )
+
+        jarvis_system = (
+            "Kimlik / roller:\n"
+            "- Sen BANTZ'sın. Kullanıcı USER'dır. Kullanıcının yerine konuşma veya karar verme.\n"
+            "- Tool çıktıları USER mesajı değildir; 'TOOL_OBSERVATION:' satırları sadece araç gözlemidir.\n\n"
+            "Rol: Jarvis-vari bir asistan gibi konuşan Bantz. Türkçe konuş; 'Efendim' hitabını kullan.\n"
+            "Amaç: Kullanıcının takvim sorularını gerçek tool'larla cevapla ve gerektiğinde plan yap.\n\n"
+            "Zaman farkındalığı:\n"
+            "- Kullanıcının yerel saatine göre düşün. `session_context.now_iso` ve `session_context.tz_name` varsa baz al.\n"
+            "- '8'den önce' gibi isteklerde saat geçtiyse bunu açıkça söyle ve alternatifler sun.\n\n"
+            "Anti-hallucination (kritik):\n"
+            "- Tool sonucu olmadan etkinlik/saat/plan uydurma.\n"
+            "- TOOL_OBSERVATION içindeki verilerin dışına çıkma; yoksa 'plan görünmüyor' de.\n\n"
+            "Takvim davranışı (önerilen):\n"
+            "- 'Bu akşam planım var mı?' => calendar.list_events (time_min=şimdi, time_max=gece yarısı).\n"
+            "  Not: SCHEMA_HINT içindeki session_context.evening_window bu değerleri hazır verir.\n"
+            "- Koşu planlama => önce calendar.find_free_slots ile slot ara; human-hours: 07:30–22:30.\n"
+            "- Yarın araması yapıyorsan time_min'i 07:30'dan başlat (00:00 değil).\n"
+            "  Not: SCHEMA_HINT içindeki session_context.tomorrow_window bu değerleri hazır verir.\n"
+            "- Slot bulamazsan seçenek menüsü gibi 2-3 alternatif öner.\n\n"
+            "Tease / sohbet:\n"
+            "- Kullanıcı 'uykuluyum' derse kısa, nazik bir şaka yap; sonra gerçekçi seçenek sun.\n\n"
+            "ASK_USER standardı (kritik):\n"
+            "- Sadece 1 soru sor.\n"
+            "- En fazla 3 seçenek sun; seçenekler 1/2/0 ile numaralı olsun.\n"
+            "- Kullanıcının son mesajını aynen tekrar soru olarak sorma.\n\n"
+            "ÇIKTI FORMATI (kritik):\n"
+            "- Sadece tek bir JSON object döndür; Markdown yok; açıklama yok.\n"
+            "- type ∈ {SAY, CALL_TOOL, ASK_USER, FAIL}.\n"
+            "- SAY => {\"type\":\"SAY\",\"text\":\"...\"}\n"
+            "- ASK_USER => {\"type\":\"ASK_USER\",\"question\":\"...\"}\n"
+            "- CALL_TOOL => {\"type\":\"CALL_TOOL\",\"name\":\"tool\",\"params\":{...}}\n\n"
+            "Kontrol kuralı:\n"
+            "- CONVERSATION_TAIL içinde 'TOOL_OBSERVATION:' varsa, yeni tool çağırma; SAY ile özetle.\n\n"
+            "Mini örnek (few-shot):\n"
+            "USER: Bu akşam planım var mı?\n"
+            "ASSISTANT: {\"type\":\"CALL_TOOL\",\"name\":\"calendar.list_events\",\"params\":{\"time_min\":\"<now>\",\"time_max\":\"<midnight>\"}}\n"
+            "TOOL_OBSERVATION: {\"tool\":\"calendar.list_events\",\"ok\":true,\"result\":{\"count\":0,\"events\":[]}}\n"
+            "ASSISTANT: {\"type\":\"SAY\",\"text\":\"Efendim bu akşam için şu andan sonra bir plan görünmüyor.\"}\n"
+        )
+
+        prompt = (
+            "Görev: Aşağıdaki şemaya uygun şekilde yalnızca tek bir JSON object döndür.\n"
+            "Kurallar: Output sadece JSON object; ekstra alan yok; Markdown yok.\n"
+            "Zorunlu: 'type' alanını birebir kullan. type ∈ {SAY, CALL_TOOL, ASK_USER, FAIL}.\n\n"
+            f"JARVIS_SYSTEM:\n{jarvis_system}\n\n"
+            f"SCHEMA_HINT:\n{schema_hint}\n\n"
+            f"CONVERSATION_TAIL:\n{conversation_tail}\n"
+        )
+
+        raw_text = self._llm.complete_text(prompt=prompt)
+        return validate_or_repair_action(
+            llm=self._llm,
+            raw_text=raw_text,
+            tool_registry=self._tools,
+            max_attempts=self._max_attempts,
+        )
+
+
+def _build_calendar_tools(
+    *,
+    calendar_id: Optional[str],
+    dry_run: bool,
+    runtime: Optional[dict[str, Any]] = None,
+) -> ToolRegistry:
+    full = build_default_registry()
+    wanted = [
+        "calendar.list_events",
+        "calendar.find_free_slots",
+        "calendar.create_event",
+    ]
+
+    tools = ToolRegistry()
+    for name in wanted:
+        t = full.get(name)
+        if t is None:
+            raise RuntimeError(f"Tool not found in default registry: {name}")
+
+        fn = t.function
+
+        # Default calendar_id injection if the tool supports it.
+        def _wrap(fn, *, tool_name: str):
+            def _call(**params):
+                # Deterministic override hook (demo-only): fix LLM window mistakes.
+                if runtime is not None and tool_name in {"calendar.list_events", "calendar.find_free_slots"}:
+                    try:
+                        user_text = str(runtime.get("last_user_text") or "")
+                        session_context = runtime.get("session_context")
+                        if not isinstance(session_context, dict):
+                            session_context = {}
+                        debug = bool(runtime.get("debug"))
+                        params = _override_time_params(
+                            tool_name=tool_name,
+                            params=dict(params),
+                            user_text=user_text,
+                            session_context=session_context,
+                            debug=debug,
+                        )
+                    except Exception:
+                        pass
+
+                # Demo guard: don't allow creating events in the past.
+                if runtime is not None and tool_name == "calendar.create_event":
+                    try:
+                        start_raw = params.get("start")
+                        if isinstance(start_raw, str) and start_raw.strip():
+                            tzinfo = runtime.get("tzinfo")
+                            now_local = datetime.now(tzinfo).replace(microsecond=0)
+                            v = start_raw.strip()
+                            if v.endswith("Z"):
+                                v = v[:-1] + "+00:00"
+                            start_dt = datetime.fromisoformat(v)
+                            if start_dt.tzinfo is None:
+                                start_dt = start_dt.replace(tzinfo=tzinfo)
+                            if start_dt < now_local:
+                                raise ValueError(
+                                    "start_is_in_past (Bugün geçti efendim. Yarın mı, en erken uygun saat mi?)"
+                                )
+                    except Exception as e:
+                        # If parsing fails, let the tool handle validation.
+                        if isinstance(e, ValueError) and str(e).startswith("start_is_in_past"):
+                            raise
+
+                if calendar_id and "calendar_id" not in params:
+                    params["calendar_id"] = calendar_id
+                return fn(**params) if fn is not None else {"ok": False, "error": "tool_not_executable"}
+
+            _call.__name__ = f"wrapped_{tool_name.replace('.', '_')}"
+            return _call
+
+        wrapped_fn = _wrap(fn, tool_name=name) if fn is not None else None
+
+        # Safety: in dry-run, never hit the network for writes.
+        if dry_run and name == "calendar.create_event":
+            def _dry_run_create_event(**params):
+                if calendar_id and "calendar_id" not in params:
+                    params["calendar_id"] = calendar_id
+                return {"ok": True, "dry_run": True, "would_create": dict(params)}
+
+            wrapped_fn = _dry_run_create_event
+
+        tools.register(
+            Tool(
+                name=t.name,
+                description=t.description,
+                parameters=t.parameters,
+                function=wrapped_fn,
+                risk_level=t.risk_level,
+                requires_confirmation=bool(t.requires_confirmation),
+            )
+        )
+
+    return tools
+
+
+def _iter_input_lines() -> Iterable[str]:
+    """Yield user lines from stdin when piped.
+
+    Empty lines are ignored. Lines starting with '#' are ignored.
+    """
+
+    for raw in sys.stdin:
+        line = (raw or "").strip("\n")
+        if not line.strip():
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        yield line.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Jarvis-like BrainLoop Calendar demo (Issue #100)")
+    parser.add_argument("--ollama-url", default="http://127.0.0.1:11434")
+    parser.add_argument("--ollama-model", default="qwen2.5:3b-instruct")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--temperature", type=float, default=0.2)
+    parser.add_argument("--max-tokens", type=int, default=768)
+
+    parser.add_argument("--max-steps", type=int, default=8)
+    parser.add_argument("--debug", action="store_true")
+
+    parser.add_argument("--session", default="demo")
+    parser.add_argument("--calendar-id", default=None)
+    parser.add_argument("--tz", default="Europe/Istanbul")
+    parser.add_argument("--date", default=None, help="Override date YYYY-MM-DD (optional)")
+
+    parser.add_argument("--dry-run", action="store_true", help="Never write; calendar.create_event is stubbed")
+    parser.add_argument("--run", action="store_true", help="Allow real calendar writes (will ask confirmation)")
+
+    # Interactive mode: read from file or pipe (avoids heredoc issues)
+    parser.add_argument("--script", type=str, default=None, help="Read conversation from file (one line per user message)")
+    parser.add_argument("--interactive", action="store_true", help="Force interactive mode even if stdin is piped")
+
+    args = parser.parse_args()
+
+    if args.dry_run and args.run:
+        raise SystemExit("Choose only one: --dry-run or --run")
+
+    run_mode = bool(args.run)
+    dry_run = bool(args.dry_run) or not run_mode
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    tz_name = str(args.tz)
+    d = date.fromisoformat(args.date) if args.date else datetime.now().date()
+
+    try:
+        from zoneinfo import ZoneInfo
+
+        tzinfo = ZoneInfo(tz_name)
+    except Exception:
+        tzinfo = datetime.now().astimezone().tzinfo
+
+    # Runtime state shared with tool wrappers (override hook).
+    runtime: dict[str, Any] = {
+        "debug": bool(args.debug),
+        "tz_name": tz_name,
+        "tzinfo": tzinfo,
+        "last_user_text": "",
+    }
+
+    # Build initial session context (refreshed each turn).
+    now_local = datetime.now(tzinfo).replace(microsecond=0)
+    windows = _compute_windows(now_local=now_local, tzinfo=tzinfo)
+    session_context: dict[str, Any] = {
+        "user": "demo",
+        "now_iso": now_local.isoformat(),
+        "tz_name": tz_name,
+        "date": d.isoformat(),
+        "mode": "calendar_brainloop_demo",
+        "human_hours": {"start": "07:30", "end": "22:30"},
+        "dry_run": bool(dry_run),
+        # Demo-only: render certain tool results deterministically (LLM can't hallucinate them).
+        "deterministic_render": True,
+        **windows,
+    }
+    runtime["session_context"] = session_context
+
+    # Build tools + policy.
+    tools = _build_calendar_tools(calendar_id=args.calendar_id, dry_run=dry_run, runtime=runtime)
+
+    policy = PolicyEngine(
+        risk_map=RiskMap({
+            # Make sure create_event is treated as MED even if tool metadata changes.
+            "calendar.create_event": "MED",
+        })
+    )
+
+    # LLM client.
+    llm = OllamaTextLLM(
+        base_url=args.ollama_url,
+        model=args.ollama_model,
+        timeout_seconds=float(args.timeout),
+        temperature=float(args.temperature),
+        max_tokens=int(args.max_tokens),
+    )
+
+    if not llm.is_available():
+        print(f"Ollama erişilemedi: {llm.base_url}")
+        print("- Başlat: ollama serve")
+        print(f"- Model indir: ollama pull {args.ollama_model}")
+        return 2
+
+    adapter = JarvisRepairingLLMAdapter(llm=llm, tools=tools)
+
+    bus = EventBus()
+    bus.subscribe_all(_print_event_stream)
+
+    loop = BrainLoop(
+        llm=adapter,
+        tools=tools,
+        event_bus=bus,
+        config=BrainLoopConfig(max_steps=int(args.max_steps), debug=bool(args.debug)),
+    )
+
+    # Shared state across turns: keeps policy pending action + session confirmation memory.
+    state: dict[str, Any] = {"session_id": str(args.session)}
+
+    print("BANTZ (BrainLoop): Hazırım efendim.")
+    if dry_run:
+        print("BANTZ (BrainLoop): Not: dry-run modundayım; takvime yazma yapılmaz.")
+
+    # Determine input source: --script file, stdin pipe, or interactive terminal
+    scripted: Optional[Iterable[str]] = None
+    if args.script:
+        # Read from script file
+        try:
+            with open(args.script, encoding="utf-8") as f:
+                lines = [ln.strip() for ln in f if ln.strip() and not ln.strip().startswith("#")]
+            scripted = iter(lines)
+            print(f"BANTZ: Script dosyasından okuyorum: {args.script} ({len(lines)} satır)")
+        except Exception as e:
+            print(f"BANTZ: Script dosyası okunamadı: {e}")
+            return 1
+    elif not sys.stdin.isatty() and not args.interactive:
+        # Stdin is piped and not forced to interactive
+        scripted = iter(_iter_input_lines())
+
+    def _read_user(prompt: str) -> Optional[str]:
+        if scripted is not None:
+            try:
+                line = next(scripted)
+                # Echo scripted input for visibility
+                print(f"{prompt}{line}")
+                return line
+            except StopIteration:
+                return None
+        try:
+            return input(prompt)
+        except EOFError:
+            return None
+
+    while True:
+        user_text = _read_user("USER: ")
+        if user_text is None:
+            # End of scripted input.
+            return 0
+
+        user_text = (user_text or "").strip()
+        if not user_text:
+            continue
+        if user_text.lower() in {"quit", "exit", "çık", "cik"}:
+            print("BANTZ: Görüşürüz efendim.")
+            return 0
+
+        # Refresh time-aware session context each turn.
+        now_local = datetime.now(tzinfo).replace(microsecond=0)
+        session_context["now_iso"] = now_local.isoformat()
+        session_context["date"] = (d.isoformat() if isinstance(d, date) else str(d))
+        windows = _compute_windows(now_local=now_local, tzinfo=tzinfo)
+        session_context.update(windows)
+        runtime["session_context"] = session_context
+        runtime["last_user_text"] = user_text
+
+        result = loop.run(
+            turn_input=user_text,
+            session_context=session_context,
+            policy=policy,
+            context=state,
+        )
+
+        if result.kind == "say":
+            print(f"BANTZ: {result.text}")
+            continue
+
+        if result.kind == "ask_user":
+            print(f"BANTZ: {result.text}")
+            # Next loop iteration will read user input.
+            continue
+
+        # fail
+        print(f"BANTZ: Üzgünüm efendim. {result.text}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spec_voice_and_policy.md
+++ b/spec_voice_and_policy.md
@@ -1,0 +1,81 @@
+# Bantz — Voice & Policy Contract (v1)
+
+Bu doküman, **deterministik çekirdek** (router + state machine + tool guard) ile **Formal‑Friend** persona katmanının ortak anayasasıdır.
+
+## 1) Hitap ve ilişki tonu (değişmez kurallar)
+
+- **Daima sizli‑bizli**: “sen/ben” yok; “siz/biz” var.
+- İlişki: **Jarvis–Tony / Alfred–Bruce**.
+  - Sıcak bir “dost” tonu vardır, ama hiyerarşi nettir.
+  - Saygı çizgisi aşılmaz; iğneleme kişiye değil, duruma/işe olur.
+- Dil: Türkçe, kısa, net, zeki.
+- Emoji: varsayılan **kapalı**.
+- “Efendim”: **maksimum 1 kez / mesaj** (spam yok).
+
+## 2) Çıkış kontratı (LLM protokolü)
+
+Sistem yalnızca şu tipleri üretir:
+
+- `SAY`: Sonucu/yanıtı söyler.
+- `ASK_USER`: Kullanıcıdan seçim ya da eksik slot için soru ister.
+- `CALL_TOOL`: Bir aracı çağırmayı dener.
+- `FAIL`: Hata/uygunsuzluk.
+
+> Not: Deterministik modda (`deterministic_render=true`) `ASK_USER` metni LLM’den gelse bile **BrainLoop menü sahibi**dir.
+
+## 3) Takvime “tam sahiplik” tanımı
+
+Takvime sahip olmak şu yetenekleri kapsar:
+
+1. **Okuma**: "Bugün ne var?", "Bu akşam planım var mı?"
+2. **Boşluk bulma**: "Yarın 30 dk boşluk bulun"
+3. **Yazma/Değiştirme**: "Şunu ekleyin", "Şunu 1 saat ileri alın"
+4. **Akıllı öneri**: "Bugün çok yoğunum → en uygun yere yerleştireyim mi?"
+
+### 3.1 Güvenlik ve onay (değişmez)
+
+- **Yazma / değiştirme / iptal** işlemleri: **onaysız asla**.
+- Onay formatı: tek cümle, net, **`(1/0)`**.
+  - Örnek: `09:00–09:30 "Mola" ekleyeyim mi? (1/0)`
+
+## 4) Persona şablonu (Formal‑Friend)
+
+Her mesaj (özellikle `ASK_USER`) şu düzeni takip eder:
+
+1. Kısa acknowledge
+2. Net aksiyon / menü / tek soru
+3. (Opsiyonel) ince dokundurma (yalnızca low‑risk)
+
+## 5) Deterministik UX kuralları
+
+- **Öncelik sırası**: `PENDING_CONFIRMATION` > `PENDING_MENU` > router.
+- Menü beklerken router devreye girmez.
+- Belirsiz input (“hmm”, “şey”, …):
+  - 1. kez: reprompt
+  - 2. kez: default seçenek uygulanır
+
+## 6) Test kalkanı: metinden bağımsız doğrulama
+
+Persona metni zamanla değişebilir. Bu yüzden testler **metne değil** aşağıdaki standart alanlara dayanır.
+
+### 6.1 BrainResult.metadata standart alanları
+
+- `route`: `smalltalk | unknown | calendar_query | calendar_modify | ...`
+- `state`: durum makinesi durumu (örn. `PENDING_CHOICE`, `PENDING_CONFIRMATION`)
+- `menu_id`: hangi menünün gösterildiği (örn. `smalltalk_stage1`, `free_slots`, `pending_confirmation`, `unknown`)
+- `options`: seçenekler sözlüğü (`{"1": "...", "0": "..."}`)
+- `action_type`: `create_event | list_events | ...`
+- `requires_confirmation`: `true/false`
+- `reprompt_for`: reprompt hangi menu/action için yapıldı
+
+### 6.2 Test ilkeleri
+
+- Menü testleri: `menu_id` + `options` anahtarları üzerinden doğrulanır.
+- Confirmation testleri: `menu_id="pending_confirmation"`, `action_type`, `requires_confirmation` üzerinden doğrulanır.
+- Smalltalk: tool çağrısı yok; yalnızca menü/yanıt.
+
+## 7) Calendar tool güvenliği (özet)
+
+- Deterministik modda calendar dışı route’larda tool çalıştırılmaz.
+- Calendar route’larda dahi allowlist dışı tool adları engellenir.
+- Confirmation gerektiren tüm tool’lar `PENDING_CONFIRMATION` akışına alınır.

--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -577,4 +577,77 @@ def build_default_registry() -> ToolRegistry:
         )
     )
 
+    try:
+        from bantz.google.calendar import delete_event as google_calendar_delete_event
+    except Exception:  # pragma: no cover
+        google_calendar_delete_event = None
+
+    reg.register(
+        Tool(
+            name="calendar.delete_event",
+            description="Delete a calendar event (write). Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "event_id": {"type": "string", "description": "Event ID"},
+                    "calendar_id": {"type": "string", "description": "Calendar ID (default: primary)"},
+                },
+                "required": ["event_id"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "id": {"type": "string"},
+                    "calendar_id": {"type": "string"},
+                },
+                "required": ["ok", "id", "calendar_id"],
+            },
+            risk_level="MED",
+            requires_confirmation=True,
+            function=google_calendar_delete_event,
+        )
+    )
+
+    try:
+        from bantz.google.calendar import update_event as google_calendar_update_event
+    except Exception:  # pragma: no cover
+        google_calendar_update_event = None
+
+    reg.register(
+        Tool(
+            name="calendar.update_event",
+            description="Update/move a calendar event (write). Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "event_id": {"type": "string", "description": "Event ID"},
+                    "start": {"type": "string", "description": "RFC3339 start datetime (with timezone)"},
+                    "end": {"type": "string", "description": "RFC3339 end datetime (with timezone)"},
+                    "summary": {"type": "string", "description": "Optional new summary/title"},
+                    "calendar_id": {"type": "string", "description": "Calendar ID (default: primary)"},
+                    "description": {"type": "string", "description": "Optional description"},
+                    "location": {"type": "string", "description": "Optional location"},
+                },
+                "required": ["event_id", "start", "end"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "id": {"type": "string"},
+                    "htmlLink": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "start": {"type": "string"},
+                    "end": {"type": "string"},
+                    "calendar_id": {"type": "string"},
+                },
+                "required": ["ok", "id", "start", "end", "calendar_id"],
+            },
+            risk_level="MED",
+            requires_confirmation=True,
+            function=google_calendar_update_event,
+        )
+    )
+
     return reg

--- a/src/bantz/brain/calendar_intent.py
+++ b/src/bantz/brain/calendar_intent.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import re
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class CalendarEventRef:
+    kind: str  # index | id
+    index: Optional[int] = None
+    event_id: Optional[str] = None
+    summary: Optional[str] = None
+    start: Optional[str] = None
+    end: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CalendarIntent:
+    type: str
+    params: dict[str, Any]
+    confidence: float
+    missing: list[str]
+    source_text: str
+    event_ref: Optional[CalendarEventRef] = None
+
+
+# Accept common Turkish time separators: 23:50, 23.50, 23,50, 23 50
+_TIME_RE = re.compile(r"\b([01]?\d|2[0-3])\s*[:., ]\s*([0-5]\d)\b")
+_HASH_REF_RE = re.compile(r"#\s*(\d+)\b")
+
+
+def parse_hhmm(text: str) -> Optional[str]:
+    m = _TIME_RE.search(text or "")
+    if not m:
+        return None
+    try:
+        hh = int(m.group(1))
+        mm = int(m.group(2))
+    except Exception:
+        return None
+    if hh < 0 or hh > 23 or mm < 0 or mm > 59:
+        return None
+    return f"{hh:02d}:{mm:02d}"
+
+
+def parse_duration_minutes(text: str) -> Optional[int]:
+    t = (text or "").lower()
+    m = re.search(r"\b(\d{1,3})\s*(dk|dakika)\b", t)
+    if m:
+        try:
+            val = int(m.group(1))
+            return val if 1 <= val <= 24 * 60 else None
+        except Exception:
+            return None
+    if re.search(r"\b1\s*saat\b", t):
+        return 60
+    m = re.search(r"\b(\d{1,2})\s*saat\b", t)
+    if m:
+        try:
+            val = int(m.group(1))
+            mins = val * 60
+            return mins if 1 <= mins <= 24 * 60 else None
+        except Exception:
+            return None
+    return None
+
+
+def parse_offset_minutes(text: str) -> Optional[int]:
+    """Parse offsets like '1 saat ileri', '30 dk geri'."""
+    t = (text or "").lower()
+    sign = None
+    if any(k in t for k in ["ileri", "sonra", "erte", "ertele"]):
+        sign = 1
+    if any(k in t for k in ["geri", "once", "önce"]):
+        sign = -1
+    if sign is None:
+        return None
+
+    m = re.search(r"\b(\d{1,3})\s*(dk|dakika)\b", t)
+    if m:
+        return sign * int(m.group(1))
+
+    m = re.search(r"\b(\d{1,2})\s*saat\b", t)
+    if m:
+        return sign * (int(m.group(1)) * 60)
+
+    if "1 saat" in t:
+        return sign * 60
+
+    return None
+
+
+def parse_day_hint(text: str) -> Optional[str]:
+    t = (text or "").lower()
+    if "bu hafta" in t:
+        return "this_week"
+    if "öbür gün" in t or "obur gun" in t:
+        return "day_after_tomorrow"
+    if "yarın" in t:
+        return "tomorrow"
+    if "bugün" in t:
+        return "today"
+    if "bu sabah" in t or "sabah" in t:
+        return "morning"
+    if "öğleden sonra" in t or "ogleden sonra" in t:
+        return "afternoon"
+    if "bu akşam" in t or "akşam" in t:
+        return "evening"
+    return None
+
+
+def parse_hash_ref_index(text: str) -> Optional[int]:
+    m = _HASH_REF_RE.search(text or "")
+    if not m:
+        return None
+    try:
+        idx = int(m.group(1))
+        return idx if idx > 0 else None
+    except Exception:
+        return None
+
+
+def iso_from_date_hhmm(*, date_iso: str, hhmm: str, offset: str) -> str:
+    base = f"{date_iso}T{hhmm}:00{offset}"
+    # Validate and normalize
+    dt = datetime.fromisoformat(base)
+    return dt.isoformat()
+
+
+def add_minutes(iso_dt: str, minutes: int) -> str:
+    dt = datetime.fromisoformat(iso_dt)
+    return (dt + timedelta(minutes=int(minutes))).isoformat()
+
+
+def add_days_keep_time(iso_dt: str, days: int) -> str:
+    dt = datetime.fromisoformat(iso_dt)
+    return (dt + timedelta(days=int(days))).isoformat()
+
+
+def build_intent(user_text: str) -> CalendarIntent:
+    """Deterministic calendar intent builder (minimal v1).
+
+    This is intentionally conservative: it focuses on clear create/move/cancel/list.
+    Missing fields are returned via `missing`.
+    """
+
+    text = (user_text or "").strip()
+    t = text.lower()
+
+    day_hint = parse_day_hint(text)
+    hhmm = parse_hhmm(text)
+    dur = parse_duration_minutes(text)
+    offset = parse_offset_minutes(text)
+    ref_idx = parse_hash_ref_index(text)
+
+    is_cancel = any(k in t for k in ["iptal", "sil", "kaldır", "kaldirin", "kaldırın"])
+    # Treat "#2 ... al" as move when there's an explicit event ref.
+    looks_like_take = bool(ref_idx) and bool(re.search(r"\b(al|alin|alın)\b", t))
+    is_move = any(k in t for k in ["kaydır", "kaydir", "erte", "ertele", "ileri al", "geri al", "taşı", "tasi"]) or looks_like_take
+    is_create = any(k in t for k in ["ekle", "koy", "planla", "ayarla", "oluştur", "olustur"])
+    is_list = any(k in t for k in ["ne var", "planım", "planim", "takvim", "randevu", "etkinlik", "toplantı", "toplanti"]) and not (is_create or is_move or is_cancel)
+
+    if is_cancel:
+        missing: list[str] = []
+        ref = CalendarEventRef(kind="index", index=ref_idx) if ref_idx else None
+        if ref is None:
+            missing.append("event_ref")
+        return CalendarIntent(
+            type="cancel_event",
+            params={"day_hint": day_hint},
+            confidence=0.9 if ref_idx else 0.7,
+            missing=missing,
+            source_text=text,
+            event_ref=ref,
+        )
+
+    if is_move:
+        missing = []
+        ref = CalendarEventRef(kind="index", index=ref_idx) if ref_idx else None
+        if ref is None:
+            missing.append("event_ref")
+        target_hhmm = hhmm
+        # If user says "bu hafta" for a write, force clarification.
+        if day_hint == "this_week":
+            missing.append("day_hint")
+        # Need either an offset ("1 saat ileri") OR a concrete target time ("yarın 09:30").
+        if offset is None and not target_hhmm and day_hint not in {"tomorrow", "day_after_tomorrow"}:
+            missing.append("offset_or_target")
+        return CalendarIntent(
+            type="move_event",
+            params={"day_hint": day_hint, "offset_minutes": offset, "target_hhmm": target_hhmm},
+            confidence=0.9 if ref_idx else 0.65,
+            missing=missing,
+            source_text=text,
+            event_ref=ref,
+        )
+
+    if is_create:
+        missing = []
+        # If user says "bu hafta" for a write, force clarification.
+        if day_hint == "this_week":
+            missing.append("day_hint")
+        if not hhmm:
+            missing.append("start_time")
+        if dur is None:
+            missing.append("duration_minutes")
+        # summary heuristic: remove common time phrases/verbs/filler and trim.
+        summary = text
+        summary = re.sub(_TIME_RE, "", summary)
+        summary = re.sub(r"\b(\d{1,3})\s*(dk|dakika)\b", "", summary, flags=re.IGNORECASE)
+        # Remove verb variations like "ekler misin", "koyar mısın", etc.
+        summary = re.sub(r"\b(ekle\w*|koy\w*|planla\w*|ayarla\w*|oluştur\w*|olustur\w*)\b", "", summary, flags=re.IGNORECASE)
+        summary = re.sub(r"\b(bugün|yarın|öbür\s*gün|bu\s*akşam|aksam|akşam|sabah|öğleden\s*sonra|ogleden\s*sonra)\b", "", summary, flags=re.IGNORECASE)
+        summary = re.sub(r"\b(saat)\b", "", summary, flags=re.IGNORECASE)
+        summary = re.sub(r"'\s*(ye|ya|e|a)\b", "", summary, flags=re.IGNORECASE)
+        summary = re.sub(
+            r"\b(dostum|lütfen|lutfen|rica|acaba|ya|misin|mısın|misiniz|mısınız|miyim|mıyım|mi|mı)\b",
+            "",
+            summary,
+            flags=re.IGNORECASE,
+        )
+        summary = re.sub(r"\s+", " ", summary).strip(" -:\n\t")
+        if not summary:
+            missing.append("summary")
+        return CalendarIntent(
+            type="create_event",
+            params={"day_hint": day_hint, "start_hhmm": hhmm, "duration_minutes": dur, "summary": summary},
+            confidence=0.9 if (hhmm and (dur is not None) and summary) else 0.6,
+            missing=missing,
+            source_text=text,
+        )
+
+    # Default: list/query
+    return CalendarIntent(
+        type="list_events",
+        params={"day_hint": day_hint},
+        confidence=0.7 if day_hint else 0.55,
+        missing=[],
+        source_text=text,
+    )

--- a/src/bantz/voice_style.py
+++ b/src/bantz/voice_style.py
@@ -1,0 +1,304 @@
+"""VoiceStyle: Jarvis-like persona consistency layer.
+
+This module provides deterministic formatting for Jarvis persona responses.
+Key principles:
+- "Efendim" max 1x per response (not in every line)
+- Empathy before menu (one human sentence)
+- Natural, conversational menu labels
+- Variation bank with deterministic selection (hash-based, not random)
+- Turkish language with warm formality
+
+The module does NOT use LLM - it's a deterministic style engine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Optional
+
+
+def _pick_variant(variants: list[str], seed: str) -> str:
+    """Deterministically pick a variant based on seed hash.
+    
+    Same seed always returns same variant (test-stable).
+    Different seeds give variety (no robot feel).
+    """
+    if not variants:
+        return ""
+    if len(variants) == 1:
+        return variants[0]
+    h = int(hashlib.md5(seed.encode()).hexdigest(), 16)
+    return variants[h % len(variants)]
+
+
+class JarvisVoice:
+    """Jarvis persona - warm, concise, human."""
+
+    # ─────────────────────────────────────────────────────────────
+    # Variation Banks (deterministik seçim için)
+    # ─────────────────────────────────────────────────────────────
+
+    # Smalltalk giriş empati cümleleri
+    EMPATHY_INTRO = [
+        "Anlaşıldı. Enerji düşük gibi.",
+        "Tamam. Bugün mod düşük.",
+        "Anladım. Uykun ağır basıyor.",
+    ]
+
+    # Smalltalk "ne yapalım" sorusu
+    WHAT_TO_DO = [
+        "Ne yapalım?",
+        "Nasıl yardımcı olayım?",
+        "Ne tercih edersin?",
+    ]
+
+    # İptal/vazgeç varyasyonları
+    CANCEL_VARIANTS = [
+        "Tamam, vazgeçtim.",
+        "Anlaşıldı, iptal.",
+        "Peki, bırakıyorum.",
+    ]
+
+    # Onay reprompt varyasyonları
+    CONFIRM_REPROMPT = [
+        "1 mi 0 mı?",
+        "Evet için 1, hayır için 0.",
+        "Onay mı iptal mi? (1/0)",
+    ]
+
+    # ─────────────────────────────────────────────────────────────
+    # Menü Label'ları (daha doğal)
+    # ─────────────────────────────────────────────────────────────
+
+    MENU_STAGE1 = {
+        "1": "Sadece durumumu söyle",
+        "2": "Hafifletme öner",
+        "0": "Boşver",
+    }
+
+    MENU_STAGE2 = {
+        "1": "Yarın daha yumuşak yap",
+        "2": "60 dk mola ekle",
+        "3": "En erken boşluk neresi?",
+        "0": "Vazgeç",
+    }
+
+    MENU_FREE_SLOTS = {
+        "9": "Süre: 60 dk",
+        "0": "Vazgeç",
+    }
+
+    MENU_UNKNOWN = {
+        "1": "Takvim",
+        "2": "Sohbet/destek",
+        "0": "Boşver",
+    }
+
+    # ─────────────────────────────────────────────────────────────
+    # Core Formatters
+    # ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def empathy_intro(seed: str = "default") -> str:
+        """Get an empathy intro line for smalltalk."""
+        return _pick_variant(JarvisVoice.EMPATHY_INTRO, seed)
+
+    @staticmethod
+    def what_to_do(seed: str = "default") -> str:
+        """Get a 'what to do' question."""
+        return _pick_variant(JarvisVoice.WHAT_TO_DO, seed)
+
+    @staticmethod
+    def cancel_msg(seed: str = "default") -> str:
+        """Get a cancel confirmation message."""
+        return _pick_variant(JarvisVoice.CANCEL_VARIANTS, seed)
+
+    @staticmethod
+    def confirm_reprompt(seed: str = "default") -> str:
+        """Get a confirmation reprompt message."""
+        return _pick_variant(JarvisVoice.CONFIRM_REPROMPT, seed)
+
+    @staticmethod
+    def format_stage1_menu(seed: str = "default") -> str:
+        """Format smalltalk stage1 menu with empathy intro."""
+        empathy = JarvisVoice.empathy_intro(seed)
+        question = JarvisVoice.what_to_do(seed + "_q")
+        m = JarvisVoice.MENU_STAGE1
+        return "\n".join([
+            empathy,
+            question,
+            f"1. {m['1']}",
+            f"2. {m['2']}",
+            f"0. {m['0']}",
+        ])
+
+    @staticmethod
+    def format_stage2_menu(seed: str = "default") -> str:
+        """Format smalltalk stage2 menu."""
+        m = JarvisVoice.MENU_STAGE2
+        return "\n".join([
+            "Hangi tür hafifletme?",
+            f"1. {m['1']}",
+            f"2. {m['2']}",
+            f"3. {m['3']}",
+            f"0. {m['0']}",
+        ])
+
+    @staticmethod
+    def format_free_slots_menu(
+        slots: list[tuple[str, str]],
+        duration_minutes: int,
+        seed: str = "default",
+    ) -> str:
+        """Format free slots menu with time slots."""
+        lines = [f"{duration_minutes} dk için uygun boşluklar:"]
+        for idx, (start, end) in enumerate(slots[:3], start=1):
+            lines.append(f"{idx}. {start}–{end}")
+        m = JarvisVoice.MENU_FREE_SLOTS
+        lines.append(f"9. {m['9']}")
+        lines.append(f"0. {m['0']}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_unknown_menu(seed: str = "default") -> str:
+        """Format unknown route menu."""
+        m = JarvisVoice.MENU_UNKNOWN
+        return "\n".join([
+            "Takvim mi sohbet mi?",
+            f"1. {m['1']}",
+            f"2. {m['2']}",
+            f"0. {m['0']}",
+        ])
+
+    @staticmethod
+    def format_confirmation(
+        summary: str,
+        start_time: str,
+        end_time: str,
+        seed: str = "default",
+    ) -> str:
+        """Format event creation confirmation - Jarvis style."""
+        return f'{start_time}–{end_time} "{summary}" ekleyeyim mi? (1/0)'
+
+    @staticmethod
+    def format_event_added(
+        summary: str,
+        start_time: str,
+        end_time: str,
+    ) -> str:
+        """Format event added confirmation."""
+        return f"Eklendi: {start_time}–{end_time} | {summary}"
+
+    @staticmethod
+    def format_dry_run(
+        summary: str,
+        start_time: str,
+        end_time: str,
+    ) -> str:
+        """Format dry-run confirmation."""
+        return f"Dry-run: '{summary}' {start_time}–{end_time} eklenecekti."
+
+    @staticmethod
+    def format_list_events(
+        count: int,
+        events: list[tuple[str, str, str]],  # (start, end, summary)
+        intent: Optional[str] = None,
+    ) -> str:
+        """Format calendar list events result."""
+        if count == 0:
+            if intent == "evening":
+                return "Bu akşam için plan görünmüyor."
+            return "Bu aralıkta plan görünmüyor."
+        
+        lines = [f"{count} plan var:"]
+        shown = 3
+        for start, end, summary in events[:shown]:
+            if start and end:
+                lines.append(f"- {start}–{end} | {summary}")
+            else:
+                lines.append(f"- {summary}")
+        hidden = count - shown
+        if hidden > 0:
+            lines.append(f"(+{hidden} daha)")
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_reprompt(menu_id: str, seed: str = "default") -> str:
+        """Format a gentle reprompt for unclear input."""
+        if menu_id == "smalltalk_stage1":
+            return "1, 2 veya 0 yazabilir misin?"
+        if menu_id == "smalltalk_stage2":
+            return "Hangisi? (1/2/3/0)"
+        if menu_id == "free_slots":
+            return "Hangi boşluk? (1/2/3 veya 0)"
+        if menu_id == "unknown":
+            return "Takvim için 1, sohbet için 2."
+        return "Hangisini tercih edersin?"
+
+
+# ─────────────────────────────────────────────────────────────
+# Legacy VoiceStyle (backward compat)
+# ─────────────────────────────────────────────────────────────
+
+class VoiceStyle:
+    """Legacy wrapper - delegates to JarvisVoice."""
+
+    PREFIX = "Efendim"
+    CANCEL = "Vazgeçtim."
+    OK = "Tamam."
+    DONE = "Tamamdır."
+
+    @staticmethod
+    def strip_emoji(text: str) -> str:
+        """Remove emoji from text."""
+        if not text:
+            return ""
+        emoji_pattern = re.compile(
+            "["
+            "\U0001F600-\U0001F64F"
+            "\U0001F300-\U0001F5FF"
+            "\U0001F680-\U0001F6FF"
+            "\U0001F900-\U0001F9FF"
+            "\U00002702-\U000027B0"
+            "]+",
+            flags=re.UNICODE,
+        )
+        return emoji_pattern.sub("", text).strip()
+
+    @staticmethod
+    def limit_sentences(text: str, max_sentences: int = 2) -> str:
+        """Limit to N sentences."""
+        if not text or max_sentences < 1:
+            return text or ""
+        parts = re.split(r"(?<=[.!?])\s+", text.strip())
+        if len(parts) <= max_sentences:
+            return text.strip()
+        return " ".join(parts[:max_sentences])
+
+    @staticmethod
+    def acknowledge(message: str) -> str:
+        """Add Efendim prefix if missing."""
+        msg = (message or "").strip()
+        if not msg:
+            return VoiceStyle.PREFIX
+        if msg.lower().startswith("efendim"):
+            return msg
+        return f"Efendim, {msg[0].lower()}{msg[1:]}" if msg else VoiceStyle.PREFIX
+
+    @staticmethod
+    def format_list_with_more(items: list[str], shown: int = 3, more_label: str = "daha fazla") -> str:
+        """Format list with 'more' indicator."""
+        if not items:
+            return ""
+        visible = items[:shown]
+        hidden = len(items) - shown
+        result = "\n".join(f"- {item}" for item in visible)
+        if hidden > 0:
+            result += f"\n(+{hidden} {more_label})"
+        return result
+
+
+# Convenience aliases
+JARVIS = JarvisVoice
+JARVIS = VoiceStyle

--- a/tests/test_brain_loop_observation_and_ask_user_guard.py
+++ b/tests/test_brain_loop_observation_and_ask_user_guard.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+from bantz.agent.tools import Tool, ToolRegistry
+from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+
+
+class _CapturingLLM:
+    def __init__(self, outputs: list[dict]):
+        self.outputs = list(outputs)
+        self.seen_messages: list[list[dict[str, str]]] = []
+
+    def complete_json(self, *, messages: list[dict[str, str]], schema_hint: str) -> dict:
+        self.seen_messages.append(list(messages))
+        if not self.outputs:
+            return {"type": "FAIL", "error": "no_more_outputs"}
+        return self.outputs.pop(0)
+
+
+def test_tool_observation_is_not_user_role() -> None:
+    tools = ToolRegistry()
+
+    def echo_tool(**params):
+        return {"ok": True, "echo": dict(params)}
+
+    tools.register(
+        Tool(
+            name="demo.echo",
+            description="echo",
+            parameters={"type": "object", "properties": {"x": {"type": "string"}}},
+            function=echo_tool,
+        )
+    )
+
+    llm = _CapturingLLM(
+        outputs=[
+            {"type": "CALL_TOOL", "name": "demo.echo", "params": {"x": "hi"}},
+            {"type": "SAY", "text": "ok"},
+        ]
+    )
+
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=3, debug=False))
+    result = loop.run(turn_input="test", session_context={}, policy=None, context={"session_id": "t"})
+    assert result.kind == "say"
+
+    # The second LLM call should contain the tool observation.
+    assert len(llm.seen_messages) >= 2
+    tail = llm.seen_messages[1]
+    obs_msgs = [m for m in tail if isinstance(m, dict) and str(m.get("content", "")).startswith("TOOL_OBSERVATION:")]
+    assert obs_msgs, "expected TOOL_OBSERVATION marker"
+    assert all(m.get("role") != "user" for m in obs_msgs)
+
+
+def test_ask_user_echo_is_rejected_with_fallback_say() -> None:
+    tools = ToolRegistry()
+    llm = _CapturingLLM(outputs=[{"type": "ASK_USER", "question": "Bu aksam planim var mi?"}])
+
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    result = loop.run(turn_input="Bu akşam planım var mı?", session_context={}, policy=None, context={"session_id": "t"})
+
+    assert result.kind == "say"
+    assert "netleştirebilir" in result.text
+    assert "(1)" in result.text and "(0)" in result.text
+
+    # Ensure we didn't crash on JSON serialization metadata.
+    json.dumps(result.metadata)

--- a/tests/test_calendar_intent_time_parsing.py
+++ b/tests/test_calendar_intent_time_parsing.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from bantz.brain.calendar_intent import parse_hhmm
+
+
+def test_parse_hhmm_accepts_dot_comma_and_space() -> None:
+    assert parse_hhmm("23:50") == "23:50"
+    assert parse_hhmm("23.50") == "23:50"
+    assert parse_hhmm("23,50") == "23:50"
+    assert parse_hhmm("23 50") == "23:50"

--- a/tests/test_dialog_policy_router.py
+++ b/tests/test_dialog_policy_router.py
@@ -1,0 +1,1146 @@
+from __future__ import annotations
+
+from bantz.agent.tools import Tool, ToolRegistry
+from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+
+
+class _FailingLLM:
+    def complete_json(self, *, messages, schema_hint):  # type: ignore[no-untyped-def]
+        raise AssertionError("LLM should not be called in this test")
+
+
+class _QueueLLM:
+    def __init__(self, outputs: list[dict]):
+        self.outputs = list(outputs)
+        self.calls = 0
+
+    def complete_json(self, *, messages, schema_hint):  # type: ignore[no-untyped-def]
+        self.calls += 1
+        if not self.outputs:
+            return {"type": "FAIL", "error": "no_more_outputs"}
+        return self.outputs.pop(0)
+
+
+def test_smalltalk_routes_to_scripted_menu_and_bypasses_llm_and_tools() -> None:
+    tools = ToolRegistry()
+
+    def should_never_run(**params):
+        raise AssertionError("tool should not execute")
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=should_never_run,
+        )
+    )
+
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    res = loop.run(
+        turn_input="uykuluyum okula gitmek istemiyorum",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "smalltalk_stage1"
+    assert res.metadata.get("state") == "PENDING_CHOICE"
+    opts = res.metadata.get("options")
+    assert isinstance(opts, dict)
+    assert set(opts.keys()) >= {"0", "1", "2"}
+
+
+def test_unknown_routes_to_domain_choice_menu_and_bypasses_llm() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    res = loop.run(
+        turn_input="asdf qwer",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "unknown"
+    assert res.metadata.get("state") == "PENDING_CHOICE"
+    opts = res.metadata.get("options")
+    assert isinstance(opts, dict)
+    assert set(opts.keys()) >= {"0", "1", "2"}
+
+
+def test_calendar_route_allows_llm_and_renders_list_events_deterministically() -> None:
+    tools = ToolRegistry()
+
+    def list_events(**params):
+        return {"ok": True, "count": 0, "events": []}
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=list_events,
+        )
+    )
+
+    llm = _QueueLLM(outputs=[{"type": "CALL_TOOL", "name": "calendar.list_events", "params": {}}])
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    res = loop.run(
+        turn_input="Bu akşam planım var mı?",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert llm.calls == 1
+    assert res.kind == "say"
+    assert res.metadata.get("action_type") == "list_events"
+    assert res.metadata.get("events_count") == 0
+
+
+def test_llm_ask_user_is_ignored_and_replaced_with_brainloop_menu_in_deterministic_mode() -> None:
+    tools = ToolRegistry()
+    llm = _QueueLLM(outputs=[{"type": "ASK_USER", "question": "Efendim, kaçta okula gitmek istemiyorsun?"}])
+
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    res = loop.run(
+        turn_input="Bu akşam planım var mı?",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert res.kind == "ask_user"
+    # Calendar route -> BrainLoop replaces LLM-authored question with deterministic next-step menu.
+    assert res.metadata.get("menu_id") == "calendar_next"
+    opts = res.metadata.get("options")
+    assert isinstance(opts, dict)
+    assert set(opts.keys()) >= {"0", "1", "2"}
+
+
+def test_weak_time_words_do_not_force_calendar_route_when_message_is_smalltalk() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    res = loop.run(
+        turn_input="Yarın okula gitmek istemiyorum",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "smalltalk_stage1"
+    assert res.metadata.get("route") == "smalltalk"
+
+
+def test_calendar_keywords_force_calendar_route_even_with_time_words() -> None:
+    tools = ToolRegistry()
+
+    def list_events(**params):
+        return {"ok": True, "count": 0, "events": []}
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=list_events,
+        )
+    )
+
+    llm = _QueueLLM(outputs=[{"type": "CALL_TOOL", "name": "calendar.list_events", "params": {}}])
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    res = loop.run(
+        turn_input="Yarın sabah boşluk var mı?",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert llm.calls == 1
+    assert res.kind == "say"
+
+
+def test_calendar_create_event_is_deterministic_and_requires_confirmation() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict[str, object] = {"session_id": "t"}
+    res = loop.run(
+        turn_input="15:45 koşu ekle 30 dk",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "today_window": {"time_min": "2026-01-28T10:00:00+03:00", "time_max": "2026-01-28T23:59:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "pending_confirmation"
+    assert res.metadata.get("action_type") == "create_event"
+    assert res.metadata.get("requires_confirmation") is True
+    assert isinstance(state.get("_policy_pending_action"), dict)
+
+
+def test_calendar_cancel_event_without_ref_uses_event_pick_when_last_events_available() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict = {
+        "session_id": "t",
+        "_calendar_last_events": [
+            {"id": "evt_1", "summary": "Toplantı", "start": "2026-01-28T15:00:00+03:00", "end": "2026-01-28T16:00:00+03:00"},
+            {"id": "evt_2", "summary": "Diş", "start": "2026-01-28T17:00:00+03:00", "end": "2026-01-28T17:30:00+03:00"},
+        ],
+    }
+
+    r1 = loop.run(
+        turn_input="Toplantıyı iptal et",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "event_pick"
+    assert r1.metadata.get("state") == "PENDING_CHOICE"
+    opts = r1.metadata.get("options")
+    assert isinstance(opts, dict)
+    assert set(opts.keys()) >= {"0", "1", "2"}
+
+
+def test_event_pick_accepts_natural_language_ordinal() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {
+            "menu_id": "event_pick",
+            "default": "0",
+            "op": "cancel_event",
+            "params": {},
+            "events": [
+                {"id": "evt_1", "summary": "Toplantı", "start": "2026-01-28T15:00:00+03:00", "end": "2026-01-28T16:00:00+03:00"},
+                {"id": "evt_2", "summary": "Diş", "start": "2026-01-28T17:00:00+03:00", "end": "2026-01-28T17:30:00+03:00"},
+            ],
+        },
+    }
+
+    r = loop.run(
+        turn_input="ikincisini",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert r.kind == "ask_user"
+    assert r.metadata.get("menu_id") == "pending_confirmation"
+    assert r.metadata.get("action_type") == "delete_event"
+    assert r.metadata.get("requires_confirmation") is True
+
+
+def test_delete_update_pending_confirmation_does_not_accept_ok() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict = {
+        "session_id": "t",
+        "_policy_pending_action": {
+            "action": {"type": "CALL_TOOL", "name": "calendar.delete_event", "params": {"event_id": "evt_1"}},
+            "decision": {"risk_level": "MED", "requires_confirmation": True, "allowed": False},
+            "original_user_input": "#1'i iptal et",
+        },
+    }
+
+    r = loop.run(
+        turn_input="ok",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+
+    assert r.kind == "ask_user"
+    assert r.metadata.get("menu_id") == "pending_confirmation"
+    assert r.metadata.get("reprompt_for") == "pending_confirmation"
+
+
+def test_p1_acceptance_create_net_requires_confirmation() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    state: dict = {"session_id": "t"}
+
+    r1 = loop.run(
+        turn_input="Yarın 14:00'te toplantı ekle 30 dk",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "tomorrow_window": {"time_min": "2026-01-29T00:00:00+03:00", "time_max": "2026-01-29T23:59:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "pending_confirmation"
+    assert r1.metadata.get("action_type") == "create_event"
+    assert r1.metadata.get("requires_confirmation") is True
+    pending = state.get("_policy_pending_action")
+    assert isinstance(pending, dict)
+    action = pending.get("action")
+    assert isinstance(action, dict)
+    assert action.get("name") == "calendar.create_event"
+
+
+def test_p1_acceptance_create_missing_info_asks_single_question() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    state: dict = {"session_id": "t"}
+
+    r1 = loop.run(
+        turn_input="Yarın toplantı ekle",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "tomorrow_window": {"time_min": "2026-01-29T00:00:00+03:00", "time_max": "2026-01-29T23:59:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "calendar_slot_fill"
+    missing = r1.metadata.get("missing")
+    assert isinstance(missing, list)
+    assert "start_time" in missing
+
+
+def test_calendar_slot_fill_continues_even_if_followup_has_no_calendar_keywords() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    state: dict = {"session_id": "t"}
+
+    # Missing duration -> asks a single question.
+    r1 = loop.run(
+        turn_input="Bugün 23.50'ye kitap okuma saati ekle",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "today_window": {"time_min": "2026-01-28T00:00:00+03:00", "time_max": "2026-01-28T23:59:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "calendar_slot_fill"
+    missing = r1.metadata.get("missing")
+    assert isinstance(missing, list)
+    assert "duration_minutes" in missing
+
+    # Follow-up contains no 'ekle' keyword; should still proceed via pending intent.
+    r2 = loop.run(
+        turn_input="30 dk",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "today_window": {"time_min": "2026-01-28T00:00:00+03:00", "time_max": "2026-01-28T23:59:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+
+    assert r2.kind == "ask_user"
+    assert r2.metadata.get("menu_id") == "pending_confirmation"
+    assert r2.metadata.get("action_type") == "create_event"
+
+
+def test_p1_acceptance_list_then_reference_cancel_second() -> None:
+    tools = ToolRegistry()
+
+    def list_events(**params):
+        return {
+            "ok": True,
+            "count": 2,
+            "events": [
+                {"id": "evt_1", "summary": "Toplantı", "start": "2026-01-28T10:00:00+03:00", "end": "2026-01-28T10:30:00+03:00"},
+                {"id": "evt_2", "summary": "Diş", "start": "2026-01-28T12:00:00+03:00", "end": "2026-01-28T12:30:00+03:00"},
+            ],
+        }
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=list_events,
+        )
+    )
+
+    llm = _QueueLLM(outputs=[{"type": "CALL_TOOL", "name": "calendar.list_events", "params": {}}])
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    state: dict = {"session_id": "t"}
+
+    r1 = loop.run(
+        turn_input="Bugün takvimimde ne var?",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert r1.kind == "say"
+    assert r1.metadata.get("action_type") == "list_events"
+    assert isinstance(state.get("_calendar_last_events"), list)
+
+    r2 = loop.run(
+        turn_input="İkincisini iptal et",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert r2.kind == "ask_user"
+    assert r2.metadata.get("menu_id") == "pending_confirmation"
+    assert r2.metadata.get("action_type") == "delete_event"
+    pending = state.get("_policy_pending_action")
+    assert isinstance(pending, dict)
+    action = pending.get("action")
+    assert isinstance(action, dict)
+    assert action.get("name") == "calendar.delete_event"
+
+
+def test_p1_acceptance_move_reference_to_tomorrow_target_time() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict = {
+        "session_id": "t",
+        "_calendar_last_events": [
+            {"id": "evt_1", "summary": "Toplantı", "start": "2026-01-28T10:00:00+03:00", "end": "2026-01-28T10:30:00+03:00"},
+            {"id": "evt_2", "summary": "Koşu", "start": "2026-01-28T11:00:00+03:00", "end": "2026-01-28T12:00:00+03:00"},
+        ],
+        "last_intent": "calendar_query",
+        "last_tool_used": "calendar.list_events",
+    }
+
+    r1 = loop.run(
+        turn_input="#2'yi yarın 09:30'a al",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "tomorrow_window": {"time_min": "2026-01-29T00:00:00+03:00", "time_max": "2026-01-29T23:59:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "pending_confirmation"
+    assert r1.metadata.get("action_type") == "update_event"
+    pending = state.get("_policy_pending_action")
+    assert isinstance(pending, dict)
+    action = pending.get("action")
+    assert isinstance(action, dict)
+    assert action.get("name") == "calendar.update_event"
+    params = action.get("params")
+    assert isinstance(params, dict)
+    assert params.get("event_id") == "evt_2"
+    assert isinstance(params.get("start"), str)
+    assert str(params.get("start")).startswith("2026-01-29T09:30")
+
+
+def test_p1_acceptance_cancel_fuzzy_single_match_no_menu() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict = {
+        "session_id": "t",
+        "_calendar_last_events": [
+            {"id": "evt_math", "summary": "Matematik dersi", "start": "2026-01-28T09:00:00+03:00", "end": "2026-01-28T10:00:00+03:00"},
+        ],
+        "last_intent": "calendar_query",
+        "last_tool_used": "calendar.list_events",
+    }
+
+    r1 = loop.run(
+        turn_input="Matematik dersini iptal et",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "pending_confirmation"
+    assert r1.metadata.get("action_type") == "delete_event"
+
+
+def test_p1_acceptance_ambiguity_event_pick_then_ordinal() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict = {
+        "session_id": "t",
+        "_calendar_last_events": [
+            {"id": "evt_1", "summary": "Ders (Matematik)", "start": "2026-01-28T09:00:00+03:00", "end": "2026-01-28T10:00:00+03:00"},
+            {"id": "evt_2", "summary": "Ders (Fizik)", "start": "2026-01-28T11:00:00+03:00", "end": "2026-01-28T12:00:00+03:00"},
+        ],
+        "last_intent": "calendar_query",
+        "last_tool_used": "calendar.list_events",
+    }
+
+    r1 = loop.run(
+        turn_input="Dersi iptal et",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "event_pick"
+    assert r1.metadata.get("state") == "PENDING_CHOICE"
+
+    r2 = loop.run(
+        turn_input="ikinci",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert r2.kind == "ask_user"
+    assert r2.metadata.get("menu_id") == "pending_confirmation"
+    assert r2.metadata.get("action_type") == "delete_event"
+
+
+def test_calendar_flow_hard_exit_resets_flow_and_clears_intent() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    state: dict = {"session_id": "t", "last_intent": "calendar_query", "last_tool_used": "calendar.list_events"}
+    r1 = loop.run(
+        turn_input="konu değiştir",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+
+    assert r1.kind == "say"
+    assert r1.metadata.get("action_type") == "exit_calendar"
+    assert state.get("last_intent") is None
+    assert state.get("last_tool_used") is None
+
+    # After exit, smalltalk should route normally.
+    r2 = loop.run(
+        turn_input="uykuluyum",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert r2.kind == "ask_user"
+    assert r2.metadata.get("menu_id") == "smalltalk_stage1"
+
+
+def test_calendar_list_events_with_smalltalk_clause_sets_mini_ack_metadata() -> None:
+    tools = ToolRegistry()
+
+    def list_events(**params):
+        return {"ok": True, "count": 0, "events": []}
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=list_events,
+        )
+    )
+
+    llm = _QueueLLM(outputs=[{"type": "CALL_TOOL", "name": "calendar.list_events", "params": {}}])
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    res = loop.run(
+        turn_input="Bu akşam planım var mı, bu arada moralim bozuk",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert res.kind == "say"
+    assert res.metadata.get("action_type") == "list_events"
+    assert res.metadata.get("mini_ack") is True
+
+
+def test_smalltalk_two_stage_menu_then_free_slots_menu() -> None:
+    tools = ToolRegistry()
+
+    def find_free_slots(**params):
+        return {
+            "ok": True,
+            "slots": [
+                {"start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"},
+                {"start": "2026-01-29T10:00:00+03:00", "end": "2026-01-29T10:30:00+03:00"},
+                {"start": "2026-01-29T11:00:00+03:00", "end": "2026-01-29T11:30:00+03:00"},
+            ],
+        }
+
+    tools.register(
+        Tool(
+            name="calendar.find_free_slots",
+            description="free",
+            parameters={"type": "object", "properties": {}},
+            function=find_free_slots,
+        )
+    )
+
+    state: dict = {"session_id": "t"}
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+
+    r1 = loop.run(
+        turn_input="uykuluyum okula gitmek istemiyorum",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "morning_tomorrow_window": {"time_min": "2026-01-29T07:30:00+03:00", "time_max": "2026-01-29T11:30:00+03:00"},
+            "today_window": {"time_min": "2026-01-28T21:00:00+03:00", "time_max": "2026-01-28T22:30:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+    assert r1.kind == "ask_user"
+    assert r1.metadata.get("menu_id") == "smalltalk_stage1"
+    assert r1.metadata.get("state") == "PENDING_CHOICE"
+
+    r2 = loop.run(
+        turn_input="2",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "morning_tomorrow_window": {"time_min": "2026-01-29T07:30:00+03:00", "time_max": "2026-01-29T11:30:00+03:00"},
+            "today_window": {"time_min": "2026-01-28T21:00:00+03:00", "time_max": "2026-01-28T22:30:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+    assert r2.kind == "ask_user"
+    assert r2.metadata.get("menu_id") == "smalltalk_stage2"
+    assert r2.metadata.get("state") == "PENDING_CHOICE"
+
+    r3 = loop.run(
+        turn_input="3",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "morning_tomorrow_window": {"time_min": "2026-01-29T07:30:00+03:00", "time_max": "2026-01-29T11:30:00+03:00"},
+            "today_window": {"time_min": "2026-01-28T21:00:00+03:00", "time_max": "2026-01-28T22:30:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+    assert r3.kind == "ask_user"
+    assert r3.metadata.get("menu_id") == "free_slots"
+    assert r3.metadata.get("state") == "PENDING_CHOICE"
+    opts = r3.metadata.get("options")
+    assert isinstance(opts, dict)
+    assert "0" in opts and "9" in opts
+
+
+def test_free_slots_invalid_input_triggers_reprompt_first_then_cancel() -> None:
+    """With 2-stage reprompt, first unclear input triggers reprompt, second cancels."""
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {
+            "menu_id": "free_slots",
+            "default": "0",
+            "duration": 30,
+            "time_min": "2026-01-29T07:30:00+03:00",
+            "time_max": "2026-01-29T11:30:00+03:00",
+            "slots": [{"start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"}],
+        },
+    }
+    # First unclear input → reprompt
+    res1 = loop.run(
+        turn_input="ben bilmem",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert res1.kind == "ask_user"
+    assert res1.metadata.get("menu_id") == "free_slots"
+    assert res1.metadata.get("reprompt_for") == "free_slots"
+
+    # Second unclear input → cancel (default=0)
+    res2 = loop.run(
+        turn_input="yine bilmem",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert res2.kind == "say"
+    assert res2.metadata.get("menu_id") == "free_slots"
+
+
+def test_free_slots_pick_slot_transitions_to_pending_confirmation_prompt() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {
+            "menu_id": "free_slots",
+            "default": "0",
+            "duration": 30,
+            "time_min": "2026-01-29T07:30:00+03:00",
+            "time_max": "2026-01-29T11:30:00+03:00",
+            "slots": [
+                {"start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"}
+            ],
+        },
+    }
+    res = loop.run(
+        turn_input="1",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "pending_confirmation"
+    assert res.metadata.get("action_type") == "create_event"
+    assert res.metadata.get("requires_confirmation") is True
+    assert "_policy_pending_action" in state
+
+
+def test_pending_confirmation_deny_takes_precedence_over_router_menus() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_policy_pending_action": {
+            "action": {"type": "CALL_TOOL", "name": "calendar.create_event", "params": {"summary": "Mola", "start": "2026-01-29T09:00:00+03:00"}},
+            "decision": {"risk_level": "MED", "requires_confirmation": True, "allowed": False},
+            "original_user_input": "test",
+        },
+    }
+
+    res = loop.run(
+        turn_input="hayır",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "say"
+    assert res.metadata.get("menu_id") == "pending_confirmation"
+    assert res.metadata.get("action_type") == "create_event"
+    assert res.metadata.get("requires_confirmation") is True
+
+
+def test_pending_confirmation_random_input_repompts_yes_no() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_policy_pending_action": {
+            "action": {"type": "CALL_TOOL", "name": "calendar.create_event", "params": {"summary": "Mola", "start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"}},
+            "decision": {"risk_level": "MED", "requires_confirmation": True, "allowed": False},
+            "original_user_input": "test",
+        },
+    }
+
+    res = loop.run(
+        turn_input="hmm",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "pending_confirmation"
+    assert res.metadata.get("action_type") == "create_event"
+    assert res.metadata.get("requires_confirmation") is True
+    assert res.metadata.get("reprompt_for") == "pending_confirmation"
+
+
+def test_pending_confirmation_deny_clears_pending_action() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_policy_pending_action": {
+            "action": {"type": "CALL_TOOL", "name": "calendar.create_event", "params": {"summary": "Mola", "start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"}},
+            "decision": {"risk_level": "MED", "requires_confirmation": True, "allowed": False},
+            "original_user_input": "test",
+        },
+    }
+    res = loop.run(
+        turn_input="hayır",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "say"
+    assert "_policy_pending_action" not in state
+
+
+def test_pending_confirmation_confirm_runs_tool_and_renders_create_event_deterministically() -> None:
+    tools = ToolRegistry()
+    seen: dict = {}
+
+    def create_event(**params):
+        seen.update(params)
+        return {
+            "ok": True,
+            "summary": str(params.get("summary") or ""),
+            "start": str(params.get("start") or ""),
+            "end": str(params.get("end") or ""),
+        }
+
+    tools.register(
+        Tool(
+            name="calendar.create_event",
+            description="create",
+            parameters={"type": "object", "properties": {}},
+            function=create_event,
+            requires_confirmation=True,
+            risk_level="MED",
+        )
+    )
+
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_policy_pending_action": {
+            "action": {
+                "type": "CALL_TOOL",
+                "name": "calendar.create_event",
+                "params": {"summary": "Mola", "start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"},
+            },
+            "decision": {"risk_level": "MED", "requires_confirmation": True, "allowed": False},
+            "original_user_input": "test",
+        },
+    }
+
+    res = loop.run(
+        turn_input="evet",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul", "dry_run": True},
+        policy=None,
+        context=state,
+    )
+
+    assert res.kind == "say"
+    assert res.metadata.get("action_type") == "create_event"
+    assert res.metadata.get("requires_confirmation") is True
+    assert res.metadata.get("dry_run") is True
+    assert seen.get("summary") == "Mola"
+
+
+def test_pending_confirmation_zero_means_deny() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_policy_pending_action": {
+            "action": {"type": "CALL_TOOL", "name": "calendar.create_event", "params": {"summary": "Mola", "start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"}},
+            "decision": {"risk_level": "MED", "requires_confirmation": True, "allowed": False},
+            "original_user_input": "test",
+        },
+    }
+    res = loop.run(
+        turn_input="0",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "say"
+    assert "_policy_pending_action" not in state
+
+
+def test_pending_confirmation_one_means_confirm() -> None:
+    tools = ToolRegistry()
+
+    def create_event(**params):
+        return {"ok": True, "summary": "Mola", "start": params.get("start"), "end": params.get("end")}
+
+    tools.register(
+        Tool(
+            name="calendar.create_event",
+            description="create",
+            parameters={"type": "object", "properties": {}},
+            function=create_event,
+            requires_confirmation=True,
+            risk_level="MED",
+        )
+    )
+
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_policy_pending_action": {
+            "action": {
+                "type": "CALL_TOOL",
+                "name": "calendar.create_event",
+                "params": {"summary": "Mola", "start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"},
+            },
+            "decision": {"risk_level": "MED", "requires_confirmation": True, "allowed": False},
+            "original_user_input": "test",
+        },
+    }
+    res = loop.run(
+        turn_input="1",
+        session_context={"deterministic_render": True, "dry_run": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "say"
+    assert res.metadata.get("action_type") == "create_event"
+    assert res.metadata.get("requires_confirmation") is True
+    assert res.metadata.get("dry_run") is True
+
+
+def test_pending_choice_smalltalk_stage2_accepts_text_yarin_kaydir() -> None:
+    tools = ToolRegistry()
+
+    def find_free_slots(**params):
+        return {"ok": True, "slots": [{"start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"}]}
+
+    tools.register(
+        Tool(
+            name="calendar.find_free_slots",
+            description="free",
+            parameters={"type": "object", "properties": {}},
+            function=find_free_slots,
+        )
+    )
+
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {"menu_id": "smalltalk_stage2", "default": "0"},
+    }
+    res = loop.run(
+        turn_input="Yarın kaydır",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "morning_tomorrow_window": {"time_min": "2026-01-29T07:30:00+03:00", "time_max": "2026-01-29T11:30:00+03:00"},
+            "today_window": {"time_min": "2026-01-28T21:00:00+03:00", "time_max": "2026-01-28T22:30:00+03:00"},
+            "tomorrow_window": {"time_min": "2026-01-29T07:30:00+03:00", "time_max": "2026-01-29T22:30:00+03:00"},
+        },
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "free_slots"
+    opts = res.metadata.get("options")
+    assert isinstance(opts, dict)
+    assert "0" in opts and "9" in opts
+
+
+def test_pending_choice_smalltalk_stage1_accepts_text_hafiflet() -> None:
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {"menu_id": "smalltalk_stage1", "default": "0"},
+    }
+    res = loop.run(
+        turn_input="hafiflet",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "smalltalk_stage2"
+    opts = res.metadata.get("options")
+    assert isinstance(opts, dict)
+    assert set(opts.keys()) >= {"0", "1", "2", "3"}
+
+
+# ─────────────────────────────────────────────────────────────────
+# NEW: 2-stage reprompt acceptance tests (Jarvis HMM rule)
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_unclear_input_triggers_reprompt_on_first_attempt() -> None:
+    """When user says 'hmm' or unclear text, first attempt should reprompt."""
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {"menu_id": "smalltalk_stage1", "default": "0"},
+    }
+    res = loop.run(
+        turn_input="hmm emin değilim",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "smalltalk_stage1"
+    assert res.metadata.get("reprompt_for") == "smalltalk_stage1"
+    # Pending choice should still be set
+    assert "_dialog_pending_choice" in state
+
+
+def test_second_unclear_input_applies_default_and_cancels() -> None:
+    """When user is unclear twice, apply default (0=İptal)."""
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {"menu_id": "smalltalk_stage1", "default": "0"},
+        "_dialog_reprompt_count": 1,  # Already reprompted once
+    }
+    res = loop.run(
+        turn_input="hmm bilmiyorum",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "say"
+    assert res.metadata.get("menu_id") == "smalltalk_stage1"
+    # Pending choice should be cleared
+    assert "_dialog_pending_choice" not in state
+
+
+def test_unclear_input_on_free_slots_menu_triggers_reprompt() -> None:
+    """free_slots menu should also use 2-stage reprompt."""
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {
+            "menu_id": "free_slots",
+            "default": "0",
+            "time_min": "2026-01-29T09:00:00+03:00",
+            "time_max": "2026-01-29T12:00:00+03:00",
+            "slots": [{"start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T09:30:00+03:00"}],
+        },
+    }
+    res = loop.run(
+        turn_input="şey ee",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "free_slots"
+    assert res.metadata.get("reprompt_for") == "free_slots"
+
+
+def test_unknown_menu_processes_choice_1_asks_for_calendar_query() -> None:
+    """Unknown menu choice 1 should ask user for their calendar query."""
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {"menu_id": "unknown", "default": "0"},
+    }
+    res = loop.run(
+        turn_input="1",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=state,
+    )
+    # Should ask user for their calendar query
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "calendar_query"
+    # Pending choice should be cleared
+    assert "_dialog_pending_choice" not in state
+
+
+def test_unknown_menu_choice_2_routes_to_smalltalk_stage1() -> None:
+    """Unknown menu choice 2 should show smalltalk stage1 menu."""
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    state: dict = {
+        "session_id": "t",
+        "_dialog_pending_choice": {"menu_id": "unknown", "default": "0"},
+    }
+    res = loop.run(
+        turn_input="2",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=state,
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "smalltalk_stage1"
+    assert state.get("_dialog_pending_choice", {}).get("menu_id") == "smalltalk_stage1"
+
+
+def test_list_events_renderer_shows_plus_more_for_many_events() -> None:
+    """list_events with >3 events should show '+N daha' indicator."""
+    tools = ToolRegistry()
+
+    def list_events(**params):
+        return {
+            "ok": True,
+            "count": 5,
+            "events": [
+                {"summary": "Event 1", "start": "2026-01-29T09:00:00+03:00", "end": "2026-01-29T10:00:00+03:00"},
+                {"summary": "Event 2", "start": "2026-01-29T10:00:00+03:00", "end": "2026-01-29T11:00:00+03:00"},
+                {"summary": "Event 3", "start": "2026-01-29T11:00:00+03:00", "end": "2026-01-29T12:00:00+03:00"},
+                {"summary": "Event 4", "start": "2026-01-29T12:00:00+03:00", "end": "2026-01-29T13:00:00+03:00"},
+                {"summary": "Event 5", "start": "2026-01-29T13:00:00+03:00", "end": "2026-01-29T14:00:00+03:00"},
+            ],
+        }
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=list_events,
+        )
+    )
+
+    llm = _QueueLLM(outputs=[{"type": "CALL_TOOL", "name": "calendar.list_events", "params": {}}])
+    loop = BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=2, debug=False))
+    res = loop.run(
+        turn_input="Bu akşam planım var mı?",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context={"session_id": "t"},
+    )
+    assert res.kind == "say"
+    assert res.metadata.get("action_type") == "list_events"
+    assert res.metadata.get("events_count") == 5
+    assert res.metadata.get("events_shown") == 3
+    assert res.metadata.get("events_more") == 2
+
+
+def test_menus_are_concise_without_hint_lines() -> None:
+    """Jarvis menus should be short - no long hint lines."""
+    tools = ToolRegistry()
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, config=BrainLoopConfig(max_steps=1, debug=False))
+    res = loop.run(
+        turn_input="uykuluyum",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context={"session_id": "t"},
+    )
+    assert res.kind == "ask_user"
+    assert res.metadata.get("menu_id") == "smalltalk_stage1"
+    opts = res.metadata.get("options")
+    assert isinstance(opts, dict)
+    # Concise contract: stage1 exposes exactly 3 numbered options
+    assert set(opts.keys()) == {"0", "1", "2"}
+
+
+def test_voice_style_module_exists_and_works() -> None:
+    """VoiceStyle module provides Jarvis persona consistency."""
+    from bantz.voice_style import VoiceStyle, JARVIS
+
+    # Test acknowledge
+    assert VoiceStyle.acknowledge("test message").startswith("Efendim")
+    assert VoiceStyle.acknowledge("Efendim, already").startswith("Efendim")
+
+    # Test strip_emoji
+    assert VoiceStyle.strip_emoji("Hello 😀 World") == "Hello  World"
+
+    # Test limit_sentences
+    assert VoiceStyle.limit_sentences("One. Two. Three.", max_sentences=2) == "One. Two."
+
+    # Test format_list_with_more
+    items = ["A", "B", "C", "D", "E"]
+    result = VoiceStyle.format_list_with_more(items, shown=3)
+    assert "- A" in result
+    assert "- C" in result
+    assert "+2 daha fazla" in result
+    assert "- D" not in result
+
+    # Convenience alias
+    assert JARVIS is VoiceStyle

--- a/tests/test_google_calendar_rfc3339_normalize.py
+++ b/tests/test_google_calendar_rfc3339_normalize.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import re
+
+from bantz.google import calendar
+
+
+def test_normalize_rfc3339_adds_seconds_and_preserves_offset() -> None:
+    # LLMs often emit timestamps without seconds.
+    v = "2026-01-28T17:00+03:00"
+    out = calendar._normalize_rfc3339(v)
+    assert out == "2026-01-28T17:00:00+03:00"
+    assert re.search(r"T\d{2}:\d{2}:\d{2}", out)
+
+
+def test_normalize_rfc3339_accepts_z_suffix() -> None:
+    v = "2026-01-28T17:00Z"
+    out = calendar._normalize_rfc3339(v)
+    assert out == "2026-01-28T17:00:00+00:00"
+    assert out.endswith("+00:00")
+
+
+def test_time_range_validation_requires_min_lt_max() -> None:
+    tmn = calendar._normalize_rfc3339("2026-01-28T17:00+03:00")
+    tmx = calendar._normalize_rfc3339("2026-01-28T17:00+03:00")
+
+    try:
+        calendar._validate_time_range(time_min=tmn, time_max=tmx)
+        raise AssertionError("expected ValueError")
+    except ValueError as e:
+        assert str(e) == "time_min must be < time_max"

--- a/tests/test_google_calendar_update_delete_event.py
+++ b/tests/test_google_calendar_update_delete_event.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from bantz.agent.builtin_tools import build_default_registry
+from bantz.google.calendar import delete_event, update_event
+
+
+def test_calendar_delete_event_tool_registered() -> None:
+    reg = build_default_registry()
+    tool = reg.get("calendar.delete_event")
+    assert tool is not None
+    assert tool.risk_level == "MED"
+    assert tool.requires_confirmation is True
+
+
+def test_calendar_update_event_tool_registered() -> None:
+    reg = build_default_registry()
+    tool = reg.get("calendar.update_event")
+    assert tool is not None
+    assert tool.risk_level == "MED"
+    assert tool.requires_confirmation is True
+
+
+def test_calendar_delete_event_builds_delete_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    import bantz.google.auth as auth
+
+    monkeypatch.setattr(auth, "get_credentials", lambda *args, **kwargs: object())
+
+    calls: dict[str, Any] = {}
+
+    class _FakeDelete:
+        def __init__(self, *, calendarId: str, eventId: str):
+            calls["calendarId"] = calendarId
+            calls["eventId"] = eventId
+
+        def execute(self):
+            return {}
+
+    class _FakeEvents:
+        def delete(self, *, calendarId: str, eventId: str):
+            return _FakeDelete(calendarId=calendarId, eventId=eventId)
+
+    class _FakeService:
+        def events(self):
+            return _FakeEvents()
+
+    def _fake_build(api: str, version: str, *, credentials: object, cache_discovery: bool):
+        calls["build"] = {"api": api, "version": version, "cache_discovery": cache_discovery, "has_creds": credentials is not None}
+        return _FakeService()
+
+    discovery = ModuleType("googleapiclient.discovery")
+    discovery.build = _fake_build  # type: ignore[attr-defined]
+    googleapiclient = ModuleType("googleapiclient")
+
+    monkeypatch.setitem(sys.modules, "googleapiclient", googleapiclient)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", discovery)
+
+    out = delete_event(event_id="evt_123", calendar_id="primary")
+
+    assert out["ok"] is True
+    assert out["id"] == "evt_123"
+    assert out["calendar_id"] == "primary"
+    assert calls["build"]["api"] == "calendar"
+    assert calls["calendarId"] == "primary"
+    assert calls["eventId"] == "evt_123"
+
+
+def test_calendar_update_event_builds_patch_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    import bantz.google.auth as auth
+
+    monkeypatch.setattr(auth, "get_credentials", lambda *args, **kwargs: object())
+
+    calls: dict[str, Any] = {}
+
+    class _FakePatch:
+        def __init__(self, *, calendarId: str, eventId: str, body: dict[str, Any]):
+            calls["calendarId"] = calendarId
+            calls["eventId"] = eventId
+            calls["body"] = body
+
+        def execute(self):
+            return {
+                "id": calls["eventId"],
+                "summary": calls["body"].get("summary"),
+                "start": calls["body"].get("start"),
+                "end": calls["body"].get("end"),
+                "htmlLink": "https://example.test/event",
+            }
+
+    class _FakeEvents:
+        def patch(self, *, calendarId: str, eventId: str, body: dict[str, Any]):
+            return _FakePatch(calendarId=calendarId, eventId=eventId, body=body)
+
+    class _FakeService:
+        def events(self):
+            return _FakeEvents()
+
+    def _fake_build(api: str, version: str, *, credentials: object, cache_discovery: bool):
+        calls["build"] = {"api": api, "version": version, "cache_discovery": cache_discovery, "has_creds": credentials is not None}
+        return _FakeService()
+
+    discovery = ModuleType("googleapiclient.discovery")
+    discovery.build = _fake_build  # type: ignore[attr-defined]
+    googleapiclient = ModuleType("googleapiclient")
+
+    monkeypatch.setitem(sys.modules, "googleapiclient", googleapiclient)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", discovery)
+
+    out = update_event(
+        event_id="evt_123",
+        start="2026-01-28T15:45:00+03:00",
+        end="2026-01-28T16:45:00+03:00",
+        summary="Koşu",
+        calendar_id="primary",
+    )
+
+    assert out["ok"] is True
+    assert out["id"] == "evt_123"
+    assert out["calendar_id"] == "primary"
+    assert calls["build"]["api"] == "calendar"
+    assert calls["calendarId"] == "primary"
+    assert calls["eventId"] == "evt_123"
+
+    body = calls["body"]
+    assert body["summary"] == "Koşu"
+    assert "dateTime" in body["start"]
+    assert "dateTime" in body["end"]

--- a/tests/test_policy_engine_llm_first.py
+++ b/tests/test_policy_engine_llm_first.py
@@ -25,7 +25,7 @@ class FakeLLM:
 
     def complete_json(self, *, messages: list[dict[str, str]], schema_hint: str) -> dict[str, Any]:
         tail = messages[-1]["content"] if messages else ""
-        if "Observation (tool sonucu):" in tail:
+        if "TOOL_OBSERVATION:" in tail or "Observation (tool sonucu):" in tail:
             return {"type": "SAY", "text": "Tamam efendim."}
         return {"type": "CALL_TOOL", "name": self.tool_name, "params": dict(self.params)}
 


### PR DESCRIPTION
Bu PR, demo’da yaşanan gerçek kullanıcı akışını ("bugün 23.50" → slot-fill → create → confirmation) deterministik olarak düzeltir.

- Saat parse normalize: 23.50 / 23,50 / 23 50 → 23:50
- Slot-filling follow-up’larda (sadece "30 dk" gibi) calendar flow devam eder; "Nasıl ilerleyelim" menüsüne düşmez
- "calendar_next" menüsü gerçek pending-choice olarak çalışır (1/2/0 uygulanır)
- Metadata tabanlı regression testler eklendi
