### PR TITLE
Docs: router + tiered demo issue stubs

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -15,6 +15,25 @@ Bantz uses **vLLM** for local LLM inference:
 
 ---
 
+## P0 — Calendar Router & Menu Fallback (2026-02)
+
+Bu bölüm, "Takvim mi sohbet mi?" menüsünün **normal akışta asla görünmemesi** için gereken işleri takip eder.
+
+- P0: Router fallback menü çıkarmasın (parse fail/unknown → smalltalk fallback)
+	- Spec: [docs/issues/2026-02-router-no-menus.md](docs/issues/2026-02-router-no-menus.md)
+	- GitHub issue açmak için:
+		- `gh issue create --title "Router fallback: no user-facing menus" --body-file docs/issues/2026-02-router-no-menus.md`
+
+- P0: Router strict JSON + heuristics (temp=0, max_tokens küçük)
+	- Spec: [docs/issues/2026-02-router-strict-json.md](docs/issues/2026-02-router-strict-json.md)
+	- GitHub issue açmak için:
+		- `gh issue create --title "Router: strict JSON + heuristics" --body-file docs/issues/2026-02-router-strict-json.md`
+
+- P1: Tiered LLM demo (3B router + Gemini quality)
+	- Spec: [docs/issues/2026-02-tiered-gemini-demo.md](docs/issues/2026-02-tiered-gemini-demo.md)
+	- GitHub issue açmak için:
+		- `gh issue create --title "Tiered LLM demo: fast router + quality writing" --body-file docs/issues/2026-02-tiered-gemini-demo.md`
+
 ## Epic V2 — “Jarvis Seviye” Roadmap (Phases 0–8 + UI/Voice)
 
 Bu bölüm, v2 mimarisi için **faz bazlı** epic issue’ları takip etmek içindir. Detaylar roadmap dokümanında.

--- a/docs/issues/2026-02-router-no-menus.md
+++ b/docs/issues/2026-02-router-no-menus.md
@@ -1,0 +1,18 @@
+# Issue: Router fallback must not show menus
+
+**Type:** Bug / UX
+
+## Problem
+In some flows (especially small-context local models), router/classifier output may be `unknown` or fail to parse, leading to a user-facing choice menu (e.g., “Takvim mi sohbet mi? 1/2/0”). This is acceptable as debug UX, but not in normal product behavior.
+
+## Goal
+- No user-facing “choose 1/2/0” menu in normal flows.
+- On router parse failure or `unknown`, default to safe smalltalk fallback.
+
+## Acceptance Criteria
+- Greeting like “Selam nasılsın?” produces a normal smalltalk response, never a menu.
+- Router parse failure does not surface a menu; it logs a reason token and falls back to smalltalk.
+- Debug menus remain available behind a debug flag.
+
+## Notes
+This should be handled in core (BrainLoop), not only in the demo script.

--- a/docs/issues/2026-02-router-strict-json.md
+++ b/docs/issues/2026-02-router-strict-json.md
@@ -1,0 +1,23 @@
+# Issue: Router strict JSON + heuristics
+
+**Type:** Reliability
+
+## Problem
+Router classification is sensitive to sampling and prompt length. When it produces non-JSON or extra text, downstream routing can fail and create poor UX.
+
+## Goal
+- Router classification should be stable:
+  - `temperature=0.0`
+  - small output budget (e.g., `max_tokens=64`)
+  - minimal prompt
+- Add deterministic heuristics to bias:
+  - If no calendar markers -> `smalltalk` (confidence >= 0.8)
+  - If calendar markers -> `calendar` (confidence >= 0.7)
+
+## Acceptance Criteria
+- “Selam” -> `smalltalk` with high confidence.
+- Calendar queries (“bugün planım var mı?”, “yarın 10:00 toplantı ekle”) -> `calendar`.
+- Parse failures never propagate to user-facing menus.
+
+## Notes
+Core should not depend on demo-only adapters.

--- a/docs/issues/2026-02-tiered-gemini-demo.md
+++ b/docs/issues/2026-02-tiered-gemini-demo.md
@@ -1,0 +1,15 @@
+# Issue: Tiered LLM demo (3B router + Gemini quality)
+
+**Type:** Feature / Demo
+
+## Goal
+Demonstrate tiered behavior:
+- Fast local 3B is always used for routing + tool selection.
+- Gemini (quality tier) is used for writing-heavy tasks (email drafts, long explanations, summaries).
+
+## Acceptance Criteria
+- A demo scenario exists where the user asks for an email draft and the system uses the quality provider.
+- Calendar tool answers remain fast and do not unnecessarily escalate to Gemini.
+
+## Notes
+This is primarily to reduce confusion: in a calendar demo, Gemini may not trigger naturally.


### PR DESCRIPTION
Adds local issue specs under docs/issues and links from docs/issues.md.

Refs #204 #205 #206.