### PR TITLE
Hybrid quality: Gemini Flash + cloud privacy gating + metrics

### DIFF
--- a/docs/setup/vllm.md
+++ b/docs/setup/vllm.md
@@ -24,11 +24,8 @@ Bu durumda `.venv` zorunlu değil; önemli olan `python3 -c 'import vllm'` çal�
 ./scripts/vllm/start_3b.sh
 ```
 
-- 7B (kalite / daha uzun cevaplar):
-
-```bash
-./scripts/vllm/start_7b.sh
-```
+Not: 6GB VRAM cihazlarda **3B tek başına** en stabil moddur.
+"Quality" (uzun yazı / doküman / plan) için aşağıdaki **Gemini** entegrasyonunu öneriyoruz.
 
 ### 3B + 7B aynı anda (tek GPU)
 
@@ -68,6 +65,31 @@ curl -s http://127.0.0.1:8001/v1/models
 - 8002: 7B (kalite)
 
 Not: 6GB VRAM cihazlarda 3B ve 7B aynı anda çalışmayabilir.
+
+## Hybrid Quality (Önerilen): 3B local + Gemini Flash
+
+Amaç:
+- Router / tool seçimi / hızlı cevaplar **3B (local)**
+- Mail / uzun yazı / PDF yönerge / 3+ adım plan gibi işler **Gemini (cloud)**
+
+Cloud çağrıları **varsayılan olarak kapalıdır**. Açmak için:
+
+```bash
+export BANTZ_CLOUD_MODE=cloud
+export QUALITY_PROVIDER=gemini
+export GEMINI_API_KEY="..."
+export QUALITY_MODEL="gemini-1.5-flash"   # örnek
+```
+
+Gizlilik/minimize:
+
+```bash
+export BANTZ_CLOUD_REDACT=1        # (varsayılan) email/token vb maskele
+export BANTZ_CLOUD_MAX_CHARS=12000 # outbound text limit
+export BANTZ_LOCAL_ONLY=1          # cloud'u tamamen kapat (override)
+```
+
+Kalite endpoint'i yoksa / cloud kapalıysa Bantz otomatik **fast** tier'a düşer.
 
 ## Yönetim Komutları
 
@@ -109,7 +131,7 @@ export BANTZ_VLLM_QUALITY_MODEL=auto
 ## Tiered routing (3B → 7B eskalasyon)
 
 Varsayılan davranış: Bantz çoğu yerde **3B (fast)** ile gider.
-7B (quality) otomatik devreye girsin istiyorsan:
+Quality otomatik devreye girsin istiyorsan:
 
 ```bash
 export BANTZ_TIERED_MODE=1

--- a/src/bantz/llm/__init__.py
+++ b/src/bantz/llm/__init__.py
@@ -4,6 +4,7 @@ import os
 
 from .base import LLMMessage, LLMClient, LLMClientProtocol, create_client
 from .vllm_openai_client import VLLMOpenAIClient
