### PR TITLE
Issue #216: Secrets hygiene (mask logs/CLI + env loader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ Recommended helper scripts:
 For high-quality writing (mail drafts, long summaries), enable Gemini (cloud):
 
 ```bash
-export BANTZ_CLOUD_MODE=cloud
-export QUALITY_PROVIDER=gemini
-export GEMINI_API_KEY="PASTE_YOUR_KEY_HERE"
+# Prefer .env to avoid leaking keys into shell history.
+# See: docs/secrets-hygiene.md
+cat > .env <<'EOF'
+BANTZ_CLOUD_MODE=cloud
+QUALITY_PROVIDER=gemini
+GEMINI_API_KEY=PASTE_YOUR_KEY_HERE
+EOF
 ```
 
 ### 3) Point Bantz to vLLM
@@ -78,6 +82,8 @@ Bantz supports flexible hybrid LLM architectures for optimal quality/latency bal
 - **Use case**: Best quality, cloud dependency acceptable
 
 ```python
+import os
+
 from bantz.brain.gemini_hybrid_orchestrator import create_gemini_hybrid_orchestrator
 from bantz.llm.vllm_openai_client import VLLMOpenAIClient
 
@@ -87,7 +93,7 @@ router = VLLMOpenAIClient(
 )
 orchestrator = create_gemini_hybrid_orchestrator(
     router_client=router,
-    gemini_api_key="YOUR_API_KEY"
+    gemini_api_key=os.getenv("GEMINI_API_KEY", "")
 )
 ```
 
@@ -288,7 +294,7 @@ python scripts/bench_hybrid_vs_3b_only.py --mode both
 python scripts/bench_hybrid_vs_3b_only.py --mode 3b_only
 
 # Hybrid mode (3B router + Gemini finalizer)
-python scripts/bench_hybrid_vs_3b_only.py --mode hybrid --use-gemini --gemini-api-key "$GEMINI_API_KEY"
+python scripts/bench_hybrid_vs_3b_only.py --mode hybrid --use-gemini
 
 # Generate markdown report
 python scripts/generate_benchmark_report.py

--- a/docs/secrets-hygiene.md
+++ b/docs/secrets-hygiene.md
@@ -1,0 +1,59 @@
+# Secrets hygiene (Issue #216)
+
+Goal: Prevent accidental leakage of API keys, OAuth tokens, and credential paths into logs, CLI output, and shell history.
+
+## Recommended ways to set secrets
+
+### 1) `.env` (local dev)
+
+Create a local `.env` file that is **not committed** (add to `.gitignore`):
+
+- Put only environment variables (no quotes needed unless your shell requires it):
+
+```
+BANTZ_CLOUD_MODE=cloud
+QUALITY_PROVIDER=gemini
+GEMINI_API_KEY=...your key...
+BANTZ_GEMINI_MODEL=gemini-1.5-flash
+```
+
+Load it with one of:
+
+- `direnv` (recommended):
+  - `.envrc`:
+    - `dotenv`
+  - Run: `direnv allow`
+
+### 2) `systemd` user service (Linux)
+
+Use an EnvironmentFile so secrets don’t end up in shell history.
+
+- Example: `~/.config/bantz/bantz.env`
+
+```
+GEMINI_API_KEY=...your key...
+QUALITY_PROVIDER=gemini
+BANTZ_CLOUD_MODE=cloud
+```
+
+- In your service unit:
+  - `EnvironmentFile=%h/.config/bantz/bantz.env`
+
+### 3) Secret Manager (production)
+
+Use your platform’s secret manager to inject env vars at runtime.
+
+- GCP Secret Manager (conceptual example):
+  - Store `GEMINI_API_KEY` as a secret
+  - Inject it into the service environment at startup (Cloud Run / GCE / Kubernetes)
+
+## What BANTZ does now
+
+- CLI `bantz google env` prints only **presence booleans** for secrets, and masks credential paths.
+- Missing-file errors for Google OAuth / service-account credentials mask full paths.
+- Use `BANTZ_LLM_METRICS=1` for LLM call metrics; it should not print keys.
+
+## What to avoid
+
+- Don’t run commands like `GEMINI_API_KEY=... bantz ...` (shell history risk)
+- Don’t paste tokens/keys into logs/issues

--- a/src/bantz/google/auth.py
+++ b/src/bantz/google/auth.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Optional
 import os
 
+from bantz.security.secrets import mask_path
+
 
 DEFAULT_CLIENT_SECRET_PATH = "~/.config/bantz/google/client_secret.json"
 DEFAULT_TOKEN_PATH = "~/.config/bantz/google/token.json"
