### PR TITLE
feat(285): Add query parameter to gmail.list_messages

### DIFF
--- a/scripts/terminal_jarvis.py
+++ b/scripts/terminal_jarvis.py
@@ -246,13 +246,17 @@ def _build_registry() -> ToolRegistry:
     reg.register(
         Tool(
             name="gmail.list_messages",
-            description="Gmail: list inbox messages (read-only)",
+            description="Gmail: list inbox messages with optional search query (read-only)",
             parameters={
                 "type": "object",
                 "properties": {
                     **common_slot_props,
                     "max_results": {"type": "integer"},
                     "unread_only": {"type": "boolean"},
+                    "query": {
+                        "type": "string",
+                        "description": "Gmail search query (from:, subject:, after:, label:). Examples: 'from:linkedin', 'from:amazon subject:order', 'label:CATEGORY_UPDATES'",
+                    },
                 },
                 "required": [],
                 "additionalProperties": True,

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -144,7 +144,7 @@ TOOL_PLAN:
 - "calendar.list_events": takvim sorgusu
 - "calendar.find_free_slots": boş slot ara
 - "calendar.create_event": etkinlik oluştur
-- "gmail.list_messages": Gmail gelen kutusu listele (read-only)
+- "gmail.list_messages": Gmail gelen kutusu listele (read-only) - query parametresi ile arama yapılabilir!
 - "gmail.unread_count": Gmail okunmamış sayısı (read-only)
 - "gmail.get_message": Gmail mesajını oku + thread genişlet (read-only)
 - "gmail.download_attachment": Gmail attachment indir (confirmation required)
@@ -174,6 +174,16 @@ TOOL_PLAN:
 - "gmail.send_draft": Gmail taslağını gönder (confirmation required)
 - "gmail.delete_draft": Gmail taslağını sil (SAFE)
 - Birden fazla tool sıralı çağrılabilir.
+
+GMAIL ARAMA ÖRNEKLERİ (Issue #285):
+gmail.list_messages tool'u "query" parametresi alır:
+- "linkedin maili var mı" → query="from:linkedin OR subject:LinkedIn"
+- "amazon siparişi" → query="from:amazon subject:order"
+- "dün gelen mailler" → query="after:YYYY/MM/DD" (dünün tarihi)
+- "güncellemeler kategorisi" → query="label:CATEGORY_UPDATES"
+- "promosyon mailleri" → query="label:CATEGORY_PROMOTIONS"
+- "sosyal mailleri" → query="label:CATEGORY_SOCIAL"
+- "okunmamış linkedinden" → query="from:linkedin" + unread_only=true
 
 TIME AWARENESS:
 - "bu akşam" → window_hint="evening"

--- a/src/bantz/tools/gmail_tools.py
+++ b/src/bantz/tools/gmail_tools.py
@@ -22,16 +22,28 @@ def gmail_list_messages_tool(
     *,
     max_results: int = 5,
     unread_only: bool = False,
+    query: str = "",
     **_: Any,
 ) -> dict[str, Any]:
-    """Read-only: list recent inbox messages.
+    """Read-only: list recent inbox messages with optional search query.
 
-    Orchestrator slots are ignored; we keep args small & safe.
+    Args:
+        max_results: Max number of messages to return (default 5).
+        unread_only: If True, only return unread messages.
+        query: Gmail search query (from:, subject:, after:, label:, etc.).
+               Examples:
+               - "from:linkedin" → LinkedIn emails
+               - "from:amazon subject:sipariş" → Amazon orders
+               - "after:2026/02/01" → Emails after date
+               - "label:CATEGORY_UPDATES" → Updates category
+    
+    Issue #285: Added query parameter support.
     """
     try:
         return gmail_list_messages(
             max_results=int(max_results),
             unread_only=bool(unread_only),
+            query=query.strip() if query else None,
             interactive=False,
         )
     except Exception as e:

--- a/tests/test_gmail_query.py
+++ b/tests/test_gmail_query.py
@@ -1,0 +1,221 @@
+"""Tests for Gmail Query Parameter (Issue #285).
+
+Tests that gmail.list_messages supports the query parameter for
+filtering messages (from:, subject:, label:, etc.).
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ============================================================================
+# Test gmail_list_messages_tool with query
+# ============================================================================
+
+class TestGmailListMessagesQuery:
+    """Test gmail_list_messages_tool with query parameter."""
+    
+    def test_list_messages_with_linkedin_query(self):
+        """Query 'from:linkedin' should be passed to API."""
+        from bantz.tools.gmail_tools import gmail_list_messages_tool
+        
+        with patch('bantz.tools.gmail_tools.gmail_list_messages') as mock_list:
+            mock_list.return_value = {
+                "ok": True,
+                "query": "from:linkedin",
+                "messages": [{"id": "1", "subject": "Job Alert"}],
+            }
+            
+            result = gmail_list_messages_tool(query="from:linkedin")
+            
+            assert mock_list.called
+            call_kwargs = mock_list.call_args.kwargs
+            assert call_kwargs.get("query") == "from:linkedin"
+    
+    def test_list_messages_with_amazon_query(self):
+        """Query 'from:amazon' should be passed to API."""
+        from bantz.tools.gmail_tools import gmail_list_messages_tool
+        
+        with patch('bantz.tools.gmail_tools.gmail_list_messages') as mock_list:
+            mock_list.return_value = {"ok": True, "messages": []}
+            
+            result = gmail_list_messages_tool(query="from:amazon subject:order")
+            
+            call_kwargs = mock_list.call_args.kwargs
+            assert "amazon" in call_kwargs.get("query", "")
+    
+    def test_list_messages_with_label_query(self):
+        """Query 'label:CATEGORY_UPDATES' should work."""
+        from bantz.tools.gmail_tools import gmail_list_messages_tool
+        
+        with patch('bantz.tools.gmail_tools.gmail_list_messages') as mock_list:
+            mock_list.return_value = {"ok": True, "messages": []}
+            
+            result = gmail_list_messages_tool(query="label:CATEGORY_UPDATES")
+            
+            call_kwargs = mock_list.call_args.kwargs
+            assert call_kwargs.get("query") == "label:CATEGORY_UPDATES"
+    
+    def test_list_messages_without_query(self):
+        """Without query, should list inbox normally."""
+        from bantz.tools.gmail_tools import gmail_list_messages_tool
+        
+        with patch('bantz.tools.gmail_tools.gmail_list_messages') as mock_list:
+            mock_list.return_value = {"ok": True, "messages": []}
+            
+            result = gmail_list_messages_tool()
+            
+            call_kwargs = mock_list.call_args.kwargs
+            assert call_kwargs.get("query") is None
+    
+    def test_list_messages_with_unread_and_query(self):
+        """Query and unread_only should work together."""
+        from bantz.tools.gmail_tools import gmail_list_messages_tool
+        
+        with patch('bantz.tools.gmail_tools.gmail_list_messages') as mock_list:
+            mock_list.return_value = {"ok": True, "messages": []}
+            
+            result = gmail_list_messages_tool(
+                query="from:linkedin",
+                unread_only=True,
+            )
+            
+            call_kwargs = mock_list.call_args.kwargs
+            assert call_kwargs.get("query") == "from:linkedin"
+            assert call_kwargs.get("unread_only") is True
+
+
+# ============================================================================
+# Test gmail.py gmail_list_messages with query
+# ============================================================================
+
+class TestGmailListMessagesAPIQuery:
+    """Test the gmail.py gmail_list_messages function with query."""
+    
+    def test_query_parameter_in_function_signature(self):
+        """Function should accept query parameter."""
+        from bantz.google.gmail import gmail_list_messages
+        import inspect
+        
+        sig = inspect.signature(gmail_list_messages)
+        assert "query" in sig.parameters
+    
+    def test_query_uses_q_parameter(self):
+        """When query is provided, should use q= in API call."""
+        from bantz.google.gmail import gmail_list_messages
+        
+        mock_service = MagicMock()
+        mock_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [],
+        }
+        
+        gmail_list_messages(
+            query="from:linkedin",
+            service=mock_service,
+            interactive=False,
+        )
+        
+        # Check that list() was called with q parameter
+        call_kwargs = mock_service.users().messages().list.call_args.kwargs
+        assert "q" in call_kwargs
+        assert "linkedin" in call_kwargs["q"]
+    
+    def test_no_query_uses_label_ids(self):
+        """Without query, should use labelIds instead of q."""
+        from bantz.google.gmail import gmail_list_messages
+        
+        mock_service = MagicMock()
+        mock_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [],
+        }
+        
+        gmail_list_messages(
+            service=mock_service,
+            interactive=False,
+        )
+        
+        call_kwargs = mock_service.users().messages().list.call_args.kwargs
+        # Should use labelIds, not q
+        assert "labelIds" in call_kwargs or "q" not in call_kwargs
+
+
+# ============================================================================
+# Test LLM Router Prompt
+# ============================================================================
+
+class TestLLMRouterGmailPrompt:
+    """Test that LLM router prompt includes Gmail query examples."""
+    
+    def test_prompt_has_gmail_query_examples(self):
+        """Prompt should have Gmail query examples."""
+        from bantz.brain.llm_router import JarvisLLMOrchestrator
+        
+        prompt = JarvisLLMOrchestrator.SYSTEM_PROMPT
+        
+        # Should have query examples
+        assert "from:linkedin" in prompt or "linkedin" in prompt.lower()
+    
+    def test_prompt_mentions_query_parameter(self):
+        """Prompt should mention query parameter for gmail.list_messages."""
+        from bantz.brain.llm_router import JarvisLLMOrchestrator
+        
+        prompt = JarvisLLMOrchestrator.SYSTEM_PROMPT
+        
+        assert "query" in prompt.lower()
+    
+    def test_prompt_has_label_category_examples(self):
+        """Prompt should have label/category examples."""
+        from bantz.brain.llm_router import JarvisLLMOrchestrator
+        
+        prompt = JarvisLLMOrchestrator.SYSTEM_PROMPT
+        
+        # Should have category labels
+        assert "CATEGORY_UPDATES" in prompt or "label:" in prompt
+
+
+# ============================================================================
+# Test Query Building
+# ============================================================================
+
+class TestQueryBuilding:
+    """Test query string building logic."""
+    
+    def test_unread_only_appends_to_query(self):
+        """unread_only should add is:unread to query."""
+        from bantz.google.gmail import gmail_list_messages
+        
+        mock_service = MagicMock()
+        mock_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [],
+        }
+        
+        gmail_list_messages(
+            query="from:linkedin",
+            unread_only=True,
+            service=mock_service,
+            interactive=False,
+        )
+        
+        call_kwargs = mock_service.users().messages().list.call_args.kwargs
+        q = call_kwargs.get("q", "")
+        assert "linkedin" in q
+        assert "is:unread" in q
+    
+    def test_empty_query_defaults_to_inbox(self):
+        """Empty query should list inbox."""
+        from bantz.google.gmail import gmail_list_messages
+        
+        mock_service = MagicMock()
+        mock_service.users.return_value.messages.return_value.list.return_value.execute.return_value = {
+            "messages": [],
+        }
+        
+        gmail_list_messages(
+            query="",
+            service=mock_service,
+            interactive=False,
+        )
+        
+        call_kwargs = mock_service.users().messages().list.call_args.kwargs
+        # Should use labelIds for inbox, not q
+        assert "labelIds" in call_kwargs or call_kwargs.get("q") is None


### PR DESCRIPTION
## Summary

Adds query parameter to `gmail.list_messages` for filtering emails.

## Changes

### gmail.py
- Added `query` parameter to `gmail_list_messages` function
- When query is provided, uses Gmail's `q=` search parameter
- Without query, falls back to `labelIds` for simple inbox listing

### gmail_tools.py  
- Updated `gmail_list_messages_tool` with query parameter

### terminal_jarvis.py
- Updated tool schema with query parameter description

### llm_router.py
- Added Gmail search examples to prompt:
```
- "linkedin maili var mı" → query="from:linkedin OR subject:LinkedIn"
- "amazon siparişi" → query="from:amazon subject:order"
- "güncellemeler kategorisi" → query="label:CATEGORY_UPDATES"
```

## Usage Examples

```python
# LinkedIn emails
gmail_list_messages_tool(query="from:linkedin")

# Amazon orders
gmail_list_messages_tool(query="from:amazon subject:order")

# Updates category
gmail_list_messages_tool(query="label:CATEGORY_UPDATES")

# Unread from LinkedIn
gmail_list_messages_tool(query="from:linkedin", unread_only=True)
```

## Tests
- 13 new tests in `test_gmail_query.py`

Closes #285