### PR TITLE
security: bump tar to 7.5.7

### DIFF
--- a/bantz-browser/package-lock.json
+++ b/bantz-browser/package-lock.json
@@ -3395,9 +3395,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4298,7 +4298,7 @@
         "read-config-file": "6.3.2",
         "sanitize-filename": "^1.6.3",
         "semver": "^7.3.8",
-        "tar": "^7.5.4",
+        "tar": "^7.5.7",
         "temp-file": "^3.4.0"
       },
       "dependencies": {
@@ -6346,9 +6346,9 @@
       }
     },
     "tar": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
-      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
       "dev": true,
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/bantz-browser/package.json
+++ b/bantz-browser/package.json
@@ -17,7 +17,7 @@
     "electron-builder": "^24.9.0"
   },
   "overrides": {
-    "tar": "^7.5.4"
+    "tar": "^7.5.7"
   },
   "build": {
     "appId": "com.bantz.browser",


### PR DESCRIPTION
Fixes Dependabot alert #5 (CVE-2026-24842 / GHSA-34x7-hfp2-rc4v).

- Updates bantz-browser npm overrides to require tar >= 7.5.7
- Refreshes package-lock.json so electron-builder's transitive tar resolves to 7.5.7

Verification: /home/iclaldogan/Desktop/Bantz
└── (empty) shows tar@7.5.7.