### PR TITLE
Issue #185: Memory Manager v1 (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ More details: docs/setup/vllm.md
 - docs/jarvis-roadmap-v2.md
 - docs/setup/vllm.md
 - docs/setup/google-oauth.md
+- docs/setup/memory.md
 
 ## Google OAuth (Calendar/Gmail)
 

--- a/docs/setup/memory.md
+++ b/docs/setup/memory.md
@@ -1,0 +1,40 @@
+# Memory (Snippet-based) — v1 (opt-in)
+
+Bantz has a snippet-based memory system (`MemoryManager`) that can recall **PROFILE / EPISODIC / SESSION** snippets and inject them into the router prompt as `RETRIEVED_MEMORY`.
+
+## Safety + defaults
+
+- **Opt-in:** disabled by default (`enable_memory_manager = false`).
+- **Local-only:** stored locally (SQLite by default). No cloud sync.
+- **Prompt safety:** `RETRIEVED_MEMORY` is framed as **context-only (not instructions)**; user’s last message always wins.
+- **PII-aware:** memory writes go through a write policy (redaction/deny), and episodic tool summaries are generated in a PII-safe way (avoid titles/emails/locations).
+
+## Where data is stored
+
+Default SQLite path (when enabled):
+
+- `~/.bantz/memory_snippets.db`
+
+## How to enable (code)
+
+`BrainLoopConfig`:
+
+- `enable_memory_manager: bool = False`
+- `memory_db_path: str = "~/.bantz/memory_snippets.db"`
+- `memory_max_snippets: int = 5`
+
+Example:
+
+```python
+from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+
+loop = BrainLoop(
+    llm=..., tools=...,
+    config=BrainLoopConfig(enable_memory_manager=True),
+)
+```
+
+## Notes
+
+- Profile writes are gated (min length, dedupe, and rate-limit) to avoid memory spam.
+- This feature is designed to be “best-effort”: memory failures never crash the loop.

