### PR TITLE
Gmail send tool + confirmation policy (Issue #172)

### DIFF
--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -598,6 +598,59 @@ def build_default_registry() -> ToolRegistry:
         )
     )
 
+    # ─────────────────────────────────────────────────────────────────
+    # Gmail Tools (Google) - Send (Issue #172)
+    # ─────────────────────────────────────────────────────────────────
+    try:
+        from bantz.google.gmail import gmail_send as google_gmail_send
+    except Exception:  # pragma: no cover
+        google_gmail_send = None
+
+    reg.register(
+        Tool(
+            name="gmail.send",
+            description="Send an email via Gmail (compose & send). Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "to": {
+                        "type": "string",
+                        "description": "Recipient email(s). Comma/semicolon separated supported.",
+                    },
+                    "subject": {"type": "string", "description": "Email subject"},
+                    "body": {"type": "string", "description": "Plain-text email body"},
+                    "cc": {
+                        "type": "string",
+                        "description": "CC recipient(s). Comma/semicolon separated.",
+                    },
+                    "bcc": {
+                        "type": "string",
+                        "description": "BCC recipient(s). Comma/semicolon separated.",
+                    },
+                },
+                "required": ["to", "subject", "body"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "to": {"type": "array", "items": {"type": "string"}},
+                    "cc": {"type": ["array", "null"], "items": {"type": "string"}},
+                    "bcc": {"type": ["array", "null"], "items": {"type": "string"}},
+                    "subject": {"type": "string"},
+                    "message_id": {"type": "string"},
+                    "thread_id": {"type": "string"},
+                    "label_ids": {"type": ["array", "null"], "items": {"type": "string"}},
+                    "error": {"type": "string"},
+                },
+                "required": ["ok", "to", "subject", "message_id", "thread_id", "label_ids"],
+            },
+            risk_level="MED",
+            requires_confirmation=True,
+            function=google_gmail_send,
+        )
+    )
+
     try:
         from bantz.google.calendar import find_free_slots as google_calendar_find_free_slots
     except Exception:  # pragma: no cover

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -146,6 +146,7 @@ TOOL_PLAN:
 - "gmail.list_messages": Gmail gelen kutusu listele (read-only)
 - "gmail.unread_count": Gmail okunmamış sayısı (read-only)
 - "gmail.get_message": Gmail mesajını oku + thread genişlet (read-only)
+- "gmail.send": Gmail ile mail gönder (confirmation required)
 - Birden fazla tool sıralı çağrılabilir.
 
 TIME AWARENESS:

--- a/src/bantz/tools/metadata.py
+++ b/src/bantz/tools/metadata.py
@@ -37,6 +37,7 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "gmail.list_messages": ToolRisk.SAFE,
     "gmail.unread_count": ToolRisk.SAFE,
     "gmail.get_message": ToolRisk.SAFE,
+    "gmail.send": ToolRisk.MODERATE,
     "time.now": ToolRisk.SAFE,
     "time.date": ToolRisk.SAFE,
     "weather.current": ToolRisk.SAFE,
@@ -83,6 +84,12 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "email.delete": ToolRisk.DESTRUCTIVE,
     "database.delete": ToolRisk.DESTRUCTIVE,
     "database.update": ToolRisk.DESTRUCTIVE,
+}
+
+
+# Moderate tools that must always require confirmation.
+ALWAYS_CONFIRM_TOOLS: set[str] = {
+    "gmail.send",
 }
 
 
@@ -151,6 +158,10 @@ def requires_confirmation(tool_name: str, llm_requested: bool = False) -> bool:
     # DESTRUCTIVE tools ALWAYS require confirmation (firewall)
     if is_destructive(tool_name):
         return True
+
+    # Some MODERATE tools still require confirmation by policy.
+    if tool_name in ALWAYS_CONFIRM_TOOLS:
+        return True
     
     # Non-destructive tools respect LLM decision
     return llm_requested
@@ -182,6 +193,7 @@ def get_confirmation_prompt(tool_name: str, params: dict) -> str:
         "app.close": "Close application '{app_name}'? Unsaved work may be lost.",
         "email.delete": "Delete email '{subject}'? This cannot be undone.",
         "database.delete": "Delete from database? This cannot be undone.",
+        "gmail.send": "Send email to '{to}' with subject '{subject}'?",
     }
     
     # Get template or use generic

--- a/tests/test_confirmation_firewall.py
+++ b/tests/test_confirmation_firewall.py
@@ -453,6 +453,13 @@ def test_moderate_tools_respect_llm_decision(tool_registry):
     assert requires_confirmation(tool_name, llm_requested=True) is True
 
 
+def test_gmail_send_requires_confirmation_even_if_llm_does_not_request_it():
+    tool_name = "gmail.send"
+    assert get_tool_risk(tool_name) == ToolRisk.MODERATE
+    assert is_destructive(tool_name) is False
+    assert requires_confirmation(tool_name, llm_requested=False) is True
+
+
 def test_confirmation_flow_full_cycle(tool_registry, audit_logger):
     """Test full confirmation flow from request to execution."""
     executor = Executor(tool_registry)


### PR DESCRIPTION
Closes #172.

- Adds `gmail_send(to, subject, body, cc=None, bcc=None)` with RFC2822 MIME + base64url encoding and multiple recipient support.
- Registers new tool `gmail.send` with confirmation required.
- Updates confirmation firewall metadata so `gmail.send` requires confirmation even if the LLM forgets.
- Adds unit tests for send + confirmation.

Tests:
- `pytest -q tests/test_gmail_tools.py`
- `pytest -q tests/test_confirmation_firewall.py::test_gmail_send_requires_confirmation_even_if_llm_does_not_request_it`