### PR TITLE
Issue #117: Apply PlanDraft (dry-run + safe failure)

### DIFF
--- a/src/bantz/planning/executor.py
+++ b/src/bantz/planning/executor.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Callable, Optional
+
+from bantz.planning.plan_draft import PlanDraft, PlanItem, plan_draft_from_dict
+
+
+@dataclass(frozen=True)
+class PlannedEvent:
+    summary: str
+    start: str
+    end: str
+    location: Optional[str] = None
+
+
+def plan_events_from_draft(
+    *,
+    draft: dict[str, Any],
+    time_min: str,
+    time_max: str,
+) -> dict[str, Any]:
+    """Create a deterministic list of events from a PlanDraft within a window.
+
+    This does not call external services.
+    """
+
+    if not isinstance(draft, dict):
+        return {"ok": False, "error": "invalid_draft"}
+    if not isinstance(time_min, str) or not isinstance(time_max, str) or not time_min or not time_max:
+        return {"ok": False, "error": "invalid_window"}
+
+    plan = plan_draft_from_dict(draft)
+
+    try:
+        w_start = _parse_iso(time_min)
+        w_end = _parse_iso(time_max)
+    except Exception:
+        return {"ok": False, "error": "invalid_window"}
+
+    cursor = w_start
+    events: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for idx, item in enumerate(plan.items):
+        if not isinstance(item, PlanItem):
+            continue
+
+        dur = _duration_minutes(item)
+        start = cursor
+        end = start + timedelta(minutes=dur)
+
+        if end > w_end:
+            warnings.append(f"item_{idx+1}_exceeds_window")
+            break
+
+        events.append(
+            {
+                "summary": str(item.label or "").strip() or "(etkinlik)",
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                "location": str(item.location or "").strip() or None,
+            }
+        )
+        cursor = end
+
+    return {
+        "ok": True,
+        "count": len(events),
+        "events": events,
+        "warnings": warnings,
+        "time_min": time_min,
+        "time_max": time_max,
+    }
+
+
+def apply_plan_draft(
+    *,
+    draft: dict[str, Any],
+    time_min: str,
+    time_max: str,
+    dry_run: bool = False,
+    calendar_id: str = "primary",
+    create_event_fn: Optional[Callable[..., dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    """Apply a PlanDraft by creating calendar events.
+
+    - If dry_run=True, returns the proposed events and performs no writes.
+    - If a create fails, stops and returns which item failed.
+    """
+
+    planned = plan_events_from_draft(draft=draft, time_min=time_min, time_max=time_max)
+    if not planned.get("ok"):
+        return {"ok": False, "error": planned.get("error") or "plan_failed"}
+
+    events = planned.get("events")
+    if not isinstance(events, list):
+        events = []
+
+    if dry_run:
+        return {
+            "ok": True,
+            "dry_run": True,
+            "created_count": 0,
+            "events": events,
+            "warnings": planned.get("warnings") if isinstance(planned.get("warnings"), list) else [],
+        }
+
+    if create_event_fn is None:
+        return {"ok": False, "error": "missing_create_event_fn"}
+
+    created: list[dict[str, Any]] = []
+    for idx, ev in enumerate(events):
+        if not isinstance(ev, dict):
+            continue
+        try:
+            res = create_event_fn(
+                summary=str(ev.get("summary") or "").strip() or "(etkinlik)",
+                start=str(ev.get("start") or "").strip(),
+                end=str(ev.get("end") or "").strip(),
+                location=str(ev.get("location") or "").strip() or None,
+                calendar_id=calendar_id,
+            )
+        except Exception as e:
+            return {
+                "ok": False,
+                "error": str(e),
+                "failed_index": idx + 1,
+                "created_count": len(created),
+                "created": created,
+            }
+
+        if not isinstance(res, dict) or res.get("ok") is not True:
+            return {
+                "ok": False,
+                "error": (res.get("error") if isinstance(res, dict) else None) or "create_failed",
+                "failed_index": idx + 1,
+                "created_count": len(created),
+                "created": created,
+                "last_result": res,
+            }
+
+        created.append(res)
+
+    return {
+        "ok": True,
+        "dry_run": False,
+        "created_count": len(created),
+        "events": events,
+        "created": created,
+        "warnings": planned.get("warnings") if isinstance(planned.get("warnings"), list) else [],
+    }
+
+
+def _duration_minutes(item: PlanItem) -> int:
+    try:
+        dm = int(item.duration_minutes) if item.duration_minutes is not None else 0
+    except Exception:
+        dm = 0
+    if dm <= 0:
+        return 30
+    return max(5, min(24 * 60, dm))
+
+
+def _parse_iso(s: str) -> datetime:
+    t = str(s or "").strip()
+    if t.endswith("Z"):
+        t = t[:-1] + "+00:00"
+    return datetime.fromisoformat(t)

--- a/tests/test_plan_confirmation.py
+++ b/tests/test_plan_confirmation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from bantz.agent.tools import ToolRegistry
+from bantz.agent.tools import Tool
 from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
 from bantz.core.events import EventBus, EventType
 
@@ -51,8 +52,8 @@ def test_pending_plandraft_accept_onayla() -> None:
         policy=None,
         context=ctx,
     )
-    assert r2.kind == "say"
-    assert "onay" in r2.text.lower()
+    assert r2.kind == "ask_user"
+    assert "1/0" in r2.text.lower() or "uygul" in r2.text.lower()
 
 
 def test_pending_plandraft_cancel_iptal() -> None:
@@ -117,3 +118,114 @@ def test_pending_plandraft_edit_updates_preview() -> None:
     slots = trace.get("slots")
     assert isinstance(slots, dict)
     assert slots.get("item_count") == 4
+
+
+def test_plandraft_apply_state_machine_two_turns() -> None:
+    tools = ToolRegistry()
+    bus = EventBus()
+    ctx: dict[str, object] = {"session_id": "t"}
+
+    calls: list[dict[str, object]] = []
+
+    def _stub_apply_plan_draft(**params):  # type: ignore[no-untyped-def]
+        calls.append(dict(params))
+        if bool(params.get("dry_run")):
+            return {
+                "ok": True,
+                "dry_run": True,
+                "created_count": 0,
+                "events": [
+                    {"summary": "A", "start": "2026-01-30T09:00:00+03:00", "end": "2026-01-30T09:30:00+03:00"},
+                    {"summary": "B", "start": "2026-01-30T09:30:00+03:00", "end": "2026-01-30T10:00:00+03:00"},
+                ],
+                "warnings": [],
+            }
+        return {
+            "ok": True,
+            "dry_run": False,
+            "created_count": 2,
+            "events": [],
+            "created": [{"ok": True, "id": "1"}, {"ok": True, "id": "2"}],
+            "warnings": [],
+        }
+
+    tools.register(
+        Tool(
+            name="calendar.apply_plan_draft",
+            description="test stub",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "draft": {"type": "object"},
+                    "time_min": {"type": "string"},
+                    "time_max": {"type": "string"},
+                    "dry_run": {"type": "boolean"},
+                    "calendar_id": {"type": "string"},
+                },
+                "required": ["draft", "time_min", "time_max"],
+            },
+            requires_confirmation=True,
+            function=_stub_apply_plan_draft,
+        )
+    )
+
+    loop = BrainLoop(llm=_FailingLLM(), tools=tools, event_bus=bus, config=BrainLoopConfig(max_steps=1, debug=False))
+
+    # Turn 0: create pending plan draft + persisted window.
+    r1 = loop.run(
+        turn_input="bugün plan yap",
+        session_context={
+            "deterministic_render": True,
+            "tz_name": "Europe/Istanbul",
+            "today_window": {"time_min": "2026-01-30T00:00:00+03:00", "time_max": "2026-01-30T23:59:00+03:00"},
+        },
+        policy=None,
+        context=ctx,
+    )
+    assert r1.kind == "say"
+    assert isinstance(ctx.get("_planning_pending_plan_draft"), dict)
+
+    # Turn A: accept -> dry-run preview + queued confirmation.
+    r2 = loop.run(
+        turn_input="onayla",
+        session_context={"deterministic_render": True},
+        policy=None,
+        context=ctx,
+    )
+    assert r2.kind == "ask_user"
+    assert "dry-run" in r2.text.lower()  # preview visible in returned text
+    assert "1/0" in r2.text.lower() or "uygula" in r2.text.lower()
+
+    # State assertions after Turn A
+    assert ctx.get("_planning_pending_plan_draft") is None
+    assert isinstance(ctx.get("_planning_confirmed_plan_draft"), dict)
+    pending_action = ctx.get("_policy_pending_action")
+    assert isinstance(pending_action, dict)
+    action = pending_action.get("action")
+    assert isinstance(action, dict)
+    assert action.get("name") == "calendar.apply_plan_draft"
+    params = action.get("params")
+    assert isinstance(params, dict)
+    assert params.get("dry_run") is False
+    assert isinstance(params.get("draft"), dict)
+    assert isinstance(params.get("time_min"), str) and params.get("time_min")
+    assert isinstance(params.get("time_max"), str) and params.get("time_max")
+
+    # Turn B: confirm -> real apply
+    r3 = loop.run(
+        turn_input="1",
+        session_context={"deterministic_render": True, "tz_name": "Europe/Istanbul"},
+        policy=None,
+        context=ctx,
+    )
+    assert r3.kind == "say"
+    assert "2" in r3.text  # created_count rendered
+
+    # Pending confirmation cleared; confirmed draft cleared after successful apply.
+    assert ctx.get("_policy_pending_action") is None
+    assert ctx.get("_planning_confirmed_plan_draft") is None
+
+    # Tool call evidence: first dry-run, then real apply.
+    assert len(calls) == 2
+    assert bool(calls[0].get("dry_run")) is True
+    assert bool(calls[1].get("dry_run")) is False

