### PR TITLE
Issue #176: Gmail attachment download

### DIFF
--- a/src/bantz/agent/builtin_tools.py
+++ b/src/bantz/agent/builtin_tools.py
@@ -599,6 +599,50 @@ def build_default_registry() -> ToolRegistry:
     )
 
     # ─────────────────────────────────────────────────────────────────
+    # Gmail Tools (Google) - Attachment Download (Issue #176)
+    # ─────────────────────────────────────────────────────────────────
+    try:
+        from bantz.google.gmail import gmail_download_attachment as google_gmail_download_attachment
+    except Exception:  # pragma: no cover
+        google_gmail_download_attachment = None
+
+    reg.register(
+        Tool(
+            name="gmail.download_attachment",
+            description="Download a Gmail attachment to disk. Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message_id": {"type": "string", "description": "Gmail message id"},
+                    "attachment_id": {"type": "string", "description": "Attachment id (from gmail.get_message attachments)"},
+                    "save_path": {"type": "string", "description": "File path to save to"},
+                    "overwrite": {"type": "boolean", "description": "Overwrite existing file (default: false)"},
+                },
+                "required": ["message_id", "attachment_id", "save_path"],
+            },
+            returns_schema={
+                "type": "object",
+                "properties": {
+                    "ok": {"type": "boolean"},
+                    "message_id": {"type": "string"},
+                    "attachment_id": {"type": "string"},
+                    "saved_path": {"type": "string"},
+                    "filename": {"type": "string"},
+                    "mimeType": {"type": ["string", "null"]},
+                    "declared_size_bytes": {"type": ["integer", "null"]},
+                    "size_bytes": {"type": ["integer", "null"]},
+                    "warnings": {"type": "array", "items": {"type": "string"}},
+                    "error": {"type": "string"},
+                },
+                "required": ["ok", "saved_path"],
+            },
+            risk_level="MED",
+            requires_confirmation=True,
+            function=google_gmail_download_attachment,
+        )
+    )
+
+    # ─────────────────────────────────────────────────────────────────
     # Gmail Tools (Google) - Smart Search (Issue #175)
     # ─────────────────────────────────────────────────────────────────
     try:

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -146,6 +146,7 @@ TOOL_PLAN:
 - "gmail.list_messages": Gmail gelen kutusu listele (read-only)
 - "gmail.unread_count": Gmail okunmamış sayısı (read-only)
 - "gmail.get_message": Gmail mesajını oku + thread genişlet (read-only)
+- "gmail.download_attachment": Gmail attachment indir (confirmation required)
 - "gmail.query_from_nl": Doğal dil → Gmail query (SAFE)
 - "gmail.smart_search": Doğal dille Gmail araması (SAFE)
 - "gmail.search_template_upsert": Gmail arama şablonu kaydet (SAFE)

--- a/src/bantz/tools/metadata.py
+++ b/src/bantz/tools/metadata.py
@@ -37,6 +37,7 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "gmail.list_messages": ToolRisk.SAFE,
     "gmail.unread_count": ToolRisk.SAFE,
     "gmail.get_message": ToolRisk.SAFE,
+    "gmail.download_attachment": ToolRisk.MODERATE,
     "gmail.query_from_nl": ToolRisk.SAFE,
     "gmail.smart_search": ToolRisk.SAFE,
     "gmail.search_template_upsert": ToolRisk.SAFE,
@@ -115,6 +116,7 @@ ALWAYS_CONFIRM_TOOLS: set[str] = {
     "gmail.send",
     "gmail.send_draft",
     "gmail.send_to_contact",
+    "gmail.download_attachment",
 }
 
 
@@ -221,6 +223,7 @@ def get_confirmation_prompt(tool_name: str, params: dict) -> str:
         "gmail.send": "Send email to '{to}' with subject '{subject}'?",
         "gmail.send_draft": "Send draft '{draft_id}'?",
         "gmail.send_to_contact": "Send email to contact '{name}' with subject '{subject}'?",
+        "gmail.download_attachment": "Download attachment '{attachment_id}' from email '{message_id}' to '{save_path}'?",
         "gmail.archive": "Archive email '{message_id}' (remove INBOX label)?",
         "gmail.batch_modify": "Batch modify labels for multiple emails?",
     }


### PR DESCRIPTION
Closes #176\n\nAdds  (MODERATE + confirmation) which:\n- Fetches attachment metadata (filename/mimeType/declared size)\n- Downloads and decodes base64url payload\n- Writes atomically to disk and returns warnings (virus scan + >10MB)\n\nTests: ....................                                                     [100%]
20 passed in 0.06s