### PR TITLE
Issue #103: CLI adapter for BrainLoop event stream

### DIFF
--- a/src/bantz/cli.py
+++ b/src/bantz/cli.py
@@ -26,6 +26,88 @@ from bantz.router.context import ConversationContext
 from bantz.logs.logger import JsonlLogger
 
 
+def run_brainloop_demo_once(command: str) -> int:
+    """Minimal BrainLoop CLI demo with Jarvis-like event stream.
+
+    Issue #103 scope: render ACK/PROGRESS/FOUND/SUMMARIZING/RESULT in-order.
+    This is intentionally a deterministic, dependency-light demo.
+    """
+
+    from datetime import timedelta
+
+    from bantz.agent.tools import Tool, ToolRegistry
+    from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+    from bantz.core.events import Event, EventBus, EventType
+
+    class _FailingLLM:
+        def complete_json(self, *, messages, schema_hint):  # type: ignore[no-untyped-def]
+            raise AssertionError("LLM should not be called in brainloop demo")
+
+    # Deterministic windows (stable enough for CLI demo).
+    now = datetime.now().astimezone().replace(microsecond=0)
+    day_end = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0)
+    session_context = {
+        "deterministic_render": True,
+        "tz_name": "Europe/Istanbul",
+        "today_window": {"time_min": now.isoformat(), "time_max": day_end.isoformat()},
+    }
+
+    tools = ToolRegistry()
+
+    def list_events(**params):
+        # Demo-friendly stub: empty calendar.
+        _ = params
+        return {"ok": True, "count": 0, "events": []}
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=list_events,
+        )
+    )
+
+    bus = EventBus()
+
+    def on_event(ev: Event) -> None:
+        et = str(ev.event_type)
+        data = ev.data or {}
+
+        if et == EventType.ACK.value or et == EventType.PROGRESS.value:
+            msg = str(data.get("text") or data.get("message") or "").strip()
+            prefix = "Kontrol ediyorum efendim…"
+            if msg:
+                print(f"{Colors.DIM}{prefix}{Colors.RESET} {Colors.DIM}({msg}){Colors.RESET}")
+            else:
+                print(f"{Colors.DIM}{prefix}{Colors.RESET}")
+            return
+
+        if et == EventType.FOUND.value:
+            tool = str(data.get("tool") or data.get("name") or "").strip()
+            suffix = f" ({tool})" if tool else ""
+            print(f"{Colors.DIM}Buldum efendim…{suffix}{Colors.RESET}")
+            return
+
+        if et == EventType.SUMMARIZING.value:
+            status = str(data.get("status") or "").strip() or "started"
+            if status == "complete":
+                return
+            print(f"{Colors.DIM}Özetliyorum efendim…{Colors.RESET}")
+            return
+
+        if et == EventType.RESULT.value:
+            text = str(data.get("text") or data.get("summary") or "").strip()
+            print(text)
+            return
+
+    bus.subscribe_all(on_event)
+
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, event_bus=bus, config=BrainLoopConfig(max_steps=2, debug=False))
+    _ = loop.run(turn_input=command, session_context=session_context, policy=None, context={"session_id": "cli-demo"})
+    return 0
+
+
 # ANSI colors
 class Colors:
     RESET = "\033[0m"
@@ -380,6 +462,11 @@ Kullanım örnekleri:
     parser.add_argument("--serve", action="store_true", help="Interactive server modu başlat")
     parser.add_argument("--once", default=None, metavar="CMD", help="Tek seferlik komut")
     parser.add_argument("--stop", action="store_true", help="Çalışan session'ı kapat")
+    parser.add_argument(
+        "--brainloop-demo",
+        action="store_true",
+        help="BrainLoop event stream CLI demo (Issue #103). Kullanım: --once \"...\" --brainloop-demo",
+    )
 
     # Compatibility flags (README/back-compat)
     parser.add_argument("--text", action="store_true", help="Text mod (varsayılan). (Uyumluluk)")