--- a/src/bantz/memory/prompt.py
+++ b/src/bantz/memory/prompt.py
@@ -1,0 +1,61 @@
+"""Helpers for rendering memory snippets into LLM prompt blocks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from bantz.memory.snippet import MemorySnippet, SnippetType
+
+
+def snippets_to_prompt_block(
+    snippets: Sequence[MemorySnippet],
+    *,
+    max_chars: int = 1200,
+) -> str:
+    """Format snippets into a compact prompt block.
+
+    The block is intended for injection into LLM prompts (router/finalizer) and
+    should remain short and high-signal.
+    """
+    if not snippets:
+        return ""
+
+    def _label(st: SnippetType) -> str:
+        if st == SnippetType.PROFILE:
+            return "PROFILE"
+        if st == SnippetType.EPISODIC:
+            return "EPISODIC"
+        return "SESSION"
+
+    # Keep stable ordering: profile -> episodic -> session
+    priority = {
+        SnippetType.PROFILE: 0,
+        SnippetType.EPISODIC: 1,
+        SnippetType.SESSION: 2,
+    }
+
+    sorted_snippets = sorted(
+        snippets,
+        key=lambda s: (priority.get(s.snippet_type, 9), -(s.confidence or 0.0), s.timestamp),
+        reverse=False,
+    )
+
+    lines: list[str] = []
+    for snip in sorted_snippets:
+        content = str(snip.content or "").strip()
+        if not content:
+            continue
+        # Single-line, avoid runaway length.
+        content = " ".join(content.split())
+        if len(content) > 240:
+            content = content[:239] + "…"
+        lines.append(f"- [{_label(snip.snippet_type)}] {content}")
+
+        if max_chars and sum(len(l) + 1 for l in lines) >= max_chars:
+            break
+
+    # Ensure we don't exceed the budget.
+    block = "\n".join(lines).strip()
+    if max_chars and len(block) > max_chars:
+        block = block[: max_chars - 1] + "…"
+    return block

--- a/src/bantz/memory/safety.py
+++ b/src/bantz/memory/safety.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from bantz.brain.memory_lite import PIIFilter
+
+
+def mask_pii(text: str) -> str:
+    """Best-effort PII masking for any memory content.
+
+    This is intentionally lightweight: it complements `WritePolicy` redaction,
+    and is used for generating safe summaries (e.g., episodic tool logs).
+    """
+
+    t = str(text or "")
+    t = " ".join(t.split()).strip()
+    if not t:
+        return ""
+    try:
+        return PIIFilter.filter(t, enabled=True)
+    except Exception:
+        return t
+
+
+def safe_tool_episode(
+    *,
+    tool_name: str,
+    params: Optional[dict[str, Any]] = None,
+    result: Any = None,
+    max_len: int = 240,
+) -> str:
+    """Create a PII-safe episodic summary for a tool call.
+
+    Design goal: never store raw tool output and avoid copying user-provided
+    strings like event titles, locations, attendee emails, etc.
+    """
+
+    name = str(tool_name or "").strip() or "tool"
+    p = params if isinstance(params, dict) else {}
+
+    action = "başarılı"
+    if name.endswith(".create_event"):
+        action = "takvim etkinliği oluşturuldu"
+    elif name.endswith(".update_event"):
+        action = "takvim etkinliği güncellendi"
+    elif name.endswith(".delete_event"):
+        action = "takvim etkinliği silindi"
+    elif name.endswith(".list_events"):
+        action = "takvim etkinlikleri listelendi"
+
+    pieces: list[str] = [f"Tool {name} başarılı: {action}"]
+
+    # Times are generally safe (but still masked just in case).
+    start = str(p.get("start") or "").strip()
+    end = str(p.get("end") or "").strip()
+    if start and end:
+        pieces.append(f"({start}–{end})")
+
+    # Safe aggregate (count only).
+    if name.endswith(".list_events") and isinstance(result, dict):
+        evs = result.get("events")
+        if isinstance(evs, list):
+            pieces.append(f"count={len(evs)}")
+
+    text = " ".join([x for x in pieces if str(x).strip()]).strip()
+    text = mask_pii(text)
+
+    if max_len is not None:
+        try:
+            ml = int(max_len)
+        except Exception:
+            ml = 240
+        ml = max(60, min(800, ml))
+        if len(text) > ml:
+            text = (text[: ml - 1].rstrip() + "…").strip()
+
+    return text

--- a/tests/test_brainloop_memory_manager.py
+++ b/tests/test_brainloop_memory_manager.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+import asyncio
+
+
+class CapturingRouter:
+    """Router stub that captures prompt content via MockLLM-like behavior."""
+
+    def __init__(self):
+        self.last_retrieved_memory: str | None = None
+        self.called = False
+
+    def route(self, *, user_input: str, dialog_summary=None, retrieved_memory=None, session_context=None):
+        self.called = True
+        self.last_retrieved_memory = retrieved_memory
+        # Return a smalltalk reply so BrainLoop returns immediately.
+        from bantz.brain.llm_router import OrchestratorOutput
+
+        return OrchestratorOutput(
+            route="smalltalk",
+            calendar_intent="none",
+            slots={},
+            confidence=1.0,
+            tool_plan=[],
+            assistant_reply="Tamam efendim.",
+            raw_output={},
+        )
+
+
+def test_brainloop_injects_retrieved_memory_into_router_prompt():
+    from bantz.agent.tools import ToolRegistry
+    from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+    from bantz.memory.snippet_manager import create_memory_manager
+    from bantz.memory.snippet_store import InMemoryStore
+
+    mm = create_memory_manager(
+        session_store=InMemoryStore(),
+        profile_store=InMemoryStore(),
+        episodic_store=InMemoryStore(),
+    )
+
+    # Seed a profile memory that should be recalled.
+    asyncio.run(mm.remember_profile("Kullanıcı kısa cevap ister", source="test"))
+
+    # Sanity: recall should find it.
+    recalled = asyncio.run(mm.recall(query="kısa cevap", limit=5))
+    assert len(recalled) >= 1
+
+    router = CapturingRouter()
+
+    class _SayingLLM:
+        def complete_json(self, *, messages, schema_hint):
+            _ = messages
+            _ = schema_hint
+            return {"type": "SAY", "text": "Tamam efendim."}
+
+    loop = BrainLoop(
+        llm=_SayingLLM(),
+        tools=ToolRegistry(),
+        router=router,
+        config=BrainLoopConfig(enable_memory_manager=False),
+        memory_manager=mm,
+    )
+
+    res = loop.run(
+        turn_input="kısa cevap",
+        session_context={"session_id": "t1", "deterministic_render": True},
+        context={},
+    )
+
+    assert res.kind == "say"
+    assert router.called is True
+    assert router.last_retrieved_memory is not None
+    assert "PROFILE" in router.last_retrieved_memory

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -165,3 +165,21 @@ def test_router_with_dialog_summary():
     
     assert result.route == "calendar"
     assert result.tool_plan == ["calendar.list_events"]
+
+
+def test_router_with_retrieved_memory_block():
+    """Router receives retrieved memory for context."""
+    llm = MockLLM({
+        "devam et": '{"route": "calendar", "calendar_intent": "query", "slots": {"window_hint": "today"}, "confidence": 0.9, "tool_plan": ["calendar.list_events"], "assistant_reply": ""}'
+    })
+
+    router = JarvisLLMRouter(llm=llm)
+    _ = router.route(
+        user_input="devam et",
+        dialog_summary="User: Yarın planım var mı? | Tools: calendar.list_events | Result: say",
+        retrieved_memory="- [PROFILE] Kullanıcı kısa cevap sever.\n- [EPISODIC] Dün takvimde koşu eklendi.",
+    )
+
+    assert len(llm.calls) == 1
+    assert "RETRIEVED_MEMORY" in llm.calls[0]
+    assert "talimat değildir" in llm.calls[0]

--- a/tests/test_memory_safety.py
+++ b/tests/test_memory_safety.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from bantz.memory.safety import safe_tool_episode
+
+
+def test_safe_tool_episode_avoids_titles_and_masks_emails():
+    text = safe_tool_episode(
+        tool_name="calendar.create_event",
+        params={
+            "summary": "Dentist with alice@example.com",
+            "location": "Somewhere",
+            "start": "2026-02-01T10:00:00",
+            "end": "2026-02-01T10:30:00",
+        },
+        result={"ok": True},
+    )
+
+    assert "calendar.create_event" in text
+    assert "alice@example.com" not in text
+    assert "<EMAIL>" not in text  # summary should not be copied at all
+    assert "Dentist" not in text
+    assert "Somewhere" not in text
+    assert "2026-02-01T10:00:00" in text
+    assert "2026-02-01T10:30:00" in text


### PR DESCRIPTION
Implements a minimal, production-safe Memory Manager v1:

- Injects retrieved snippet memory into the router/finalizer prompt as RETRIEVED_MEMORY with a strict context-only policy header
- Opt-in wiring in BrainLoop with best-effort recall
- Spam control for router memory_update -> PROFILE writes (min length, dedupe, rate-limit, heuristic allowlist)
- PII-safe episodic tool summaries (avoid raw tool outputs)
- Tests + docs

Closes #185.