### PR TITLE
Issue #260: make default pytest run skip-free

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,8 +3,8 @@ addopts = -ra
 testpaths = tests
 markers =
     asyncio: mark a test as using asyncio
-    vllm: marks tests requiring vLLM server (deselect with '-m "not vllm"')
-    integration: marks integration tests that may require external services
-    benchmark: marks performance benchmark tests (deselect with '-m "not benchmark"')
-    regression: marks regression tests for CI (run with '-m regression')
+    vllm: marks tests that talk to a vLLM/OpenAI-compatible endpoint (run with --run-integration)
+    integration: marks integration tests that may require external services (run with --run-integration)
+    benchmark: marks performance benchmark tests (run with --run-benchmark)
+    regression: marks regression tests for CI (run with --run-regression)
 asyncio_mode = auto

--- a/src/bantz/document/parsers/pdf.py
+++ b/src/bantz/document/parsers/pdf.py
@@ -59,14 +59,14 @@ class PDFParser(DocumentParser):
             ValueError: If PDF cannot be parsed.
             ImportError: If no PDF library is available.
         """
+        if not self.can_parse(data):
+            raise ValueError("Data does not appear to be a valid PDF")
+
         if not self.is_available:
             raise ImportError(
                 "No PDF library available. Install pdfplumber or PyMuPDF: "
                 "pip install pdfplumber or pip install PyMuPDF"
             )
-        
-        if not self.can_parse(data):
-            raise ValueError("Data does not appear to be a valid PDF")
         
         if self._pdfplumber:
             return await self._parse_with_pdfplumber(data)

--- a/src/bantz/llm/base.py
+++ b/src/bantz/llm/base.py
@@ -35,6 +35,7 @@ class LLMResponse:
     model: str  # Model used
     tokens_used: int  # Total tokens (prompt + completion)
     finish_reason: str  # "stop" | "length" | "error"
+    usage: Optional[object] = None  # Backend-specific usage payload (optional)
 
 
 class LLMClientError(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
 
 import pytest
 
@@ -28,3 +34,187 @@ def _ensure_event_loop_for_sync_tests():
             created_loop.close()
         # Prevent returning a closed loop in later tests
         asyncio.set_event_loop(None)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run tests marked with @pytest.mark.integration or @pytest.mark.vllm.",
+    )
+    parser.addoption(
+        "--run-regression",
+        action="store_true",
+        default=False,
+        help="Run tests marked with @pytest.mark.regression.",
+    )
+    parser.addoption(
+        "--run-benchmark",
+        action="store_true",
+        default=False,
+        help="Run tests marked with @pytest.mark.benchmark.",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    run_integration = bool(config.getoption("--run-integration"))
+    run_regression = bool(config.getoption("--run-regression"))
+    run_benchmark = bool(config.getoption("--run-benchmark"))
+
+    deselected: list[pytest.Item] = []
+    selected: list[pytest.Item] = []
+
+    for item in items:
+        if not run_integration and (item.get_closest_marker("integration") or item.get_closest_marker("vllm")):
+            deselected.append(item)
+            continue
+        if not run_regression and item.get_closest_marker("regression"):
+            deselected.append(item)
+            continue
+        if not run_benchmark and item.get_closest_marker("benchmark"):
+            deselected.append(item)
+            continue
+        selected.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
+
+
+class _OpenAIMockHandler(BaseHTTPRequestHandler):
+    server_version = "bantz-vllm-mock/1.0"
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        # Keep pytest output clean.
+        return
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") == "/v1/models":
+            model_name = getattr(self.server, "model_name", "Qwen/Qwen2.5-3B-Instruct")
+            self._send_json(
+                200,
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": model_name,
+                            "object": "model",
+                            "created": int(time.time()),
+                            "owned_by": "mock-vllm",
+                        }
+                    ],
+                },
+            )
+            return
+
+        self._send_json(404, {"error": {"message": "not found"}})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path.rstrip("/") != "/v1/chat/completions":
+            self._send_json(404, {"error": {"message": "not found"}})
+            return
+
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw = self.rfile.read(length) if length > 0 else b"{}"
+
+        try:
+            req = json.loads(raw.decode("utf-8"))
+        except Exception:
+            self._send_json(400, {"error": {"message": "invalid json"}})
+            return
+
+        model_name = getattr(self.server, "model_name", "Qwen/Qwen2.5-3B-Instruct")
+        requested_model = str(req.get("model") or "").strip()
+        if requested_model and requested_model != model_name:
+            self._send_json(
+                404,
+                {
+                    "error": {
+                        "message": "model not found: 404",
+                        "type": "invalid_request_error",
+                        "code": "model_not_found",
+                    }
+                },
+            )
+            return
+
+        messages = req.get("messages") or []
+        response_format = req.get("response_format") or {}
+
+        # Extract last user message content
+        last_user = ""
+        for msg in reversed(messages):
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                last_user = str(msg.get("content") or "")
+                break
+
+        if isinstance(response_format, dict) and response_format.get("type") == "json_object":
+            content = json.dumps(
+                {"route": "smalltalk", "confidence": 1.0, "reply": "ok"},
+                ensure_ascii=False,
+            )
+        elif "count from 1 to 5" in last_user.lower():
+            content = "1 2 3 4 5"
+        elif "capital of france" in last_user.lower():
+            content = "Paris"
+        elif last_user.strip():
+            content = f"Mock response: {last_user.strip()}"
+        else:
+            content = "Mock response"
+
+        self._send_json(
+            200,
+            {
+                "id": f"chatcmpl-mock-{int(time.time())}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": content},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20},
+            },
+        )
+
+
+@pytest.fixture(scope="session")
+def vllm_mock_server_url() -> str:
+    """Start a tiny OpenAI-compatible mock server for vLLM integration tests."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OpenAIMockHandler)
+    server.model_name = "Qwen/Qwen2.5-3B-Instruct"  # type: ignore[attr-defined]
+
+    host, port = server.server_address
+    url = f"http://{host}:{port}"
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    # Basic readiness check
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.2):
+                break
+        except OSError:
+            time.sleep(0.05)
+    else:
+        server.shutdown()
+        raise RuntimeError("Failed to start vLLM mock server")
+
+    yield url
+
+    server.shutdown()
+    server.server_close()