@@ -526,6 +613,13 @@ Kullanım örnekleri:
         os.environ["BANTZ_ASR_CACHE_DIR"] = args.asr_cache_dir
         os.environ["BANTZ_ASR_ALLOW_DOWNLOAD"] = "1" if args.asr_allow_download else "0"
         return run_voice_loop(cfg)
+
+    # BrainLoop CLI demo (deterministic, local).
+    if args.brainloop_demo:
+        if not args.once:
+            print("❌ --brainloop-demo için --once gerekli.")
+            return 1
+        return run_brainloop_demo_once(str(args.once))
 
     # Stop session
     if args.stop:

--- a/tests/test_brainloop_event_stream.py
+++ b/tests/test_brainloop_event_stream.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from bantz.agent.tools import Tool, ToolRegistry
+from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+from bantz.core.events import EventBus, EventType
+
+
+class _FailingLLM:
+    def complete_json(self, *, messages, schema_hint):  # type: ignore[no-untyped-def]
+        raise AssertionError("LLM should not be called in this test")
+
+
+def test_event_stream_for_deterministic_list_events_is_ordered() -> None:
+    """Issue #103: ACK/PROGRESS/FOUND/SUMMARIZING/RESULT order for CLI."""
+
+    tools = ToolRegistry()
+
+    def list_events(**params):
+        assert "time_min" in params
+        assert "time_max" in params
+        return {"ok": True, "count": 0, "events": []}
+
+    tools.register(
+        Tool(
+            name="calendar.list_events",
+            description="list",
+            parameters={"type": "object", "properties": {}},
+            function=list_events,
+        )
+    )
+
+    bus = EventBus()
+    seen: list[str] = []
+
+    def on_any(ev):  # type: ignore[no-untyped-def]
+        t = str(ev.event_type)
+        if t in {
+            EventType.ACK.value,
+            EventType.PROGRESS.value,
+            EventType.FOUND.value,
+            EventType.SUMMARIZING.value,
+            EventType.RESULT.value,
+        }:
+            seen.append(t)
+
+    bus.subscribe_all(on_any)
+
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, event_bus=bus, config=BrainLoopConfig(max_steps=1, debug=False))
+    res = loop.run(
+        turn_input="Bu akşam planım var mı?",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "today_window": {"time_min": "2026-01-28T00:00:00+03:00", "time_max": "2026-01-28T23:59:00+03:00"},
+        },
+        policy=None,
+        context={"session_id": "t"},
+    )
+
+    assert res.kind == "say"
+
+    # Must be ordered (duplicates allowed, but the first occurrence order must hold)
+    joined = " > ".join(seen)
+    assert joined.find(EventType.ACK.value) != -1
+    assert joined.find(EventType.PROGRESS.value) > joined.find(EventType.ACK.value)
+    assert joined.find(EventType.FOUND.value) > joined.find(EventType.PROGRESS.value)
+    assert joined.find(EventType.SUMMARIZING.value) > joined.find(EventType.FOUND.value)
+    assert joined.find(EventType.RESULT.value) > joined.find(EventType.SUMMARIZING.value)


### PR DESCRIPTION
Implements Issue #103 by adding a minimal CLI demo adapter that prints the BrainLoop EventBus stream in a Jarvis-like order.

What changed
- Emit consistent ACK/PROGRESS/FOUND/SUMMARIZING/RESULT events in deterministic calendar paths
- Add `--brainloop-demo` CLI mode for a one-shot demo output
- Add an ordering test to lock the event sequence

How to test
- `/home/iclaldogan/Desktop/Bantz/.venv/bin/python -m pytest -q tests/test_brainloop_event_stream.py`
- `/home/iclaldogan/Desktop/Bantz/.venv/bin/python -m bantz.cli --once "Bu akşam planım var mı?" --brainloop-demo --no-llm --text`

Closes #103.