### PR TITLE
feat(brain): Add Turkish time parsing v1 (#229)

### DIFF
--- a/src/bantz/brain/turkish_time.py
+++ b/src/bantz/brain/turkish_time.py
@@ -1,0 +1,514 @@
+"""Turkish Time Window Parsing (Issue #229).
+
+This module provides Turkish natural language time parsing for:
+- "önümüzdeki X saat" (next X hours)
+- "bu akşam" (this evening)
+- "yarın" (tomorrow)
+- "yarın sabah" (tomorrow morning)
+- "bu hafta" (this week)
+- "öğle" (noon)
+- Relative time expressions
+
+All outputs are timezone-aware RFC3339 datetime strings.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, time, timedelta, tzinfo
+from typing import Any, Optional, Tuple, Union
+
+try:
+    import zoneinfo
+    ZoneInfo = zoneinfo.ZoneInfo
+except ImportError:
+    # Python 3.8 fallback
+    try:
+        from backports import zoneinfo  # type: ignore
+        ZoneInfo = zoneinfo.ZoneInfo
+    except ImportError:
+        ZoneInfo = None  # type: ignore
+
+
+# Turkish word to number mapping
+TURKISH_NUMBERS: dict[str, int] = {
+    "bir": 1, "iki": 2, "üç": 3, "dört": 4, "beş": 5,
+    "altı": 6, "yedi": 7, "sekiz": 8, "dokuz": 9, "on": 10,
+    "onbir": 11, "oniki": 12, "yarım": 0,  # yarım saat = 30 min
+}
+
+# Turkish time period definitions (start_hour, end_hour)
+TIME_PERIODS: dict[str, tuple[int, int]] = {
+    "sabah": (6, 12),      # Morning: 06:00-12:00
+    "öğle": (12, 14),      # Noon: 12:00-14:00
+    "öğleden_sonra": (14, 18),  # Afternoon: 14:00-18:00
+    "akşam": (18, 22),     # Evening: 18:00-22:00
+    "gece": (22, 6),       # Night: 22:00-06:00
+}
+
+
+def get_timezone(tz: Optional[Union[str, tzinfo]] = None) -> tzinfo:
+    """Get timezone object from string or tzinfo."""
+    if tz is None:
+        # Default to UTC if no timezone provided
+        if ZoneInfo is not None:
+            return ZoneInfo("UTC")
+        from datetime import timezone
+        return timezone.utc
+    
+    if isinstance(tz, tzinfo):
+        return tz
+    
+    if isinstance(tz, str):
+        if ZoneInfo is not None:
+            try:
+                return ZoneInfo(tz)
+            except Exception:
+                pass
+        # Fallback to UTC for unknown strings
+        from datetime import timezone
+        return timezone.utc
+    
+    from datetime import timezone
+    return timezone.utc
+
+
+def parse_time_window_tr(
+    text: str,
+    now: Optional[datetime] = None,
+    tz: Optional[Union[str, tzinfo]] = None,
+) -> Optional[dict[str, Any]]:
+    """Parse Turkish natural language time expression to time window.
+    
+    Args:
+        text: Turkish time expression (e.g., "yarın akşam", "önümüzdeki 2 saat")
+        now: Reference datetime (defaults to current time)
+        tz: Timezone (string like "Europe/Istanbul" or tzinfo object)
+        
+    Returns:
+        Dict with:
+            - start: RFC3339 datetime string
+            - end: RFC3339 datetime string  
+            - hint: Original time hint (e.g., "tomorrow_evening")
+            - confidence: Parsing confidence 0.0-1.0
+        Or None if no time expression found.
+    
+    Examples:
+        >>> parse_time_window_tr("yarın sabah", tz="Europe/Istanbul")
+        {"start": "2024-01-16T06:00:00+03:00", "end": "2024-01-16T12:00:00+03:00", ...}
+        
+        >>> parse_time_window_tr("önümüzdeki 3 saat", tz="Europe/Istanbul")
+        {"start": "2024-01-15T14:00:00+03:00", "end": "2024-01-15T17:00:00+03:00", ...}
+    """
+    if not text:
+        return None
+    
+    text = text.lower().strip()
+    timezone_obj = get_timezone(tz)
+    
+    if now is None:
+        now = datetime.now(timezone_obj)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone_obj)
+    
+    # Try each pattern in order of specificity
+    parsers = [
+        _parse_next_n_hours,
+        _parse_tomorrow_period,
+        _parse_today_period,
+        _parse_this_week,
+        _parse_specific_day,
+        _parse_relative_period,
+    ]
+    
+    for parser in parsers:
+        result = parser(text, now, timezone_obj)
+        if result is not None:
+            return result
+    
+    return None
+
+
+def _parse_next_n_hours(
+    text: str, 
+    now: datetime, 
+    tz: tzinfo,
+) -> Optional[dict[str, Any]]:
+    """Parse 'önümüzdeki X saat' pattern."""
+    
+    # Pattern: önümüzdeki/sonraki + number + saat/dakika
+    patterns = [
+        r"önümüzdeki\s+(\d+)\s*saat",
+        r"sonraki\s+(\d+)\s*saat",
+        r"önümüzdeki\s+(\w+)\s*saat",
+        r"sonraki\s+(\w+)\s*saat",
+        r"(\d+)\s*saat\s*içinde",
+        r"(\w+)\s*saat\s*içinde",
+        r"önümüzdeki\s+(\d+)\s*dakika",
+        r"(\d+)\s*dakika\s*içinde",
+        r"yarım\s*saat\s*içinde",
+        r"önümüzdeki\s+yarım\s*saat",
+    ]
+    
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            # Handle "yarım saat" (half hour)
+            if "yarım" in pattern or "yarım" in text:
+                minutes = 30
+                hours = 0
+            elif match.groups():
+                num_str = match.group(1)
+                # Try parsing as integer
+                try:
+                    num = int(num_str)
+                except ValueError:
+                    # Try Turkish word
+                    num = TURKISH_NUMBERS.get(num_str.lower())
+                    if num is None:
+                        continue
+                
+                if "dakika" in pattern:
+                    minutes = num
+                    hours = 0
+                else:
+                    hours = num
+                    minutes = 0
+            else:
+                continue
+            
+            start = now.replace(second=0, microsecond=0)
+            delta = timedelta(hours=hours, minutes=minutes)
+            end = start + delta
+            
+            return {
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+                "hint": f"next_{hours}h_{minutes}m" if minutes else f"next_{hours}h",
+                "confidence": 0.9,
+            }
+    
+    return None
+
+
+def _parse_tomorrow_period(
+    text: str, 
+    now: datetime, 
+    tz: tzinfo,
+) -> Optional[dict[str, Any]]:
+    """Parse 'yarın' with optional period."""
+    
+    if "yarın" not in text:
+        return None
+    
+    tomorrow = now.date() + timedelta(days=1)
+    
+    # Check for period qualifiers
+    if "sabah" in text:
+        start_hour, end_hour = TIME_PERIODS["sabah"]
+        hint = "tomorrow_morning"
+    elif "öğle" in text:
+        start_hour, end_hour = TIME_PERIODS["öğle"]
+        hint = "tomorrow_noon"
+    elif "öğleden sonra" in text or "öğleden_sonra" in text:
+        start_hour, end_hour = TIME_PERIODS["öğleden_sonra"]
+        hint = "tomorrow_afternoon"
+    elif "akşam" in text:
+        start_hour, end_hour = TIME_PERIODS["akşam"]
+        hint = "tomorrow_evening"
+    elif "gece" in text:
+        start_hour, end_hour = TIME_PERIODS["gece"]
+        hint = "tomorrow_night"
+    else:
+        # Default: whole day
+        start_hour, end_hour = 0, 24
+        hint = "tomorrow"
+    
+    # Handle night period (crosses midnight)
+    if start_hour > end_hour:
+        start_dt = datetime.combine(tomorrow, time(start_hour, 0), tzinfo=tz)
+        end_dt = datetime.combine(tomorrow + timedelta(days=1), time(end_hour, 0), tzinfo=tz)
+    else:
+        start_dt = datetime.combine(tomorrow, time(start_hour, 0), tzinfo=tz)
+        if end_hour == 24:
+            end_dt = datetime.combine(tomorrow + timedelta(days=1), time(0, 0), tzinfo=tz)
+        else:
+            end_dt = datetime.combine(tomorrow, time(end_hour, 0), tzinfo=tz)
+    
+    return {
+        "start": start_dt.isoformat(),
+        "end": end_dt.isoformat(),
+        "hint": hint,
+        "confidence": 0.85,
+    }
+
+
+def _parse_today_period(
+    text: str, 
+    now: datetime, 
+    tz: tzinfo,
+) -> Optional[dict[str, Any]]:
+    """Parse 'bugün' or 'bu akşam/sabah' patterns."""
+    
+    today = now.date()
+    
+    # Check for "bu akşam"
+    if "bu akşam" in text or (text.strip() == "akşam"):
+        start_hour, end_hour = TIME_PERIODS["akşam"]
+        start_dt = datetime.combine(today, time(start_hour, 0), tzinfo=tz)
+        end_dt = datetime.combine(today, time(end_hour, 0), tzinfo=tz)
+        return {
+            "start": start_dt.isoformat(),
+            "end": end_dt.isoformat(),
+            "hint": "evening",
+            "confidence": 0.9,
+        }
+    
+    # Check for "bu sabah"
+    if "bu sabah" in text or (text.strip() == "sabah"):
+        start_hour, end_hour = TIME_PERIODS["sabah"]
+        start_dt = datetime.combine(today, time(start_hour, 0), tzinfo=tz)
+        end_dt = datetime.combine(today, time(end_hour, 0), tzinfo=tz)
+        return {
+            "start": start_dt.isoformat(),
+            "end": end_dt.isoformat(),
+            "hint": "morning",
+            "confidence": 0.9,
+        }
+    
+    # Check for "öğle"/"öğlen"
+    if "öğle" in text or "öğlen" in text:
+        start_hour, end_hour = TIME_PERIODS["öğle"]
+        start_dt = datetime.combine(today, time(start_hour, 0), tzinfo=tz)
+        end_dt = datetime.combine(today, time(end_hour, 0), tzinfo=tz)
+        return {
+            "start": start_dt.isoformat(),
+            "end": end_dt.isoformat(),
+            "hint": "noon",
+            "confidence": 0.85,
+        }
+    
+    # Check for "bugün"
+    if "bugün" in text:
+        start_dt = datetime.combine(today, time(0, 0), tzinfo=tz)
+        end_dt = datetime.combine(today + timedelta(days=1), time(0, 0), tzinfo=tz)
+        return {
+            "start": start_dt.isoformat(),
+            "end": end_dt.isoformat(),
+            "hint": "today",
+            "confidence": 0.8,
+        }
+    
+    return None
+
+
+def _parse_this_week(
+    text: str, 
+    now: datetime, 
+    tz: tzinfo,
+) -> Optional[dict[str, Any]]:
+    """Parse 'bu hafta' pattern."""
+    
+    if "bu hafta" not in text and "hafta içi" not in text:
+        return None
+    
+    today = now.date()
+    
+    if "hafta içi" in text:
+        # Weekdays only (Mon-Fri)
+        # Find next Monday if already past
+        days_until_monday = (7 - today.weekday()) % 7
+        if days_until_monday == 0 and today.weekday() == 0:
+            monday = today
+        elif today.weekday() < 5:  # Currently weekday
+            monday = today - timedelta(days=today.weekday())
+        else:  # Weekend
+            days_until_monday = (7 - today.weekday()) % 7
+            monday = today + timedelta(days=days_until_monday)
+        
+        friday = monday + timedelta(days=4)
+        start_dt = datetime.combine(monday, time(0, 0), tzinfo=tz)
+        end_dt = datetime.combine(friday + timedelta(days=1), time(0, 0), tzinfo=tz)
+        hint = "weekdays"
+    else:
+        # This week (Sun/Mon to Sat/Sun depending on locale)
+        # Use Monday as week start
+        monday = today - timedelta(days=today.weekday())
+        sunday = monday + timedelta(days=6)
+        start_dt = datetime.combine(monday, time(0, 0), tzinfo=tz)
+        end_dt = datetime.combine(sunday + timedelta(days=1), time(0, 0), tzinfo=tz)
+        hint = "week"
+    
+    return {
+        "start": start_dt.isoformat(),
+        "end": end_dt.isoformat(),
+        "hint": hint,
+        "confidence": 0.8,
+    }
+
+
+def _parse_specific_day(
+    text: str, 
+    now: datetime, 
+    tz: tzinfo,
+) -> Optional[dict[str, Any]]:
+    """Parse specific day names like 'pazartesi', 'salı', etc."""
+    
+    # Turkish day names to weekday number (0=Monday)
+    # Sorted by length descending to match longer names first (cumartesi before cuma)
+    day_names = [
+        ("cumartesi", 5),
+        ("pazartesi", 0),
+        ("perşembe", 3),
+        ("çarşamba", 2),
+        ("pazar", 6),
+        ("salı", 1),
+        ("cuma", 4),
+    ]
+    
+    today = now.date()
+    
+    for day_name, weekday in day_names:
+        if day_name in text:
+            # Calculate days until that weekday
+            days_ahead = weekday - today.weekday()
+            if days_ahead <= 0:  # Target day already passed this week
+                days_ahead += 7
+            
+            target_date = today + timedelta(days=days_ahead)
+            
+            # Check for period qualifier
+            if "sabah" in text:
+                start_hour, end_hour = TIME_PERIODS["sabah"]
+                hint = f"{day_name}_morning"
+            elif "akşam" in text:
+                start_hour, end_hour = TIME_PERIODS["akşam"]
+                hint = f"{day_name}_evening"
+            else:
+                start_hour, end_hour = 0, 24
+                hint = day_name
+            
+            start_dt = datetime.combine(target_date, time(start_hour, 0), tzinfo=tz)
+            if end_hour == 24:
+                end_dt = datetime.combine(target_date + timedelta(days=1), time(0, 0), tzinfo=tz)
+            else:
+                end_dt = datetime.combine(target_date, time(end_hour, 0), tzinfo=tz)
+            
+            return {
+                "start": start_dt.isoformat(),
+                "end": end_dt.isoformat(),
+                "hint": hint,
+                "confidence": 0.85,
+            }
+    
+    return None
+
+
+def _parse_relative_period(
+    text: str, 
+    now: datetime, 
+    tz: tzinfo,
+) -> Optional[dict[str, Any]]:
+    """Parse relative periods like 'birazdan', 'az sonra', etc."""
+    
+    # birazdan, az sonra -> next 30 minutes
+    if any(p in text for p in ["birazdan", "az sonra", "biraz sonra"]):
+        start = now.replace(second=0, microsecond=0)
+        end = start + timedelta(minutes=30)
+        return {
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "hint": "soon",
+            "confidence": 0.7,
+        }
+    
+    # şimdi -> next 15 minutes
+    if text.strip() == "şimdi" or "şu an" in text:
+        start = now.replace(second=0, microsecond=0)
+        end = start + timedelta(minutes=15)
+        return {
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "hint": "now",
+            "confidence": 0.75,
+        }
+    
+    # daha sonra, sonra -> next 2 hours
+    if text.strip() == "sonra" or text.strip() == "daha sonra":
+        start = now.replace(second=0, microsecond=0)
+        end = start + timedelta(hours=2)
+        return {
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "hint": "later",
+            "confidence": 0.6,
+        }
+    
+    return None
+
+
+def parse_duration_tr(text: str) -> Optional[int]:
+    """Parse Turkish duration expression to minutes.
+    
+    Args:
+        text: Duration text (e.g., "1 saat", "30 dakika", "bir buçuk saat")
+        
+    Returns:
+        Duration in minutes, or None if not parseable.
+    """
+    if not text:
+        return None
+    
+    text = text.lower().strip()
+    total_minutes = 0
+    has_hours = False
+    
+    # Hour patterns
+    hour_patterns = [
+        r"(\d+)\s*saat",
+        r"(bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz|on|onbir|oniki)\s*(?:buçuk\s*)?saat",
+    ]
+    
+    for pattern in hour_patterns:
+        match = re.search(pattern, text)
+        if match:
+            num_str = match.group(1)
+            try:
+                hours = int(num_str)
+            except ValueError:
+                hours = TURKISH_NUMBERS.get(num_str, 0)
+            total_minutes += hours * 60
+            has_hours = True
+            break
+    
+    # Check for "buçuk" with implied hour (e.g., "bir buçuk saat" = 1.5 hours)
+    # If "buçuk" appears with "saat" but no explicit hour, assume 0.5
+    if "buçuk" in text and "saat" in text and not has_hours:
+        # Just "buçuk saat" without number = 0.5 hours (30 min)
+        total_minutes += 30
+    elif "buçuk" in text and has_hours:
+        # "X buçuk saat" = X + 0.5 hours
+        total_minutes += 30
+    
+    # Minute patterns
+    minute_patterns = [
+        r"(\d+)\s*dakika",
+        r"(bir|iki|üç|dört|beş|altı|yedi|sekiz|dokuz|on)\s*dakika",
+    ]
+    
+    for pattern in minute_patterns:
+        match = re.search(pattern, text)
+        if match:
+            num_str = match.group(1)
+            try:
+                minutes = int(num_str)
+            except ValueError:
+                minutes = TURKISH_NUMBERS.get(num_str, 0)
+            total_minutes += minutes
+            break
+    
+    # "yarım saat" = 30 minutes (but not if we already counted buçuk)
+    if "yarım" in text and "buçuk" not in text:
+        total_minutes += 30
+    
+    return total_minutes if total_minutes > 0 else None

--- a/tests/test_turkish_time_parsing.py
+++ b/tests/test_turkish_time_parsing.py
@@ -1,0 +1,402 @@
+"""Tests for Issue #229: Turkish Time Parsing v1.
+
+Comprehensive tests for Turkish natural language time expressions.
+30+ golden tests as specified in the issue.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from bantz.brain.turkish_time import (
+    TURKISH_NUMBERS,
+    TIME_PERIODS,
+    get_timezone,
+    parse_duration_tr,
+    parse_time_window_tr,
+)
+
+
+# Timezone for testing
+TZ_ISTANBUL = "Europe/Istanbul"
+
+
+class TestGetTimezone:
+    """Tests for get_timezone helper."""
+
+    def test_string_timezone(self) -> None:
+        """String timezone should be converted."""
+        tz = get_timezone("Europe/Istanbul")
+        assert tz is not None
+        assert "Istanbul" in str(tz) or "Turkey" in str(tz) or tz is not None
+
+    def test_none_returns_utc(self) -> None:
+        """None should return UTC."""
+        tz = get_timezone(None)
+        assert tz is not None
+
+    def test_tzinfo_passthrough(self) -> None:
+        """tzinfo object should pass through."""
+        from datetime import timezone
+        utc = timezone.utc
+        tz = get_timezone(utc)
+        assert tz is utc
+
+
+class TestParseNextNHours:
+    """Tests for 'önümüzdeki X saat' patterns."""
+
+    @pytest.fixture
+    def now(self) -> datetime:
+        """Fixed reference time for testing."""
+        tz = get_timezone(TZ_ISTANBUL)
+        return datetime(2024, 1, 15, 14, 0, 0, tzinfo=tz)
+
+    def test_next_2_hours_numeric(self, now: datetime) -> None:
+        """'önümüzdeki 2 saat' should parse."""
+        result = parse_time_window_tr("önümüzdeki 2 saat", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "next_2h" in result["hint"]
+        assert result["confidence"] >= 0.8
+
+    def test_next_3_hours_word(self, now: datetime) -> None:
+        """'önümüzdeki üç saat' should parse."""
+        result = parse_time_window_tr("önümüzdeki üç saat", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "3h" in result["hint"]
+
+    def test_sonraki_5_saat(self, now: datetime) -> None:
+        """'sonraki 5 saat' should parse."""
+        result = parse_time_window_tr("sonraki 5 saat", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "5h" in result["hint"]
+
+    def test_3_saat_icinde(self, now: datetime) -> None:
+        """'3 saat içinde' should parse."""
+        result = parse_time_window_tr("3 saat içinde", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "3h" in result["hint"]
+
+    def test_yarim_saat(self, now: datetime) -> None:
+        """'yarım saat içinde' should parse."""
+        result = parse_time_window_tr("yarım saat içinde", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "30m" in result["hint"] or "0h_30m" in result["hint"]
+
+    def test_30_dakika_icinde(self, now: datetime) -> None:
+        """'30 dakika içinde' should parse."""
+        result = parse_time_window_tr("30 dakika içinde", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        # Should have 30 minute window
+
+
+class TestParseTomorrowPeriod:
+    """Tests for 'yarın' patterns."""
+
+    @pytest.fixture
+    def now(self) -> datetime:
+        """Fixed reference time for testing."""
+        tz = get_timezone(TZ_ISTANBUL)
+        return datetime(2024, 1, 15, 14, 0, 0, tzinfo=tz)
+
+    def test_yarin_alone(self, now: datetime) -> None:
+        """'yarın' alone should be whole day."""
+        result = parse_time_window_tr("yarın", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "tomorrow"
+        # Should be Jan 16th
+        assert "2024-01-16" in result["start"]
+
+    def test_yarin_sabah(self, now: datetime) -> None:
+        """'yarın sabah' should be morning window."""
+        result = parse_time_window_tr("yarın sabah", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "tomorrow_morning"
+        # Morning: 06:00-12:00
+        assert "T06:00" in result["start"]
+        assert "T12:00" in result["end"]
+
+    def test_yarin_aksam(self, now: datetime) -> None:
+        """'yarın akşam' should be evening window."""
+        result = parse_time_window_tr("yarın akşam", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "tomorrow_evening"
+        # Evening: 18:00-22:00
+        assert "T18:00" in result["start"]
+        assert "T22:00" in result["end"]
+
+    def test_yarin_ogle(self, now: datetime) -> None:
+        """'yarın öğle' should be noon window."""
+        result = parse_time_window_tr("yarın öğle", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "tomorrow_noon"
+
+    def test_yarin_gece(self, now: datetime) -> None:
+        """'yarın gece' should be night window."""
+        result = parse_time_window_tr("yarın gece", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "tomorrow_night"
+
+
+class TestParseTodayPeriod:
+    """Tests for 'bugün' and 'bu akşam' patterns."""
+
+    @pytest.fixture
+    def now(self) -> datetime:
+        """Fixed reference time for testing."""
+        tz = get_timezone(TZ_ISTANBUL)
+        return datetime(2024, 1, 15, 14, 0, 0, tzinfo=tz)
+
+    def test_bugun(self, now: datetime) -> None:
+        """'bugün' should be whole day."""
+        result = parse_time_window_tr("bugün", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "today"
+        assert "2024-01-15" in result["start"]
+
+    def test_bu_aksam(self, now: datetime) -> None:
+        """'bu akşam' should be evening window."""
+        result = parse_time_window_tr("bu akşam", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "evening"
+        assert "T18:00" in result["start"]
+
+    def test_bu_sabah(self, now: datetime) -> None:
+        """'bu sabah' should be morning window."""
+        result = parse_time_window_tr("bu sabah", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "morning"
+
+    def test_aksam_alone(self, now: datetime) -> None:
+        """'akşam' alone should be evening."""
+        result = parse_time_window_tr("akşam", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "evening"
+
+    def test_ogle(self, now: datetime) -> None:
+        """'öğle' should be noon window."""
+        result = parse_time_window_tr("öğle", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "noon"
+
+    def test_oglen(self, now: datetime) -> None:
+        """'öğlen' (alternative spelling) should be noon."""
+        result = parse_time_window_tr("öğlen", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "noon"
+
+
+class TestParseThisWeek:
+    """Tests for 'bu hafta' patterns."""
+
+    @pytest.fixture
+    def now(self) -> datetime:
+        """Fixed reference time (Monday)."""
+        tz = get_timezone(TZ_ISTANBUL)
+        # Jan 15, 2024 is a Monday
+        return datetime(2024, 1, 15, 14, 0, 0, tzinfo=tz)
+
+    def test_bu_hafta(self, now: datetime) -> None:
+        """'bu hafta' should be whole week."""
+        result = parse_time_window_tr("bu hafta", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "week"
+
+    def test_hafta_ici(self, now: datetime) -> None:
+        """'hafta içi' should be weekdays."""
+        result = parse_time_window_tr("hafta içi", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "weekdays"
+
+
+class TestParseSpecificDay:
+    """Tests for specific day names."""
+
+    @pytest.fixture
+    def now(self) -> datetime:
+        """Fixed reference time (Monday Jan 15)."""
+        tz = get_timezone(TZ_ISTANBUL)
+        return datetime(2024, 1, 15, 14, 0, 0, tzinfo=tz)
+
+    def test_pazartesi(self, now: datetime) -> None:
+        """'pazartesi' should find next Monday."""
+        result = parse_time_window_tr("pazartesi", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        # Since today is Monday, should be next Monday
+        assert "pazartesi" in result["hint"]
+
+    def test_cuma(self, now: datetime) -> None:
+        """'cuma' should find Friday."""
+        result = parse_time_window_tr("cuma", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "cuma" in result["hint"]
+        # From Monday, Friday is 4 days away
+        assert "2024-01-19" in result["start"]
+
+    def test_cumartesi_sabah(self, now: datetime) -> None:
+        """'cumartesi sabah' should be Saturday morning."""
+        result = parse_time_window_tr("cumartesi sabah", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "cumartesi_morning" in result["hint"]
+        assert "T06:00" in result["start"]
+
+    def test_pazar_aksam(self, now: datetime) -> None:
+        """'pazar akşam' should be Sunday evening."""
+        result = parse_time_window_tr("pazar akşam", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert "pazar_evening" in result["hint"]
+
+
+class TestParseRelativePeriod:
+    """Tests for relative time expressions."""
+
+    @pytest.fixture
+    def now(self) -> datetime:
+        """Fixed reference time."""
+        tz = get_timezone(TZ_ISTANBUL)
+        return datetime(2024, 1, 15, 14, 0, 0, tzinfo=tz)
+
+    def test_birazdan(self, now: datetime) -> None:
+        """'birazdan' should be next ~30 minutes."""
+        result = parse_time_window_tr("birazdan", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "soon"
+
+    def test_az_sonra(self, now: datetime) -> None:
+        """'az sonra' should be soon."""
+        result = parse_time_window_tr("az sonra", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "soon"
+
+    def test_simdi(self, now: datetime) -> None:
+        """'şimdi' should be now."""
+        result = parse_time_window_tr("şimdi", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "now"
+
+    def test_su_an(self, now: datetime) -> None:
+        """'şu an' should be now."""
+        result = parse_time_window_tr("şu an", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "now"
+
+    def test_daha_sonra(self, now: datetime) -> None:
+        """'daha sonra' should be later."""
+        result = parse_time_window_tr("daha sonra", now=now, tz=TZ_ISTANBUL)
+        assert result is not None
+        assert result["hint"] == "later"
+
+
+class TestParseDuration:
+    """Tests for parse_duration_tr function."""
+
+    def test_1_saat(self) -> None:
+        """'1 saat' should be 60 minutes."""
+        assert parse_duration_tr("1 saat") == 60
+
+    def test_2_saat(self) -> None:
+        """'2 saat' should be 120 minutes."""
+        assert parse_duration_tr("2 saat") == 120
+
+    def test_bir_saat(self) -> None:
+        """'bir saat' should be 60 minutes."""
+        assert parse_duration_tr("bir saat") == 60
+
+    def test_30_dakika(self) -> None:
+        """'30 dakika' should be 30 minutes."""
+        assert parse_duration_tr("30 dakika") == 30
+
+    def test_yarim_saat(self) -> None:
+        """'yarım saat' should be 30 minutes."""
+        assert parse_duration_tr("yarım saat") == 30
+
+    def test_bir_bucuk_saat(self) -> None:
+        """'bir buçuk saat' should be 90 minutes."""
+        assert parse_duration_tr("bir buçuk saat") == 90
+
+    def test_1_saat_30_dakika(self) -> None:
+        """'1 saat 30 dakika' should be 90 minutes."""
+        assert parse_duration_tr("1 saat 30 dakika") == 90
+
+    def test_empty_returns_none(self) -> None:
+        """Empty string should return None."""
+        assert parse_duration_tr("") is None
+
+    def test_invalid_returns_none(self) -> None:
+        """Invalid text should return None."""
+        assert parse_duration_tr("hello world") is None
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_empty_text(self) -> None:
+        """Empty text should return None."""
+        assert parse_time_window_tr("") is None
+        assert parse_time_window_tr(None) is None  # type: ignore
+
+    def test_no_time_expression(self) -> None:
+        """Text without time expression should return None."""
+        result = parse_time_window_tr("merhaba nasılsın", tz=TZ_ISTANBUL)
+        assert result is None
+
+    def test_now_defaults_to_current(self) -> None:
+        """When now is None, should use current time."""
+        result = parse_time_window_tr("yarın", tz=TZ_ISTANBUL)
+        assert result is not None
+        # Just verify it parsed without error
+
+    def test_confidence_varies(self) -> None:
+        """Different patterns should have different confidence."""
+        tz = get_timezone(TZ_ISTANBUL)
+        now = datetime(2024, 1, 15, 14, 0, 0, tzinfo=tz)
+        
+        # High confidence
+        r1 = parse_time_window_tr("bu akşam", now=now, tz=TZ_ISTANBUL)
+        # Lower confidence  
+        r2 = parse_time_window_tr("daha sonra", now=now, tz=TZ_ISTANBUL)
+        
+        assert r1 is not None and r2 is not None
+        assert r1["confidence"] > r2["confidence"]
+
+
+class TestTurkishNumbers:
+    """Tests for Turkish number mapping."""
+
+    def test_numbers_mapping(self) -> None:
+        """Turkish numbers should map correctly."""
+        assert TURKISH_NUMBERS["bir"] == 1
+        assert TURKISH_NUMBERS["iki"] == 2
+        assert TURKISH_NUMBERS["üç"] == 3
+        assert TURKISH_NUMBERS["dört"] == 4
+        assert TURKISH_NUMBERS["beş"] == 5
+        assert TURKISH_NUMBERS["altı"] == 6
+        assert TURKISH_NUMBERS["yedi"] == 7
+        assert TURKISH_NUMBERS["sekiz"] == 8
+        assert TURKISH_NUMBERS["dokuz"] == 9
+        assert TURKISH_NUMBERS["on"] == 10
+
+
+class TestTimePeriods:
+    """Tests for time period definitions."""
+
+    def test_sabah_period(self) -> None:
+        """Morning should be 06:00-12:00."""
+        start, end = TIME_PERIODS["sabah"]
+        assert start == 6
+        assert end == 12
+
+    def test_aksam_period(self) -> None:
+        """Evening should be 18:00-22:00."""
+        start, end = TIME_PERIODS["akşam"]
+        assert start == 18
+        assert end == 22
+
+    def test_ogle_period(self) -> None:
+        """Noon should be 12:00-14:00."""
+        start, end = TIME_PERIODS["öğle"]
+        assert start == 12
+        assert end == 14


### PR DESCRIPTION
## Summary
Adds comprehensive Turkish natural language time parsing module.

## Features
- `parse_time_window_tr()`: Parse time expressions to RFC3339 windows
- `parse_duration_tr()`: Parse duration expressions to minutes

## Supported Patterns
- **Relative hours**: önümüzdeki X saat, sonraki 3 saat, 2 saat içinde
- **Today**: bugün, bu akşam, bu sabah, öğle
- **Tomorrow**: yarın, yarın sabah, yarın akşam
- **This week**: bu hafta, hafta içi
- **Specific days**: pazartesi, salı, çarşamba, perşembe, cuma, cumartesi, pazar
- **Relative**: birazdan, şimdi, daha sonra
- **Durations**: 1 saat, 30 dakika, bir buçuk saat, yarım saat

## Tests
- 48 comprehensive tests covering all patterns
- Golden examples for each pattern type

## Issue
Closes #229