--- a/tests/test_llm_clients.py
+++ b/tests/test_llm_clients.py
@@ -145,8 +145,8 @@ def test_vllm_is_available_failure(mock_get):
 
 
 @pytest.mark.integration
-@pytest.mark.skip(reason="Requires real vLLM server or mock - run with --run-integration")
-def test_vllm_chat_integration():
+@pytest.mark.vllm
+def test_vllm_chat_integration(vllm_mock_server_url: str):
     """Integration test: chat with real vLLM server.
     
     Run with: pytest tests/test_llm_clients.py::test_vllm_chat_integration --run-integration
@@ -154,10 +154,7 @@ def test_vllm_chat_integration():
     Requires:
         python scripts/vllm_mock_server.py  # or real vLLM server
     """
-    client = VLLMOpenAIClient(base_url="http://127.0.0.1:8001")  # Mock server port
-    
-    if not client.is_available():
-        pytest.skip("vLLM server not available (start scripts/vllm_mock_server.py)")
+    client = VLLMOpenAIClient(base_url=vllm_mock_server_url)
     
     messages = [LLMMessage(role="user", content="Hello")]
     response = client.chat(messages, temperature=0.0, max_tokens=50)
@@ -167,13 +164,10 @@ def test_vllm_chat_integration():
 
 
 @pytest.mark.integration
-@pytest.mark.skip(reason="Requires real vLLM server or mock")
-def test_vllm_complete_text_integration():
+@pytest.mark.vllm
+def test_vllm_complete_text_integration(vllm_mock_server_url: str):
     """Integration test: complete_text with real server."""
-    client = VLLMOpenAIClient(base_url="http://127.0.0.1:8001")
-    
-    if not client.is_available():
-        pytest.skip("vLLM server not available")
+    client = VLLMOpenAIClient(base_url=vllm_mock_server_url)
     
     result = client.complete_text(prompt="Test prompt", temperature=0.0, max_tokens=50)
     
@@ -182,13 +176,10 @@ def test_vllm_complete_text_integration():
 
 
 @pytest.mark.integration
-@pytest.mark.skip(reason="Requires real vLLM server or mock")
-def test_vllm_list_models():
+@pytest.mark.vllm
+def test_vllm_list_models(vllm_mock_server_url: str):
     """Test list_available_models with real server."""
-    client = VLLMOpenAIClient(base_url="http://127.0.0.1:8001")
-    
-    if not client.is_available():
-        pytest.skip("vLLM server not available")
+    client = VLLMOpenAIClient(base_url=vllm_mock_server_url)
     
     models = client.list_available_models()
     
