### PR TITLE
Issue #190: Docker vLLM deployment (GPU passthrough)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.venv
+__pycache__
+**/__pycache__
+**/*.pyc
+artifacts/tmp
+artifacts/results
+artifacts/logs
+node_modules
+bantz-browser/node_modules
+bantz-browser/dist
+bantz-browser/build
+bantz-extension/node_modules

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ More details: docs/setup/vllm.md
 - docs/setup/vllm.md
 - docs/setup/google-oauth.md
 - docs/setup/memory.md
+- docs/setup/docker-vllm.md
 
 ## Google OAuth (Calendar/Gmail)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+version: "3.9"
+
+# Issue #190: vLLM Docker Deployment & GPU Passthrough
+#
+# Requirements:
+# - Docker Engine + docker compose plugin
+# - NVIDIA Container Toolkit for GPU support
+#
+# Usage:
+#   docker compose up -d
+#   curl http://127.0.0.1:8001/v1/models
+#
+services:
+  vllm-3b:
+    build:
+      context: .
+      dockerfile: docker/vllm/Dockerfile
+    command:
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8001"
+      - --model
+      - ${BANTZ_VLLM_3B_MODEL:-Qwen/Qwen2.5-3B-Instruct-AWQ}
+      - --max-model-len
+      - ${BANTZ_VLLM_3B_MAX_LEN:-4096}
+    ports:
+      - "8001:8001"
+    environment:
+      - HF_HOME=/data/hf
+    volumes:
+      - ./artifacts/logs:/logs
+      - vllm_hf_cache:/data/hf
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8001/v1/models"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    # GPU passthrough (compose v2)
+    device_requests:
+      - driver: nvidia
+        count: all
+        capabilities: [gpu]
+
+  vllm-7b:
+    build:
+      context: .
+      dockerfile: docker/vllm/Dockerfile
+    command:
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8002"
+      - --model
+      - ${BANTZ_VLLM_7B_MODEL:-Qwen/Qwen2.5-7B-Instruct-AWQ}
+      - --max-model-len
+      - ${BANTZ_VLLM_7B_MAX_LEN:-4096}
+    ports:
+      - "8002:8002"
+    environment:
+      - HF_HOME=/data/hf
+    volumes:
+      - ./artifacts/logs:/logs
+      - vllm_hf_cache:/data/hf
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8002/v1/models"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    device_requests:
+      - driver: nvidia
+        count: all
+        capabilities: [gpu]
+
+volumes:
+  vllm_hf_cache:

--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+# Multi-stage to keep runtime smaller.
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04 AS builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     python3 python3-venv python3-pip \
+     ca-certificates git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create a venv so we can copy it into the final image.
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# vLLM pinned per Issue #190 acceptance criteria.
+RUN pip install --no-cache-dir -U pip \
+  && pip install --no-cache-dir "vllm==0.6.0" \
+  && pip install --no-cache-dir "uvicorn[standard]" "fastapi" "pydantic" \
+  && pip install --no-cache-dir "requests"
+
+
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04 AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     python3 \
+     ca-certificates \
+     curl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Hugging Face cache location (mount as volume in compose).
+ENV HF_HOME=/data/hf
+ENV TRANSFORMERS_CACHE=/data/hf
+
+# Default to OpenAI-compatible server.
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]

--- a/docs/setup/docker-vllm.md
+++ b/docs/setup/docker-vllm.md
@@ -1,0 +1,39 @@
+# Docker vLLM (GPU)
+
+Issue #190 adds a minimal Docker setup to run vLLM (OpenAI-compatible server) with NVIDIA GPU passthrough.
+
+## Prereqs
+
+- Docker Engine
+- Docker Compose plugin (`docker compose`)
+- NVIDIA Container Toolkit
+
+## Start 3B + 7B
+
+From repo root:
+
+```bash
+docker compose up -d
+```
+
+Health checks:
+
+```bash
+curl http://127.0.0.1:8001/v1/models
+curl http://127.0.0.1:8002/v1/models
+```
+
+## Config
+
+Override models via env vars:
+
+```bash
+export BANTZ_VLLM_3B_MODEL="Qwen/Qwen2.5-3B-Instruct-AWQ"
+export BANTZ_VLLM_7B_MODEL="Qwen/Qwen2.5-7B-Instruct-AWQ"
+```
+
+## Notes
+
+- Hugging Face cache is persisted as a named volume (`vllm_hf_cache`).
+- Logs are mounted to `./artifacts/logs`.
+- The image is built from `docker/vllm/Dockerfile` (multi-stage) and pins `vllm==0.6.0`.


### PR DESCRIPTION
Adds Docker deployment for vLLM with GPU passthrough:\n\n- Multi-stage Dockerfile pinning vllm==0.6.0 + CUDA 12.1 runtime\n- docker compose services for 3B (8001) + 7B (8002) with healthchecks and restart policy\n- HF cache persisted via volume; logs mounted to ./artifacts/logs\n- Docs: docs/setup/docker-vllm.md\n\nCloses #190.