### PR TITLE
Issue #187: Google Vision API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ More details: docs/setup/vllm.md
 - docs/setup/google-oauth.md
 - docs/setup/memory.md
 - docs/setup/docker-vllm.md
+- docs/setup/google-vision.md
 
 ## Google OAuth (Calendar/Gmail)
 

--- a/docs/setup/google-vision.md
+++ b/docs/setup/google-vision.md
@@ -1,0 +1,43 @@
+# Google Vision (OCR + Labels)
+
+This repo already has local vision options (Tesseract OCR + optional vision LLM). If you want **high-quality OCR / labels** with Google Cloud Vision, you can enable the service-account integration.
+
+## 1) Create a service account
+
+- In Google Cloud Console, enable **Cloud Vision API**.
+- Create a **service account** and download the JSON key file.
+
+## 2) Configure credentials
+
+Set one of these env vars to point to the JSON file:
+
+- `BANTZ_GOOGLE_SERVICE_ACCOUNT=/path/to/service_account.json`
+- OR the standard `GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json`
+
+If you do nothing, Bantz looks for:
+
+- `~/.config/bantz/google/service_account.json`
+
+## 3) Install vision deps
+
+- `pip install -e '.[vision]'`
+
+## 4) Use
+
+Python helpers:
+
+- `bantz.vision.google_vision.vision_ocr(path)`
+- `bantz.vision.google_vision.vision_describe(path)`
+
+Agent tools (if registered):
+
+- `vision_ocr` (returns extracted text)
+- `vision_describe` (returns labels + scores; also logo/face detections)
+
+## Quota safety
+
+A small persisted quota limiter prevents accidentally exceeding the free tier.
+
+- Default: `1000` requests/month
+- Override: `BANTZ_VISION_MONTHLY_QUOTA=2000`
+- Quota state path: `BANTZ_VISION_QUOTA_PATH=/path/to/quota.json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ vision = [
 	"mss>=9.0.0",
 	"PyMuPDF>=1.24.0",
 	"pytesseract>=0.3.10",
+	"google-auth>=2.0.0",
 ]
 security = [
 	"cryptography>=42.0.0",
@@ -103,6 +104,7 @@ all = [
 	"mss>=9.0.0",
 	"PyMuPDF>=1.24.0",
 	"pytesseract>=0.3.10",
+	"google-auth>=2.0.0",
 	"cryptography>=42.0.0",
 ]
 

--- a/requirements-vision.txt
+++ b/requirements-vision.txt
@@ -2,3 +2,4 @@ mss>=9.0.0
 Pillow>=10.0.0
 PyMuPDF>=1.24.0
 pytesseract>=0.3.10
+google-auth>=2.0.0

--- a/src/bantz/google/service_account.py
+++ b/src/bantz/google/service_account.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+import os
+
+
+DEFAULT_SERVICE_ACCOUNT_PATH = "~/.config/bantz/google/service_account.json"
+
+
+@dataclass(frozen=True)
+class GoogleServiceAccountConfig:
+    service_account_path: Path
+
+
+def _resolve_path(value: str) -> Path:
+    return Path(os.path.expanduser(value)).resolve()
+
+
+def get_google_service_account_config(
+    *,
+    service_account_path: Optional[str] = None,
+) -> GoogleServiceAccountConfig:
+    # Prefer standard GCP env var, but allow a Bantz-specific override.
+    env_path = os.getenv("BANTZ_GOOGLE_SERVICE_ACCOUNT") or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+    raw = service_account_path or env_path or DEFAULT_SERVICE_ACCOUNT_PATH
+    return GoogleServiceAccountConfig(service_account_path=_resolve_path(raw))
+
+
+def get_service_account_credentials(
+    *,
+    scopes: list[str],
+    service_account_path: Optional[str] = None,
+):
+    """Return Google service-account credentials.
+
+    Reads path from env vars by default:
+    - BANTZ_GOOGLE_SERVICE_ACCOUNT
+    - GOOGLE_APPLICATION_CREDENTIALS
+
+    Falls back to: ~/.config/bantz/google/service_account.json
+
+    Lazy-imports google-auth so repo can run without vision deps.
+    """
+
+    cfg = get_google_service_account_config(service_account_path=service_account_path)
+    if not cfg.service_account_path.exists():
+        raise FileNotFoundError(
+            "Google service account JSON not found. Set BANTZ_GOOGLE_SERVICE_ACCOUNT or "
+            "GOOGLE_APPLICATION_CREDENTIALS, or place the file at "
+            f"{DEFAULT_SERVICE_ACCOUNT_PATH}. Missing: {cfg.service_account_path}"
+        )
+
+    try:
+        from google.oauth2 import service_account  # type: ignore
+    except Exception as e:  # pragma: no cover
+        raise RuntimeError(
+            "Google auth dependencies are not installed. Install with: pip install -e '.[vision]'"
+        ) from e
+
+    return service_account.Credentials.from_service_account_file(str(cfg.service_account_path), scopes=scopes)

--- a/src/bantz/vision/__init__.py
+++ b/src/bantz/vision/__init__.py
@@ -34,6 +34,12 @@ from bantz.vision.document import (
     OCRResult,
     MockDocumentAnalyzer,
 )
+from bantz.vision.google_vision import (
+    GoogleVisionClient,
+    GoogleVisionError,
+    vision_ocr,
+    vision_describe,
+)
 from bantz.vision.screen import (
     ScreenUnderstanding,
     ScreenAnalysis,
@@ -74,6 +80,11 @@ __all__ = [
     "DocumentPage",
     "OCRResult",
     "MockDocumentAnalyzer",
+    # Google Vision
+    "GoogleVisionClient",
+    "GoogleVisionError",
+    "vision_ocr",
+    "vision_describe",
     # Screen
     "ScreenUnderstanding",
     "ScreenAnalysis",

--- a/src/bantz/vision/google_vision.py
+++ b/src/bantz/vision/google_vision.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+import base64
+import json
+import logging
+import os
+
+import requests
+
+from bantz.google.service_account import get_service_account_credentials
+from bantz.vision.quota import MonthlyQuotaLimiter, VisionQuotaExceeded
+
+logger = logging.getLogger(__name__)
+
+
+GOOGLE_VISION_ENDPOINT = "https://vision.googleapis.com/v1/images:annotate"
+
+
+class GoogleVisionError(RuntimeError):
+    pass
+
+
+def _b64(content: bytes) -> str:
+    return base64.b64encode(content).decode("ascii")
+
+
+def _read_bytes(path: Union[str, Path]) -> bytes:
+    return Path(path).read_bytes()
+
+
+def _load_images_from_path(
+    path: Union[str, Path],
+    *,
+    max_pdf_pages: int = 5,
+) -> List[bytes]:
+    p = Path(path)
+    suffix = p.suffix.lower()
+
+    if suffix in {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}:
+        return [_read_bytes(p)]
+
+    if suffix == ".pdf":
+        try:
+            import fitz  # PyMuPDF
+        except Exception as e:
+            raise RuntimeError("PyMuPDF is required for PDF support. Install with: pip install -e '.[vision]'") from e
+
+        doc = fitz.open(str(p))
+        try:
+            images: List[bytes] = []
+            page_count = min(len(doc), max_pdf_pages)
+            matrix = fitz.Matrix(2, 2)  # ~144 DPI
+            for idx in range(page_count):
+                page = doc[idx]
+                pix = page.get_pixmap(matrix=matrix)
+                images.append(pix.tobytes("png"))
+            return images
+        finally:
+            doc.close()
+
+    raise ValueError(f"Unsupported file type for vision: {suffix}")
+
+
+@dataclass
+class GoogleVisionConfig:
+    max_pdf_pages: int = 5
+    monthly_quota: int = 1000
+
+
+class GoogleVisionClient:
+    """Google Vision API client (REST).
+
+    Uses service-account credentials and sends base64-encoded content.
+    """
+
+    def __init__(
+        self,
+        *,
+        credentials_path: Optional[str] = None,
+        quota_limiter: Optional[MonthlyQuotaLimiter] = None,
+        session: Optional[requests.Session] = None,
+        max_pdf_pages: int = 5,
+    ):
+        self._credentials_path = credentials_path
+        self._quota = quota_limiter or MonthlyQuotaLimiter.from_env()
+        self._session = session or requests.Session()
+        self._max_pdf_pages = max_pdf_pages
+
+    def _authorized_headers(self) -> Dict[str, str]:
+        creds = get_service_account_credentials(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            service_account_path=self._credentials_path,
+        )
+
+        try:
+            from google.auth.transport.requests import Request  # type: ignore
+        except Exception as e:  # pragma: no cover
+            raise RuntimeError(
+                "Google auth dependencies are not installed. Install with: pip install -e '.[vision]'"
+            ) from e
+
+        creds.refresh(Request())
+        return {"Authorization": f"Bearer {creds.token}"}
+
+    def annotate(
+        self,
+        *,
+        images: Sequence[bytes],
+        features: Sequence[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        # Free-tier safety: count 1 request per API call.
+        self._quota.check_and_increment(units=1)
+
+        headers = {
+            "Content-Type": "application/json",
+            **self._authorized_headers(),
+        }
+
+        reqs = [
+            {
+                "image": {"content": _b64(content)},
+                "features": list(features),
+            }
+            for content in images
+        ]
+
+        payload = {"requests": reqs}
+        resp = self._session.post(GOOGLE_VISION_ENDPOINT, headers=headers, data=json.dumps(payload), timeout=30)
+        if resp.status_code >= 400:
+            raise GoogleVisionError(f"Google Vision API error {resp.status_code}: {resp.text[:500]}")
+
+        data = resp.json()
+        # API returns errors per response
+        for r in data.get("responses", []) or []:
+            if "error" in r:
+                raise GoogleVisionError(f"Google Vision response error: {r['error']}")
+        return data
+
+    def ocr_path(self, path: Union[str, Path]) -> str:
+        images = _load_images_from_path(path, max_pdf_pages=self._max_pdf_pages)
+        data = self.annotate(images=images, features=[{"type": "TEXT_DETECTION"}])
+
+        texts: List[str] = []
+        for r in data.get("responses", []) or []:
+            full = (r.get("fullTextAnnotation") or {}).get("text")
+            if full:
+                texts.append(full)
+                continue
+            anns = r.get("textAnnotations") or []
+            if anns:
+                texts.append((anns[0] or {}).get("description") or "")
+
+        return "\n\n".join([t.strip() for t in texts if t and t.strip()]).strip()
+
+    def describe_path(
+        self,
+        path: Union[str, Path],
+        *,
+        max_labels: int = 10,
+        include_faces: bool = True,
+        include_logos: bool = True,
+    ) -> Dict[str, Any]:
+        images = _load_images_from_path(path, max_pdf_pages=self._max_pdf_pages)
+
+        features: List[Dict[str, Any]] = [
+            {"type": "LABEL_DETECTION", "maxResults": max_labels},
+        ]
+        if include_logos:
+            features.append({"type": "LOGO_DETECTION", "maxResults": 10})
+        if include_faces:
+            features.append({"type": "FACE_DETECTION", "maxResults": 5})
+
+        data = self.annotate(images=images, features=features)
+
+        # Aggregate labels across pages.
+        label_scores: Dict[str, float] = {}
+        logos: List[Dict[str, Any]] = []
+        faces: List[Dict[str, Any]] = []
+
+        for r in data.get("responses", []) or []:
+            for lab in r.get("labelAnnotations") or []:
+                desc = (lab or {}).get("description")
+                score = float((lab or {}).get("score") or 0.0)
+                if not desc:
+                    continue
+                label_scores[desc] = max(label_scores.get(desc, 0.0), score)
+
+            for logo in r.get("logoAnnotations") or []:
+                desc = (logo or {}).get("description")
+                score = float((logo or {}).get("score") or 0.0)
+                if desc:
+                    logos.append({"description": desc, "score": score})
+
+            for face in r.get("faceAnnotations") or []:
+                faces.append(
+                    {
+                        "detectionConfidence": (face or {}).get("detectionConfidence"),
+                        "landmarkingConfidence": (face or {}).get("landmarkingConfidence"),
+                        "joyLikelihood": (face or {}).get("joyLikelihood"),
+                        "sorrowLikelihood": (face or {}).get("sorrowLikelihood"),
+                        "angerLikelihood": (face or {}).get("angerLikelihood"),
+                        "surpriseLikelihood": (face or {}).get("surpriseLikelihood"),
+                        "headwearLikelihood": (face or {}).get("headwearLikelihood"),
+                    }
+                )
+
+        labels = [
+            {"label": k, "score": v}
+            for k, v in sorted(label_scores.items(), key=lambda kv: kv[1], reverse=True)
+        ]
+
+        return {
+            "labels": labels[:max_labels],
+            "logos": logos,
+            "faces": faces,
+        }
+
+
+_DEFAULT_CLIENT: Optional[GoogleVisionClient] = None
+
+
+def get_default_google_vision_client() -> GoogleVisionClient:
+    global _DEFAULT_CLIENT
+    if _DEFAULT_CLIENT is None:
+        _DEFAULT_CLIENT = GoogleVisionClient()
+    return _DEFAULT_CLIENT
+
+
+def vision_ocr(image_path: Union[str, Path]) -> str:
+    """Extract text from an image or PDF using Google Vision (service account)."""
+    return get_default_google_vision_client().ocr_path(image_path)
+
+
+def vision_describe(image_path: Union[str, Path]) -> Dict[str, Any]:
+    """Describe an image or PDF using Google Vision labels/logos/faces."""
+    return get_default_google_vision_client().describe_path(image_path)

--- a/src/bantz/vision/quota.py
+++ b/src/bantz/vision/quota.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+import json
+import os
+
+
+class VisionQuotaExceeded(RuntimeError):
+    pass
+
+
+def _month_key(now: datetime) -> str:
+    return f"{now.year:04d}-{now.month:02d}"
+
+
+def _default_quota_path() -> Path:
+    base = Path(os.path.expanduser(os.getenv("XDG_CONFIG_HOME", "~/.config"))).expanduser()
+    return (base / "bantz" / "vision" / "quota.json").resolve()
+
+
+@dataclass
+class MonthlyQuotaLimiter:
+    """Persisted monthly quota limiter.
+
+    This is meant for low-volume paid APIs (e.g. Google Vision free tier).
+    """
+
+    max_requests_per_month: int = 1000
+    quota_path: Path = _default_quota_path()
+
+    @classmethod
+    def from_env(cls) -> "MonthlyQuotaLimiter":
+        raw_max = os.getenv("BANTZ_VISION_MONTHLY_QUOTA")
+        raw_path = os.getenv("BANTZ_VISION_QUOTA_PATH")
+
+        max_requests = 1000
+        if raw_max:
+            try:
+                max_requests = int(raw_max)
+            except ValueError:
+                max_requests = 1000
+
+        quota_path = Path(os.path.expanduser(raw_path)).resolve() if raw_path else _default_quota_path()
+        return cls(max_requests_per_month=max_requests, quota_path=quota_path)
+
+    def _read_state(self) -> dict[str, Any]:
+        if not self.quota_path.exists():
+            return {}
+        try:
+            return json.loads(self.quota_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def _write_state(self, data: dict[str, Any]) -> None:
+        self.quota_path.parent.mkdir(parents=True, exist_ok=True)
+        self.quota_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def check_and_increment(self, *, units: int = 1, now: Optional[datetime] = None) -> dict[str, Any]:
+        now = now or datetime.now(timezone.utc)
+        key = _month_key(now)
+
+        data = self._read_state()
+        month = data.get(key) or {"used": 0, "updated_at": None}
+
+        used = int(month.get("used") or 0)
+        if used + units > self.max_requests_per_month:
+            raise VisionQuotaExceeded(
+                f"Monthly vision quota exceeded ({used}/{self.max_requests_per_month}). "
+                "Set BANTZ_VISION_MONTHLY_QUOTA to override, or wait until next month."
+            )
+
+        month["used"] = used + units
+        month["updated_at"] = now.isoformat()
+        data[key] = month
+        self._write_state(data)
+
+        return {"month": key, "used": month["used"], "max": self.max_requests_per_month}

--- a/tests/test_google_vision.py
+++ b/tests/test_google_vision.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from bantz.vision.google_vision import GoogleVisionClient, GoogleVisionError
+from bantz.vision.quota import MonthlyQuotaLimiter
+
+
+class _DummyResponse:
+    def __init__(self, status_code: int, payload: Dict[str, Any]):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self) -> Dict[str, Any]:
+        return self._payload
+
+
+class _DummySession:
+    def __init__(self, responder):
+        self._responder = responder
+        self.last_request = None
+
+    def post(self, url: str, headers=None, data=None, timeout=None):
+        self.last_request = {
+            "url": url,
+            "headers": headers,
+            "data": data,
+            "timeout": timeout,
+        }
+        return self._responder(url=url, headers=headers, data=data, timeout=timeout)
+
+
+def test_annotate_sends_base64_and_features(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    quota = MonthlyQuotaLimiter(max_requests_per_month=1000, quota_path=tmp_path / "quota.json")
+
+    def responder(**kwargs):
+        return _DummyResponse(
+            200,
+            {
+                "responses": [
+                    {
+                        "textAnnotations": [
+                            {"description": "HELLO"},
+                        ]
+                    }
+                ]
+            },
+        )
+
+    session = _DummySession(responder)
+    client = GoogleVisionClient(quota_limiter=quota, session=session)
+
+    monkeypatch.setattr(client, "_authorized_headers", lambda: {"Authorization": "Bearer test"})
+
+    img = b"fake-image-bytes"
+    out = client.annotate(images=[img], features=[{"type": "TEXT_DETECTION"}])
+    assert out["responses"][0]["textAnnotations"][0]["description"] == "HELLO"
+
+    sent = session.last_request
+    assert sent is not None
+    assert sent["headers"]["Authorization"] == "Bearer test"
+
+    payload = sent["data"]
+    assert "TEXT_DETECTION" in payload
+
+    expected_b64 = base64.b64encode(img).decode("ascii")
+    assert expected_b64 in payload
+
+
+def test_ocr_path_uses_full_text_annotation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    quota = MonthlyQuotaLimiter(max_requests_per_month=1000, quota_path=tmp_path / "quota.json")
+
+    def responder(**kwargs):
+        return _DummyResponse(
+            200,
+            {
+                "responses": [
+                    {"fullTextAnnotation": {"text": "Line1\nLine2\n"}},
+                ]
+            },
+        )
+
+    session = _DummySession(responder)
+    client = GoogleVisionClient(quota_limiter=quota, session=session)
+    monkeypatch.setattr(client, "_authorized_headers", lambda: {"Authorization": "Bearer test"})
+
+    img_path = tmp_path / "x.png"
+    img_path.write_bytes(b"img")
+
+    text = client.ocr_path(img_path)
+    assert text == "Line1\nLine2"
+
+
+def test_describe_path_aggregates_labels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    quota = MonthlyQuotaLimiter(max_requests_per_month=1000, quota_path=tmp_path / "quota.json")
+
+    def responder(**kwargs):
+        return _DummyResponse(
+            200,
+            {
+                "responses": [
+                    {
+                        "labelAnnotations": [
+                            {"description": "Cat", "score": 0.8},
+                            {"description": "Pet", "score": 0.7},
+                        ],
+                        "logoAnnotations": [{"description": "ACME", "score": 0.9}],
+                        "faceAnnotations": [{"detectionConfidence": 0.5, "joyLikelihood": "VERY_LIKELY"}],
+                    },
+                    {
+                        "labelAnnotations": [
+                            {"description": "Cat", "score": 0.85},
+                        ]
+                    },
+                ]
+            },
+        )
+
+    session = _DummySession(responder)
+    client = GoogleVisionClient(quota_limiter=quota, session=session)
+    monkeypatch.setattr(client, "_authorized_headers", lambda: {"Authorization": "Bearer test"})
+
+    img_path = tmp_path / "x.jpg"
+    img_path.write_bytes(b"img")
+
+    result = client.describe_path(img_path, max_labels=10)
+    labels = {x["label"]: x["score"] for x in result["labels"]}
+
+    assert labels["Cat"] == pytest.approx(0.85)
+    assert labels["Pet"] == pytest.approx(0.7)
+    assert result["logos"][0]["description"] == "ACME"
+    assert result["faces"][0]["joyLikelihood"] == "VERY_LIKELY"
+
+
+def test_annotate_raises_on_per_response_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    quota = MonthlyQuotaLimiter(max_requests_per_month=1000, quota_path=tmp_path / "quota.json")
+
+    def responder(**kwargs):
+        return _DummyResponse(
+            200,
+            {"responses": [{"error": {"message": "boom", "code": 400}}]},
+        )
+
+    session = _DummySession(responder)
+    client = GoogleVisionClient(quota_limiter=quota, session=session)
+    monkeypatch.setattr(client, "_authorized_headers", lambda: {"Authorization": "Bearer test"})
+
+    with pytest.raises(GoogleVisionError):
+        client.annotate(images=[b"img"], features=[{"type": "TEXT_DETECTION"}])


### PR DESCRIPTION
Closes #187

Implements Google Cloud Vision REST integration using service-account auth (google-auth) with base64 requests and a small persisted monthly quota limiter.

Adds tools:
- vision_ocr(image_path) -> extracted text
- vision_describe(image_path) -> labels + confidence (plus optional logo/face signals)

Docs: docs/setup/google-vision.md
Tests: tests/test_google_vision.py