### PR TITLE
Issue #171: Gmail message reading & thread view

### DIFF
--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -566,6 +566,39 @@ def build_default_registry() -> ToolRegistry:
     )
 
     try:
+        from bantz.google.gmail import gmail_get_message as google_gmail_get_message
+    except Exception:  # pragma: no cover
+        google_gmail_get_message = None
+
+    reg.register(
+        Tool(
+            name="gmail.get_message",
+            description="Read a Gmail message body and detect attachments (read-only).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message_id": {"type": "string", "description": "Gmail message id"},
+                    "expand_thread": {"type": "boolean", "description": "Also fetch full thread (default: false)"},
+                    "max_thread_messages": {"type": "integer", "description": "Max thread messages to return (default: 25)"},
+                },
+                "required": ["message_id"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "message": {"type": ["object", "null"]},
+                    "thread": {"type": ["object", "null"]},
+                },
+                "required": ["ok", "message", "thread"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_gmail_get_message,
+        )
+    )
+
+    try:
         from bantz.google.calendar import find_free_slots as google_calendar_find_free_slots
     except Exception:  # pragma: no cover
         google_calendar_find_free_slots = None

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -145,6 +145,7 @@ TOOL_PLAN:
 - "calendar.create_event": etkinlik oluştur
 - "gmail.list_messages": Gmail gelen kutusu listele (read-only)
 - "gmail.unread_count": Gmail okunmamış sayısı (read-only)
+- "gmail.get_message": Gmail mesajını oku + thread genişlet (read-only)
 - Birden fazla tool sıralı çağrılabilir.
 
 TIME AWARENESS:

--- a/src/bantz/google/gmail.py
+++ b/src/bantz/google/gmail.py
@@ -9,9 +9,130 @@ Return payloads follow the tool-friendly `{ok: bool, ...}` pattern.
 
 from __future__ import annotations
 
+import base64
+import re
 from typing import Any, Optional
 
