### PR TITLE
Issue #170: Gmail inbox listing & unread count tool

### DIFF
--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -491,6 +491,80 @@ def build_default_registry() -> ToolRegistry:
         )
     )
 
+    # ─────────────────────────────────────────────────────────────────
+    # Gmail Tools (Google) - Read-only (Issue #170)
+    # ─────────────────────────────────────────────────────────────────
+    try:
+        from bantz.google.gmail import gmail_list_messages as google_gmail_list_messages
+    except Exception:  # pragma: no cover
+        google_gmail_list_messages = None
+
+    reg.register(
+        Tool(
+            name="gmail.list_messages",
+            description="List messages from Gmail inbox (read-only).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "max_results": {"type": "integer", "description": "Max results (default: 10)"},
+                    "unread_only": {"type": "boolean", "description": "Only unread messages (default: false)"},
+                    "page_token": {"type": "string", "description": "Pagination token (nextPageToken)"},
+                },
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "query": {"type": "string"},
+                    "estimated_count": {"type": ["integer", "null"]},
+                    "next_page_token": {"type": ["string", "null"]},
+                    "messages": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {"type": "string"},
+                                "from": {"type": ["string", "null"]},
+                                "subject": {"type": ["string", "null"]},
+                                "snippet": {"type": "string"},
+                                "date": {"type": ["string", "null"]},
+                            },
+                            "required": ["id", "snippet"],
+                        },
+                    },
+                },
+                "required": ["ok", "query", "messages", "estimated_count", "next_page_token"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_gmail_list_messages,
+        )
+    )
+
+    try:
+        from bantz.google.gmail import gmail_unread_count as google_gmail_unread_count
+    except Exception:  # pragma: no cover
+        google_gmail_unread_count = None
+
+    reg.register(
+        Tool(
+            name="gmail.unread_count",
+            description="Get estimated unread count from Gmail (read-only).",
+            parameters={"type": "object", "properties": {}},
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "unread_count_estimate": {"type": "integer"},
+                },
+                "required": ["ok", "unread_count_estimate"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_gmail_unread_count,
+        )
+    )
+
     try:
         from bantz.google.calendar import find_free_slots as google_calendar_find_free_slots
     except Exception:  # pragma: no cover

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1,7 +1,7 @@
 """LLM Orchestrator: Single entry point for all user inputs (LLM-first architecture).
 
 Provides:
-- Route classification (calendar | smalltalk | unknown)
+- Route classification (calendar | gmail | smalltalk | unknown)
 - Intent extraction (create | modify | cancel | query)
 - Slot extraction (date, time, duration, title, window_hint)
 - Confidence scoring
@@ -34,7 +34,7 @@ class OrchestratorOutput:
     """
 
     # Core routing (from original RouterOutput)
-    route: str  # calendar | smalltalk | unknown
+    route: str  # calendar | gmail | smalltalk | unknown
     calendar_intent: str  # create | modify | cancel | query | none
     slots: dict[str, Any]  # {date?, time?, duration?, title?, window_hint?}
     confidence: float  # 0.0-1.0
