### PR TITLE
Issue #164: Calendar Multi-Day Event Support (All-Day Events)

### DIFF
--- a/docs/google/calendar.md
+++ b/docs/google/calendar.md
@@ -12,9 +12,136 @@ Kod: `src/bantz/google/calendar.py`
 
 - `list_events(...)` - Liste calendar events
 - `find_free_slots(...)` - Find available time slots
-- `create_event(...)` (write) - Create new event
+- `create_event(...)` (write) - Create new event (supports all-day events - Issue #164)
 - `update_event(...)` (write) - **Update event with partial updates (Issue #163)**
 - `delete_event(...)` (write) - Delete event
+
+## create_event - All-Day Event Support (Issue #164)
+
+`create_event` now supports **all-day events** in addition to time-based events.
+
+### Time-Based Events (Original)
+
+```python
+from bantz.google.calendar import create_event
+
+# With end datetime
+create_event(
+    summary="Team Meeting",
+    start="2026-02-03T14:00:00+03:00",
+    end="2026-02-03T15:00:00+03:00"
+)
+
+# With duration
+create_event(
+    summary="Team Meeting",
+    start="2026-02-03T14:00:00+03:00",
+    duration_minutes=60
+)
+```
+
+### All-Day Events (New - Issue #164)
+
+```python
+# Single-day all-day event
+create_event(
+    summary="Conference",
+    start="2026-02-03",
+    all_day=True
+)
+
+# Multi-day all-day event
+create_event(
+    summary="Vacation",
+    start="2026-02-23",
+    end="2026-02-26",  # Exclusive: Feb 23-25 (3 days)
+    all_day=True
+)
+
+# All-day event with location and description
+create_event(
+    summary="Home Office",
+    start="2026-02-05",
+    all_day=True,
+    location="Home",
+    description="Working from home today"
+)
+```
+
+### Parameters
+
+**Time-based events:**
+- `start`: RFC3339 datetime with timezone (e.g., "2026-02-03T14:00:00+03:00")
+- `end`: RFC3339 datetime (optional if `duration_minutes` provided)
+- `duration_minutes`: Duration in minutes (optional if `end` provided)
+
+**All-day events:**
+- `all_day=True`: Must be set to `True`
+- `start`: Date in YYYY-MM-DD format (e.g., "2026-02-03")
+- `end`: Date in YYYY-MM-DD format (optional, exclusive)
+  - If not provided, creates single-day event
+  - If provided, end date is exclusive (e.g., "2026-02-23" to "2026-02-26" = Feb 23-25)
+- `duration_minutes`: Ignored for all-day events
+
+**Common parameters:**
+- `summary` (required): Event title
+- `calendar_id` (optional): Calendar ID (default: primary)
+- `description` (optional): Event description
+- `location` (optional): Event location
+
+### Rules
+
+**All-day events:**
+- `start` must be in YYYY-MM-DD format
+- `end` (if provided) must be in YYYY-MM-DD format
+- `end` must be after `start` (at least +1 day)
+- `end` is exclusive (next day after last day of event)
+
+**Time-based events:**
+- `start` must be RFC3339 with timezone
+- Either `end` or `duration_minutes` must be provided
+- `end` must be after `start`
+
+### CLI Usage
+
+```bash
+# Time-based event
+bantz google calendar create \
+  --summary "Meeting" \
+  --start "2026-02-03T14:00:00+03:00" \
+  --duration-minutes 60 \
+  --yes
+
+# Single-day all-day event
+bantz google calendar create \
+  --summary "Conference" \
+  --start "2026-02-03" \
+  --all-day \
+  --yes
+
+# Multi-day all-day event
+bantz google calendar create \
+  --summary "Vacation" \
+  --start "2026-02-23" \
+  --end "2026-02-26" \
+  --all-day \
+  --yes
+
+# All-day event with details
+bantz google calendar create \
+  --summary "Home Office" \
+  --start "2026-02-05" \
+  --all-day \
+  --location "Home" \
+  --description "Working from home" \
+  --yes
+```
+
+### User Stories Addressed
+
+- ✅ "Pazartesi tüm gün konferans ekle"
+- ✅ "23-25 Şubat arası tatil işaretle"
+- ✅ "Cuma günü home office olarak belirt"
 
 ## update_event - Partial Update Support (Issue #163)
 

--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -545,17 +545,41 @@ def build_default_registry() -> ToolRegistry:
     reg.register(
         Tool(
             name="calendar.create_event",
-            description="Create a calendar event (write). Requires confirmation.",
+            description=(
+                "Create a calendar event (write). Supports both time-based and all-day events. "
+                "For all-day events (Issue #164), set all_day=true and use YYYY-MM-DD format for start/end dates. "
+                "Requires confirmation."
+            ),
             parameters={
                 "type": "object",
                 "properties": {
                     "summary": {"type": "string", "description": "Event summary/title"},
-                    "start": {"type": "string", "description": "RFC3339 start datetime (with timezone)"},
-                    "end": {"type": "string", "description": "RFC3339 end datetime (optional if duration_minutes provided)"},
-                    "duration_minutes": {"type": "integer", "description": "Duration in minutes (optional if end provided)"},
+                    "start": {
+                        "type": "string",
+                        "description": (
+                            "Start datetime (RFC3339 with timezone) or date (YYYY-MM-DD for all-day events)"
+                        ),
+                    },
+                    "end": {
+                        "type": "string",
+                        "description": (
+                            "End datetime (RFC3339) or date (YYYY-MM-DD). "
+                            "Optional if duration_minutes provided (time-based events) or "
+                            "for single-day all-day events."
+                        ),
+                    },
+                    "duration_minutes": {"type": "integer", "description": "Duration in minutes (ignored for all-day events)"},
                     "calendar_id": {"type": "string", "description": "Calendar ID (default: primary)"},
                     "description": {"type": "string", "description": "Optional description"},
                     "location": {"type": "string", "description": "Optional location"},
+                    "all_day": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, creates an all-day event. "
+                            "Start and end must be YYYY-MM-DD format. "
+                            "End is exclusive (e.g., 2026-02-23 to 2026-02-26 = Feb 23-25)."
+                        ),
+                    },
                 },
                 "required": ["summary", "start"],
             },
@@ -568,6 +592,7 @@ def build_default_registry() -> ToolRegistry:
                     "summary": {"type": "string"},
                     "start": {"type": "string"},
                     "end": {"type": "string"},
+                    "all_day": {"type": "boolean"},
                 },
                 "required": ["ok", "id", "start", "end", "summary"],
             },