@@ -295,8 +286,8 @@ def test_vllm_chat_detailed_response(mock_get_client):
 # ========================================================================
 
 @pytest.mark.integration
-@pytest.mark.skip(reason="Requires real server")
-def test_determinism_vllm():
+@pytest.mark.vllm
+def test_determinism_vllm(vllm_mock_server_url: str):
     """Test deterministic output with seed (vLLM).
 
     This test verifies that vLLM respects temperature=0 and seed for deterministic output.
@@ -305,8 +296,7 @@ def test_determinism_vllm():
     messages = [LLMMessage(role="user", content=prompt)]
 
     # Test vLLM (if available)
-    vllm = create_client("vllm", base_url="http://127.0.0.1:8001")
-    if vllm.is_available():
-        resp1 = vllm.chat_detailed(messages, temperature=0.0, max_tokens=50, seed=42)
-        resp2 = vllm.chat_detailed(messages, temperature=0.0, max_tokens=50, seed=42)
-        assert resp1.content == resp2.content, "vLLM should be deterministic with temp=0 and seed"
+    vllm = create_client("vllm", base_url=vllm_mock_server_url)
+    resp1 = vllm.chat_detailed(messages, temperature=0.0, max_tokens=50, seed=42)
+    resp2 = vllm.chat_detailed(messages, temperature=0.0, max_tokens=50, seed=42)
+    assert resp1.content == resp2.content, "vLLM should be deterministic with temp=0 and seed"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -155,10 +155,7 @@ class TestPDFParser:
     async def test_parse_invalid_pdf_raises(self):
         """Test parsing invalid PDF raises error."""
         parser = PDFParser()
-        
-        if not parser.is_available:
-            pytest.skip("PDF library not available")
-        
+
         with pytest.raises(ValueError):
             await parser.parse(b"Not a PDF")
 

--- a/tests/test_vllm_integration.py
+++ b/tests/test_vllm_integration.py
@@ -1,12 +1,10 @@
 """vLLM integration tests (Issue #139).
 
-These tests require a running vLLM server (local GPU or mock).
-They are marked with @pytest.mark.vllm and will be skipped by default.
+These tests are integration-level and are deselected by default.
 
 Run:
-    pytest tests/test_vllm_integration.py -v -m vllm  # Run only vLLM tests
-    pytest tests/test_vllm_integration.py -v  # Skip vLLM tests (default)
-    pytest -m "not vllm"  # Exclude all vLLM tests
+    pytest --run-integration -m vllm -v
+    pytest --run-integration tests/test_vllm_integration.py -v
 """
 
 from __future__ import annotations
@@ -34,7 +32,7 @@ def is_vllm_server_available(url: str = "http://127.0.0.1:8001") -> bool:
 
 
 @pytest.fixture
-def vllm_url() -> str:
+def vllm_url(vllm_mock_server_url: str) -> str:
     """vLLM server URL (or mock server URL)."""
     # Prefer explicit env if provided.
     env_url = (os.getenv("BANTZ_VLLM_URL") or "").strip()
@@ -46,12 +44,8 @@ def vllm_url() -> str:
         if is_vllm_server_available(candidate):
             return candidate
 
-    # Back-compat / mock servers.
-    for candidate in ("http://127.0.0.1:8000",):
-        if is_vllm_server_available(candidate):
-            return candidate
-
-    pytest.skip("No vLLM server available (start vLLM or scripts/vllm_mock_server.py)")
+    # Otherwise, start and use a lightweight in-test mock server.
+    return vllm_mock_server_url.rstrip("/")
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #260

Changes:
- Default `pytest` run deselects `integration`/`vllm`/`regression`/`benchmark` tests unless explicitly enabled via `--run-*` flags (so no more SKIPPED in default runs)
- DOCX parser now has a built-in ZIP/XML fallback; no `python-docx` dependency for basic parsing/errors
- PDF parser validates magic bytes before requiring optional libs (invalid-PDF test no longer skips)
- vLLM integration tests run against an in-test OpenAI-compatible mock server when enabled; removed unconditional `@pytest.mark.skip`
- vLLM client supports optional `response_format` and returns `LLMResponse.usage` metadata

How to run:
- Default: `pytest -q`
- Integration/vLLM: `pytest --run-integration -m vllm`
- Regression: `pytest --run-regression -m regression`
