### PR TITLE
Add LLM confirmation flow for calendar actions

### DIFF
--- a/scripts/test_confirmation_flow.py
+++ b/scripts/test_confirmation_flow.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Test LLM confirmation flow for calendar actions."""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+from bantz.brain.llm_router import JarvisLLMRouter
+from bantz.llm.ollama_client import OllamaClient, LLMMessage
+from bantz.agent.tools import ToolRegistry
+
+
+class MockToolRegistry(ToolRegistry):
+    """Mock tool registry for testing."""
+    
+    def call_tool(self, tool_name: str, **kwargs):
+        print(f"[MOCK TOOL] {tool_name}({kwargs})")
+        return {"status": "success", "message": "Mock tool call"}
+
+
+class RouterLLMWrapper:
+    """Wrapper for Ollama to match LLM Router protocol."""
+    
+    def __init__(self, client: OllamaClient, temperature: float = 0.0):
+        self._client = client
+        self._temperature = temperature
+    
+    def complete_text(self, prompt: str) -> str:
+        """Simple text completion for router (no JSON mode)."""
+        messages = [LLMMessage(role="user", content=prompt)]
+        return self._client.chat(
+            messages=messages,
+            temperature=self._temperature,
+            max_tokens=512,
+        )
+
+
+def test_confirmation_flow():
+    """Test the confirmation flow with calendar actions."""
+    
+    print("[TEST] Initializing LLM Router...")
+    ollama_client = OllamaClient(model="qwen2.5:3b-instruct")
+    router_llm = RouterLLMWrapper(client=ollama_client, temperature=0.0)
+    router = JarvisLLMRouter(llm=router_llm)
+    
+    print("[TEST] Initializing BrainLoop...")
+    config = BrainLoopConfig(debug=True)
+    tool_registry = MockToolRegistry()
+    
+    # Create a simple LLM wrapper for BrainLoop
+    class SimpleLLM:
+        def complete_json(self, messages, schema_hint=None):
+            return {"route": "unknown", "calendar_intent": "none", "confidence": 0.0}
+    
+    brain = BrainLoop(llm=SimpleLLM(), tools=tool_registry, config=config, router=router)
+    
+    session_context = {
+        "user": "test_user",
+        "session_id": "test_session",
+        "today_window": {"start": "2026-01-30T00:00:00", "end": "2026-01-30T23:59:59"},
+        "tomorrow_window": {"start": "2026-01-31T00:00:00", "end": "2026-01-31T23:59:59"},
+    }
+    
+    state = {}
+    
+    # Test 1: Request calendar action
+    print("\n" + "="*60)
+    print("[TEST 1] User: 'bu akşam sekize parti ekle'")
+    print("="*60)
+    
+    result = brain.run(
+        turn_input="bu akşam sekize parti ekle",
+        session_context=session_context,
+        context=state,
+    )
+    
+    print(f"\n[RESULT] kind={result.kind}")
+    print(f"[RESULT] text={result.text}")
+    print(f"[STATE] dialog_state={state.get('_dialog_state')}")
+    
+    if state.get("_dialog_state") != "PENDING_LLM_CONFIRMATION":
+        print("\n❌ FAIL: Expected PENDING_LLM_CONFIRMATION state")
+        return False
+    
+    print("\n✅ PASS: Confirmation requested")
+    
+    # Test 2a: User confirms with "evet"
+    print("\n" + "="*60)
+    print("[TEST 2a] User: 'evet'")
+    print("="*60)
+    
+    result = brain.run(
+        turn_input="evet",
+        session_context=session_context,
+        context=state,
+    )
+    
+    print(f"\n[RESULT] kind={result.kind}")
+    print(f"[RESULT] text={result.text}")
+    print(f"[STATE] dialog_state={state.get('_dialog_state')}")
+    
+    # Reset for next test
+    state = {}
+    
+    # Test 2b: User rejects with "hayır"
+    print("\n" + "="*60)
+    print("[TEST 2b] User: 'hayır' (after new request)")
+    print("="*60)
+    
+    result = brain.run(
+        turn_input="yarın öğlene toplantı ekle",
+        session_context=session_context,
+        context=state,
+    )
+    
+    print(f"\n[RESULT] kind={result.kind}")
+    print(f"[RESULT] text={result.text}")
+    
+    if state.get("_dialog_state") != "PENDING_LLM_CONFIRMATION":
+        print("\n❌ FAIL: Expected PENDING_LLM_CONFIRMATION state")
+        return False
+    
+    result = brain.run(
+        turn_input="hayır",
+        session_context=session_context,
+        context=state,
+    )
+    
+    print(f"\n[RESULT] kind={result.kind}")
+    print(f"[RESULT] text={result.text}")
+    print(f"[STATE] dialog_state={state.get('_dialog_state')}")
+    
+    if state.get("_dialog_state") != "IDLE":
+        print("\n❌ FAIL: Expected IDLE state after rejection")
+        return False
+    
+    if "iptal" not in result.text.lower():
+        print("\n❌ FAIL: Expected cancellation message")
+        return False
+    
+    print("\n✅ PASS: Rejection handled correctly")
+    
+    # Test 3: Unclear response
+    print("\n" + "="*60)
+    print("[TEST 3] User: 'belki' (unclear response)")
+    print("="*60)
+    
+    state = {}
+    result = brain.run(
+        turn_input="bu gece on bir buçukta uyku zamanı koy",
+        session_context=session_context,
+        context=state,
+    )
+    
+    print(f"\n[RESULT] text={result.text}")
+    
+    result = brain.run(
+        turn_input="belki",
+        session_context=session_context,
+        context=state,
+    )
+    
+    print(f"\n[RESULT] kind={result.kind}")
+    print(f"[RESULT] text={result.text}")
+    print(f"[STATE] dialog_state={state.get('_dialog_state')}")
+    
+    if state.get("_dialog_state") != "PENDING_LLM_CONFIRMATION":
+        print("\n❌ FAIL: Expected to stay in PENDING_LLM_CONFIRMATION state")
+        return False
+    
+    if "evet" not in result.text.lower() or "hayır" not in result.text.lower():
+        print("\n❌ FAIL: Expected clarification question")
+        return False
+    
+    print("\n✅ PASS: Unclear response handled with clarification")
+    
+    print("\n" + "="*60)
+    print("✅ ALL TESTS PASSED")
+    print("="*60)
+    return True
+
+
+if __name__ == "__main__":
+    try:
+        success = test_confirmation_flow()
+        sys.exit(0 if success else 1)
+    except Exception as e:
+        print(f"\n❌ TEST FAILED WITH EXCEPTION: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/src/bantz/brain/brain_loop.py
+++ b/src/bantz/brain/brain_loop.py
@@ -784,6 +784,46 @@ def _calendar_route_from_intent(intent: str) -> str:
     return _ROUTE_CALENDAR_QUERY  # Default to query for calendar route
 
 
+def _llm_parse_confirmation(user_text: str, llm_wrapper: Any) -> str:
+    """
+    Use LLM to parse user's response to a confirmation question.
+    Returns: 'confirm', 'reject', or 'unclear'
+    """
+    prompt = f"""Kullanıcıya bir onay sorusu soruldu. Kullanıcının cevabı onay mı, red mi, yoksa belirsiz mi?
+
+Kullanıcı cevabı: "{user_text}"
+
+Sadece şu kelimeleri kullanarak cevap ver:
+- "confirm" (onayladı: evet, tamam, olur, onaylıyorum, devam, uygula, ekle, yap vb.)
+- "reject" (reddetti: hayır, iptal, vazgeç, istemiyorum, olmaz vb.)
+- "unclear" (belirsiz: anlaşılmıyor veya alakasız cevap)
+
+Cevap:"""
+
+    try:
+        from bantz.llm.ollama_client import LLMMessage
+        response = llm_wrapper.chat(
+            messages=[LLMMessage(role="user", content=prompt)],
+            temperature=0.0,
+            max_tokens=10,
+        )
+        result = response.content.strip().lower()
+        if "confirm" in result:
+            return "confirm"
+        if "reject" in result:
+            return "reject"
+        return "unclear"
+    except Exception as e:
+        logger.warning(f"LLM confirmation parse failed: {e}")
+        # Fallback to simple keyword matching
+        t = _normalize_text_for_match(user_text)
+        if any(w in t for w in ["evet", "tamam", "olur", "onay", "devam", "uygula", "ekle", "yap"]):
+            return "confirm"
+        if any(w in t for w in ["hayir", "hayır", "iptal", "vazgec", "vazgeç", "istemiyorum", "olmaz"]):
+            return "reject"
+        return "unclear"
+
+
 def _window_from_ctx(ctx: dict[str, Any], *, day_hint: Optional[str]) -> Optional[dict[str, Any]]:
     if day_hint == "today":
         w = ctx.get("today_window")
@@ -1857,6 +1897,89 @@ class BrainLoop:
                     },
                 )
 
+        # Handle PENDING_LLM_CONFIRMATION state (from LLM Router)
+        if isinstance(state, dict) and state.get(_DIALOG_STATE_KEY) == "PENDING_LLM_CONFIRMATION":
+            pending_action = state.get("_pending_confirmation_action")
+            if isinstance(pending_action, dict):
+                # Use LLM to parse user's confirmation/rejection
+                confirmation_result = _llm_parse_confirmation(user_text, self._router._llm if self._router else None)
+                
+                if confirmation_result == "confirm":
+                    # User confirmed - execute the action
+                    intent = pending_action.get("intent")
+                    slots = pending_action.get("slots")
+                    route = pending_action.get("route")
+                    
+                    # Clear confirmation state
+                    state.pop("_pending_confirmation_action", None)
+                    state[_DIALOG_STATE_KEY] = "IDLE"
+                    
+                    # Build calendar intent from router slots
+                    if intent == "create" and isinstance(slots, dict):
+                        pending_intent = {
+                            "action": "create",
+                            "source_text": pending_action.get("user_text", ""),
+                        }
+                        
+                        # Map router slots to calendar intent format
+                        if slots.get("time"):
+                            pending_intent["start"] = slots["time"]
+                        if slots.get("duration"):
+                            pending_intent["duration_minutes"] = int(slots["duration"])
+                        if slots.get("title"):
+                            pending_intent["summary"] = slots["title"]
+                        if slots.get("day_hint"):
+                            pending_intent["day_hint"] = slots["day_hint"]
+                        
+                        state[_CALENDAR_PENDING_INTENT_KEY] = pending_intent
+                        state["last_intent"] = route
+                        
+                        # Continue with calendar create flow
+                        trace = _ensure_trace()
+                        trace["llm_confirmation"] = "confirmed"
+                        
+                        # Acknowledge and proceed
+                        _emit_ack("Anladım efendim, ekliyorum.")
+                        
+                        # Re-run with calendar route
+                        return self.run(
+                            turn_input=pending_action.get("user_text", user_text),
+                            session_context=session_context,
+                            policy=policy,
+                            context=state,
+                        )
+                
+                elif confirmation_result == "reject":
+                    # User rejected - cancel
+                    state.pop("_pending_confirmation_action", None)
+                    state[_DIALOG_STATE_KEY] = "IDLE"
+                    
+                    reply = "Anlaşıldı efendim, iptal ediyorum."
+                    try:
+                        self._events.publish(EventType.RESULT.value, {"text": reply}, source="brain")
+                    except Exception:
+                        pass
+                    return BrainResult(
+                        kind="say",
+                        text=reply,
+                        steps_used=0,
+                        metadata={"trace": _ensure_trace(), "llm_confirmation": "rejected"},
+                    )
+                
+                else:
+                    # Unclear response - ask again
+                    reply = "Efendim anlayamadım, 'evet' ya da 'hayır' diyebilir misiniz?"
+                    try:
+                        self._events.publish(EventType.QUESTION.value, {"question": reply}, source="brain")
+                    except Exception:
+                        pass
+                    return BrainResult(
+                        kind="ask_user",
+                        text=reply,
+                        steps_used=0,
+                        metadata={"trace": _ensure_trace(), "llm_confirmation": "unclear"},
+                    )
+        
         # Deterministic state machine: confirmation > choice > router.
         # If we have a pending confirmation, do NOT consume pending choice menus.
         if (
@@ -2916,6 +3039,60 @@ class BrainLoop:
                                 steps_used=0,
                                 metadata={"trace": trace, "route": "smalltalk", "router": "llm"},
                             )
+                    
+                    # If router provides calendar intent with high confidence and slots, ask for confirmation
+                    if (router_output.route == "calendar" 
+                        and router_output.confidence >= 0.7 
+                        and router_output.slots
+                        and router_output.calendar_intent in ["create", "modify"]):
+                        
+                        # Store router slots in pending confirmation
+                        state["_pending_confirmation_action"] = {
+                            "intent": router_output.calendar_intent,
+                            "slots": router_output.slots,
+                            "route": route,
+                            "user_text": user_text,
+                        }
+                        state[_DIALOG_STATE_KEY] = "PENDING_LLM_CONFIRMATION"
+                        
+                        # Build confirmation message
+                        slots = router_output.slots
+                        if router_output.calendar_intent == "create":
+                            parts = ["Efendim"]
+                            
+                            # Time
+                            if slots.get("time"):
+                                parts.append(f"saat {slots['time']}'de")
+                            elif slots.get("day_hint"):
+                                parts.append(slots["day_hint"])
+                            
+                            # Duration
+                            if slots.get("duration"):
+                                parts.append(f"{slots['duration']} dakika sürecek")
+                            
+                            # Title
+                            title = slots.get("title", "etkinlik")
+                            parts.append(f"'{title}' etkinliğini ekliyorum")
+                            
+                            confirmation_msg = " ".join(parts) + ", onaylar mısınız?"
+                        
+                        elif router_output.calendar_intent == "modify":
+                            confirmation_msg = f"Efendim etkinliği değiştiriyorum, onaylar mısınız?"
+                        else:
+                            confirmation_msg = "Onaylar mısınız?"
+                        
+                        try:
+                            self._events.publish(EventType.RESULT.value, {"text": confirmation_msg}, source="brain")
+                        except Exception:
+                            pass
+                        
+                        return BrainResult(
+                            kind="say",
+                            text=confirmation_msg,
+                            steps_used=0,
+                            metadata={"trace": trace, "pending_confirmation": True},
+                        )
+                        
                 except Exception as e:
                     logger.warning(f"Router failed: {e}")
                     # Fallback to deterministic routing


### PR DESCRIPTION
## Summary
User istekleri için onay akışı eklendi. Router slot'ları parse ettiğinde, işlem gerçekleştirilmeden önce kullanıcıdan onay istenir.

## Changes
- **Confirmation Request**: Router confidence >= 0.7 ve slot'lar varsa:
  - Kullanıcıya onay sorusu soruluyor
  - Örnek: "Efendim saat 20:00'de parti ekliyorum, onaylar mısınız?"
  - State: `PENDING_LLM_CONFIRMATION`

- **Confirmation Parser**: Keyword-based parsing
  - Onay: evet, tamam, olur, onay, devam, uygula, ekle, yap
  - Red: hayır, iptal, vazgeç, istemiyorum, olmaz
  - Belirsiz: Tekrar sor ("Efendim 'evet' ya da 'hayır' diyebilir misiniz?")

- **Action Execution**:
  - Onay: Router slot'larından calendar intent oluştur → işlemi gerçekleştir
  - Red: İşlemi iptal et, IDLE state'e dön
  - Belirsiz: Onay sorusunu tekrar sor

## User Experience
**Önceki Akış:**


**Yeni Akış:**


## Testing
- Keyword-based confirmation parsing: simple, fast, reliable
- Handles "evet", "hayır", "tamam", "iptal", etc.
- Graceful handling of unclear responses

## Related
- Builds on PR #129 (LLM Router always active)
- Completes natural conversation flow
- Resolves slot-filling redundancy