### PR TITLE
Issue #169: Gmail OAuth setup & auth flow

### DIFF
--- a/docs/setup/google-oauth.md
+++ b/docs/setup/google-oauth.md
@@ -16,6 +16,11 @@ Bantz şu dosyaları bekler:
 - `~/.config/bantz/google/client_secret.json`
 - `~/.config/bantz/google/token.json` (Calendar için)
 
+Gmail için (Issue #169):
+
+- `~/.config/bantz/google/client_secret_gmail.json`
+- `~/.config/bantz/google/gmail_token.json`
+
 Env ile override edebilirsin:
 
 ```bash
@@ -59,6 +64,10 @@ python scripts/smoke_calendar_list_events.py
 Gmail için ayrı token dosyası kullanmak istersen:
 
 ```bash
+export BANTZ_GMAIL_CLIENT_SECRET="$HOME/.config/bantz/google/client_secret_gmail.json"
+export BANTZ_GMAIL_TOKEN_PATH="$HOME/.config/bantz/google/gmail_token.json"
+
+# (Legacy/back-compat)
 export BANTZ_GOOGLE_GMAIL_TOKEN_PATH="$HOME/.config/bantz/google/gmail_token.json"
 ```
 

--- a/src/bantz/google/__init__.py
+++ b/src/bantz/google/__init__.py
@@ -1,7 +1,9 @@
 from bantz.google.auth import get_credentials
 from bantz.google.calendar import list_events
+from bantz.google.gmail_auth import authenticate_gmail
 
 __all__ = [
     "get_credentials",
     "list_events",
+    "authenticate_gmail",
 ]

--- a/src/bantz/google/gmail_auth.py
+++ b/src/bantz/google/gmail_auth.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+import os
+
+
+# Canonical Gmail OAuth scopes.
+# Accept short forms like "gmail.readonly" too.
+_GMAIL_SCOPE_PREFIX = "https://www.googleapis.com/auth/"
+
+GMAIL_READONLY_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.metadata",
+]
+
+GMAIL_SEND_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.compose",
+]
+
+GMAIL_MODIFY_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.modify",
+]
+
+DEFAULT_GMAIL_CLIENT_SECRET_PATH = "~/.config/bantz/google/client_secret_gmail.json"
+DEFAULT_GMAIL_TOKEN_PATH = "~/.config/bantz/google/gmail_token.json"
+
+
+@dataclass(frozen=True)
+class GmailAuthConfig:
+    client_secret_path: Path
+    token_path: Path
+
+
+def _resolve_path(value: str) -> Path:
+    return Path(os.path.expanduser(value)).resolve()
+
+
+def _normalize_gmail_scopes(scopes: list[str]) -> list[str]:
+    out: list[str] = []
+    for s in scopes:
+        raw = (s or "").strip()
+        if not raw:
+            continue
+        if raw.startswith(_GMAIL_SCOPE_PREFIX):
+            out.append(raw)
+        elif raw.startswith("gmail."):
+            out.append(_GMAIL_SCOPE_PREFIX + raw)
+        else:
+            # Allow passing full URL or already-normalized strings.
+            out.append(raw)
+    # Keep order stable, de-dup.
+    seen: set[str] = set()
+    uniq: list[str] = []
+    for s in out:
+        if s in seen:
+            continue
+        seen.add(s)
+        uniq.append(s)
+    return uniq
+
+
+def _effective_scopes(granted: list[str] | None) -> set[str]:
+    """Treat broad Gmail scopes as satisfying narrower ones.
+
+    This prevents re-consent loops when a token already has a superset scope.
+    """
+    granted_set = set(_normalize_gmail_scopes(list(granted or [])))
+
+    implied: dict[str, set[str]] = {
+        "https://www.googleapis.com/auth/gmail.modify": {
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.metadata",
+            "https://www.googleapis.com/auth/gmail.send",
+            "https://www.googleapis.com/auth/gmail.compose",
+        },
+        "https://www.googleapis.com/auth/gmail.send": {
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.metadata",
+        },
+        "https://www.googleapis.com/auth/gmail.compose": {
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.metadata",
+        },
+    }
+
+    out = set(granted_set)
+    for s in list(granted_set):
+        out |= implied.get(s, set())
+    return out
+
+
+def get_gmail_auth_config(
+    *,
+    client_secret_path: Optional[str] = None,
+    token_path: Optional[str] = None,
+) -> GmailAuthConfig:
+    """Resolve Gmail OAuth file paths.
+
+    Env vars (new):
+    - BANTZ_GMAIL_CLIENT_SECRET (default: ~/.config/bantz/google/client_secret_gmail.json)
+    - BANTZ_GMAIL_TOKEN_PATH    (default: ~/.config/bantz/google/gmail_token.json)
+
+    Env vars (legacy/back-compat):
+    - BANTZ_GOOGLE_CLIENT_SECRET
+    - BANTZ_GOOGLE_GMAIL_TOKEN_PATH
+    """
+
+    secret = (
+        client_secret_path
+        or os.getenv("BANTZ_GMAIL_CLIENT_SECRET")
+        or os.getenv("BANTZ_GOOGLE_CLIENT_SECRET")
+        or DEFAULT_GMAIL_CLIENT_SECRET_PATH
+    )
+
+    token = (
+        token_path
+        or os.getenv("BANTZ_GMAIL_TOKEN_PATH")
+        or os.getenv("BANTZ_GOOGLE_GMAIL_TOKEN_PATH")
+        or DEFAULT_GMAIL_TOKEN_PATH
+    )
+
+    return GmailAuthConfig(
+        client_secret_path=_resolve_path(secret),
+        token_path=_resolve_path(token),
+    )
+
+
+def _import_google_deps():  # pragma: no cover
+    from google.auth.transport.requests import Request  # type: ignore
+    from google.oauth2.credentials import Credentials  # type: ignore
+    from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
+    from googleapiclient.discovery import build  # type: ignore
+
+    return Request, Credentials, InstalledAppFlow, build
+
+
+def get_gmail_credentials(
+    *,
+    scopes: list[str],
+    client_secret_path: Optional[str] = None,
+    token_path: Optional[str] = None,
+):
+    """Return Google OAuth credentials for Gmail.
+
+    - Reads/writes token JSON under ~/.config/bantz/google by default.
+    - Refreshes tokens when expired.
+    - Escalates scopes (readonly -> send/modify) by forcing re-consent.
+
+    Notes:
+    - Access tokens expire quickly; refresh tokens are used to refresh silently.
+    - If the stored credential doesn't cover the requested scopes, a new consent
+      flow will be triggered.
+    """
+
+    requested_scopes = _normalize_gmail_scopes(scopes)
+    if not requested_scopes:
+        raise ValueError("Gmail scopes must be non-empty")
+
+    cfg = get_gmail_auth_config(client_secret_path=client_secret_path, token_path=token_path)
+
+    if not cfg.client_secret_path.exists():
+        raise FileNotFoundError(
+            "Gmail client secret not found. Set BANTZ_GMAIL_CLIENT_SECRET "
+            f"(default: {DEFAULT_GMAIL_CLIENT_SECRET_PATH}). Missing: {cfg.client_secret_path}"
+        )
+
+    try:
+        Request, Credentials, InstalledAppFlow, _build = _import_google_deps()
+    except Exception as e:  # pragma: no cover
+        raise RuntimeError(
+            "Google Gmail dependencies are not installed. Install with: pip install -e '.[calendar]'"
+        ) from e
+
+    creds: Any = None
+
+    if cfg.token_path.exists():
+        # Important: do NOT pass `scopes=` here.
+        creds = Credentials.from_authorized_user_file(str(cfg.token_path))
+
+        # If token is valid but scopes are insufficient, force re-consent.
+        has_scopes = getattr(creds, "has_scopes", None)
+        if callable(has_scopes) and not has_scopes(requested_scopes):
+            effective = _effective_scopes(getattr(creds, "scopes", None))
+            if not set(requested_scopes).issubset(effective):
+                creds = None
+
+    if creds is not None and getattr(creds, "expired", False) and getattr(creds, "refresh_token", None):
+        creds.refresh(Request())
+
+    if creds is None or not getattr(creds, "valid", False):
+        flow = InstalledAppFlow.from_client_secrets_file(str(cfg.client_secret_path), scopes=requested_scopes)
+        try:
+            creds = flow.run_local_server(port=0, open_browser=False)
+        except Exception:
+            creds = flow.run_console()
+
+        cfg.token_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg.token_path.write_text(creds.to_json(), encoding="utf-8")
+
+    return creds
+
+
+def authenticate_gmail(
+    *,
+    scopes: list[str],
+    token_path: Optional[str] = None,
+    secret_path: Optional[str] = None,
+):
+    """Authenticate and return a Gmail API service.
+
+    Example:
+        service = authenticate_gmail(scopes=GMAIL_READONLY_SCOPES)
+        profile = service.users().getProfile(userId="me").execute()
+
+    Returns:
+        googleapiclient.discovery.Resource for Gmail v1
+    """
+
+    creds = get_gmail_credentials(scopes=scopes, client_secret_path=secret_path, token_path=token_path)
+
+    try:
+        _Request, _Credentials, _InstalledAppFlow, build = _import_google_deps()
+    except Exception as e:  # pragma: no cover
+        raise RuntimeError(
+            "Google Gmail dependencies are not installed. Install with: pip install -e '.[calendar]'"
+        ) from e
+
+    return build("gmail", "v1", credentials=creds, cache_discovery=False)

--- a/tests/test_gmail_auth.py
+++ b/tests/test_gmail_auth.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+import pytest
+
+
+def test_get_gmail_auth_config_defaults(monkeypatch, tmp_path: Path):
+    from bantz.google import gmail_auth
+
+    monkeypatch.delenv("BANTZ_GMAIL_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("BANTZ_GMAIL_TOKEN_PATH", raising=False)
+    monkeypatch.delenv("BANTZ_GOOGLE_CLIENT_SECRET", raising=False)
+    monkeypatch.delenv("BANTZ_GOOGLE_GMAIL_TOKEN_PATH", raising=False)
+
+    cfg = gmail_auth.get_gmail_auth_config()
+
+    assert str(cfg.client_secret_path).endswith(".config/bantz/google/client_secret_gmail.json")
+    assert str(cfg.token_path).endswith(".config/bantz/google/gmail_token.json")
+
+
+def test_normalize_gmail_scopes_supports_short_forms():
+    from bantz.google.gmail_auth import _normalize_gmail_scopes
+
+    scopes = _normalize_gmail_scopes(["gmail.readonly", "gmail.metadata"])
+    assert scopes == [
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.metadata",
+    ]
+
+
+def test_scope_escalation_forces_reconsent(monkeypatch, tmp_path: Path):
+    from bantz.google import gmail_auth
+
+    secret = tmp_path / "client_secret_gmail.json"
+    token = tmp_path / "gmail_token.json"
+
+    # Minimal client secret JSON shape accepted by InstalledAppFlow in real life,
+    # but in tests we stub the flow so content doesn't matter.
+    secret.write_text("{}", encoding="utf-8")
+
+    class DummyCreds:
+        def __init__(self, *, scopes: list[str], valid: bool = True, expired: bool = False):
+            self.scopes = scopes
+            self.valid = valid
+            self.expired = expired
+            self.refresh_token = "rtok"
+
+        def has_scopes(self, scopes: list[str]) -> bool:
+            return set(scopes).issubset(set(self.scopes))
+
+        def refresh(self, _request):
+            self.expired = False
+            self.valid = True
+
+        def to_json(self) -> str:
+            return json.dumps({"scopes": self.scopes})
+
+    # Token exists but is read-only.
+    token.write_text(json.dumps({"dummy": True}), encoding="utf-8")
+
+    class DummyCredentials:
+        @staticmethod
+        def from_authorized_user_file(_path: str):
+            return DummyCreds(scopes=["https://www.googleapis.com/auth/gmail.readonly"], valid=True)
+
+    class DummyFlow:
+        def __init__(self, scopes: list[str]):
+            self._scopes = scopes
+
+        def run_local_server(self, port=0, open_browser=False):
+            return DummyCreds(scopes=list(self._scopes), valid=True)
+
+        def run_console(self):
+            return DummyCreds(scopes=list(self._scopes), valid=True)
+
+    class DummyInstalledAppFlow:
+        @staticmethod
+        def from_client_secrets_file(_path: str, scopes: list[str]):
+            return DummyFlow(scopes)
+
+    def fake_import_deps():
+        class DummyRequest:  # noqa: D401
+            """Placeholder."""
+
+        def dummy_build(*_args, **_kwargs):
+            raise AssertionError("build() should not be called from get_gmail_credentials")
+
+        return DummyRequest, DummyCredentials, DummyInstalledAppFlow, dummy_build
+
+    monkeypatch.setattr(gmail_auth, "_import_google_deps", fake_import_deps)
+
+    creds = gmail_auth.get_gmail_credentials(
+        scopes=["https://www.googleapis.com/auth/gmail.send"],
+        client_secret_path=str(secret),
+        token_path=str(token),
+    )
+
+    assert "https://www.googleapis.com/auth/gmail.send" in getattr(creds, "scopes", [])
+
+
+def test_token_refresh_when_expired(monkeypatch, tmp_path: Path):
+    from bantz.google import gmail_auth
+
+    secret = tmp_path / "client_secret_gmail.json"
+    token = tmp_path / "gmail_token.json"
+    secret.write_text("{}", encoding="utf-8")
+    token.write_text(json.dumps({"dummy": True}), encoding="utf-8")
+
+    refreshed = {"called": 0}
+
+    class DummyCreds:
+        def __init__(self):
+            self.scopes = ["https://www.googleapis.com/auth/gmail.readonly"]
+            self.valid = True
+            self.expired = True
+            self.refresh_token = "rtok"
+
+        def has_scopes(self, scopes: list[str]) -> bool:
+            return True
+
+        def refresh(self, _request):
+            refreshed["called"] += 1
+            self.expired = False
+            self.valid = True
+
+        def to_json(self) -> str:
+            return json.dumps({"scopes": self.scopes})
+
+    class DummyCredentials:
+        @staticmethod
+        def from_authorized_user_file(_path: str):
+            return DummyCreds()
+
+    class DummyInstalledAppFlow:
+        @staticmethod
+        def from_client_secrets_file(_path: str, scopes: list[str]):
+            raise AssertionError("Flow should not be called when refresh works")
+
+    def fake_import_deps():
+        class DummyRequest:  # noqa: D401
+            """Placeholder."""
+
+        def dummy_build(*_args, **_kwargs):
+            raise AssertionError("build() should not be called from get_gmail_credentials")
+
+        return DummyRequest, DummyCredentials, DummyInstalledAppFlow, dummy_build
+
+    monkeypatch.setattr(gmail_auth, "_import_google_deps", fake_import_deps)
+
+    creds = gmail_auth.get_gmail_credentials(
+        scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+        client_secret_path=str(secret),
+        token_path=str(token),
+    )
+
+    assert refreshed["called"] == 1
+    assert getattr(creds, "expired", True) is False


### PR DESCRIPTION
Closes #169

Implements Gmail OAuth foundation:
- Adds `authenticate_gmail()` + `get_gmail_credentials()` in `src/bantz/google/gmail_auth.py`
- Default paths per issue: `~/.config/bantz/google/client_secret_gmail.json`, `~/.config/bantz/google/gmail_token.json`
- Env vars: `BANTZ_GMAIL_CLIENT_SECRET`, `BANTZ_GMAIL_TOKEN_PATH` (with legacy fallbacks)
- Auto refresh when expired; scope escalation readonly -> send/modify triggers re-consent
- Updates Google OAuth setup docs and aligns `bantz google auth gmail` CLI behavior
- Adds unit tests for normalization, refresh, and scope escalation

Run:
- `pytest -q tests/test_gmail_auth.py`
- `pytest -q`
