### PR TITLE
Issue #118: Add GitHub issue templates (Feature Planning + Bug Report)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,60 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: '[Bug] '
+labels: 'type:bug, priority:P1'
+assignees: ''
+
+---
+
+## Describe the Bug
+
+<!--
+A clear and concise description of what the bug is.
+-->
+
+## Steps to Reproduce
+
+<!--
+Steps to reproduce the behavior:
+1. Run command '...'
+2. Say '...'
+3. See error
+-->
+
+## Expected Behavior
+
+<!--
+What did you expect to happen?
+-->
+
+## Actual Behavior
+
+<!--
+What actually happened?
+-->
+
+## Environment
+
+- OS: [e.g., Ubuntu 22.04]
+- Python version: [e.g., 3.10.12]
+- Bantz version: [e.g., 0.2.0-alpha]
+- Installation method: [pip, source]
+
+## Logs
+
+<!--
+Paste relevant logs here. Use triple backticks for code blocks.
+Check: bantz.log.jsonl, test.log.jsonl, or terminal output.
+-->
+
+```
+Paste logs here
+```
+
+## Additional Context
+
+<!--
+Add any other context about the problem here.
+Screenshots, videos, or related issues.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/miclaldogan/bantz/blob/dev/SECURITY.md
+    about: Report security vulnerabilities privately
+  - name: General Questions
+    url: https://github.com/miclaldogan/bantz/discussions
+    about: Ask questions or discuss ideas

--- a/.github/ISSUE_TEMPLATE/feature_planning.md
+++ b/.github/ISSUE_TEMPLATE/feature_planning.md
@@ -1,0 +1,83 @@
+---
+name: Feature Planning
+about: Structured template for planning new features (Goal/Scope/AC/Tests/Deps)
+title: '[Feature] '
+labels: 'type:feature, priority:P2'
+assignees: ''
+
+---
+
+## Goal
+
+<!-- 
+What is the main objective of this feature?
+Example: "Make it easy to create high-quality planning issues with consistent structure"
+-->
+
+## Background
+
+<!--
+Why is this needed? What problem does it solve?
+Provide context for reviewers and future maintainers.
+Example: "Current planning issues lack consistent structure, making it hard to review and execute work."
+-->
+
+## Scope
+
+### In Scope
+<!--
+What will be implemented?
+Example:
+- Add GitHub issue template
+- Include sections: Goal, Background, Scope, AC, Tests, Dependencies
+- Add example for Jarvis-Calendar features
+-->
+
+### Out of Scope
+<!--
+What will NOT be implemented in this issue?
+Example:
+- Automated issue validation
+- Multi-language templates
+-->
+
+## Acceptance Criteria
+
+<!--
+Clear, testable conditions that must be met for this feature to be complete.
+Example:
+- [ ] New issues created via template include the above sections
+- [ ] Template encourages adding at least one test or explicit justification
+- [ ] Template is linked from README or CONTRIBUTING
+-->
+
+## How to Test
+
+<!--
+How can reviewers verify this feature works correctly?
+Example:
+- Create a new issue using the template
+- Verify all sections are present
+- Check README links to template
+-->
+
+## Dependencies
+
+<!--
+List any dependencies or blockers:
+- Other issues that must be completed first
+- External libraries or tools needed
+- Team member availability
+Example:
+- Depends on #115, #116, #117
+- Requires GitHub template directory
+-->
+
+## Notes
+
+<!--
+Any additional context, design decisions, or open questions.
+Example:
+- Consider adding automation in the future
+- Template structure inspired by [source]
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,10 @@ While the source code is publicly visible for educational purposes, we are **not
 ✅ **View & Learn**: Study the code to learn about voice assistants, browser automation, and LLM integration.
 
 ✅ **Report Issues**: If you find bugs or security vulnerabilities, please report them:
