### PR TITLE
fix: Redact client secret in env command (Security Alert #25)

### DIFF
--- a/src/bantz/google/cli.py
+++ b/src/bantz/google/cli.py
@@ -28,6 +28,11 @@ def cmd_env(_args: argparse.Namespace) -> int:
     from bantz.google.auth import get_google_auth_config
 
     cfg = get_google_auth_config()
+    
+    # Redact sensitive client secret value for security
+    client_secret_env = os.getenv("BANTZ_GOOGLE_CLIENT_SECRET")
+    client_secret_display = "***REDACTED***" if client_secret_env else None
+    
     out = {
         "client_secret_path": str(cfg.client_secret_path),
         "client_secret_exists": cfg.client_secret_path.exists(),
@@ -36,7 +41,7 @@ def cmd_env(_args: argparse.Namespace) -> int:
         "calendar_id": os.getenv("BANTZ_GOOGLE_CALENDAR_ID") or None,
         "gmail_token_path": _default_gmail_token_path(),
         "env": {
-            "BANTZ_GOOGLE_CLIENT_SECRET": os.getenv("BANTZ_GOOGLE_CLIENT_SECRET") or None,
+            "BANTZ_GOOGLE_CLIENT_SECRET": client_secret_display,
             "BANTZ_GOOGLE_TOKEN_PATH": os.getenv("BANTZ_GOOGLE_TOKEN_PATH") or None,
             "BANTZ_GOOGLE_CALENDAR_ID": os.getenv("BANTZ_GOOGLE_CALENDAR_ID") or None,
             "BANTZ_GOOGLE_GMAIL_TOKEN_PATH": os.getenv("BANTZ_GOOGLE_GMAIL_TOKEN_PATH") or None,


### PR DESCRIPTION
## Security Fix: Clear-text Logging of Sensitive Data

**Alert:** #25 (ERROR - Critical)
**Rule:** py/clear-text-logging-sensitive-data

## Problem
The `bantz google env` command was printing the `BANTZ_GOOGLE_CLIENT_SECRET` environment variable value in clear text, exposing sensitive OAuth credentials in terminal output, logs, or screenshots.

## Solution
- Redact client secret value with `***REDACTED***` when present
- Only show if the environment variable is set, not its actual value
- Maintains visibility of other non-sensitive configuration

## Security Impact
Prevents accidental exposure of OAuth client secrets.

## Testing
```bash
# Before: Would show actual secret value
# After: Shows ***REDACTED*** instead
bantz google env
```

Severity: **ERROR** (Critical)