--- a/src/bantz/google/cli.py
+++ b/src/bantz/google/cli.py
@@ -140,6 +140,7 @@ def cmd_calendar_create(args: argparse.Namespace) -> int:
         duration_minutes=args.duration_minutes,
         description=args.description,
         location=args.location,
+        all_day=bool(args.all_day),
     )
     _print_json(resp)
     return 0 if resp.get("ok") else 1
@@ -264,11 +265,24 @@ def build_parser() -> argparse.ArgumentParser:
     p_create = cal_sub.add_parser("create", help="Create an event (write)")
     add_calendar_common(p_create)
     p_create.add_argument("--summary", required=True, help="Event summary/title")
-    p_create.add_argument("--start", required=True, help="RFC3339 datetime")
-    p_create.add_argument("--end", default=None, help="RFC3339 datetime")
-    p_create.add_argument("--duration-minutes", type=int, default=None, help="Used if --end is missing")
+    p_create.add_argument(
+        "--start",
+        required=True,
+        help="RFC3339 datetime or YYYY-MM-DD (for all-day events)",
+    )
+    p_create.add_argument(
+        "--end",
+        default=None,
+        help="RFC3339 datetime or YYYY-MM-DD (for all-day events)",
+    )
+    p_create.add_argument("--duration-minutes", type=int, default=None, help="Used if --end is missing (time-based only)")
     p_create.add_argument("--description", default=None)
     p_create.add_argument("--location", default=None)
