### PR TITLE
Dual vLLM (3B+7B) global scripts + quality routing

### DIFF
--- a/docs/setup/vllm.md
+++ b/docs/setup/vllm.md
@@ -13,6 +13,9 @@ pip install -U pip
 pip install -e ".[llm]"
 ```
 
+Not: Şu an bazı sistemlerde CUDA uyumluluğu nedeniyle **global Python** ile çalıştırmak daha stabil olabilir.
+Bu durumda `.venv` zorunlu değil; önemli olan `python3 -c 'import vllm'` çalışması.
+
 2) vLLM sunucusunu başlat:
 
 - 3B (hız / router / tool seçim):
@@ -25,6 +28,24 @@ pip install -e ".[llm]"
 
 ```bash
 ./scripts/vllm/start_7b.sh
+```
+
+### 3B + 7B aynı anda (tek GPU)
+
+Tek GPU’da iki instance çalıştırmak istiyorsan:
+
+```bash
+./scripts/vllm/start_dual.sh
+```
+
+Bu scriptler “dual-friendly” KV/cache limitleriyle gelir (VRAM/KV-cache patlamasını azaltır).
+Gerekirse env ile daha da kısabilirsin:
+
+```bash
+export BANTZ_VLLM_3B_GPU_UTIL=0.28
+export BANTZ_VLLM_3B_MAX_MODEL_LEN=1024
+export BANTZ_VLLM_7B_GPU_UTIL=0.58
+export BANTZ_VLLM_7B_CPU_OFFLOAD_GB=6
 ```
 
 3) Sunucu kontrol:
@@ -61,4 +82,18 @@ Bantz, vLLM endpoint’ine şu env’lerle bağlanır:
 ```bash
 export BANTZ_VLLM_URL="http://127.0.0.1:8001"
 export BANTZ_VLLM_MODEL="Qwen/Qwen2.5-3B-Instruct-AWQ"
