### PR TITLE
fix: Replace MD5 with SHA-256 (Security Alert #24)

### DIFF
--- a/src/bantz/voice_style.py
+++ b/src/bantz/voice_style.py
@@ -23,12 +23,15 @@ def _pick_variant(variants: list[str], seed: str) -> str:
     
     Same seed always returns same variant (test-stable).
     Different seeds give variety (no robot feel).
+    
+    Uses SHA-256 instead of MD5 for better security practices.
     """
     if not variants:
         return ""
     if len(variants) == 1:
         return variants[0]
-    h = int(hashlib.md5(seed.encode()).hexdigest(), 16)
+    # Use SHA-256 instead of MD5 for security best practices
+    h = int(hashlib.sha256(seed.encode()).hexdigest(), 16)
     return variants[h % len(variants)]
 
 


### PR DESCRIPTION
## Security Fix: Weak Hashing Algorithm

**Alert:** #24 (WARNING)
**Rule:** py/weak-sensitive-data-hashing

## Problem
The `_pick_variant()` function in `voice_style.py` was using MD5 for deterministic variant selection. While not used for cryptographic purposes, using a weak hashing algorithm is a security anti-pattern.

## Solution
- Replace `hashlib.md5()` with `hashlib.sha256()`
- Add security rationale to docstring
- Maintains same deterministic behavior

## Security Impact
Eliminates use of weak MD5 algorithm, following security best practices.

## Notes
This change may affect deterministic test outputs if any tests rely on specific variant selections, but the functionality remains identical (deterministic mapping from seed to variant).

Severity: **WARNING**