### PR TITLE
fix(316): Accept 'ekle', 'yap', 'koy', 'kaydet' as confirmation

### DIFF
--- a/scripts/terminal_jarvis.py
+++ b/scripts/terminal_jarvis.py
@@ -444,7 +444,8 @@ def _is_confirmation_yes(text: str) -> bool:
     t = _normalize_elongated(t)
     
     # Exact match for common confirmations
-    yes_tokens = {"evet", "e", "ok", "tamam", "onay", "onaylıyorum", "kabul", "yes", "y", "olur", "peki"}
+    # Issue #316: Added 'ekle', 'yap', 'koy', 'kaydet' as action confirmations
+    yes_tokens = {"evet", "e", "ok", "tamam", "onay", "onaylıyorum", "kabul", "yes", "y", "olur", "peki", "ekle", "yap", "koy", "kaydet"}
     if t in yes_tokens:
         return True
     
@@ -454,7 +455,7 @@ def _is_confirmation_yes(text: str) -> bool:
         return True
     
     # Startswith patterns (handles "evet," "tamam." etc. with punctuation)
-    yes_prefixes = ("evet", "tamam", "ok ", "onay", "kabul", "yes ", "olur")
+    yes_prefixes = ("evet", "tamam", "ok ", "onay", "kabul", "yes ", "olur", "ekle", "yap ", "koy ", "kaydet")
     if t.startswith(yes_prefixes):
         return True
     

--- a/tests/test_elongated_confirmation.py
+++ b/tests/test_elongated_confirmation.py
@@ -218,3 +218,55 @@ class TestElongatedEdgeCases:
         assert _normalize_elongated("öööö") == "ö"
         assert _normalize_elongated("çççç") == "ç"
         assert _normalize_elongated("ğğğğ") == "ğ"
+
+
+# ============================================================================
+# Test Action Words as Confirmation (Issue #316)
+# ============================================================================
+
+class TestActionWordConfirmations:
+    """Test that action words like 'ekle', 'yap', 'koy' are accepted as yes."""
+    
+    def test_ekle_is_yes(self):
+        """'ekle' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("ekle") is True
+    
+    def test_ekle_bakalim_is_yes(self):
+        """'ekle bakalım' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("ekle bakalım") is True
+    
+    def test_ekle_onu_is_yes(self):
+        """'ekle onu' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("ekle onu") is True
+    
+    def test_yap_is_yes(self):
+        """'yap' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("yap") is True
+    
+    def test_yap_hadi_is_yes(self):
+        """'yap hadi' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("yap hadi") is True
+    
+    def test_koy_is_yes(self):
+        """'koy' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("koy") is True
+    
+    def test_koy_onu_is_yes(self):
+        """'koy onu' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("koy onu") is True
+    
+    def test_kaydet_is_yes(self):
+        """'kaydet' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("kaydet") is True
+    
+    def test_kaydet_lutfen_is_yes(self):
+        """'kaydet lütfen' should be detected as yes confirmation."""
+        assert _is_confirmation_yes("kaydet lütfen") is True
+    
+    def test_ekleee_elongated_is_yes(self):
+        """'ekleee' (elongated) should be detected as yes."""
+        assert _is_confirmation_yes("ekleee") is True
+    
+    def test_yappp_elongated_is_yes(self):
+        """'yappp' (elongated) should be detected as yes."""
+        assert _is_confirmation_yes("yappp") is True


### PR DESCRIPTION
## Summary

Action words like 'ekle' are now accepted as confirmation.

## Problem

When confirmation is asked, 'ekle' was not recognized:
```
> bugün saat beşe toplantı koy
'toplantı' 17:00 için eklensin mi?
> ekle
'toplantı' 17:00 için eklensin mi?  ← Didn't accept!
```

## Solution

Added action words to confirmation tokens:
- `ekle` (add)
- `yap` (do)
- `koy` (put)
- `kaydet` (save)

Also works with elongated versions: `ekleee`, `yappp`

## Tests
- 11 new tests in `test_elongated_confirmation.py`

Closes #316