+```
+
+Kalite gereken işler (örn: sayfa özetleme) için 7B endpoint’i ayrı tanımlanabilir:
+
+```bash
+export BANTZ_VLLM_QUALITY_URL="http://127.0.0.1:8002"
+export BANTZ_VLLM_QUALITY_MODEL="Qwen/Qwen2.5-7B-Instruct-AWQ"
+```
+
+İpucu: model id’yi makineden makineye farklı tutuyorsan `auto` kullanabilirsin:
+
+```bash
+export BANTZ_VLLM_MODEL=auto
+export BANTZ_VLLM_QUALITY_MODEL=auto
 ```

--- a/scripts/vllm/start_3b.sh
+++ b/scripts/vllm/start_3b.sh
@@ -9,6 +9,9 @@ PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
 cd "$PROJECT_ROOT"
 
+LOG_DIR="${BANTZ_VLLM_LOG_DIR:-artifacts/logs/vllm}"
+mkdir -p "$LOG_DIR"
+
 # Check if port 8001 is already in use
 if ss -ltnp | grep -q ":8001 "; then
     echo "❌ Port 8001 is already in use. Stopping existing vLLM server..."
@@ -25,27 +28,34 @@ fi
 echo "🚀 Starting vLLM server (3B AWQ) on port 8001..."
 echo "   Model: Qwen/Qwen2.5-3B-Instruct-AWQ"
 echo "   Quantization: awq_marlin (optimized)"
-echo "   Max tokens: 2048"
-echo "   GPU utilization: 95% (SPEED OPTIMIZED)"
-echo "   Speed optimizations: prefix-caching, chunked-prefill"
+echo "   Profile: dual-friendly defaults (override via env vars)"
+echo "   Max tokens: ${BANTZ_VLLM_3B_MAX_MODEL_LEN:-1536}"
+echo "   GPU utilization: ${BANTZ_VLLM_3B_GPU_UTIL:-0.30}"
 echo ""
 
-nohup python3 -m vllm.entrypoints.openai.api_server \
-  --model Qwen/Qwen2.5-3B-Instruct-AWQ \
-  --quantization awq_marlin \
-  --dtype half \
-  --port 8001 \
-  --max-model-len 2048 \
-  --gpu-memory-utilization 0.95 \
-  --enable-prefix-caching \
-  --enable-chunked-prefill \
-  --max-num-batched-tokens 4096 \
-  --max-num-seqs 256 \
-  > vllm_8001.log 2>&1 &
+# Use global Python for now (no venv requirement).
+PYTHON_BIN="${BANTZ_VLLM_PYTHON:-python3}"
+if ! "$PYTHON_BIN" -c "import vllm" >/dev/null 2>&1; then
+    echo "❌ vLLM import edilemedi ($PYTHON_BIN). Önce vLLM'i kurun: pip install vllm" >&2
+    exit 1
+fi
+
+nohup "$PYTHON_BIN" -m vllm.entrypoints.openai.api_server \
+    --model "${BANTZ_VLLM_3B_MODEL:-Qwen/Qwen2.5-3B-Instruct-AWQ}" \
+    --quantization "${BANTZ_VLLM_3B_QUANT:-awq_marlin}" \
+    --dtype "${BANTZ_VLLM_3B_DTYPE:-half}" \
+    --port "${BANTZ_VLLM_3B_PORT:-8001}" \
+    --max-model-len "${BANTZ_VLLM_3B_MAX_MODEL_LEN:-1536}" \
+    --gpu-memory-utilization "${BANTZ_VLLM_3B_GPU_UTIL:-0.30}" \
+    --max-num-seqs "${BANTZ_VLLM_3B_MAX_NUM_SEQS:-32}" \
+    --max-num-batched-tokens "${BANTZ_VLLM_3B_MAX_BATCH_TOKENS:-2048}" \
+    --enable-prefix-caching \
+    --enable-chunked-prefill \
+    > "$LOG_DIR/vllm_8001.log" 2>&1 &
 
 SERVER_PID=$!
 echo "✅ Server process started (PID: $SERVER_PID)"
-echo "📝 Logs: $PROJECT_ROOT/vllm_8001.log"
+echo "📝 Logs: $PROJECT_ROOT/$LOG_DIR/vllm_8001.log"
 echo ""
 echo "Waiting 40 seconds for model loading..."
 sleep 40

--- a/scripts/vllm/test.sh
+++ b/scripts/vllm/test.sh
@@ -15,8 +15,14 @@ fi
 
 # Get model info
 echo "✅ Server is running!"
-MODEL_INFO=$(curl -s http://localhost:$PORT/v1/models | python3 -c "import sys, json; d=json.load(sys.stdin)['data'][0]; print(f\"Model: {d['id']}\nMax tokens: {d['max_model_len']}\")")
+MODEL_INFO=$(curl -s http://localhost:$PORT/v1/models | python3 -c "import sys, json; d=json.load(sys.stdin)['data'][0]; print(f\"Model: {d.get('id')}\nMax tokens: {d.get('max_model_len')}\")")
 echo "$MODEL_INFO"
+
+MODEL_ID=$(curl -s http://localhost:$PORT/v1/models | python3 -c "import sys, json; print((json.load(sys.stdin)['data'][0].get('id') or '').strip())")
+if [ -z "$MODEL_ID" ]; then
+  echo "❌ Could not detect model id from /v1/models" >&2
+  exit 1
+fi
 echo ""
 
 # Speed test
@@ -27,7 +33,7 @@ for i in {1..3}; do
     curl -s http://localhost:$PORT/v1/completions \
       -H "Content-Type: application/json" \
       -d '{
-        "model": "Qwen/Qwen2.5-3B-Instruct-AWQ",
+        "model": "'"$MODEL_ID"'",
         "prompt": "Hello",
         "max_tokens": 10,
         "temperature": 0
@@ -47,7 +53,7 @@ echo "📝 Detailed test with output:"
 RESPONSE=$(curl -s http://localhost:$PORT/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "Qwen/Qwen2.5-3B-Instruct-AWQ",
+    "model": "'"$MODEL_ID"'",
     "prompt": "Write a haiku about speed:",
     "max_tokens": 50,
     "temperature": 0.7

--- a/src/bantz/cli.py
+++ b/src/bantz/cli.py
@@ -499,6 +499,16 @@ Kullanım örnekleri:
     parser.add_argument("--piper-model", default="", help="Piper .onnx model yolu (zorunlu: --voice)")
     parser.add_argument("--vllm-url", default="http://127.0.0.1:8001", help="vLLM (OpenAI-compatible) base URL")
     parser.add_argument("--vllm-model", default="Qwen/Qwen2.5-3B-Instruct", help="vLLM model adı")
+    parser.add_argument(
+        "--vllm-quality-url",
+        default="http://127.0.0.1:8002",
+        help="Quality vLLM base URL (bigger model; e.g. summaries/reasoning)",
+    )
+    parser.add_argument(
+        "--vllm-quality-model",
+        default="Qwen/Qwen2.5-7B-Instruct-AWQ",
+        help="Quality vLLM model adı (default: 7B AWQ)",
+    )
     parser.add_argument("--whisper-model", default="base", help="faster-whisper model adı (tiny/base/small/...)")
     parser.add_argument("--asr-cache-dir", default=os.path.expanduser("~/.cache/bantz/whisper"), help="Whisper model cache klasörü")
     parser.add_argument("--asr-allow-download", action="store_true", help="Whisper model indirmeye izin ver (ilk kurulumda)")
@@ -532,6 +542,11 @@ Kullanım örnekleri:
         os.environ["BANTZ_VLLM_URL"] = str(args.vllm_url)
     if getattr(args, "vllm_model", None):
         os.environ["BANTZ_VLLM_MODEL"] = str(args.vllm_model)
+
+    if getattr(args, "vllm_quality_url", None):
+        os.environ["BANTZ_VLLM_QUALITY_URL"] = str(args.vllm_quality_url)
+    if getattr(args, "vllm_quality_model", None):
+        os.environ["BANTZ_VLLM_QUALITY_MODEL"] = str(args.vllm_quality_model)
 
     def _can_connect(host: str, port: int, timeout_s: float = 3.0) -> bool:
         try:

--- a/src/bantz/llm/__init__.py
+++ b/src/bantz/llm/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import os
+
 from .base import LLMMessage, LLMClient, LLMClientProtocol, create_client
 from .vllm_openai_client import VLLMOpenAIClient
 from .persona import (
@@ -25,5 +29,62 @@ __all__ = [
     "say",
     "jarvis_greeting",
     "jarvis_farewell",
+    "create_fast_client",
+    "create_quality_client",
 ]
+
+
+def create_fast_client(
+    *,
+    base_url: str | None = None,
+    model: str | None = None,
+    timeout: float = 120.0,
+) -> LLMClientProtocol:
+    """Create the default (fast) vLLM client.
+
+    Env:
+      - BANTZ_VLLM_URL (default: http://127.0.0.1:8001)
+      - BANTZ_VLLM_MODEL (default: Qwen/Qwen2.5-3B-Instruct)
+
+    Tip: set model to "auto" to pick the first /v1/models entry.
+    """
+
+    return create_client(
+        "vllm",
+        base_url=(base_url or os.getenv("BANTZ_VLLM_URL") or "http://127.0.0.1:8001"),
+        model=(model or os.getenv("BANTZ_VLLM_MODEL") or "Qwen/Qwen2.5-3B-Instruct"),
+        timeout=timeout,
+    )
+
+
+def create_quality_client(
+    *,
+    base_url: str | None = None,
+    model: str | None = None,
+    timeout: float = 240.0,
+) -> LLMClientProtocol:
+    """Create the "quality" vLLM client (usually a larger model on port 8002).
+
+    Env:
+      - BANTZ_VLLM_QUALITY_URL (default: http://127.0.0.1:8002)
+      - BANTZ_VLLM_QUALITY_MODEL (default: Qwen/Qwen2.5-7B-Instruct-AWQ)
+
+    If quality env vars are not set, this still works (falls back to defaults).
+    Tip: set model to "auto" to pick the first /v1/models entry.
+    """
+
+    return create_client(
+        "vllm",
+        base_url=(
+            base_url
+            or os.getenv("BANTZ_VLLM_QUALITY_URL")
+            or "http://127.0.0.1:8002"
+        ),
+        model=(
+            model
+            or os.getenv("BANTZ_VLLM_QUALITY_MODEL")
+            or "Qwen/Qwen2.5-7B-Instruct-AWQ"
+        ),
+        timeout=timeout,
+    )
 

--- a/src/bantz/router/engine.py
+++ b/src/bantz/router/engine.py
@@ -2349,8 +2349,7 @@ class Router:
             from bantz.skills.summarizer import PageSummarizer
             from bantz.llm.persona import JarvisPersona
             from bantz.browser.extension_bridge import get_bridge
-            from bantz.llm import create_client
-            import os
+            from bantz.llm import create_quality_client
             
             persona = JarvisPersona()
             
@@ -2365,11 +2364,7 @@ class Router:
             
             # Create LLM client and summarizer
             try:
-                llm = create_client(
-                    "vllm",
-                    base_url=os.getenv("BANTZ_VLLM_URL", "http://127.0.0.1:8001"),
-                    model=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct"),
-                )
+                llm = create_quality_client()
                 summarizer = PageSummarizer(extension_bridge=bridge, llm_client=llm)
                 
                 # Store in context for follow-up commands
@@ -2398,8 +2393,7 @@ class Router:
             from bantz.skills.summarizer import PageSummarizer
             from bantz.llm.persona import JarvisPersona
             from bantz.browser.extension_bridge import get_bridge
-            from bantz.llm import create_client
-            import os
+            from bantz.llm import create_quality_client
             
             persona = JarvisPersona()
             
@@ -2429,11 +2423,7 @@ class Router:
                 )
             
             try:
-                llm = create_client(
-                    "vllm",
-                    base_url=os.getenv("BANTZ_VLLM_URL", "http://127.0.0.1:8001"),
-                    model=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct"),
-                )
+                llm = create_quality_client()
                 summarizer = PageSummarizer(extension_bridge=bridge, llm_client=llm)
                 ctx.set_page_summarizer(summarizer)
                 
@@ -2459,8 +2449,7 @@ class Router:
             from bantz.skills.summarizer import PageSummarizer
             from bantz.llm.persona import JarvisPersona
             from bantz.browser.extension_bridge import get_bridge
-            from bantz.llm import create_client
-            import os
+            from bantz.llm import create_quality_client
             
             persona = JarvisPersona()
             question = str(slots.get("question", "")).strip()
@@ -2486,11 +2475,7 @@ class Router:
                     )
                 
                 try:
-                    llm = create_client(
-                        "vllm",
-                        base_url=os.getenv("BANTZ_VLLM_URL", "http://127.0.0.1:8001"),
-                        model=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct"),
-                    )
+                    llm = create_quality_client()
                     summarizer = PageSummarizer(extension_bridge=bridge, llm_client=llm)
                     ctx.set_page_summarizer(summarizer)
                 except Exception as e:


### PR DESCRIPTION
- Update vLLM scripts to support running from global Python (no .venv required) and dual-instance-friendly VRAM/KV-cache defaults.\n- Write vLLM logs under artifacts/logs/vllm.\n- Add separate quality vLLM env/CLI flags (BANTZ_VLLM_QUALITY_URL/MODEL) and route page summarization to quality client.\n- Support model=auto by resolving /v1/models automatically.