--- a/tests/test_plan_executor.py
+++ b/tests/test_plan_executor.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from bantz.planning.executor import apply_plan_draft, plan_events_from_draft
+from bantz.planning.plan_draft import PlanDraft, PlanItem, plan_draft_to_dict
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(tzinfo=timezone.utc).isoformat()
+
+
+def test_plan_events_from_draft_basic_sequence():
+    draft = PlanDraft(
+        title="Yarın planı (sabah)",
+        goal=None,
+        day_hint="tomorrow",
+        time_of_day="morning",
+        items=[
+            PlanItem(label="Spor", duration_minutes=30),
+            PlanItem(label="Okuma", duration_minutes=60),
+        ],
+    )
+
+    time_min = _iso(datetime(2026, 1, 30, 9, 0, 0))
+    time_max = _iso(datetime(2026, 1, 30, 12, 0, 0))
+
+    res = plan_events_from_draft(draft=plan_draft_to_dict(draft), time_min=time_min, time_max=time_max)
+    assert res["ok"] is True
+    assert res["count"] == 2
+
+    events = res["events"]
+    assert isinstance(events, list)
+    assert events[0]["summary"] == "Spor"
+    assert events[0]["start"] == time_min
+    assert events[0]["end"].endswith("09:30:00+00:00")
+    assert events[1]["summary"] == "Okuma"
+    assert events[1]["start"].endswith("09:30:00+00:00")
+    assert events[1]["end"].endswith("10:30:00+00:00")
+
+
+def test_apply_plan_draft_dry_run_never_writes():
+    draft = PlanDraft(
+        title="Bugün planı",
+        goal=None,
+        day_hint="today",
+        time_of_day=None,
+        items=[PlanItem(label="Yürüyüş", duration_minutes=30)],
+    )
+    raw = plan_draft_to_dict(draft)
+
+    time_min = _iso(datetime(2026, 1, 30, 18, 0, 0))
+    time_max = _iso(datetime(2026, 1, 30, 19, 0, 0))
+
+    def _should_not_be_called(**_):
+        raise AssertionError("create_event_fn should not be called in dry_run")
+
+    res = apply_plan_draft(
+        draft=raw,
+        time_min=time_min,
+        time_max=time_max,
+        dry_run=True,
+        calendar_id="primary",
+        create_event_fn=_should_not_be_called,
+    )
+
+    assert res["ok"] is True
+    assert res["dry_run"] is True
+    assert res["created_count"] == 0
+    assert isinstance(res["events"], list)
+    assert len(res["events"]) == 1
+
+
+def test_apply_plan_draft_stops_on_first_failure():
+    draft = PlanDraft(
+        title="Bugün planı",
+        goal=None,
+        day_hint="today",
+        time_of_day=None,
+        items=[
+            PlanItem(label="A", duration_minutes=30),
+            PlanItem(label="B", duration_minutes=30),
+            PlanItem(label="C", duration_minutes=30),
+        ],
+    )
+    raw = plan_draft_to_dict(draft)
+
+    time_min = _iso(datetime(2026, 1, 30, 9, 0, 0))
+    time_max = _iso(datetime(2026, 1, 30, 12, 0, 0))
+
+    calls: list[str] = []
+
+    def _stub_create_event(**params):
+        calls.append(str(params.get("summary")))
+        if len(calls) == 2:
+            return {"ok": False, "error": "boom"}
+        return {"ok": True, "id": f"id-{len(calls)}"}
+
+    res = apply_plan_draft(
+        draft=raw,
+        time_min=time_min,
+        time_max=time_max,
+        dry_run=False,
+        calendar_id="primary",
+        create_event_fn=_stub_create_event,
+    )
+
+    assert res["ok"] is False
+    assert res["failed_index"] == 2
+    assert res["created_count"] == 1
+    assert calls == ["A", "B"]


### PR DESCRIPTION
Implements Issue #117 end-to-end:\n\n- Adds deterministic PlanDraft executor (plan_events_from_draft + apply_plan_draft)\n- BrainLoop flow: Onayla -> dry-run preview + queued confirmation -> "1" executes real apply\n- UI-friendly: returns preview+prompt in one message; EventBus RESULT/QUESTION preserved\n- Trace evidence for queued/seen pending confirmation\n- Tests: executor unit tests + 2-turn BrainLoop state-machine test\n\nTest: pytest -q