### PR TITLE
Issue #168: Calendar smart conflict detection & auto-rescheduling

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = -ra
+testpaths = tests
 markers =
     asyncio: mark a test as using asyncio
     vllm: marks tests requiring vLLM server (deselect with '-m "not vllm"')

--- a/src/bantz/voice_style.py
+++ b/src/bantz/voice_style.py
@@ -235,6 +235,8 @@ class JarvisVoice:
             return "Hangisi? (1/2/3/0)"
         if menu_id == "free_slots":
             return "Hangi boşluk? (1/2/3 veya 0)"
+        if menu_id == "conflict_slots":
+            return "Hangisi uygun? (1/2/3 veya 0)"
         if menu_id == "unknown":
             return "Takvim için 1, sohbet için 2."
         return "Hangisini tercih edersin?"

--- a/tests/test_calendar_smart_conflict.py
+++ b/tests/test_calendar_smart_conflict.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from bantz.google import calendar as cal
+
+
+def test_detect_conflicting_events_respects_half_open_interval() -> None:
+    events = [
+        {
+            "id": "e1",
+            "summary": "A",
+            "start": "2026-01-28T10:00:00+03:00",
+            "end": "2026-01-28T11:00:00+03:00",
+        }
+    ]
+
+    # Touching at the boundary should not count as overlap.
+    assert (
+        cal.detect_conflicting_events(
+            events=events,
+            start="2026-01-28T11:00:00+03:00",
+            end="2026-01-28T11:30:00+03:00",
+        )
+        == []
+    )
+    assert (
+        cal.detect_conflicting_events(
+            events=events,
+            start="2026-01-28T09:30:00+03:00",
+            end="2026-01-28T10:00:00+03:00",
+        )
+        == []
+    )
+
+    # Real overlap.
+    conflicts = cal.detect_conflicting_events(
+        events=events,
+        start="2026-01-28T10:30:00+03:00",
+        end="2026-01-28T11:30:00+03:00",
+    )
+    assert conflicts
+    assert conflicts[0].get("id") == "e1"
+
+
+def test_suggest_alternative_slots_uses_morning_and_afternoon_windows() -> None:
+    # Day 1 is fully busy inside preferred windows.
+    events = [
+        {"start": "2026-01-28T08:00:00+03:00", "end": "2026-01-28T12:00:00+03:00"},
+        {"start": "2026-01-28T13:00:00+03:00", "end": "2026-01-28T18:00:00+03:00"},
+    ]
+
+    slots = cal.suggest_alternative_slots(
+        events=events,
+        time_min="2026-01-28T09:00:00+03:00",
+        duration_minutes=60,
+        suggestions=3,
+        days=7,
+        preferred_windows=[("08:00", "12:00"), ("13:00", "18:00")],
+    )
+
+    assert len(slots) == 3
+    assert slots[0]["start"].startswith("2026-01-29T08:00")
+    assert slots[1]["start"].startswith("2026-01-29T13:00")
+    assert slots[2]["start"].startswith("2026-01-30T08:00")


### PR DESCRIPTION
Implements smart conflict detection for deterministic calendar create flow and offers next available alternatives (morning 08–12 / afternoon 13–18) over a 7-day horizon.

- Detects overlaps before queuing create_event confirmation (read-only list_events)
- Suggests next 3 suitable slots when busy
- Adds deterministic conflict_slots menu + confirmation transition
- Adds unit tests for conflict/alternatives + BrainLoop routing

Validation:
- pytest -q (testpaths=tests)