### PR TITLE
feat(llm): Backend abstraction with LLMClient interface (Issue #133)

### DIFF
--- a/src/bantz/llm/base.py
+++ b/src/bantz/llm/base.py
@@ -1,0 +1,245 @@
+"""LLM Client Interface - Backend abstraction for Ollama, vLLM, etc.
+
+Issue #133: Backend Abstraction
+
+This module provides a unified interface for different LLM backends:
+- OllamaClient
+- vLLM OpenAI-compatible client
+- Future: Anthropic, OpenAI, etc.
+
+Design goals:
+- Single interface for BrainLoop/Router
+- Config-based backend selection
+- Easy to test (mock clients)
+- Consistent error handling
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional, Protocol
+
+
+@dataclass(frozen=True)
+class LLMMessage:
+    """Standard message format for all LLM clients."""
+    role: str  # "system" | "user" | "assistant"
+    content: str
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """Standard response from LLM client."""
+    content: str  # Generated text
+    model: str  # Model used
+    tokens_used: int  # Total tokens (prompt + completion)
+    finish_reason: str  # "stop" | "length" | "error"
+
+
+class LLMClientError(Exception):
+    """Base exception for LLM client errors."""
+    pass
+
+
+class LLMConnectionError(LLMClientError):
+    """Server connection failed."""
+    pass
+
+
+class LLMModelNotFoundError(LLMClientError):
+    """Requested model not available."""
+    pass
+
+
+class LLMTimeoutError(LLMClientError):
+    """Request timed out."""
+    pass
+
+
+class LLMInvalidResponseError(LLMClientError):
+    """Response parsing failed."""
+    pass
+
+
+class LLMClient(ABC):
+    """Abstract base class for LLM clients.
+    
+    All concrete clients (Ollama, vLLM, etc.) must implement this interface.
+    """
+    
+    @abstractmethod
+    def is_available(self, *, timeout_seconds: float = 1.5) -> bool:
+        """Check if backend is reachable.
+        
+        Args:
+            timeout_seconds: Connection timeout
+            
+        Returns:
+            True if backend responds
+        """
+        pass
+    
+    @abstractmethod
+    def chat(
+        self,
+        messages: List[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+    ) -> str:
+        """Chat completion (simple string response).
+        
+        Args:
+            messages: Conversation history
+            temperature: Sampling temperature (0.0 = deterministic)
+            max_tokens: Max tokens to generate
+            
+        Returns:
+            Generated text
+            
+        Raises:
+            LLMConnectionError: Cannot reach backend
+            LLMModelNotFoundError: Model not available
+            LLMTimeoutError: Request timed out
+            LLMInvalidResponseError: Response parsing failed
+        """
+        pass
+    
+    @abstractmethod
+    def chat_detailed(
+        self,
+        messages: List[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+        seed: Optional[int] = None,
+    ) -> LLMResponse:
+        """Chat completion (detailed response with metadata).
+        
+        Args:
+            messages: Conversation history
+            temperature: Sampling temperature
+            max_tokens: Max tokens to generate
+            seed: Random seed for determinism
+            
+        Returns:
+            LLMResponse with content and metadata
+            
+        Raises:
+            Same as chat()
+        """
+        pass
+    
+    @abstractmethod
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200) -> str:
+        """Simple text completion (used by Router).
+        
+        Args:
+            prompt: Single prompt string
+            temperature: Sampling temperature
+            max_tokens: Max tokens to generate
+            
+        Returns:
+            Generated text
+            
+        Raises:
+            Same as chat()
+        """
+        pass
+    
+    @property
+    @abstractmethod
+    def model_name(self) -> str:
+        """Current model name."""
+        pass
+    
+    @property
+    @abstractmethod
+    def backend_name(self) -> str:
+        """Backend type: 'ollama', 'vllm', etc."""
+        pass
+
+
+class LLMClientProtocol(Protocol):
+    """Protocol for type checking (duck typing).
+    
+    Use this for type hints when you don't need ABC enforcement.
+    """
+    
+    def is_available(self, *, timeout_seconds: float = 1.5) -> bool:
+        ...
+    
+    def chat(
+        self,
+        messages: List[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+    ) -> str:
+        ...
+    
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200) -> str:
+        ...
+    
+    @property
+    def model_name(self) -> str:
+        ...
+    
+    @property
+    def backend_name(self) -> str:
+        ...
+
+
+def create_client(
+    backend: str,
+    *,
+    base_url: Optional[str] = None,
+    model: Optional[str] = None,
+    timeout: float = 120.0,
+) -> LLMClient:
+    """Factory function to create LLM client.
+    
+    Args:
+        backend: 'ollama' | 'vllm' | 'openai'
+        base_url: Backend URL (optional, uses defaults)
+        model: Model name (optional, uses defaults)
+        timeout: Request timeout
+        
+    Returns:
+        Concrete LLMClient implementation
+        
+    Raises:
+        ValueError: Unknown backend
+        
+    Example:
+        >>> client = create_client('ollama', model='qwen2.5:3b-instruct')
+        >>> client = create_client('vllm', base_url='http://localhost:8000')
+    """
+    backend = backend.lower().strip()
+    
+    if backend == "ollama":
+        from bantz.llm.ollama_client import OllamaClientAdapter
+        return OllamaClientAdapter(
+            base_url=base_url or "http://127.0.0.1:11434",
+            model=model or "qwen2.5:3b-instruct",
+            timeout_seconds=timeout,
+        )
+    
+    elif backend == "vllm":
+        from bantz.llm.vllm_openai_client import VLLMOpenAIClient
+        return VLLMOpenAIClient(
+            base_url=base_url or "http://127.0.0.1:8000",
+            model=model or "Qwen/Qwen2.5-3B-Instruct",
+            timeout_seconds=timeout,
+        )
+    
+    elif backend == "openai":
+        # Future: OpenAI API client
+        raise NotImplementedError("OpenAI backend not yet implemented")
+    
+    else:
+        raise ValueError(
+            f"Unknown LLM backend: '{backend}'. "
+            f"Supported: ollama, vllm"
+        )

--- a/src/bantz/llm/vllm_openai_client.py
+++ b/src/bantz/llm/vllm_openai_client.py
@@ -1,0 +1,212 @@
+"""vLLM OpenAI-compatible client for fast GPU inference.
+
+Issue #133: Backend Abstraction
+
+This client uses vLLM's OpenAI-compatible API endpoint to run local models with GPU acceleration.
+vLLM provides 10-20x throughput compared to standard inference.
+
+Usage:
+    >>> client = VLLMOpenAIClient(base_url='http://localhost:8000')
+    >>> response = client.chat([LLMMessage(role='user', content='Hello')])
+    
+Requirements:
+    pip install openai
+    
+vLLM server must be running:
+    python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-3B-Instruct --port 8000
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List, Optional
+
+from bantz.llm.base import (
+    LLMClient,
+    LLMMessage,
+    LLMResponse,
+    LLMConnectionError,
+    LLMModelNotFoundError,
+    LLMTimeoutError,
+    LLMInvalidResponseError,
+)
+
+
+class VLLMOpenAIClient(LLMClient):
+    """vLLM client using OpenAI-compatible API.
+    
+    This client connects to a local vLLM server (or remote endpoint) that exposes
+    an OpenAI-compatible /v1/chat/completions endpoint.
+    
+    Attributes:
+        base_url: vLLM server URL (e.g., http://localhost:8000)
+        model: Model name (e.g., Qwen/Qwen2.5-3B-Instruct)
+        timeout_seconds: Request timeout
+    """
+    
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:8000",
+        model: str = "Qwen/Qwen2.5-3B-Instruct",
+        timeout_seconds: float = 120.0,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.model = model.strip()
+        self.timeout_seconds = float(timeout_seconds)
+        
+        # Lazy-import OpenAI client
+        self._client: Optional[object] = None
+    
+    def _get_client(self):
+        """Lazy-initialize OpenAI client."""
+        if self._client is None:
+            try:
+                from openai import OpenAI
+            except ModuleNotFoundError as e:
+                raise RuntimeError(
+                    "openai kütüphanesi yüklü değil. Kurulum: pip install openai"
+                ) from e
+            
+            self._client = OpenAI(
+                base_url=f"{self.base_url}/v1",
+                api_key="EMPTY",  # vLLM doesn't require API key for local usage
+                timeout=self.timeout_seconds,
+            )
+        
+        return self._client
+    
+    def is_available(self, *, timeout_seconds: float = 1.5) -> bool:
+        """Check if vLLM server is reachable."""
+        try:
+            import requests
+        except ModuleNotFoundError:
+            return False
+        
+        try:
+            r = requests.get(
+                f"{self.base_url}/v1/models",
+                timeout=float(timeout_seconds),
+            )
+            return r.status_code == 200
+        except Exception:
+            return False
+    
+    def chat(
+        self,
+        messages: List[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+    ) -> str:
+        """Chat completion (simple string response)."""
+        response = self.chat_detailed(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return response.content
+    
+    def chat_detailed(
+        self,
+        messages: List[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+        seed: Optional[int] = None,
+    ) -> LLMResponse:
+        """Chat completion with detailed metadata."""
+        client = self._get_client()
+        
+        # Convert to OpenAI message format
+        openai_messages = [
+            {"role": m.role, "content": m.content}
+            for m in messages
+        ]
+        
+        try:
+            # Call OpenAI-compatible API
+            completion = client.chat.completions.create(
+                model=self.model,
+                messages=openai_messages,
+                temperature=float(temperature),
+                max_tokens=int(max_tokens),
+                seed=seed,
+            )
+            
+            # Extract response
+            choice = completion.choices[0]
+            content = choice.message.content or ""
+            
+            return LLMResponse(
+                content=content.strip(),
+                model=completion.model,
+                tokens_used=completion.usage.total_tokens if completion.usage else -1,
+                finish_reason=choice.finish_reason or "stop",
+            )
+        
+        except Exception as e:
+            error_msg = str(e).lower()
+            
+            # Classify error type
+            if "connection" in error_msg or "refused" in error_msg or "unreachable" in error_msg:
+                raise LLMConnectionError(
+                    f"vLLM sunucusuna bağlanamadım ({self.base_url}). "
+                    f"Başlat: python -m vllm.entrypoints.openai.api_server --model {self.model}"
+                ) from e
+            
+            elif "timeout" in error_msg:
+                raise LLMTimeoutError(
+                    f"vLLM request timeout ({self.timeout_seconds}s). Model yüklenirken zaman aşımı?"
+                ) from e
+            
+            elif "model" in error_msg and ("not found" in error_msg or "404" in error_msg):
+                raise LLMModelNotFoundError(
+                    f"vLLM model bulunamadı: '{self.model}'. "
+                    f"Sunucu başka model kullanıyor olabilir."
+                ) from e
+            
+            else:
+                raise LLMInvalidResponseError(
+                    f"vLLM response parsing failed: {e}"
+                ) from e
+    
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200) -> str:
+        """Simple text completion (used by Router)."""
+        messages = [LLMMessage(role="user", content=prompt)]
+        return self.chat(messages, temperature=temperature, max_tokens=max_tokens)
+    
+    @property
+    def model_name(self) -> str:
+        return self.model
+    
+    @property
+    def backend_name(self) -> str:
+        return "vllm"
+    
+    def list_available_models(self, *, timeout_seconds: float = 2.0) -> List[str]:
+        """List models available on vLLM server.
+        
+        Returns:
+            List of model names (usually just one model per vLLM instance)
+        """
+        try:
+            import requests
+        except ModuleNotFoundError as e:
+            raise RuntimeError("requests yüklü değil. Kurulum: pip install requests") from e
+        
+        try:
+            r = requests.get(
+                f"{self.base_url}/v1/models",
+                timeout=float(timeout_seconds),
+            )
+            r.raise_for_status()
+            
+            data = r.json() or {}
+            models_list = data.get("data", [])
+            
+            return [item["id"] for item in models_list if isinstance(item, dict) and "id" in item]
+        
+        except Exception as e:
+            raise RuntimeError(
+                f"vLLM sunucusundan model listesi alınamadı ({self.base_url})"
+            ) from e

--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -1,0 +1,390 @@
+"""Tests for LLM client abstraction (Issue #133).
+
+Tests both OllamaClientAdapter and VLLMOpenAIClient against the LLMClient interface.
+
+Run:
+    pytest tests/test_llm_clients.py -v
+    pytest tests/test_llm_clients.py::test_ollama_adapter_interface -v
+    pytest tests/test_llm_clients.py -k vllm -v --skip-real-server
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import Mock, patch
+
+from bantz.llm.base import (
+    LLMClient,
+    LLMMessage,
+    LLMResponse,
+    LLMConnectionError,
+    LLMModelNotFoundError,
+    LLMTimeoutError,
+    LLMInvalidResponseError,
+    create_client,
+)
+from bantz.llm.ollama_client import OllamaClientAdapter
+from bantz.llm.vllm_openai_client import VLLMOpenAIClient
+
+
+# ========================================================================
+# Contract Tests - Verify Interface Compliance
+# ========================================================================
+
+@pytest.mark.parametrize("backend,url,model", [
+    ("ollama", "http://127.0.0.1:11434", "qwen2.5:3b-instruct"),
+    ("vllm", "http://127.0.0.1:8000", "Qwen/Qwen2.5-3B-Instruct"),
+])
+def test_factory_creates_correct_backend(backend: str, url: str, model: str):
+    """Test that factory creates correct client type."""
+    client = create_client(backend, base_url=url, model=model)
+    
+    # Verify interface compliance
+    assert hasattr(client, "chat")
+    assert hasattr(client, "chat_detailed")
+    assert hasattr(client, "complete_text")
+    assert hasattr(client, "is_available")
+    assert hasattr(client, "model_name")
+    assert hasattr(client, "backend_name")
+    
+    # Verify backend name
+    assert client.backend_name == backend
+    assert client.model_name == model
+
+
+def test_factory_invalid_backend():
+    """Test that factory raises ValueError for unknown backend."""
+    with pytest.raises(ValueError, match="Unknown LLM backend"):
+        create_client("unknown_backend")
+
+
+# ========================================================================
+# OllamaClientAdapter Tests
+# ========================================================================
+
+def test_ollama_adapter_interface():
+    """Test OllamaClientAdapter implements LLMClient interface."""
+    adapter = OllamaClientAdapter(
+        base_url="http://127.0.0.1:11434",
+        model="qwen2.5:3b-instruct",
+    )
+    
+    # Verify it's a proper LLMClient
+    assert isinstance(adapter, LLMClient)
+    assert adapter.backend_name == "ollama"
+    assert adapter.model_name == "qwen2.5:3b-instruct"
+
+
+@patch("bantz.llm.ollama_client.OllamaClient.is_available")
+def test_ollama_adapter_is_available(mock_is_available):
+    """Test is_available delegates to OllamaClient."""
+    mock_is_available.return_value = True
+    
+    adapter = OllamaClientAdapter()
+    assert adapter.is_available() is True
+    
+    mock_is_available.return_value = False
+    assert adapter.is_available() is False
+
+
+@patch("bantz.llm.ollama_client.OllamaClient.chat")
+def test_ollama_adapter_chat(mock_chat):
+    """Test chat method delegates correctly."""
+    mock_chat.return_value = "Test response"
+    
+    adapter = OllamaClientAdapter()
+    messages = [LLMMessage(role="user", content="Hello")]
+    
+    result = adapter.chat(messages, temperature=0.5, max_tokens=100)
+    
+    assert result == "Test response"
+    # Check call was made with keyword arguments
+    mock_chat.assert_called_once()
+    call_kwargs = mock_chat.call_args.kwargs
+    assert call_kwargs["temperature"] == 0.5
+    assert call_kwargs["max_tokens"] == 100
+
+
+@patch("bantz.llm.ollama_client.OllamaClient.chat")
+def test_ollama_adapter_chat_detailed(mock_chat):
+    """Test chat_detailed returns LLMResponse."""
+    mock_chat.return_value = "Detailed response"
+    
+    adapter = OllamaClientAdapter(model="test-model")
+    messages = [LLMMessage(role="user", content="Test")]
+    
+    response = adapter.chat_detailed(messages)
+    
+    assert isinstance(response, LLMResponse)
+    assert response.content == "Detailed response"
+    assert response.model == "test-model"
+    assert response.finish_reason == "stop"
+
+
+@patch("bantz.llm.ollama_client.OllamaClient.chat")
+def test_ollama_adapter_complete_text(mock_chat):
+    """Test complete_text converts prompt to message."""
+    mock_chat.return_value = "Completion result"
+    
+    adapter = OllamaClientAdapter()
+    result = adapter.complete_text(prompt="Test prompt", temperature=0.0)
+    
+    assert result == "Completion result"
+    # Verify it created a user message (check kwargs)
+    mock_chat.assert_called_once()
+    call_kwargs = mock_chat.call_args.kwargs
+    messages = call_kwargs["messages"]
+    assert len(messages) == 1
+    assert messages[0].role == "user"
+    assert messages[0].content == "Test prompt"
+
+
+@patch("bantz.llm.ollama_client.OllamaClient.chat")
+def test_ollama_adapter_error_handling(mock_chat):
+    """Test error classification from RuntimeError."""
+    adapter = OllamaClientAdapter()
+    messages = [LLMMessage(role="user", content="Test")]
+    
+    # Model not found
+    mock_chat.side_effect = RuntimeError("model not found: qwen2.5")
+    with pytest.raises(LLMModelNotFoundError):
+        adapter.chat(messages)
+    
+    # Connection error
+    mock_chat.side_effect = RuntimeError("bağlanamadım http://localhost:11434")
+    with pytest.raises(LLMConnectionError):
+        adapter.chat(messages)
+    
+    # Timeout
+    mock_chat.side_effect = RuntimeError("request timeout after 120 seconds")
+    with pytest.raises(LLMTimeoutError):
+        adapter.chat(messages)
+    
+    # Generic error
+    mock_chat.side_effect = RuntimeError("something went wrong")
+    with pytest.raises(LLMInvalidResponseError):
+        adapter.chat(messages)
+
+
+# ========================================================================
+# VLLMOpenAIClient Tests
+# ========================================================================
+
+def test_vllm_client_interface():
+    """Test VLLMOpenAIClient implements LLMClient interface."""
+    client = VLLMOpenAIClient(
+        base_url="http://127.0.0.1:8000",
+        model="Qwen/Qwen2.5-3B-Instruct",
+    )
+    
+    # Verify it's a proper LLMClient
+    assert isinstance(client, LLMClient)
+    assert client.backend_name == "vllm"
+    assert client.model_name == "Qwen/Qwen2.5-3B-Instruct"
+
+
+@patch("requests.get")
+def test_vllm_is_available(mock_get):
+    """Test vLLM is_available checks /v1/models endpoint."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_get.return_value = mock_response
+    
+    client = VLLMOpenAIClient()
+    assert client.is_available() is True
+    
+    mock_get.assert_called_once()
+    args = mock_get.call_args
+    assert "/v1/models" in args[0][0]
+
+
+@patch("requests.get")
+def test_vllm_is_available_failure(mock_get):
+    """Test is_available returns False on error."""
+    mock_get.side_effect = ConnectionError("Connection refused")
+    
+    client = VLLMOpenAIClient()
+    assert client.is_available() is False
+
+
+@pytest.mark.integration
+@pytest.mark.skip(reason="Requires real vLLM server or mock - run with --run-integration")
+def test_vllm_chat_integration():
+    """Integration test: chat with real vLLM server.
+    
+    Run with: pytest tests/test_llm_clients.py::test_vllm_chat_integration --run-integration
+    
+    Requires:
+        python scripts/vllm_mock_server.py  # or real vLLM server
+    """
+    client = VLLMOpenAIClient(base_url="http://127.0.0.1:8001")  # Mock server port
+    
+    if not client.is_available():
+        pytest.skip("vLLM server not available (start scripts/vllm_mock_server.py)")
+    
+    messages = [LLMMessage(role="user", content="Hello")]
+    response = client.chat(messages, temperature=0.0, max_tokens=50)
+    
+    assert isinstance(response, str)
+    assert len(response) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.skip(reason="Requires real vLLM server or mock")
+def test_vllm_complete_text_integration():
+    """Integration test: complete_text with real server."""
+    client = VLLMOpenAIClient(base_url="http://127.0.0.1:8001")
+    
+    if not client.is_available():
+        pytest.skip("vLLM server not available")
+    
+    result = client.complete_text(prompt="Test prompt", temperature=0.0, max_tokens=50)
+    
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.integration
+@pytest.mark.skip(reason="Requires real vLLM server or mock")
+def test_vllm_list_models():
+    """Test list_available_models with real server."""
+    client = VLLMOpenAIClient(base_url="http://127.0.0.1:8001")
+    
+    if not client.is_available():
+        pytest.skip("vLLM server not available")
+    
+    models = client.list_available_models()
+    
+    assert isinstance(models, list)
+    assert len(models) > 0
+
+
+# ========================================================================
+# Backend Comparison Tests
+# ========================================================================
+
+@pytest.mark.parametrize("backend,base_url,model", [
+    ("ollama", "http://127.0.0.1:11434", "qwen2.5:3b-instruct"),
+    ("vllm", "http://127.0.0.1:8000", "Qwen/Qwen2.5-3B-Instruct"),
+])
+def test_backend_interface_consistency(backend: str, base_url: str, model: str):
+    """Test that both backends expose consistent interface."""
+    client = create_client(backend, base_url=base_url, model=model)
+    
+    # All backends must have these methods with same signature
+    assert callable(client.chat)
+    assert callable(client.chat_detailed)
+    assert callable(client.complete_text)
+    assert callable(client.is_available)
+    
+    # All backends must have these properties
+    assert isinstance(client.model_name, str)
+    assert isinstance(client.backend_name, str)
+    
+    # Backend name must match what was requested
+    assert client.backend_name == backend
+
+
+def test_message_format_consistency():
+    """Test that LLMMessage is consistent across backends."""
+    msg = LLMMessage(role="user", content="Test")
+    
+    # Message should work with both backends
+    ollama = OllamaClientAdapter()
+    vllm = VLLMOpenAIClient()
+    
+    # Both should accept same message format (even if not connected)
+    assert msg.role == "user"
+    assert msg.content == "Test"
+
+
+# ========================================================================
+# Mock-Based Behavior Tests
+# ========================================================================
+
+@patch("bantz.llm.vllm_openai_client.VLLMOpenAIClient._get_client")
+def test_vllm_error_classification(mock_get_client):
+    """Test vLLM error classification."""
+    mock_client = Mock()
+    mock_get_client.return_value = mock_client
+    
+    client = VLLMOpenAIClient()
+    messages = [LLMMessage(role="user", content="Test")]
+    
+    # Connection error
+    mock_client.chat.completions.create.side_effect = Exception("connection refused")
+    with pytest.raises(LLMConnectionError):
+        client.chat(messages)
+    
+    # Timeout
+    mock_client.chat.completions.create.side_effect = Exception("request timeout")
+    with pytest.raises(LLMTimeoutError):
+        client.chat(messages)
+    
+    # Model not found
+    mock_client.chat.completions.create.side_effect = Exception("model not found: 404")
+    with pytest.raises(LLMModelNotFoundError):
+        client.chat(messages)
+    
+    # Generic error
+    mock_client.chat.completions.create.side_effect = Exception("something else")
+    with pytest.raises(LLMInvalidResponseError):
+        client.chat(messages)
+
+
+@patch("bantz.llm.vllm_openai_client.VLLMOpenAIClient._get_client")
+def test_vllm_chat_detailed_response(mock_get_client):
+    """Test vLLM chat_detailed returns proper LLMResponse."""
+    mock_client = Mock()
+    mock_get_client.return_value = mock_client
+    
+    # Mock OpenAI response
+    mock_completion = Mock()
+    mock_completion.choices = [Mock()]
+    mock_completion.choices[0].message.content = "Test response"
+    mock_completion.choices[0].finish_reason = "stop"
+    mock_completion.model = "test-model"
+    mock_completion.usage.total_tokens = 42
+    
+    mock_client.chat.completions.create.return_value = mock_completion
+    
+    client = VLLMOpenAIClient()
+    messages = [LLMMessage(role="user", content="Test")]
+    
+    response = client.chat_detailed(messages)
+    
+    assert isinstance(response, LLMResponse)
+    assert response.content == "Test response"
+    assert response.model == "test-model"
+    assert response.tokens_used == 42
+    assert response.finish_reason == "stop"
+
+
+# ========================================================================
+# Determinism Test (Real Server)
+# ========================================================================
+
+@pytest.mark.integration
+@pytest.mark.skip(reason="Requires real server")
+def test_determinism_vllm_vs_ollama():
+    """Test deterministic output with seed (both backends).
+    
+    This test verifies that both backends respect temperature=0 and seed
+    for deterministic output.
+    """
+    prompt = "What is 2+2?"
+    messages = [LLMMessage(role="user", content=prompt)]
+    
+    # Test Ollama (if available)
+    ollama = create_client("ollama")
+    if ollama.is_available():
+        result1 = ollama.chat(messages, temperature=0.0, max_tokens=50)
+        result2 = ollama.chat(messages, temperature=0.0, max_tokens=50)
+        assert result1 == result2, "Ollama should be deterministic with temp=0"
+    
+    # Test vLLM (if available)
+    vllm = create_client("vllm", base_url="http://127.0.0.1:8001")
+    if vllm.is_available():
+        resp1 = vllm.chat_detailed(messages, temperature=0.0, max_tokens=50, seed=42)
+        resp2 = vllm.chat_detailed(messages, temperature=0.0, max_tokens=50, seed=42)
+        assert resp1.content == resp2.content, "vLLM should be deterministic with temp=0 and seed"


### PR DESCRIPTION
## Summary
Implements backend abstraction to support both Ollama and vLLM through unified interface.

## Key Changes
- **LLMClient ABC**: Standard interface with `chat()`, `complete_text()`, `is_available()`
- **OllamaClientAdapter**: Wraps existing OllamaClient (backward compatible)
- **VLLMOpenAIClient**: Uses openai library for vLLM OpenAI-compatible endpoint
- **Factory function**: `create_client(backend, base_url, model)`
- **Demo support**: `--llm-backend ollama|vllm` flag
- **Tests**: 17 tests, all passing ✅

## Backend Features
- Consistent error types: `LLMConnectionError`, `LLMModelNotFoundError`, `LLMTimeoutError`
- Detailed responses: `LLMResponse` with content, model, tokens, finish_reason
- Router/BrainLoop work with any backend
- Easy to extend (OpenAI, Anthropic, etc.)

## Test Coverage
```bash
pytest tests/test_llm_clients.py -v
# 17 passed, 4 skipped (integration tests)
```

## Usage Examples

### Ollama (default):
```bash
python scripts/demo_calendar_brainloop.py --run
```

### vLLM:
```bash
# Start vLLM server or mock
python scripts/vllm_mock_server.py &

# Run demo with vLLM
python scripts/demo_calendar_brainloop.py --llm-backend vllm --vllm-url http://127.0.0.1:8001 --run
```

### Python API:
```python
from bantz.llm.base import create_client, LLMMessage

# Ollama
client = create_client('ollama', model='qwen2.5:3b-instruct')

# vLLM
client = create_client('vllm', base_url='http://localhost:8000')

# Same interface for both
messages = [LLMMessage(role='user', content='Hello')]
response = client.chat(messages, temperature=0.0, max_tokens=50)
```

## Acceptance Criteria (Issue #133)
- ✅ Interface abstraction (LLMClient ABC)
- ✅ Ollama adapter (preserves existing behavior)
- ✅ vLLM client (OpenAI-compatible API)
- ✅ Factory function for backend selection
- ✅ Demo script backend switching
- ✅ Test suite with >80% coverage

## Next Steps
Issue #134: Router uses vLLM backend for fast classification (<500ms)

Closes #133