@@ -93,7 +93,7 @@ Görev: Her kullanıcı mesajını şu şemaya göre sınıflandır ve **orkestr
 
 OUTPUT SCHEMA (zorunlu - genişletilmiş orchestrator):
 {
-  "route": "calendar | smalltalk | unknown",
+    "route": "calendar | gmail | smalltalk | unknown",
   "calendar_intent": "create | modify | cancel | query | none",
   "slots": {
     "date": "YYYY-MM-DD veya null",
@@ -128,6 +128,7 @@ KURALLAR (kritik):
 
 ROUTE KURALLARI:
 - "calendar": takvim sorgusu veya değişikliği
+- "gmail": Gmail mesaj okuma/sorgu (okuma-only)
 - "smalltalk": sohbet, selam, durum sorma
 - "unknown": belirsiz veya başka kategoriler
 
@@ -142,6 +143,8 @@ TOOL_PLAN:
 - "calendar.list_events": takvim sorgusu
 - "calendar.find_free_slots": boş slot ara
 - "calendar.create_event": etkinlik oluştur
+- "gmail.list_messages": Gmail gelen kutusu listele (read-only)
+- "gmail.unread_count": Gmail okunmamış sayısı (read-only)
 - Birden fazla tool sıralı çağrılabilir.
 
 TIME AWARENESS:
@@ -409,7 +412,7 @@ USER: bu akşam sekize parti ekle
     def _extract_output(self, parsed: dict[str, Any], raw_text: str) -> OrchestratorOutput:
         """Extract OrchestratorOutput from parsed JSON (expanded with orchestrator fields)."""
         route = str(parsed.get("route") or "unknown").strip().lower()
-        if route not in {"calendar", "smalltalk", "unknown"}:
+        if route not in {"calendar", "gmail", "smalltalk", "unknown"}:
             route = "unknown"
 
         calendar_intent = str(parsed.get("calendar_intent") or "none").strip().lower()

--- a/src/bantz/brain/safety_guard.py
+++ b/src/bantz/brain/safety_guard.py
@@ -257,8 +257,10 @@ class SafetyGuard:
         if not self.policy.enforce_route_tool_match:
             return tool_plan, []
         
-        # If route is not calendar, no tools should run
-        if route != "calendar" and tool_plan:
+        # If route is not a tool-allowed route, no tools should run
+        # (Issue #170 adds read-only Gmail tools under route="gmail").
+        allowed_routes = {"calendar", "gmail"}
+        if route not in allowed_routes and tool_plan:
             violations = [
                 PolicyViolation(
                     violation_type="route_tool_mismatch",

--- a/src/bantz/google/gmail.py
+++ b/src/bantz/google/gmail.py
@@ -1,0 +1,157 @@
+"""Gmail read-only helpers (Issue #170).
+
+This module intentionally keeps side effects minimal:
+- Uses OAuth credentials from `bantz.google.gmail_auth`.
+- Read-only operations (list messages, unread count estimate).
+
+Return payloads follow the tool-friendly `{ok: bool, ...}` pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from bantz.google.gmail_auth import authenticate_gmail
+
+
+def _get_header(payload: dict[str, Any], name: str) -> Optional[str]:
+    headers = payload.get("headers") if isinstance(payload, dict) else None
+    if not isinstance(headers, list):
+        return None
+
+    target = name.strip().lower()
+    for h in headers:
+        if not isinstance(h, dict):
+            continue
+        n = str(h.get("name") or "").strip().lower()
+        if n == target:
+            v = h.get("value")
+            return str(v) if v is not None else None
+
+    return None
+
+
+def gmail_list_messages(
+    *,
+    max_results: int = 10,
+    unread_only: bool = False,
+    page_token: Optional[str] = None,
+    service: Any = None,
+) -> dict[str, Any]:
+    """List messages from Gmail inbox with basic metadata.
+
+    Args:
+        max_results: Max number of messages to return.
+        unread_only: If True, query uses `is:unread`.
+        page_token: Gmail `nextPageToken` from a previous call.
+        service: Optional injected Gmail API service for testing.
+
+    Returns:
+        Dict with keys:
+        - ok: bool
+        - query: str
+        - estimated_count: int | None
+        - next_page_token: str | None
+        - messages: list[{id, from, subject, snippet, date}]
+    """
+
+    if not isinstance(max_results, int) or max_results <= 0:
+        raise ValueError("max_results must be a positive integer")
+
+    q = "is:unread" if unread_only else "in:inbox"
+
+    try:
+        svc = service or authenticate_gmail()
+
+        list_kwargs: dict[str, Any] = {
+            "userId": "me",
+            "q": q,
+            "maxResults": max_results,
+        }
+        if page_token:
+            list_kwargs["pageToken"] = page_token
+
+        list_resp = svc.users().messages().list(**list_kwargs).execute() or {}
+
+        msg_refs = list_resp.get("messages")
+        if not isinstance(msg_refs, list):
+            msg_refs = []
+
+        next_page_token = list_resp.get("nextPageToken")
+        estimated_count = list_resp.get("resultSizeEstimate")
+        if not isinstance(estimated_count, int):
+            estimated_count = None
+
+        out_messages: list[dict[str, Any]] = []
+        for ref in msg_refs:
+            if not isinstance(ref, dict):
+                continue
+            msg_id = ref.get("id")
+            if not msg_id:
+                continue
+
+            msg = (
+                svc.users()
+                .messages()
+                .get(
+                    userId="me",
+                    id=str(msg_id),
+                    format="metadata",
+                    metadataHeaders=["From", "Subject", "Date"],
+                )
+                .execute()
+                or {}
+            )
+
+            payload = msg.get("payload")
+            if not isinstance(payload, dict):
+                payload = {}
+
+            out_messages.append(
+                {
+                    "id": str(msg.get("id") or msg_id),
+                    "from": _get_header(payload, "From"),
+                    "subject": _get_header(payload, "Subject"),
+                    "snippet": str(msg.get("snippet") or ""),
+                    "date": _get_header(payload, "Date"),
+                }
+            )
+
+        return {
+            "ok": True,
+            "query": q,
+            "estimated_count": estimated_count,
+            "next_page_token": str(next_page_token) if next_page_token else None,
+            "messages": out_messages,
+        }
+
+    except Exception as e:  # pragma: no cover (covered via caller tests generally)
+        return {
+            "ok": False,
+            "query": q,
+            "error": str(e),
+            "messages": [],
+            "estimated_count": None,
+            "next_page_token": None,
+        }
+
+
+def gmail_unread_count(*, service: Any = None) -> dict[str, Any]:
+    """Return an estimated unread count using Gmail search query.
+
+    Uses `q="is:unread"` and reads `resultSizeEstimate`.
+    """
+
+    try:
+        svc = service or authenticate_gmail()
+        resp = (
+            svc.users()
+            .messages()
+            .list(userId="me", q="is:unread", maxResults=1)
+            .execute()
+            or {}
+        )
+        est = resp.get("resultSizeEstimate")
+        return {"ok": True, "unread_count_estimate": int(est) if isinstance(est, int) else 0}
+    except Exception as e:  # pragma: no cover
+        return {"ok": False, "error": str(e), "unread_count_estimate": 0}

--- a/src/bantz/tools/metadata.py
+++ b/src/bantz/tools/metadata.py
@@ -34,6 +34,8 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "calendar.list_events": ToolRisk.SAFE,
     "calendar.find_event": ToolRisk.SAFE,
     "calendar.get_event": ToolRisk.SAFE,
+    "gmail.list_messages": ToolRisk.SAFE,
+    "gmail.unread_count": ToolRisk.SAFE,
     "time.now": ToolRisk.SAFE,
     "time.date": ToolRisk.SAFE,
     "weather.current": ToolRisk.SAFE,

--- a/tests/test_gmail_tools.py
+++ b/tests/test_gmail_tools.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from bantz.google.gmail import gmail_list_messages, gmail_unread_count
+
+
+def _make_get_response(
+    *,
+    msg_id: str,
+    from_value: str | None = None,
+    subject_value: str | None = None,
+    date_value: str | None = None,
+    snippet: str = "",
+) -> dict:
+    headers = []
+    if from_value is not None:
+        headers.append({"name": "From", "value": from_value})
+    if subject_value is not None:
+        headers.append({"name": "Subject", "value": subject_value})
+    if date_value is not None:
+        headers.append({"name": "Date", "value": date_value})
+
+    return {
+        "id": msg_id,
+        "snippet": snippet,
+        "payload": {"headers": headers},
+    }
+
+
+def _mock_gmail_service(*, list_execute: dict, get_execute_by_id: dict[str, dict]) -> Mock:
+    """Build a chained mock that supports users().messages().list/get().execute()."""
+
+    service = Mock(name="gmail_service")
+    users = service.users.return_value
+    messages = users.messages.return_value
+
+    list_req = Mock(name="list_req")
+    list_req.execute.return_value = list_execute
+    messages.list.return_value = list_req
+
+    def _get_side_effect(*, userId, id, format, metadataHeaders):  # noqa: A002
+        _ = (userId, format, metadataHeaders)
+        req = Mock(name=f"get_req_{id}")
+        req.execute.return_value = get_execute_by_id[str(id)]
+        return req
+
+    messages.get.side_effect = _get_side_effect
+
+    return service
+
+
+def test_gmail_list_messages_inbox_defaults_and_pagination():
+    service = _mock_gmail_service(
+        list_execute={
+            "messages": [{"id": "m1"}, {"id": "m2"}],
+            "nextPageToken": "tok123",
+            "resultSizeEstimate": 42,
+        },
+        get_execute_by_id={
+            "m1": _make_get_response(
+                msg_id="m1",
+                from_value="a@example.com",
+                subject_value="Hello",
+                date_value="Mon, 1 Jan 2024 10:00:00 +0000",
+                snippet="Snippet 1",
+            ),
+            "m2": _make_get_response(
+                msg_id="m2",
+                from_value="b@example.com",
+                subject_value="World",
+                date_value="Mon, 1 Jan 2024 11:00:00 +0000",
+                snippet="Snippet 2",
+            ),
+        },
+    )
+
+    out = gmail_list_messages(max_results=2, service=service, page_token="p1")
+    assert out["ok"] is True
+    assert out["query"] == "in:inbox"
+    assert out["estimated_count"] == 42
+    assert out["next_page_token"] == "tok123"
+    assert [m["id"] for m in out["messages"]] == ["m1", "m2"]
+    assert out["messages"][0]["from"] == "a@example.com"
+    assert out["messages"][0]["subject"] == "Hello"
+
+    # Ensure query/pagination wired correctly
+    service.users.return_value.messages.return_value.list.assert_called_once()
+    _, kwargs = service.users.return_value.messages.return_value.list.call_args
+    assert kwargs["q"] == "in:inbox"
+    assert kwargs["maxResults"] == 2
+    assert kwargs["pageToken"] == "p1"
+
+
+def test_gmail_list_messages_unread_only_query():
+    service = _mock_gmail_service(
+        list_execute={"messages": [{"id": "m1"}], "resultSizeEstimate": 1},
+        get_execute_by_id={
+            "m1": _make_get_response(msg_id="m1", snippet="hi"),
+        },
+    )
+
+    out = gmail_list_messages(max_results=1, unread_only=True, service=service)
+    assert out["ok"] is True
+    assert out["query"] == "is:unread"
+
+    _, kwargs = service.users.return_value.messages.return_value.list.call_args
+    assert kwargs["q"] == "is:unread"
+
+
+def test_gmail_unread_count_uses_is_unread_query():
+    service = Mock(name="gmail_service")
+    users = service.users.return_value
+    messages = users.messages.return_value
+
+    list_req = Mock(name="list_req")
+    list_req.execute.return_value = {"resultSizeEstimate": 7}
+    messages.list.return_value = list_req
+
+    out = gmail_unread_count(service=service)
+    assert out == {"ok": True, "unread_count_estimate": 7}
+
+    messages.list.assert_called_once()
+    _, kwargs = messages.list.call_args
+    assert kwargs["q"] == "is:unread"


### PR DESCRIPTION
Implements Issue #170.

- Adds Gmail read-only helpers: gmail_list_messages(max_results=10, unread_only=False, page_token=...) with pagination via nextPageToken and metadata headers (From/Subject/Date).
- Adds unread count estimate helper using q="is:unread".
- Registers tools: gmail.list_messages and gmail.unread_count.
- Marks both tools as SAFE in tool risk metadata.
- Allows tool execution for route="gmail" in SafetyGuard route-tool matching.
- Updates orchestrator prompt to mention gmail route/tools.
- Adds unit tests with mocked Gmail service.

Closes #170.