+    p_create.add_argument(
+        "--all-day",
+        action="store_true",
+        help="Create all-day event (use YYYY-MM-DD format for --start and --end)",
+    )
     p_create.add_argument("--yes", action="store_true", help="Confirm write operation")
     p_create.set_defaults(func=cmd_calendar_create)
 

--- a/tests/test_calendar_all_day_events.py
+++ b/tests/test_calendar_all_day_events.py
@@ -1,0 +1,373 @@
+"""
+Test all-day event support for Google Calendar (Issue #164).
+
+Tests cover:
+- Single-day all-day events
+- Multi-day all-day events
+- Date boundary validations
+- All-day event parsing in list_events
+- Busy interval calculation for all-day events
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from types import ModuleType
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bantz.google.calendar import create_event, list_events
+
+
+def test_create_all_day_event_single_day(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test creating a single-day all-day event."""
+    mock_service = MagicMock()
+    mock_created = {
+        "id": "evt_all_day_123",
+        "summary": "Conference",
+        "htmlLink": "https://calendar.google.com/event?eid=evt_all_day_123",
+        "start": {"date": "2026-02-03"},
+        "end": {"date": "2026-02-04"},  # Next day (exclusive)
+    }
+
+    mock_service.events().insert().execute.return_value = mock_created
+
+    def mock_build(service_name: str, version: str, **kwargs):
+        assert service_name == "calendar" and version == "v3"
+        return mock_service
+
+    mock_discovery = ModuleType("googleapiclient.discovery")
+    mock_discovery.build = mock_build
+    monkeypatch.setitem(__import__("sys").modules, "googleapiclient.discovery", mock_discovery)
+
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    result = create_event(
+        summary="Conference",
+        start="2026-02-03",
+        all_day=True,
+    )
+
+    # Verify API call
+    call_args = mock_service.events().insert.call_args
+    assert call_args.kwargs["body"]["summary"] == "Conference"
+    assert call_args.kwargs["body"]["start"] == {"date": "2026-02-03"}
+    assert call_args.kwargs["body"]["end"] == {"date": "2026-02-04"}  # Auto +1 day
+
+    # Verify response
+    assert result["ok"] is True
+    assert result["id"] == "evt_all_day_123"
+    assert result["summary"] == "Conference"
+    assert result["start"] == "2026-02-03"
+    assert result["end"] == "2026-02-04"
+    assert result["all_day"] is True
+
+
+def test_create_all_day_event_multi_day(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test creating a multi-day all-day event."""
+    mock_service = MagicMock()
+    mock_created = {
+        "id": "evt_vacation",
+        "summary": "Vacation",
+        "htmlLink": "https://calendar.google.com/event?eid=evt_vacation",
+        "start": {"date": "2026-02-23"},
+        "end": {"date": "2026-02-26"},  # Exclusive: Feb 23-25 (3 days)
+    }
+
+    mock_service.events().insert().execute.return_value = mock_created
+
+    def mock_build(service_name: str, version: str, **kwargs):
+        return mock_service
+
+    mock_discovery = ModuleType("googleapiclient.discovery")
+    mock_discovery.build = mock_build
+    monkeypatch.setitem(__import__("sys").modules, "googleapiclient.discovery", mock_discovery)
+
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    result = create_event(
+        summary="Vacation",
+        start="2026-02-23",
+        end="2026-02-26",
+        all_day=True,
+    )
+
+    # Verify API call
+    call_args = mock_service.events().insert.call_args
+    assert call_args.kwargs["body"]["start"] == {"date": "2026-02-23"}
+    assert call_args.kwargs["body"]["end"] == {"date": "2026-02-26"}
+
+    # Verify response
+    assert result["ok"] is True
+    assert result["start"] == "2026-02-23"
+    assert result["end"] == "2026-02-26"
+    assert result["all_day"] is True
+
+
+def test_create_all_day_event_with_location_description(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test all-day event with location and description."""
+    mock_service = MagicMock()
+    mock_created = {
+        "id": "evt_home_office",
+        "summary": "Home Office",
+        "htmlLink": "https://calendar.google.com/event?eid=evt_home_office",
+        "start": {"date": "2026-02-05"},
+        "end": {"date": "2026-02-06"},
+        "location": "Home",
+        "description": "Working from home today",
+    }
+
+    mock_service.events().insert().execute.return_value = mock_created
+
+    def mock_build(service_name: str, version: str, **kwargs):
+        return mock_service
+
+    mock_discovery = ModuleType("googleapiclient.discovery")
+    mock_discovery.build = mock_build
+    monkeypatch.setitem(__import__("sys").modules, "googleapiclient.discovery", mock_discovery)
+
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    result = create_event(
+        summary="Home Office",
+        start="2026-02-05",
+        all_day=True,
+        location="Home",
+        description="Working from home today",
+    )
+
+    # Verify body includes location and description
+    call_args = mock_service.events().insert.call_args
+    assert call_args.kwargs["body"]["location"] == "Home"
+    assert call_args.kwargs["body"]["description"] == "Working from home today"
+
+    assert result["ok"] is True
+    assert result["all_day"] is True
+
+
+def test_create_all_day_event_error_invalid_start_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test error when all_day=True but start is not a date format."""
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    with pytest.raises(ValueError, match="all_day_start_must_be_date_format"):
+        create_event(
+            summary="Conference",
+            start="2026-02-03T14:00:00+03:00",  # RFC3339, not date
+            all_day=True,
+        )
+
+
+def test_create_all_day_event_error_invalid_end_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test error when all_day=True but end is not a date format."""
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    with pytest.raises(ValueError, match="all_day_end_must_be_date_format"):
+        create_event(
+            summary="Conference",
+            start="2026-02-03",
+            end="2026-02-05T18:00:00+03:00",  # RFC3339, not date
+            all_day=True,
+        )
+
+
+def test_create_all_day_event_error_end_before_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test error when end date is before or equal to start date."""
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    with pytest.raises(ValueError, match="end_date_must_be_after_start_date"):
+        create_event(
+            summary="Invalid Event",
+            start="2026-02-05",
+            end="2026-02-03",  # Before start
+            all_day=True,
+        )
+
+
+def test_create_all_day_event_error_end_equal_to_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test error when end date equals start date."""
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    with pytest.raises(ValueError, match="end_date_must_be_after_start_date"):
+        create_event(
+            summary="Invalid Event",
+            start="2026-02-05",
+            end="2026-02-05",  # Same as start
+            all_day=True,
+        )
+
+
+def test_create_time_based_event_not_affected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that time-based events still work (all_day=False)."""
+    mock_service = MagicMock()
+    mock_created = {
+        "id": "evt_meeting",
+        "summary": "Meeting",
+        "htmlLink": "https://calendar.google.com/event?eid=evt_meeting",
+        "start": {"dateTime": "2026-02-03T14:00:00+03:00"},
+        "end": {"dateTime": "2026-02-03T15:00:00+03:00"},
+    }
+
+    mock_service.events().insert().execute.return_value = mock_created
+
+    def mock_build(service_name: str, version: str, **kwargs):
+        return mock_service
+
+    mock_discovery = ModuleType("googleapiclient.discovery")
+    mock_discovery.build = mock_build
+    monkeypatch.setitem(__import__("sys").modules, "googleapiclient.discovery", mock_discovery)
+
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    result = create_event(
+        summary="Meeting",
+        start="2026-02-03T14:00:00+03:00",
+        duration_minutes=60,
+    )
+
+    # Verify time-based event uses dateTime
+    call_args = mock_service.events().insert.call_args
+    assert "dateTime" in call_args.kwargs["body"]["start"]
+    assert "date" not in call_args.kwargs["body"]["start"]
+
+    assert result["ok"] is True
+    assert result["all_day"] is False
+
+
+def test_list_events_parses_all_day_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that list_events correctly parses all-day events."""
+    mock_service = MagicMock()
+    mock_resp = {
+        "items": [
+            {
+                "id": "evt_1",
+                "summary": "Conference",
+                "start": {"date": "2026-02-03"},
+                "end": {"date": "2026-02-04"},
+                "status": "confirmed",
+                "htmlLink": "https://calendar.google.com/event?eid=evt_1",
+            },
+            {
+                "id": "evt_2",
+                "summary": "Meeting",
+                "start": {"dateTime": "2026-02-03T14:00:00+03:00"},
+                "end": {"dateTime": "2026-02-03T15:00:00+03:00"},
+                "status": "confirmed",
+                "htmlLink": "https://calendar.google.com/event?eid=evt_2",
+            },
+        ]
+    }
+
+    mock_service.events().list().execute.return_value = mock_resp
+
+    def mock_build(service_name: str, version: str, **kwargs):
+        return mock_service
+
+    mock_discovery = ModuleType("googleapiclient.discovery")
+    mock_discovery.build = mock_build
+    monkeypatch.setitem(__import__("sys").modules, "googleapiclient.discovery", mock_discovery)
+
+    def mock_creds(scopes):
+        return MagicMock()
+
+    monkeypatch.setattr("bantz.google.auth.get_credentials", mock_creds)
+
+    result = list_events(
+        time_min="2026-02-03T00:00:00+03:00",
+        max_results=10,
+    )
+
+    assert result["ok"] is True
+    assert result["count"] == 2
+
+    # Check all-day event
+    all_day_event = result["events"][0]
+    assert all_day_event["id"] == "evt_1"
+    assert all_day_event["summary"] == "Conference"
+    assert all_day_event["start"] == "2026-02-03"  # Date format
+    assert all_day_event["end"] == "2026-02-04"
+
+    # Check time-based event
+    time_event = result["events"][1]
+    assert time_event["id"] == "evt_2"
+    assert time_event["summary"] == "Meeting"
+    assert "T" in time_event["start"]  # RFC3339 format
+
+
+def test_all_day_event_in_busy_intervals(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that all-day events are included in busy interval calculation."""
+    from bantz.google.calendar import _extract_busy_intervals
+
+    events = [
+        {
+            "start": "2026-02-03",  # All-day event (date format)
+            "end": "2026-02-04",
+        },
+        {
+            "start": "2026-02-04T10:00:00+03:00",  # Time-based event
+            "end": "2026-02-04T11:00:00+03:00",
+        },
+    ]
+
+    tz = timezone(timedelta(hours=3))
+    intervals = _extract_busy_intervals(events, tz=tz)
+
+    assert len(intervals) == 2
+
+    # All-day event should span 00:00 to 00:00 next day
+    all_day_start, all_day_end = intervals[0]
+    assert all_day_start.date() == date(2026, 2, 3)
+    assert all_day_start.hour == 0
+    assert all_day_start.minute == 0
+    assert all_day_end.date() == date(2026, 2, 4)
+    assert all_day_end.hour == 0
+    assert all_day_end.minute == 0
+
+    # Time-based event
+    time_start, time_end = intervals[1]
+    assert time_start.hour == 10
+    assert time_end.hour == 11
+
+
+def test_tool_registration_includes_all_day(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that calendar.create_event tool is registered with all_day parameter."""
+    from bantz.agent.builtin_tools import build_default_registry
+
+    # Mock google calendar import
+    def mock_import_error(*args, **kwargs):
+        raise ImportError("test")
+
+    # Allow the tool registration to work with mock
+    import bantz.google.calendar
+    monkeypatch.setattr(bantz.google.calendar, "create_event", lambda **kwargs: {})
+
+    registry = build_default_registry()
+    tool = registry.get("calendar.create_event")
+
+    assert tool is not None
+    assert "all_day" in tool.parameters["properties"]
+    assert tool.parameters["properties"]["all_day"]["type"] == "boolean"
+    assert "all_day" in tool.returns_schema["properties"]


### PR DESCRIPTION
## Summary
Implements comprehensive all-day event support for Google Calendar, addressing Issue #164.

## Changes Made

### Core Implementation
- **src/bantz/google/calendar.py::create_event**: Added all_day parameter
  - All-day events use start.date and end.date format (not dateTime)
  - Single-day support: only start required, auto-creates +1 day exclusive end
  - Multi-day support: explicit end date (exclusive, e.g., Feb 23-26 = 23-25)
  - Date validation: end must be after start
  - Error handling: invalid date formats, date range validation
  - Comprehensive docstring with examples for both time-based and all-day events

- **src/bantz/google/calendar.py::list_events**: Already supports all-day parsing ✓
  - Correctly returns start.date or start.dateTime
  - No changes needed

- **src/bantz/google/calendar.py::_extract_busy_intervals**: Already handles all-day ✓
  - All-day events block entire 00:00-23:59 range
  - No changes needed

- **src/bantz/agent/builtin_tools.py**: Updated tool registration
  - Added all_day parameter to calendar.create_event tool
  - Enhanced description explaining all-day vs time-based events
  - Updated returns_schema to include all_day field
  - Documented date format requirements and exclusive end behavior

- **src/bantz/google/cli.py**: CLI support for all-day events
  - Added --all-day flag to calendar create command
  - Updated help text for --start and --end to mention YYYY-MM-DD format
  - Pass all_day parameter to create_event function

### Testing
- **tests/test_calendar_all_day_events.py**: 11 comprehensive test cases
  - **Positive cases**:
    - test_create_all_day_event_single_day: Verify auto +1 day end
    - test_create_all_day_event_multi_day: Verify multi-day span
    - test_create_all_day_event_with_location_description: With metadata
    - test_create_time_based_event_not_affected: Backward compatibility
    - test_list_events_parses_all_day_events: Parsing both formats
    - test_all_day_event_in_busy_intervals: Busy time calculation
    - test_tool_registration_includes_all_day: Tool schema verification
  - **Error cases**:
    - test_create_all_day_event_error_invalid_start_format
    - test_create_all_day_event_error_invalid_end_format
    - test_create_all_day_event_error_end_before_start
    - test_create_all_day_event_error_end_equal_to_start
  - All tests use mocking to avoid actual API calls
  - **Result**: ✅ 11 passed

- **All existing calendar tests pass**: 26 passed, 10 warnings

### Documentation
- **docs/google/calendar.md**: Added comprehensive all-day event section
  - Python examples for single-day and multi-day all-day events
  - Time-based vs all-day parameter differences
  - Rules section explaining date format and exclusive end
  - CLI usage examples for all patterns
  - User stories addressed section

## User Stories Addressed
- ✅ **"Pazartesi tüm gün konferans ekle"** → Single-day all-day event
- ✅ **"23-25 Şubat arası tatil işaretle"** → Multi-day all-day event
- ✅ **"Cuma günü home office olarak belirt"** → All-day with metadata

## Technical Details
- Uses Google Calendar API date format: `{"date": "YYYY-MM-DD"}`
- End date is exclusive (Google Calendar convention)
- Single-day events auto-generate end = start + 1 day
- All-day events block entire day in busy interval calculation
- Backward compatible: time-based events unchanged
- Risk Level: MODERATE (write operation, requires confirmation)

## Acceptance Criteria Met
- ✅ `calendar_create` all-day event support: `{"date": "2026-02-03"}`
- ✅ Multi-day span: `start.date = "2026-02-23"`, `end.date = "2026-02-26"` (exclusive)
- ✅ `calendar_list` all-day event parsing (already working)
- ✅ Busy interval calculation: all-day blocks entire 00:00-23:59
- ✅ Unit test: single day, multi-day, date boundary edge cases
- ✅ Tool registration updated with all_day parameter
- ✅ CLI support with --all-day flag
- ✅ Documentation with examples

## Testing Results
```
11 passed (all-day tests)
26 passed, 10 warnings (all calendar tests)
```

Closes #164