@@ -55,7 +57,7 @@ def get_credentials(
     if not cfg.client_secret_path.exists():
         raise FileNotFoundError(
             "Google client secret not found. Set BANTZ_GOOGLE_CLIENT_SECRET "
-            f"or example to {DEFAULT_CLIENT_SECRET_PATH}. Missing: {cfg.client_secret_path}"
+            f"or example to {DEFAULT_CLIENT_SECRET_PATH}. Missing: {mask_path(str(cfg.client_secret_path))}"
         )
 
     # Lazy imports

--- a/src/bantz/google/gmail_auth.py
+++ b/src/bantz/google/gmail_auth.py
@@ -6,6 +6,8 @@ from typing import Any, Optional
 import os
 import json
 
+from bantz.security.secrets import mask_path
+
 
 # Canonical Gmail OAuth scopes.
 # Accept short forms like "gmail.readonly" too.
@@ -171,7 +173,7 @@ def get_gmail_credentials(
     if not cfg.client_secret_path.exists():
         raise FileNotFoundError(
             "Gmail client secret not found. Set BANTZ_GMAIL_CLIENT_SECRET "
-            f"(default: {DEFAULT_GMAIL_CLIENT_SECRET_PATH}). Missing: {cfg.client_secret_path}"
+            f"(default: {DEFAULT_GMAIL_CLIENT_SECRET_PATH}). Missing: {mask_path(str(cfg.client_secret_path))}"
         )
 
     try:

--- a/src/bantz/google/service_account.py
+++ b/src/bantz/google/service_account.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Optional
 import os
 
+from bantz.security.secrets import mask_path
+
 
 DEFAULT_SERVICE_ACCOUNT_PATH = "~/.config/bantz/google/service_account.json"
 
@@ -49,7 +51,7 @@ def get_service_account_credentials(
         raise FileNotFoundError(
             "Google service account JSON not found. Set BANTZ_GOOGLE_SERVICE_ACCOUNT or "
             "GOOGLE_APPLICATION_CREDENTIALS, or place the file at "
-            f"{DEFAULT_SERVICE_ACCOUNT_PATH}. Missing: {cfg.service_account_path}"
+            f"{DEFAULT_SERVICE_ACCOUNT_PATH}. Missing: {mask_path(str(cfg.service_account_path))}"
         )
 
     try:

--- a/src/bantz/security/env_loader.py
+++ b/src/bantz/security/env_loader.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+
+def _strip_quotes(value: str) -> str:
+    v = value.strip()
+    if len(v) >= 2 and ((v[0] == '"' and v[-1] == '"') or (v[0] == "'" and v[-1] == "'")):
+        v = v[1:-1]
+    # Allow writing multiline values using literal \n in .env.
+    return v.replace("\\n", "\n")
+
+
+def load_env_file(path: str | os.PathLike[str], *, override: bool = False) -> list[str]:
+    """Load environment variables from a simple .env file.
+
+    - Supports lines like: KEY=VALUE or export KEY=VALUE
+    - Ignores blank lines and comments (#...)
+    - Does not print/log any values
+    - By default, does not override existing os.environ entries
+
+    Returns a list of keys loaded.
+    """
+
+    p = Path(path).expanduser()
+    if not p.exists() or not p.is_file():
+        return []
+
+    loaded: list[str] = []
+    for raw in p.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+        value = _strip_quotes(value)
+        if not override and key in os.environ:
+            continue
+        os.environ[key] = value
+        loaded.append(key)
+
+    return loaded
+
+
+def load_env(
+    *,
+    env_var: str = "BANTZ_ENV_FILE",
+    default_files: Iterable[str] = (".env",),
+    override: bool = False,
+) -> list[str]:
+    """Load a .env file into os.environ.
+
+    Prefers the file specified via `BANTZ_ENV_FILE`; otherwise tries `default_files`
+    in the current working directory.
+
+    Returns a list of loaded keys (possibly empty).
+    """
+
+    explicit = (os.getenv(env_var) or "").strip()
+    if explicit:
+        return load_env_file(explicit, override=override)
+
+    for name in default_files:
+        keys = load_env_file(name, override=override)
+        if keys:
+            return keys
+    return []

--- a/src/bantz/security/secrets.py
+++ b/src/bantz/security/secrets.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+_REDACTED = "***REDACTED***"
+
+# Common API keys / tokens
+_RE_GOOGLE_API_KEY = re.compile(r"\bAIza[0-9A-Za-z\-_]{20,}\b")
+_RE_OAUTH_YA29 = re.compile(r"\bya29\.[0-9A-Za-z\-_]+\b")
+_RE_BEARER = re.compile(r"\bBearer\s+[A-Za-z0-9\-\._~\+\/]+=*", re.IGNORECASE)
+_RE_JWT = re.compile(r"\beyJ[0-9A-Za-z_\-]{10,}\.[0-9A-Za-z_\-]{10,}\.[0-9A-Za-z_\-]{10,}\b")
+
+# Private key blocks
+_RE_PRIVATE_KEY_BLOCK = re.compile(
+    r"-----BEGIN PRIVATE KEY-----[\s\S]*?-----END PRIVATE KEY-----",
+    re.MULTILINE,
+)
+
+# Env-style assignments that might end up in logs
+_RE_ENV_ASSIGN = re.compile(
+    r"\b("
+    r"GEMINI_API_KEY|GOOGLE_API_KEY|BANTZ_GEMINI_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|"
+    r"BANTZ_GOOGLE_CLIENT_SECRET|BANTZ_GMAIL_CLIENT_SECRET|BANTZ_GOOGLE_SERVICE_ACCOUNT|GOOGLE_APPLICATION_CREDENTIALS"
+    r")\b\s*[:=]\s*([^\s'\"\n]+)",
+    re.IGNORECASE,
+)
+
+# JSON key/value patterns
+_RE_JSON_SECRET_FIELDS = re.compile(
+    r"(\"(?:api_key|access_token|refresh_token|client_secret|private_key)\"\s*:\s*)\"([^\"]*)\"",
+    re.IGNORECASE,
+)
+
+# Path-ish tokens that are commonly sensitive (credential files)
+_RE_CRED_PATH = re.compile(
+    r"(?P<path>(?:~|/)[^\s\"]*(?:service_account|client_secret|token)[^\s\"]*\.json)",
+    re.IGNORECASE,
+)
+
+
+def mask_path(path: str) -> str:
+    """Mask a filesystem path while preserving only the basename."""
+
+    p = str(path or "").strip()
+    if not p:
+        return p
+
+    # Normalize slashes; keep only the last segment.
+    sep = "/"
+    if sep in p:
+        base = p.rsplit(sep, 1)[-1]
+        return f"…/{base}"
+
+    # No directory component
+    return "…/" + p
+
+
+def mask_secrets(text: str) -> str:
+    """Best-effort masking for logs/CLI output.
+
+    This is intentionally heuristic. It aims to prevent accidental leakage of
+    API keys, OAuth tokens, private keys, and credential paths.
+    """
+
+    t = str(text or "")
+    if not t:
+        return t
+
+    # Mask private key blocks first (they can contain other patterns).
+    t = _RE_PRIVATE_KEY_BLOCK.sub(_REDACTED, t)
+
+    # Mask explicit env assignments
+    t = _RE_ENV_ASSIGN.sub(lambda m: f"{m.group(1)}={_REDACTED}", t)
+
+    # Mask JSON fields
+    t = _RE_JSON_SECRET_FIELDS.sub(lambda m: f"{m.group(1)}\"{_REDACTED}\"", t)
+
+    # Mask known token formats
+    t = _RE_GOOGLE_API_KEY.sub(_REDACTED, t)
+    t = _RE_OAUTH_YA29.sub(_REDACTED, t)
+    t = _RE_JWT.sub(_REDACTED, t)
+
+    # Mask bearer tokens but keep the word "Bearer".
+    t = _RE_BEARER.sub("Bearer " + _REDACTED, t)
+
+    # Mask credential paths.
+    t = _RE_CRED_PATH.sub(lambda m: mask_path(m.group("path")), t)
+
+    return t
+
+
+def sanitize(obj: Any) -> Any:
+    """Recursively sanitize strings inside dict/list structures for safe display."""
+
+    if obj is None:
+        return None
+    if isinstance(obj, str):
+        return mask_secrets(obj)
+    if isinstance(obj, dict):
+        return {k: sanitize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [sanitize(x) for x in obj]
+    if isinstance(obj, tuple):
+        return tuple(sanitize(x) for x in obj)
+    return obj
+
+
+class SecretsRedactionFilter(logging.Filter):
+    """Redact secrets from logging records (best-effort).
+
+    This filter replaces the *formatted* message with a masked version and
+    clears args to avoid leaking secrets via formatting.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        try:
+            msg = record.getMessage()
+            msg = mask_secrets(msg)
+            record.msg = msg
+            record.args = ()
+        except Exception:
+            # Never break logging.
+            pass
+        return True
+
+
+def install_secrets_redaction_filter(logger: logging.Logger | None = None) -> SecretsRedactionFilter:
+    """Install a secrets redaction filter on a logger (default: root)."""
+
+    log = logger or logging.getLogger()
+    filt = SecretsRedactionFilter()
+    try:
+        log.addFilter(filt)
+        for handler in getattr(log, "handlers", []) or []:
+            handler.addFilter(filt)
+    except Exception:
+        pass
+    return filt

--- a/tests/test_secrets_hygiene_issue_216.py
+++ b/tests/test_secrets_hygiene_issue_216.py
@@ -1,0 +1,91 @@
+import os
+
+from bantz.security.env_loader import load_env, load_env_file
+from bantz.security.secrets import mask_path, mask_secrets, sanitize
+
+
+def test_mask_path_basename_only() -> None:
+    assert mask_path("/home/user/.config/bantz/google/client_secret.json") == "…/client_secret.json"
+    assert mask_path("client_secret.json") == "…/client_secret.json"
+
+
+def test_mask_secrets_common_patterns() -> None:
+    google_key = "AIza" + ("A" * 30)
+    ya29 = "ya29." + ("B" * 40)
+    jwt = "eyJ" + ("A" * 12) + "." + ("B" * 12) + "." + ("C" * 12)
+    bearer = "Bearer abcDEF0123-._~+/=="
+
+    text = (
+        f"key={google_key} oauth={ya29} jwt={jwt} auth={bearer} "
+        "path=/home/user/.config/bantz/google/token.json"
+    )
+
+    masked = mask_secrets(text)
+    assert "AIza" not in masked
+    assert "ya29." not in masked
+    assert "eyJ" not in masked
+    assert "Bearer ***REDACTED***" in masked
+    assert "…/token.json" in masked
+
+
+def test_mask_secrets_env_assignment_and_json_fields() -> None:
+    google_key = "AIza" + ("A" * 30)
+
+    masked_env = mask_secrets(f"GEMINI_API_KEY={google_key}")
+    assert masked_env == "GEMINI_API_KEY=***REDACTED***"
+
+    masked_json = mask_secrets('{"access_token": "ya29.ABCDEF"}')
+    assert "ya29." not in masked_json
+    assert "***REDACTED***" in masked_json
+
+
+def test_mask_secrets_private_key_block() -> None:
+    private_key = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"
+    masked = mask_secrets(private_key)
+    assert masked == "***REDACTED***"
+
+
+def test_sanitize_recursive() -> None:
+    data = {
+        "auth": "Bearer abcDEF0123-._~+/==",
+        "nested": {"path": "/home/user/.config/bantz/google/service_account.json"},
+        "list": ["ya29.ABCDEF", "ok"],
+    }
+
+    out = sanitize(data)
+    assert out["auth"] == "Bearer ***REDACTED***"
+    assert out["nested"]["path"] == "…/service_account.json"
+    assert out["list"][0] == "***REDACTED***"
+
+
+def test_env_loader_load_env_file_and_override(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    p = tmp_path / "test.env"
+    p.write_text("GEMINI_API_KEY=AIza" + ("A" * 30) + "\n#comment\nFOO=bar\n", encoding="utf-8")
+
+    loaded = load_env_file(str(p))
+    assert set(loaded) == {"GEMINI_API_KEY", "FOO"}
+    assert os.environ.get("FOO") == "bar"
+
+    # Should not override by default
+    monkeypatch.setenv("FOO", "existing")
+    loaded2 = load_env_file(str(p), override=False)
+    assert "FOO" not in loaded2
+    assert os.environ.get("FOO") == "existing"
+
+    # But should override when asked
+    loaded3 = load_env_file(str(p), override=True)
+    assert "FOO" in loaded3
+    assert os.environ.get("FOO") == "bar"
+
+
+def test_env_loader_load_env_uses_env_var(monkeypatch, tmp_path) -> None:
+    p = tmp_path / "bantz.env"
+    p.write_text("FOO=baz\n", encoding="utf-8")
+    monkeypatch.setenv("BANTZ_ENV_FILE", str(p))
+
+    monkeypatch.delenv("FOO", raising=False)
+    loaded = load_env()
+    assert loaded == ["FOO"]
+    assert os.environ.get("FOO") == "baz"


### PR DESCRIPTION
Implements Issue #216.

- Adds .env loader (BANTZ_ENV_FILE or .env) to avoid shell-history leaks
- Adds secret/path masking utilities + installs log redaction filter in CLIs
- Sanitizes JSONL logs to avoid leaking secrets in structured fields
- Hardens Google CLI output (booleans only) and masks credential paths in errors
- Adds unit tests for masking + env loader

Docs: docs/secrets-hygiene.md