### PR TITLE
Issue #173: Gmail draft management

### DIFF
--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -651,6 +651,178 @@ def build_default_registry() -> ToolRegistry:
         )
     )
 
+    # ─────────────────────────────────────────────────────────────────
+    # Gmail Tools (Google) - Drafts (Issue #173)
+    # ─────────────────────────────────────────────────────────────────
+    try:
+        from bantz.google.gmail import gmail_create_draft as google_gmail_create_draft
+    except Exception:  # pragma: no cover
+        google_gmail_create_draft = None
+
+    reg.register(
+        Tool(
+            name="gmail.create_draft",
+            description="Create a Gmail draft (SAFE).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "to": {"type": "string", "description": "Recipient email(s)"},
+                    "subject": {"type": "string", "description": "Email subject"},
+                    "body": {"type": "string", "description": "Plain-text body"},
+                },
+                "required": ["to", "subject", "body"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "draft_id": {"type": "string"},
+                    "message_id": {"type": "string"},
+                    "thread_id": {"type": "string"},
+                    "to": {"type": "array", "items": {"type": "string"}},
+                    "subject": {"type": "string"},
+                    "error": {"type": "string"},
+                },
+                "required": ["ok", "draft_id", "message_id", "thread_id", "to", "subject"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_gmail_create_draft,
+        )
+    )
+
+    try:
+        from bantz.google.gmail import gmail_list_drafts as google_gmail_list_drafts
+    except Exception:  # pragma: no cover
+        google_gmail_list_drafts = None
+
+    reg.register(
+        Tool(
+            name="gmail.list_drafts",
+            description="List Gmail drafts with basic metadata (SAFE).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "max_results": {"type": "integer", "description": "Max results (default: 10)"},
+                    "page_token": {"type": "string", "description": "Pagination token"},
+                },
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "drafts": {"type": "array"},
+                    "estimated_count": {"type": ["integer", "null"]},
+                    "next_page_token": {"type": ["string", "null"]},
+                    "error": {"type": "string"},
+                },
+                "required": ["ok", "drafts", "estimated_count", "next_page_token"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_gmail_list_drafts,
+        )
+    )
+
+    try:
+        from bantz.google.gmail import gmail_update_draft as google_gmail_update_draft
+    except Exception:  # pragma: no cover
+        google_gmail_update_draft = None
+
+    reg.register(
+        Tool(
+            name="gmail.update_draft",
+            description="Update a Gmail draft (SAFE).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "draft_id": {"type": "string", "description": "Draft id"},
+                    "updates": {"type": "object", "description": "Fields to update (to, subject, body, cc, bcc)"},
+                },
+                "required": ["draft_id", "updates"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "draft_id": {"type": "string"},
+                    "message_id": {"type": "string"},
+                    "thread_id": {"type": "string"},
+                    "error": {"type": "string"},
+                },
+                "required": ["ok", "draft_id", "message_id", "thread_id"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_gmail_update_draft,
+        )
+    )
+
+    try:
+        from bantz.google.gmail import gmail_send_draft as google_gmail_send_draft
+    except Exception:  # pragma: no cover
+        google_gmail_send_draft = None
+
+    reg.register(
+        Tool(
+            name="gmail.send_draft",
+            description="Send a Gmail draft (MODERATE, confirmation required).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "draft_id": {"type": "string", "description": "Draft id"},
+                },
+                "required": ["draft_id"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "draft_id": {"type": "string"},
+                    "message_id": {"type": "string"},
+                    "thread_id": {"type": "string"},
+                    "label_ids": {"type": ["array", "null"], "items": {"type": "string"}},
+                    "error": {"type": "string"},
+                },
+                "required": ["ok", "draft_id", "message_id", "thread_id", "label_ids"],
+            },
+            risk_level="MED",
+            requires_confirmation=True,
+            function=google_gmail_send_draft,
+        )
+    )
+
+    try:
+        from bantz.google.gmail import gmail_delete_draft as google_gmail_delete_draft
+    except Exception:  # pragma: no cover
+        google_gmail_delete_draft = None
+
+    reg.register(
+        Tool(
+            name="gmail.delete_draft",
+            description="Delete a Gmail draft (SAFE).",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "draft_id": {"type": "string", "description": "Draft id"},
+                },
+                "required": ["draft_id"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "draft_id": {"type": "string"},
+                    "error": {"type": "string"},
+                },
+                "required": ["ok", "draft_id"],
+            },
+            risk_level="LOW",
+            requires_confirmation=False,
+            function=google_gmail_delete_draft,
+        )
+    )
+
     try:
         from bantz.google.calendar import find_free_slots as google_calendar_find_free_slots
     except Exception:  # pragma: no cover

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -147,6 +147,11 @@ TOOL_PLAN:
 - "gmail.unread_count": Gmail okunmamış sayısı (read-only)
 - "gmail.get_message": Gmail mesajını oku + thread genişlet (read-only)
 - "gmail.send": Gmail ile mail gönder (confirmation required)