+from .privacy import get_cloud_privacy_config
 from .persona import (
     JarvisPersona,
     ResponseBuilder,
@@ -32,6 +33,21 @@ __all__ = [
     "create_fast_client",
     "create_quality_client",
 ]
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = str(os.getenv(name, "")).strip().lower()
+    if not raw:
+        return bool(default)
+    return raw in {"1", "true", "yes", "y", "on", "enable", "enabled"}
+
+
+def _env_str(*names: str, default: str = "") -> str:
+    for n in names:
+        v = str(os.getenv(n, "")).strip()
+        if v:
+            return v
+    return default
 
 
 def create_fast_client(
@@ -63,17 +79,57 @@ def create_quality_client(
     model: str | None = None,
     timeout: float = 240.0,
 ) -> LLMClientProtocol:
-    """Create the "quality" vLLM client (usually a larger model on port 8002).
+    """Create the "quality" client.
 
-    Env:
+    Default: vLLM on port 8002.
+    Hybrid mode: route quality calls to Gemini (Flash) while keeping fast local vLLM.
+
+    Provider selection env (supports both names):
+      - QUALITY_PROVIDER / BANTZ_QUALITY_PROVIDER: vllm|gemini
+
+    vLLM quality env:
       - BANTZ_VLLM_QUALITY_URL (default: http://127.0.0.1:8002)
       - BANTZ_VLLM_QUALITY_MODEL (default: Qwen/Qwen2.5-7B-Instruct-AWQ)
 
-    If quality env vars are not set, this still works (falls back to defaults).
-    Tip: set model to "auto" to pick the first /v1/models entry.
+    Gemini env (cloud):
+      - BANTZ_CLOUD_MODE=cloud (or CLOUD_MODE=cloud). Default is local (cloud disabled).
+      - GEMINI_API_KEY / GOOGLE_API_KEY / BANTZ_GEMINI_API_KEY
+      - QUALITY_MODEL / QUALITY_MODEL_NAME / BANTZ_QUALITY_MODEL / BANTZ_GEMINI_MODEL
+
+    Fallback:
+      - If the quality provider isn't usable, returns fast client (3B) by default.
+        Disable via BANTZ_QUALITY_FALLBACK_TO_FAST=0.
     """
 
-    return create_client(
+    provider = _env_str("QUALITY_PROVIDER", "BANTZ_QUALITY_PROVIDER", default="vllm").lower()
+    fallback_to_fast = _env_flag("BANTZ_QUALITY_FALLBACK_TO_FAST", default=True)
+
+    if provider in {"gemini", "google", "genai"}:
+        privacy = get_cloud_privacy_config()
+        if privacy.mode != "cloud":
+            return create_fast_client(timeout=timeout)
+
+        api_key = _env_str("GEMINI_API_KEY", "GOOGLE_API_KEY", "BANTZ_GEMINI_API_KEY", default="")
+        if not api_key:
+            return create_fast_client(timeout=timeout)
+
+        gem_model = (
+            model
+            or _env_str(
+                "QUALITY_MODEL",
+                "QUALITY_MODEL_NAME",
+                "BANTZ_QUALITY_MODEL",
+                "BANTZ_GEMINI_MODEL",
+                default="gemini-1.5-flash",
+            )
+        )
+
+        from bantz.llm.gemini_client import GeminiClient
+
+        return GeminiClient(api_key=api_key, model=gem_model, timeout_seconds=timeout)
+
+    # Default: vLLM quality endpoint (8002)
+    quality_client = create_client(
         "vllm",
         base_url=(
             base_url
@@ -87,4 +143,21 @@ def create_quality_client(
         ),
         timeout=timeout,
     )
+
+    if not fallback_to_fast:
+        return quality_client
+
+    # If 8002 is down / not ready, keep the system stable by falling back to fast.
+    try:
+        probe_timeout = float(os.getenv("BANTZ_QUALITY_AVAIL_TIMEOUT", "1.0") or "1.0")
+    except Exception:
+        probe_timeout = 1.0
+
+    try:
+        if not quality_client.is_available(timeout_seconds=probe_timeout):
+            return create_fast_client(timeout=timeout)
+    except Exception:
+        return create_fast_client(timeout=timeout)
+
+    return quality_client
 

--- a/src/bantz/llm/base.py
+++ b/src/bantz/llm/base.py
@@ -201,7 +201,7 @@ def create_client(
     """Factory function to create LLM client.
     
     Args:
-        backend: 'vllm' | 'openai'
+        backend: 'vllm' | 'gemini' | 'openai'
         base_url: Backend URL (optional, uses defaults)
         model: Model name (optional, uses defaults)
         timeout: Request timeout
@@ -222,6 +222,18 @@ def create_client(
         return VLLMOpenAIClient(
             base_url=base_url or "http://127.0.0.1:8001",
             model=model or "Qwen/Qwen2.5-3B-Instruct",
+            timeout_seconds=timeout,
+        )
+
+    if backend == "gemini":
+        # Gemini uses an API key (not base_url). Pass the key via base_url for factory parity.
+        # Prefer using bantz.llm.create_quality_client() which applies privacy gating.
+        from bantz.llm.gemini_client import GeminiClient
+
+        api_key = (base_url or "").strip()
+        return GeminiClient(
+            api_key=api_key,
+            model=model or "gemini-1.5-flash",
             timeout_seconds=timeout,
         )
     

--- a/src/bantz/llm/gemini_client.py
+++ b/src/bantz/llm/gemini_client.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+import os
+from typing import List, Optional
+
+import requests
+
+from bantz.llm.base import (
+    LLMClient,
+    LLMMessage,
+    LLMResponse,
+    LLMConnectionError,
+    LLMTimeoutError,
+    LLMInvalidResponseError,
+)
+
+from bantz.llm.privacy import redact_for_cloud, minimize_for_cloud
+
+
+logger = logging.getLogger(__name__)
+metrics_logger = logging.getLogger("bantz.llm.metrics")
+
+
+class GeminiClient(LLMClient):
+    """Gemini (Google Generative Language API) client.
+
+    This implementation uses the public REST API so we don't need extra deps.
+
+    Env (recommended to set via create_quality_client):
+      - GEMINI_API_KEY / GOOGLE_API_KEY / BANTZ_GEMINI_API_KEY
+      - model: e.g. gemini-1.5-flash
+
+    Notes:
+      - This client assumes *cloud mode* is already allowed by the caller.
+      - It still applies redact+minimize helpers (best-effort) to reduce leakage.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        timeout_seconds: float = 240.0,
+        base_url: str = "https://generativelanguage.googleapis.com",
+    ):
+        self._api_key = (api_key or "").strip()
+        self._model = (model or "").strip()
+        self._timeout_seconds = float(timeout_seconds)
+        self._base_url = base_url.rstrip("/")
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def backend_name(self) -> str:
+        return "gemini"
+
+    def is_available(self, *, timeout_seconds: float = 1.5) -> bool:
+        if not self._api_key or not self._model:
+            return False
+
+        url = f"{self._base_url}/v1beta/models"
+        try:
+            r = requests.get(url, params={"key": self._api_key}, timeout=float(timeout_seconds))
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    def chat(
+        self,
+        messages: List[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+    ) -> str:
+        return self.chat_detailed(messages, temperature=temperature, max_tokens=max_tokens).content
+
+    def chat_detailed(
+        self,
+        messages: List[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+        seed: Optional[int] = None,
+    ) -> LLMResponse:
+        if not self._api_key:
+            raise LLMConnectionError("Gemini API key missing")
+        if not self._model:
+            raise LLMInvalidResponseError("Gemini model not set")
+
+        url = f"{self._base_url}/v1beta/models/{self._model}:generateContent"
+
+        # Gemini roles are "user" and "model". We'll map system separately if present.
+        system_lines: list[str] = []
+        contents = []
+        for m in messages:
+            role = (m.role or "").strip().lower()
+            content = str(m.content or "")
+            if role == "system":
+                system_lines.append(content)
+                continue
+            if role in {"assistant", "model"}:
+                gemini_role = "model"
+            else:
+                gemini_role = "user"
+
+            safe_text = minimize_for_cloud(redact_for_cloud(content))
+            contents.append({"role": gemini_role, "parts": [{"text": safe_text}]})
+
+        payload: dict = {
+            "contents": contents or [{"role": "user", "parts": [{"text": ""}]}],
+            "generationConfig": {
+                "temperature": float(temperature),
+                "maxOutputTokens": int(max_tokens),
+            },
+        }
+
+        if system_lines:
+            safe_sys = minimize_for_cloud(redact_for_cloud("\n\n".join(system_lines)))
+            payload["systemInstruction"] = {"parts": [{"text": safe_sys}]}
+
+        if seed is not None:
+            payload.setdefault("generationConfig", {})["seed"] = int(seed)
+
+        t0 = time.perf_counter()
+        try:
+            r = requests.post(
+                url,
+                params={"key": self._api_key},
+                headers={"Content-Type": "application/json"},
+                data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                timeout=self._timeout_seconds,
+            )
+            elapsed_ms = int((time.perf_counter() - t0) * 1000)
+
+            if r.status_code >= 500:
+                raise LLMConnectionError(f"Gemini server error: {r.status_code}")
+            if r.status_code == 429:
+                raise LLMConnectionError("Gemini rate limited (429)")
+            if r.status_code >= 400:
+                raise LLMInvalidResponseError(f"Gemini request failed: {r.status_code} {r.text[:300]}")
+
+            data = r.json() or {}
+            candidates = data.get("candidates") or []
+            text_out = ""
+            finish_reason = "stop"
+            if candidates and isinstance(candidates[0], dict):
+                cand = candidates[0]
+                finish_reason = str(cand.get("finishReason") or "stop")
+                content = cand.get("content") or {}
+                parts = content.get("parts") or []
+                if parts and isinstance(parts[0], dict):
+                    text_out = str(parts[0].get("text") or "")
+
+            usage = data.get("usageMetadata") or {}
+            prompt_tokens = int(usage.get("promptTokenCount") or -1)
+            completion_tokens = int(usage.get("candidatesTokenCount") or -1)
+            total_tokens = int(usage.get("totalTokenCount") or -1)
+
+            if _metrics_enabled():
+                metrics_logger.info(
+                    "llm_call backend=%s model=%s latency_ms=%s prompt_tokens=%s completion_tokens=%s total_tokens=%s",
+                    self.backend_name,
+                    self.model_name,
+                    elapsed_ms,
+                    prompt_tokens,
+                    completion_tokens,
+                    total_tokens,
+                )
+
+            return LLMResponse(
+                content=str(text_out or "").strip(),
+                model=self._model,
+                tokens_used=total_tokens,
+                finish_reason=finish_reason,
+            )
+
+        except requests.Timeout as e:
+            raise LLMTimeoutError(f"Gemini request timeout ({self._timeout_seconds}s)") from e
+        except Exception as e:
+            raise LLMInvalidResponseError(f"Gemini response parsing failed: {e}") from e
+
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200) -> str:
+        messages = [LLMMessage(role="user", content=prompt)]
+        return self.chat(messages, temperature=temperature, max_tokens=max_tokens)
+
+
+def _metrics_enabled() -> bool:
+    # Keep this local to avoid import cycles; parse env here.
+    raw = str(os.environ.get("BANTZ_LLM_METRICS", "")).strip().lower()
+    if not raw:
+        return False
+    return raw in {"1", "true", "yes", "y", "on"}

--- a/src/bantz/llm/privacy.py
+++ b/src/bantz/llm/privacy.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from bantz.security.masking import get_default_masker
+from bantz.brain.memory_lite import PIIFilter
+
+
+@dataclass(frozen=True)
+class CloudPrivacyConfig:
+    mode: str  # "local" | "cloud"
+    redact: bool
+    max_chars: int
+
+
+def _env_str(*names: str, default: str = "") -> str:
+    for name in names:
+        v = str(os.getenv(name, "")).strip()
+        if v:
+            return v
+    return default
+
+
+def _env_flag(*names: str, default: bool = False) -> bool:
+    raw = _env_str(*names, default="").strip().lower()
+    if not raw:
+        return bool(default)
+    return raw in {"1", "true", "yes", "y", "on", "enable", "enabled"}
+
+
+def _env_int(*names: str, default: int) -> int:
+    raw = _env_str(*names, default="").strip()
+    if not raw:
+        return int(default)
+    try:
+        return int(raw)
+    except Exception:
+        return int(default)
+
+
+def get_cloud_privacy_config() -> CloudPrivacyConfig:
+    """Cloud privacy gate.
+
+    Two modes:
+      - local: never call cloud providers
+      - cloud: cloud calls allowed (still redact/minimize)
+
+    Env:
+      - BANTZ_CLOUD_MODE / CLOUD_MODE: local|cloud|0|1
+      - BANTZ_LOCAL_ONLY=1 (forces local)
+      - BANTZ_CLOUD_REDACT=1 (default true)
+      - BANTZ_CLOUD_MAX_CHARS=12000
+    """
+    if _env_flag("BANTZ_LOCAL_ONLY", default=False):
+        mode = "local"
+    else:
+        raw = _env_str("BANTZ_CLOUD_MODE", "CLOUD_MODE", default="local").lower()
+        if raw in {"1", "true", "yes", "y", "on", "cloud", "cloud-quality"}:
+            mode = "cloud"
+        else:
+            mode = "local"
+
+    redact = _env_flag("BANTZ_CLOUD_REDACT", default=True)
+    max_chars = _env_int("BANTZ_CLOUD_MAX_CHARS", default=12000)
+    return CloudPrivacyConfig(mode=mode, redact=redact, max_chars=max_chars)
+
+
+def redact_for_cloud(text: str) -> str:
+    """Redact obvious PII/secrets from free-form text.
+
+    Uses:
+      - PIIFilter (email/phone/url/etc)
+      - DataMasker (tokens/keys/password patterns)
+
+    Note: This is best-effort. The caller should still minimize payload.
+    """
+    cfg = get_cloud_privacy_config()
+    if not cfg.redact:
+        return text
+
+    t = str(text or "")
+    t = PIIFilter.filter(t, enabled=True)
+    t = get_default_masker().mask(t)
+    return t
+
+
+def minimize_for_cloud(text: str) -> str:
+    """Minimize outgoing text size (best-effort).
+
+    Env: BANTZ_CLOUD_MAX_CHARS
+    """
+    cfg = get_cloud_privacy_config()
+    t = str(text or "")
+    if cfg.max_chars <= 0:
+        return t
+    if len(t) <= cfg.max_chars:
+        return t
+    head = t[: cfg.max_chars]
+    return head + "\n\n[TRUNCATED_FOR_CLOUD]"


### PR DESCRIPTION
Implements issue #195.\n\n- Keeps 3B local as stable baseline (vLLM :8001).\n- Adds QUALITY_PROVIDER/BANTZ_QUALITY_PROVIDER=gemini to route quality calls to Gemini (Flash) when BANTZ_CLOUD_MODE=cloud.\n- Adds privacy gate + best-effort redaction/minimization for outbound cloud text.\n- Adds metrics logging (BANTZ_LLM_METRICS=1) and tier decision metrics (BANTZ_TIERED_METRICS=1).\n- Adds unit tests and updates docs.\n