### PR TITLE
Issue #181: vLLM auto-recovery watchdog + QoS + tuning loop

### DIFF
--- a/scripts/tune_vllm.py
+++ b/scripts/tune_vllm.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""vLLM tuning loop helper.
+
+Runs the Issue #180 benchmark in a couple of fixed "profiles" so you can iterate
+on server flags (e.g., max-num-seqs / max-num-batched-tokens / max-model-len)
+and quickly spot regressions.
+
+This does NOT change vLLM flags itself — you tweak server start scripts/env vars,
+restart vLLM, and use this script to measure before/after.
+
+Examples:
+  # Run both profiles against local 8001
+  python3 scripts/tune_vllm.py
+
+  # Compare to baselines and fail if >10% regression
+  python3 scripts/tune_vllm.py --baseline-dir artifacts/results/baselines --fail-regression-pct 10
+
+  # Create/refresh baselines
+  python3 scripts/tune_vllm.py --baseline-dir artifacts/results/baselines --write-baseline
+
+  # Run only the router-like profile
+  python3 scripts/tune_vllm.py --profile router
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    num_requests: int
+    concurrency: int
+    max_tokens: int
+    timeout_s: float
+    temperature: float
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _run(cmd: list[str], *, cwd: Path) -> int:
+    p = subprocess.run(cmd, cwd=str(cwd))
+    return int(p.returncode)
+
+
+def _bench_cmd(
+    *,
+    targets: list[str],
+    model: str,
+    profile: Profile,
+    out_json: Path,
+    out_md: Path,
+    baseline: Path | None,
+    fail_regression_pct: float | None,
+) -> list[str]:
+    cmd = [
+        "python3",
+        "scripts/bench_vllm.py",
+        *sum([["--target", t] for t in targets], []),
+        "--model",
+        model,
+        "--num-requests",
+        str(profile.num_requests),
+        "--concurrency",
+        str(profile.concurrency),
+        "--max-tokens",
+        str(profile.max_tokens),
+        "--temperature",
+        str(profile.temperature),
+        "--timeout",
+        str(profile.timeout_s),
+        "--out-json",
+        str(out_json),
+        "--out-md",
+        str(out_md),
+    ]
+    if baseline is not None and baseline.exists():
+        cmd.extend(["--baseline", str(baseline)])
+    if fail_regression_pct is not None:
+        cmd.extend(["--fail-regression-pct", str(fail_regression_pct)])
+    return cmd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run vLLM tuning benchmarks")
+    parser.add_argument(
+        "--target",
+        action="append",
+        default=["local=http://127.0.0.1:8001"],
+        help="Benchmark target in LABEL=URL form. Repeatable.",
+    )
+    parser.add_argument("--model", default="auto")
+    parser.add_argument(
+        "--profile",
+        choices=["router", "generation", "both"],
+        default="both",
+        help="Which benchmark profile(s) to run",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default="artifacts/results/tuning",
+        help="Output directory (JSON + MD per profile)",
+    )
+    parser.add_argument(
+        "--baseline-dir",
+        default="",
+        help="Directory containing per-profile baselines (router.json, generation.json)",
+    )
+    parser.add_argument(
+        "--write-baseline",
+        action="store_true",
+        help="After a successful run, write/refresh baselines in --baseline-dir",
+    )
+    parser.add_argument(
+        "--fail-regression-pct",
+        type=float,
+        default=None,
+        help="Fail if completion tok/s regresses more than this percent vs baseline",
+    )
+
+    args = parser.parse_args()
+
+    profiles = {
+        # Router-like: keep replies short, drive concurrency.
+        "router": Profile(
+            name="router",
+            num_requests=256,
+            concurrency=64,
+            max_tokens=96,
+            timeout_s=20.0,
+            temperature=0.2,
+        ),
+        # Generation-like: typical assistant replies.
+        "generation": Profile(
+            name="generation",
+            num_requests=128,
+            concurrency=32,
+            max_tokens=256,
+            timeout_s=60.0,
+            temperature=0.2,
+        ),
+    }
+
+    selected: list[Profile]
+    if args.profile == "both":
+        selected = [profiles["router"], profiles["generation"]]
+    else:
+        selected = [profiles[str(args.profile)]]
+
+    root = _repo_root()
+    out_dir = (root / str(args.out_dir)).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    baseline_dir = (root / str(args.baseline_dir)).resolve() if args.baseline_dir else None
+    if args.write_baseline and not baseline_dir:
+        print("--write-baseline requires --baseline-dir", file=sys.stderr)
+        return 2
+    if baseline_dir is not None:
+        baseline_dir.mkdir(parents=True, exist_ok=True)
+
+    stamp = _utc_stamp()
+
+    for p in selected:
+        out_json = out_dir / f"bench_vllm_{p.name}_{stamp}.json"
+        out_md = out_dir / f"bench_vllm_{p.name}_{stamp}.md"
+
+        baseline = (baseline_dir / f"{p.name}.json") if baseline_dir is not None else None
+
+        cmd = _bench_cmd(
+            targets=list(args.target),
+            model=str(args.model),
+            profile=p,
+            out_json=out_json,
+            out_md=out_md,
+            baseline=baseline,
+            fail_regression_pct=args.fail_regression_pct,
+        )
+
+        print(f"\n== running profile={p.name} ==")
+        print(" ".join(cmd))
+
+        rc = _run(cmd, cwd=root)
+        if rc != 0:
+            return rc
+
+        if args.write_baseline and baseline_dir is not None:
+            shutil.copyfile(out_json, baseline_dir / f"{p.name}.json")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vllm/stop.sh
+++ b/scripts/vllm/stop.sh
@@ -27,5 +27,11 @@ fi
 sleep 2
 echo "✅ All vLLM servers stopped"
 echo ""
-nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | \
-    awk '{printf "   GPU Memory: %d / %d MiB (%.1f%% free)\n", $1, $2, 100*(1-$1/$2)}'
+
+# Best-effort GPU memory report (optional).
+if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits | \
+        awk '{printf "   GPU Memory: %d / %d MiB (%.1f%% free)\n", $1, $2, 100*(1-$1/$2)}' || true
+else
+    echo "   (nvidia-smi not found; skipping GPU memory report)"
+fi

--- a/scripts/vllm/watchdog.py
+++ b/scripts/vllm/watchdog.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""vLLM watchdog (Issue #181).
+
+Periodically checks a vLLM OpenAI-compatible endpoint and restarts it when unhealthy.
+
+Default behavior targets the 3B server on port 8001 via the existing scripts:
+  - scripts/vllm/stop.sh
+  - scripts/vllm/start_3b.sh
+
+Outputs crash/restart context into:
+  artifacts/logs/vllm/watchdog/
+
+Usage:
+  python3 scripts/vllm/watchdog.py --port 8001
+  python3 scripts/vllm/watchdog.py --port 8001 --interval 10 --fail-threshold 3
+  python3 scripts/vllm/watchdog.py --once  # single healthcheck + exit code
+
+Notes:
+  - This script is intentionally conservative: it only restarts after N consecutive
+    failures and enforces a cooldown between restarts.
+  - It does best-effort log capture; it will not crash if log files or tools are missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+@dataclass(frozen=True)
+class HealthResult:
+    base_url: str
+    port: int
+    status: str  # healthy|offline|timeout|error
+    model_id: str | None
+    response_time_ms: float | None
+    error: str | None
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _env_str(name: str, default: str) -> str:
+    v = str(os.getenv(name, "")).strip()
+    return v or default
+
+
+def _healthcheck(*, port: int, timeout_s: float) -> HealthResult:
+    base_url = f"http://localhost:{int(port)}"
+    url = f"{base_url}/v1/models"
+
+    t0 = time.perf_counter()
+    try:
+        r = requests.get(url, timeout=float(timeout_s))
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+        if r.status_code != 200:
+            return HealthResult(
+                base_url=base_url,
+                port=int(port),
+                status="error",
+                model_id=None,
+                response_time_ms=round(elapsed_ms, 1),
+                error=f"HTTP {r.status_code}",
+            )
+
+        data = r.json() or {}
+        items = data.get("data") or []
+        model_id = None
+        if isinstance(items, list) and items and isinstance(items[0], dict):
+            model_id = str(items[0].get("id") or "").strip() or None
+
+        if not model_id:
+            return HealthResult(
+                base_url=base_url,
+                port=int(port),
+                status="error",
+                model_id=None,
+                response_time_ms=round(elapsed_ms, 1),
+                error="No models in /v1/models",
+            )
+
+        return HealthResult(
+            base_url=base_url,
+            port=int(port),
+            status="healthy",
+            model_id=model_id,
+            response_time_ms=round(elapsed_ms, 1),
+            error=None,
+        )
+
+    except requests.exceptions.ConnectionError:
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        return HealthResult(
+            base_url=base_url,
+            port=int(port),
+            status="offline",
+            model_id=None,
+            response_time_ms=round(elapsed_ms, 1),
+            error="Connection refused",
+        )
+    except requests.exceptions.Timeout:
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        return HealthResult(
+            base_url=base_url,
+            port=int(port),
+            status="timeout",
+            model_id=None,
+            response_time_ms=round(elapsed_ms, 1),
+            error=f"Request timeout ({timeout_s}s)",
+        )
+    except Exception as e:
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        return HealthResult(
+            base_url=base_url,
+            port=int(port),
+            status="error",
+            model_id=None,
+            response_time_ms=round(elapsed_ms, 1),
+            error=str(e),
+        )
+
+
+def _read_tail(path: Path, *, max_bytes: int = 64_000) -> str:
+    try:
+        if not path.exists():
+            return ""
+        data = path.read_bytes()
+        if len(data) > max_bytes:
+            data = data[-max_bytes:]
+        try:
+            return data.decode("utf-8", errors="replace")
+        except Exception:
+            return data.decode(errors="replace")
+    except Exception:
+        return ""
+
+
+def _detect_oom(log_tail: str) -> bool:
+    t = (log_tail or "").lower()
+    if "out of memory" in t:
+        return True
+    if "cuda out of memory" in t:
+        return True
+    if "cublas" in t and "alloc" in t and "failed" in t:
+        return True
+    return False
+
+
+def _run_cmd(cmd: list[str], *, cwd: Path, timeout_s: float | None) -> tuple[int, str]:
+    try:
+        p = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=None if timeout_s is None else float(timeout_s),
+            text=True,
+            check=False,
+        )
+        return int(p.returncode), str(p.stdout or "")
+    except subprocess.TimeoutExpired as e:
+        out = "".join([str(x or "") for x in (e.stdout, e.stderr)])
+        return 124, out
+    except Exception as e:
+        return 127, str(e)
+
+
+def _ensure_exec(path: Path) -> list[str]:
+    """Return a command list that can execute path on Linux."""
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+    # Prefer direct execution when executable bit is set.
+    if os.access(path, os.X_OK):
+        return [str(path)]
+    # Fallback for repos where executable bit was lost.
+    return ["bash", str(path)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="vLLM watchdog (auto-recovery)")
+    parser.add_argument("--port", type=int, default=int(os.getenv("BANTZ_VLLM_3B_PORT", "8001")))
+    parser.add_argument("--timeout", type=float, default=3.0, help="Healthcheck timeout seconds")
+    parser.add_argument("--interval", type=float, default=10.0, help="Healthcheck interval seconds")
+    parser.add_argument("--fail-threshold", type=int, default=3, help="Consecutive failures to trigger restart")
+    parser.add_argument(
+        "--cooldown",
+        type=float,
+        default=120.0,
+        help="Minimum seconds between restarts",
+    )
+    parser.add_argument(
+        "--stop-script",
+        default="scripts/vllm/stop.sh",
+        help="Stop script path (repo-relative)",
+    )
+    parser.add_argument(
+        "--start-script",
+        default="scripts/vllm/start_3b.sh",
+        help="Start script path (repo-relative)",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default=_env_str("BANTZ_VLLM_LOG_DIR", "artifacts/logs/vllm"),
+        help="vLLM log dir (default: BANTZ_VLLM_LOG_DIR or artifacts/logs/vllm)",
+    )
+    parser.add_argument(
+        "--watchdog-dir",
+        default="artifacts/logs/vllm/watchdog",
+        help="Output dir for watchdog restart logs",
+    )
+    parser.add_argument("--once", action="store_true", help="Run one healthcheck and exit")
+    parser.add_argument("--dry-run", action="store_true", help="Do not execute stop/start scripts")
+
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    stop_path = (repo_root / str(args.stop_script)).resolve()
+    start_path = (repo_root / str(args.start_script)).resolve()
+
+    watchdog_dir = (repo_root / str(args.watchdog_dir)).resolve()
+    watchdog_dir.mkdir(parents=True, exist_ok=True)
+
+    vllm_log_dir = (repo_root / str(args.log_dir)).resolve()
+    vllm_log_file = vllm_log_dir / f"vllm_{int(args.port)}.log"
+
+    consecutive_failures = 0
+    last_restart_ts = 0.0
+
+    def report(h: HealthResult) -> None:
+        line = {
+            "ts": _utc_stamp(),
+            "status": h.status,
+            "port": h.port,
+            "base_url": h.base_url,
+            "model_id": h.model_id,
+            "rt_ms": h.response_time_ms,
+            "error": h.error,
+            "consecutive_failures": consecutive_failures,
+        }
+        print(json.dumps(line, ensure_ascii=False))
+
+    while True:
+        h = _healthcheck(port=int(args.port), timeout_s=float(args.timeout))
+
+        if h.status == "healthy":
+            consecutive_failures = 0
+        else:
+            consecutive_failures += 1
+
+        report(h)
+
+        if args.once:
+            return 0 if h.status == "healthy" else 1
+
+        should_restart = consecutive_failures >= int(args.fail_threshold)
+        cooldown_ok = (time.time() - last_restart_ts) >= float(args.cooldown)
+
+        if should_restart and cooldown_ok:
+            stamp = _utc_stamp()
+            tail = _read_tail(vllm_log_file)
+            oom = _detect_oom(tail)
+
+            ctx: dict[str, Any] = {
+                "ts": stamp,
+                "port": int(args.port),
+                "health": {
+                    "status": h.status,
+                    "error": h.error,
+                    "rt_ms": h.response_time_ms,
+                },
+                "log_file": str(vllm_log_file),
+                "log_tail_bytes": len(tail.encode("utf-8", errors="replace")) if tail else 0,
+                "oom_suspected": bool(oom),
+                "dry_run": bool(args.dry_run),
+            }
+
+            out_prefix = watchdog_dir / f"restart_{int(args.port)}_{stamp}"
+            (out_prefix.with_suffix(".json")).write_text(
+                json.dumps(ctx, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            if tail:
+                (out_prefix.with_suffix(".logtail.txt")).write_text(tail, encoding="utf-8")
+
+            if not args.dry_run:
+                stop_cmd = _ensure_exec(stop_path)
+                start_cmd = _ensure_exec(start_path)
+
+                rc1, out1 = _run_cmd(stop_cmd, cwd=repo_root, timeout_s=60.0)
+                (out_prefix.with_suffix(".stop.txt")).write_text(out1, encoding="utf-8")
+
+                # Always attempt start even if stop fails; pkill races are common.
+                rc2, out2 = _run_cmd(start_cmd, cwd=repo_root, timeout_s=600.0)
+                (out_prefix.with_suffix(".start.txt")).write_text(out2, encoding="utf-8")
+
+                ctx["stop_rc"] = rc1
+                ctx["start_rc"] = rc2
+                (out_prefix.with_suffix(".json")).write_text(
+                    json.dumps(ctx, indent=2, ensure_ascii=False), encoding="utf-8"
+                )
+
+            last_restart_ts = time.time()
+            consecutive_failures = 0
+
+        time.sleep(float(args.interval))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_vllm_watchdog.py
+++ b/tests/test_vllm_watchdog.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_watchdog_module():
+    root = Path(__file__).resolve().parents[1]
+    path = root / "scripts" / "vllm" / "watchdog.py"
+    spec = importlib.util.spec_from_file_location("bantz_watchdog_script", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Dataclasses can require sys.modules entry (similar to bench_vllm tests).
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_detect_oom_true_for_common_markers():
+    wd = _load_watchdog_module()
+    assert wd._detect_oom("CUDA out of memory") is True
+    assert wd._detect_oom("RuntimeError: out of memory") is True
+
+
+def test_detect_oom_false_for_empty():
+    wd = _load_watchdog_module()
+    assert wd._detect_oom("") is False
+    assert wd._detect_oom("all good") is False
+
+
+def test_health_result_dataclass_exists():
+    wd = _load_watchdog_module()
+    assert hasattr(wd, "HealthResult")
+
+
+@pytest.mark.parametrize(
+    "env_key,env_val,expected",
+    [
+        ("BANTZ_QOS_DEFAULT_FAST_MAX_TOKENS", "64", 64),
+        ("BANTZ_QOS_FAST_MAX_TOKENS", "96", 96),
+    ],
+)
+def test_get_qos_env_overrides(monkeypatch, env_key: str, env_val: str, expected: int):
+    from bantz.llm.tiered import get_qos
+
+    monkeypatch.setenv(env_key, env_val)
+    qos = get_qos(use_quality=False, profile="default")
+    assert qos.max_tokens == expected


### PR DESCRIPTION
Implements Issue #181 reliability + iteration tooling:

- Adds a vLLM watchdog (scripts/vllm/watchdog.py) that healthchecks /v1/models and restarts via existing start/stop scripts, writing restart context to artifacts/logs/vllm/watchdog/.
- Hardens scripts/vllm/stop.sh so missing nvidia-smi doesn't break automation.
- Adds tier QoS defaults (timeout/max_tokens) in src/bantz/llm/tiered.py and wires them into voice fallback + hybrid validation.
- Adds a small tuning wrapper (scripts/tune_vllm.py) that runs the Issue #180 bench with router-like + generation-like profiles and supports baselines/regression gates.

Tests:
- pytest -q (all green; vLLM integration tests skipped if no server)