-from bantz.google.gmail_auth import authenticate_gmail
+from bantz.google.gmail_auth import GMAIL_READONLY_SCOPES, authenticate_gmail
+
+
+_BODY_TRUNCATE_LIMIT = 5000
+
+
+def _b64url_decode(data: str) -> bytes:
+    """Decode Gmail base64url body data safely."""
+    raw = (data or "").strip()
+    if not raw:
+        return b""
+    # Gmail uses URL-safe base64 without padding.
+    pad = (-len(raw)) % 4
+    if pad:
+        raw += "=" * pad
+    return base64.urlsafe_b64decode(raw.encode("ascii"))
+
+
+def _to_text(data: bytes) -> str:
+    return (data or b"").decode("utf-8", errors="replace")
+
+
+def _truncate(text: Optional[str], limit: int = _BODY_TRUNCATE_LIMIT) -> tuple[str, bool]:
+    s = str(text or "")
+    if len(s) <= limit:
+        return s, False
+    return s[:limit], True
+
+
+def _strip_html(html: str) -> str:
+    # Keep this dependency-free; only used as a fallback.
+    h = str(html or "")
+    h = re.sub(r"<script[\s\S]*?</script>", " ", h, flags=re.IGNORECASE)
+    h = re.sub(r"<style[\s\S]*?</style>", " ", h, flags=re.IGNORECASE)
+    h = re.sub(r"<[^>]+>", " ", h)
+    h = re.sub(r"\s+", " ", h).strip()
+    return h
+
+
+def _collect_parts(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    parts = payload.get("parts") if isinstance(payload, dict) else None
+    if not isinstance(parts, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for p in parts:
+        if isinstance(p, dict):
+            out.append(p)
+    return out
+
+
+def _extract_bodies_and_attachments(payload: dict[str, Any]) -> tuple[Optional[str], Optional[str], list[dict[str, Any]]]:
+    """Extract best-effort plain/html bodies + attachment metadata from full payload."""
+
+    plain_chunks: list[str] = []
+    html_chunks: list[str] = []
+    attachments: list[dict[str, Any]] = []
+
+    def walk(part: dict[str, Any]) -> None:
+        mime = str(part.get("mimeType") or "")
+        filename = str(part.get("filename") or "")
+        body = part.get("body") if isinstance(part.get("body"), dict) else {}
+
+        data = body.get("data")
+        attachment_id = body.get("attachmentId")
+        size = body.get("size")
+
+        if filename or attachment_id:
+            # Attachment detection: keep it simple and read-only.
+            attachments.append(
+                {
+                    "filename": filename or None,
+                    "mimeType": mime or None,
+                    "size": int(size) if isinstance(size, int) else None,
+                }
+            )
+
+        if mime == "text/plain" and isinstance(data, str) and data:
+            plain_chunks.append(_to_text(_b64url_decode(data)))
+        elif mime == "text/html" and isinstance(data, str) and data:
+            html_chunks.append(_to_text(_b64url_decode(data)))
+
+        for child in _collect_parts(part):
+            walk(child)
+
+    walk(payload)
+
+    plain = "\n".join([c for c in plain_chunks if c.strip()]).strip() or None
+    html = "\n".join([c for c in html_chunks if c.strip()]).strip() or None
+    return plain, html, attachments
+
+
+def _summarize_full_message(msg: dict[str, Any]) -> dict[str, Any]:
+    payload = msg.get("payload")
+    if not isinstance(payload, dict):
+        payload = {}
+
+    plain, html, attachments = _extract_bodies_and_attachments(payload)
+
+    # Provide both. If plain is missing, fall back to HTML-derived text.
+    body_text = plain
+    body_html = html
+    if body_text is None and body_html is not None:
+        body_text = _strip_html(body_html)
+
+    body_text_trunc, truncated = _truncate(body_text)
+    body_html_trunc, html_truncated = _truncate(body_html)
+    truncated = truncated or html_truncated
+
+    return {
+        "id": str(msg.get("id") or ""),
+        "threadId": str(msg.get("threadId") or ""),
+        "from": _get_header(payload, "From"),
+        "subject": _get_header(payload, "Subject"),
+        "date": _get_header(payload, "Date"),
+        "snippet": str(msg.get("snippet") or ""),
+        "body_text": body_text_trunc,
+        "body_html": body_html_trunc if body_html_trunc else None,
+        "attachments": attachments,
+        "truncated": bool(truncated),
+    }
 
 
 def _get_header(payload: dict[str, Any], name: str) -> Optional[str]:
@@ -61,7 +182,7 @@ def gmail_list_messages(
     q = "is:unread" if unread_only else "in:inbox"
 
     try:
-        svc = service or authenticate_gmail()
+        svc = service or authenticate_gmail(scopes=GMAIL_READONLY_SCOPES)
 
         list_kwargs: dict[str, Any] = {
             "userId": "me",
@@ -143,7 +264,7 @@ def gmail_unread_count(*, service: Any = None) -> dict[str, Any]:
     """
 
     try:
-        svc = service or authenticate_gmail()
+        svc = service or authenticate_gmail(scopes=GMAIL_READONLY_SCOPES)
         resp = (
             svc.users()
             .messages()
@@ -155,3 +276,67 @@ def gmail_unread_count(*, service: Any = None) -> dict[str, Any]:
         return {"ok": True, "unread_count_estimate": int(est) if isinstance(est, int) else 0}
     except Exception as e:  # pragma: no cover
         return {"ok": False, "error": str(e), "unread_count_estimate": 0}
+
+
+def gmail_get_message(
+    *,
+    message_id: str,
+    expand_thread: bool = False,
+    max_thread_messages: int = 25,
+    service: Any = None,
+) -> dict[str, Any]:
+    """Get a Gmail message body + attachments, optionally expanding its thread.
+
+    Args:
+        message_id: Gmail message id.
+        expand_thread: If True, fetch thread and return messages.
+        max_thread_messages: Safety cap for thread expansion.
+        service: Optional injected Gmail API service for testing.
+
+    Returns:
+        Dict with keys:
+        - ok: bool
+        - message: {id, threadId, from, subject, date, snippet, body_text, body_html, attachments, truncated}
+        - thread: {id, messages: [...] } | None
+    """
+
+    if not message_id or not str(message_id).strip():
+        raise ValueError("message_id must be non-empty")
+
+    if not isinstance(max_thread_messages, int) or max_thread_messages <= 0:
+        raise ValueError("max_thread_messages must be a positive integer")
+
+    try:
+        svc = service or authenticate_gmail(scopes=GMAIL_READONLY_SCOPES)
+        msg = (
+            svc.users()
+            .messages()
+            .get(userId="me", id=str(message_id).strip(), format="full")
+            .execute()
+            or {}
+        )
+
+        message = _summarize_full_message(msg)
+
+        thread_out: Optional[dict[str, Any]] = None
+        if expand_thread:
+            thread_id = message.get("threadId") or msg.get("threadId")
+            if thread_id:
+                thread = (
+                    svc.users()
+                    .threads()
+                    .get(userId="me", id=str(thread_id).strip(), format="full")
+                    .execute()
+                    or {}
+                )
+                raw_msgs = thread.get("messages")
+                messages: list[dict[str, Any]] = []
+                if isinstance(raw_msgs, list):
+                    for m in raw_msgs[: max_thread_messages]:
+                        if isinstance(m, dict):
+                            messages.append(_summarize_full_message(m))
+                thread_out = {"id": str(thread.get("id") or thread_id), "messages": messages}
+
+        return {"ok": True, "message": message, "thread": thread_out}
+    except Exception as e:  # pragma: no cover
+        return {"ok": False, "error": str(e), "message": None, "thread": None}

--- a/src/bantz/tools/metadata.py
+++ b/src/bantz/tools/metadata.py
@@ -36,6 +36,7 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "calendar.get_event": ToolRisk.SAFE,
     "gmail.list_messages": ToolRisk.SAFE,
     "gmail.unread_count": ToolRisk.SAFE,
+    "gmail.get_message": ToolRisk.SAFE,
     "time.now": ToolRisk.SAFE,
     "time.date": ToolRisk.SAFE,
     "weather.current": ToolRisk.SAFE,


### PR DESCRIPTION
Implements Issue #171.

- Adds gmail_get_message(message_id, expand_thread=False) to fetch full message (format=full), decode base64url bodies, extract text/plain with HTML fallback, and truncate bodies >5000 chars.
- Detects attachments as [{filename, mimeType, size}] without downloading content (SAFE).
- Supports thread expansion via threads().get(format=full) with max_thread_messages cap.
- Registers tool gmail.get_message and marks it SAFE.
- Fixes Gmail tool auth to request GMAIL_READONLY_SCOPES when service isn't injected.
- Adds unit tests covering decoding, HTML fallback, attachments, truncation, and thread view.

Closes #171.