+- "gmail.create_draft": Gmail taslağı oluştur (SAFE)
+- "gmail.list_drafts": Gmail taslaklarını listele (SAFE)
+- "gmail.update_draft": Gmail taslağını güncelle (SAFE)
+- "gmail.send_draft": Gmail taslağını gönder (confirmation required)
+- "gmail.delete_draft": Gmail taslağını sil (SAFE)
 - Birden fazla tool sıralı çağrılabilir.
 
 TIME AWARENESS:

--- a/src/bantz/tools/metadata.py
+++ b/src/bantz/tools/metadata.py
@@ -38,6 +38,11 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "gmail.unread_count": ToolRisk.SAFE,
     "gmail.get_message": ToolRisk.SAFE,
     "gmail.send": ToolRisk.MODERATE,
+    "gmail.create_draft": ToolRisk.SAFE,
+    "gmail.list_drafts": ToolRisk.SAFE,
+    "gmail.update_draft": ToolRisk.SAFE,
+    "gmail.delete_draft": ToolRisk.SAFE,
+    "gmail.send_draft": ToolRisk.MODERATE,
     "time.now": ToolRisk.SAFE,
     "time.date": ToolRisk.SAFE,
     "weather.current": ToolRisk.SAFE,
@@ -90,6 +95,7 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
 # Moderate tools that must always require confirmation.
 ALWAYS_CONFIRM_TOOLS: set[str] = {
     "gmail.send",
+    "gmail.send_draft",
 }
 
 
@@ -194,6 +200,7 @@ def get_confirmation_prompt(tool_name: str, params: dict) -> str:
         "email.delete": "Delete email '{subject}'? This cannot be undone.",
         "database.delete": "Delete from database? This cannot be undone.",
         "gmail.send": "Send email to '{to}' with subject '{subject}'?",
+        "gmail.send_draft": "Send draft '{draft_id}'?",
     }
     
     # Get template or use generic

--- a/tests/test_confirmation_firewall.py
+++ b/tests/test_confirmation_firewall.py
@@ -460,6 +460,13 @@ def test_gmail_send_requires_confirmation_even_if_llm_does_not_request_it():
     assert requires_confirmation(tool_name, llm_requested=False) is True
 
 
+def test_gmail_send_draft_requires_confirmation_even_if_llm_does_not_request_it():
+    tool_name = "gmail.send_draft"
+    assert get_tool_risk(tool_name) == ToolRisk.MODERATE
+    assert is_destructive(tool_name) is False
+    assert requires_confirmation(tool_name, llm_requested=False) is True
+
+
 def test_confirmation_flow_full_cycle(tool_registry, audit_logger):
     """Test full confirmation flow from request to execution."""
     executor = Executor(tool_registry)


### PR DESCRIPTION
Implements Gmail draft CRUD + send-draft tools with policy/risk classification and tests.\n\nCloses #173.