-- Bugs: [Open an issue](https://github.com/miclaldogan/bantz/issues)
+- Bugs: [Open a bug report](https://github.com/miclaldogan/bantz/issues/new?template=bug_report.md)
 - Security: See [SECURITY.md](SECURITY.md)
 
-✅ **Suggest Features**: Open an issue with the `enhancement` label to suggest features.
+✅ **Suggest Features**: [Open a feature planning issue](https://github.com/miclaldogan/bantz/issues/new?template=feature_planning.md) to suggest features.
 
 ✅ **Star the Repo**: Show your support by starring the repository! ⭐
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="#installation">Installation</a> •
   <a href="#usage">Usage</a> •
   <a href="#roadmap">Roadmap</a> •
+  <a href="#contributing">Contributing</a> •
   <a href="#license">License</a>
 </p>
 
@@ -726,7 +727,19 @@ tail -f bantz.log.jsonl | jq
 
 ---
 
-## 📄 License
+## � Contributing
+
+**Bantz is currently a private/proprietary project**, but we welcome:
+
+- 🐛 **Bug Reports**: [Open a bug report](https://github.com/miclaldogan/bantz/issues/new?template=bug_report.md)
+- 💡 **Feature Suggestions**: [Open a feature planning issue](https://github.com/miclaldogan/bantz/issues/new?template=feature_planning.md)
+- 🔒 **Security Issues**: See [SECURITY.md](SECURITY.md)
+
+For more details, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## �📄 License
 
 **Proprietary - All Rights Reserved**
 

--- a/docs/issue-template-example.md
+++ b/docs/issue-template-example.md
@@ -1,0 +1,75 @@
+# Example: Feature Planning Template
+
+This is a filled-in example for a Jarvis-Calendar planning feature.
+
+---
+
+## Goal
+
+Enable Jarvis to create structured daily plans via natural language and apply them safely to Google Calendar with deterministic confirmation flow.
+
+## Background
+
+Current calendar features (#115, #116) can generate plan drafts and confirm edits, but lack the ability to actually write events to the calendar. Users need a safe, transparent way to:
+- See a dry-run preview of what will be created
+- Explicitly confirm before any calendar writes happen
+- Know if something fails mid-apply (stop-on-first-failure)
+
+## Scope
+
+### In Scope
+- Add `calendar.apply_plan_draft` tool with dry-run mode
+- Implement 2-turn state machine:
+  - Turn A: "Onayla" → dry-run preview + queue pending confirmation
+  - Turn B: "1" → real apply + created_count summary
+- Stop-on-first-failure: if one event fails, report failed_index + created_count
+- Deterministic renderer for apply results
+- Unit tests: executor + BrainLoop 2-turn E2E
+
+### Out of Scope
+- Retry/rollback on failure (future: #119)
+- Bulk update/delete existing events
+- Multi-calendar support (always "primary" for now)
+
+## Acceptance Criteria
+
+- [x] `plan_events_from_draft(draft, time_min, time_max)` returns deterministic event list
+- [x] `apply_plan_draft(..., dry_run=True)` never calls create_event_fn
+- [x] `apply_plan_draft(..., dry_run=False)` stops on first failure and returns failed_index
+- [x] Turn A ("onayla") queues pending confirmation with real apply payload
+- [x] Turn B ("1") executes the tool and clears pending state
+- [x] BrainResult.text includes preview + prompt (UI visibility)
+- [x] Trace evidence: queued/seen confirmation in metadata
+
+## How to Test
+
+### Unit Tests
+```bash
+pytest tests/test_plan_executor.py -v
+pytest tests/test_plan_confirmation.py::test_plandraft_apply_state_machine_two_turns -v
+```
+
+### Manual / CLI
+```bash
+python -m bantz.cli --brainloop-demo
+
+# Say: "bugün plan yap"
+# System: shows draft preview + confirmation menu
+# Say: "onayla"
+# System: shows dry-run preview + "1/0" prompt
+# Say: "1"
+# System: creates events and reports created_count
+```
+
+## Dependencies
+
+- Depends on #115 (PlanDraft model)
+- Depends on #116 (PlanDraft confirmation/edit loop)
+- Requires Google Calendar backend (`src/bantz/google/calendar.py`)
+- Requires tool registry (`src/bantz/agent/builtin_tools.py`)
+
+## Notes
+
+- Policy gate: dry-run is LOW risk (no confirmation), real apply is MED risk (requires confirmation)
+- Time window persistence: pending_plan stores time_min/time_max so follow-up turns don't need session_context
+- EventBus: preview published as RESULT, prompt as QUESTION; BrainResult.text combines both for UI fallback


### PR DESCRIPTION
Implements Issue #118:\n\n**What's Added**\n- GitHub issue templates:\n  - `.github/ISSUE_TEMPLATE/feature_planning.md` (Goal/Scope/AC/Tests/Deps)\n  - `.github/ISSUE_TEMPLATE/bug_report.md` (standard bug report)\n  - `.github/ISSUE_TEMPLATE/config.yml` (links to Security/Discussions)\n- Example filled-in template: `docs/issue-template-example.md` (based on #117)\n- Updated CONTRIBUTING.md with direct links to templates\n- Updated README.md with Contributing section + template links\n\n**Acceptance Criteria**\n- [x] New issues can be created via template with all required sections\n- [x] Template encourages adding at least one test\n- [x] Templates are linked from README and CONTRIBUTING\n\n**How to Test**\n- Visit https://github.com/miclaldogan/bantz/issues/new/choose\n- Verify templates appear and contain expected sections\n- Check README/CONTRIBUTING links work\n\nCloses #118