### PR TITLE
feat(router): add misroute collection + replay tool (#238)

### DIFF
--- a/scripts/replay_router.py
+++ b/scripts/replay_router.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Replay Router Misroutes.
+
+Issue #238: Replay misroute dataset through router for accuracy testing.
+
+Usage:
+    python scripts/replay_router.py                    # Replay all
+    python scripts/replay_router.py --limit 50         # Replay first 50
+    python scripts/replay_router.py --stats            # Show stats only
+    python scripts/replay_router.py --export out.json  # Export dataset
+    python scripts/replay_router.py --format json      # Output as JSON
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bantz.router.misroute_collector import (
+    DEFAULT_DATASET_PATH,
+    MisrouteDataset,
+    ReplaySummary,
+    get_dataset_stats,
+    replay_dataset,
+)
+
+
+# ============================================================================
+# MOCK ROUTER (for testing without vLLM)
+# ============================================================================
+
+def mock_router(user_text: str) -> dict:
+    """Simple mock router for testing replay without LLM.
+    
+    This is a pattern-matching fallback router.
+    """
+    text = user_text.lower().strip()
+    
+    # Calendar patterns
+    if any(w in text for w in ["takvim", "etkinlik", "toplantı", "randevu", "bugün", "yarın"]):
+        if any(w in text for w in ["ekle", "oluştur", "ayarla"]):
+            return {"route": "calendar", "intent": "create", "slots": {}, "confidence": 0.7}
+        else:
+            return {"route": "calendar", "intent": "query", "slots": {}, "confidence": 0.7}
+    
+    # Gmail patterns
+    if any(w in text for w in ["mail", "e-posta", "email", "inbox"]):
+        if any(w in text for w in ["gönder", "yaz"]):
+            return {"route": "gmail", "intent": "send", "slots": {}, "confidence": 0.7}
+        else:
+            return {"route": "gmail", "intent": "read", "slots": {}, "confidence": 0.7}
+    
+    # System patterns
+    if any(w in text for w in ["saat", "tarih", "cpu", "ram", "sistem"]):
+        return {"route": "system", "intent": "query", "slots": {}, "confidence": 0.8}
+    
+    # Smalltalk patterns
+    if any(w in text for w in ["merhaba", "selam", "nasılsın", "günaydın", "iyi geceler"]):
+        return {"route": "smalltalk", "intent": "greeting", "slots": {}, "confidence": 0.9}
+    
+    return {"route": "unknown", "intent": "fallback", "slots": {}, "confidence": 0.3}
+
+
+# ============================================================================
+# vLLM ROUTER (actual router)
+# ============================================================================
+
+def create_vllm_router() -> Optional[callable]:
+    """Create vLLM router function if available."""
+    try:
+        from bantz.brain.llm_router import JarvisLLMOrchestrator
+        
+        # Check if vLLM is running
+        import requests
+        try:
+            resp = requests.get(
+                os.getenv("BANTZ_VLLM_BASE", "http://localhost:8001") + "/health",
+                timeout=2,
+            )
+            if resp.status_code != 200:
+                return None
+        except Exception:
+            return None
+        
+        # Create orchestrator
+        orchestrator = JarvisLLMOrchestrator()
+        
+        def router_fn(user_text: str) -> dict:
+            """Route using actual LLM."""
+            result = orchestrator.route(user_text)
+            return {
+                "route": result.get("route", "unknown"),
+                "intent": result.get("calendar_intent", result.get("intent", "")),
+                "slots": result.get("slots", {}),
+                "confidence": result.get("confidence", 0.0),
+            }
+        
+        return router_fn
+        
+    except ImportError:
+        return None
+
+
+# ============================================================================
+# MAIN
+# ============================================================================
+
+def show_stats(dataset_path: str, format_json: bool = False) -> None:
+    """Show dataset statistics."""
+    stats = get_dataset_stats(dataset_path)
+    
+    if format_json:
+        print(json.dumps(stats, indent=2, ensure_ascii=False))
+        return
+    
+    print("=" * 60)
+    print("Router Misroute Dataset Statistics")
+    print("=" * 60)
+    print(f"\nTotal Records: {stats['total']}")
+    
+    if stats["total"] == 0:
+        print("\nNo records in dataset yet.")
+        return
+    
+    print(f"\nTime Range:")
+    print(f"  First: {stats.get('first_record', 'N/A')}")
+    print(f"  Last:  {stats.get('last_record', 'N/A')}")
+    
+    print("\nBy Reason:")
+    for reason, count in sorted(stats.get("by_reason", {}).items(), key=lambda x: -x[1]):
+        pct = count / stats["total"] * 100
+        print(f"  {reason}: {count} ({pct:.1f}%)")
+    
+    print("\nBy Route:")
+    for route, count in sorted(stats.get("by_route", {}).items(), key=lambda x: -x[1]):
+        pct = count / stats["total"] * 100
+        print(f"  {route}: {count} ({pct:.1f}%)")
+    
+    print("\nBy Model:")
+    for model, count in sorted(stats.get("by_model", {}).items(), key=lambda x: -x[1]):
+        pct = count / stats["total"] * 100
+        print(f"  {model}: {count} ({pct:.1f}%)")
+
+
+def run_replay(
+    dataset_path: str,
+    use_mock: bool = False,
+    limit: Optional[int] = None,
+    format_json: bool = False,
+) -> None:
+    """Run replay and show results."""
+    
+    # Select router
+    if use_mock:
+        print("Using mock router (pattern matching)")
+        router_fn = mock_router
+    else:
+        router_fn = create_vllm_router()
+        if router_fn is None:
+            print("vLLM not available, falling back to mock router")
+            router_fn = mock_router
+        else:
+            print("Using vLLM router")
+    
+    # Run replay
+    print(f"\nReplaying dataset: {dataset_path}")
+    if limit:
+        print(f"Limit: {limit} records")
+    print("-" * 40)
+    
+    summary = replay_dataset(router_fn, dataset_path, limit)
+    
+    if format_json:
+        print(json.dumps(summary.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        print(summary.format_markdown())
+
+
+def export_dataset(dataset_path: str, output_path: str) -> None:
+    """Export dataset to JSON."""
+    dataset = MisrouteDataset(path=dataset_path, redact=False)
+    count = dataset.export_json(output_path)
+    print(f"Exported {count} records to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Replay router misroutes for accuracy testing",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    
+    parser.add_argument(
+        "--dataset",
+        default=DEFAULT_DATASET_PATH,
+        help=f"Path to misroute dataset (default: {DEFAULT_DATASET_PATH})",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Show dataset statistics only",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Limit number of records to replay",
+    )
+    parser.add_argument(
+        "--mock",
+        action="store_true",
+        help="Use mock router instead of vLLM",
+    )
+    parser.add_argument(
+        "--export",
+        metavar="PATH",
+        help="Export dataset to JSON file",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json", "markdown"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    
+    args = parser.parse_args()
+    format_json = args.format == "json"
+    
+    # Check dataset exists
+    dataset_path = args.dataset
+    if not Path(dataset_path).exists():
+        print(f"Dataset not found: {dataset_path}")
+        print("No misroutes have been logged yet.")
+        return 1
+    
+    # Handle commands
+    if args.export:
+        export_dataset(dataset_path, args.export)
+        return 0
+    
+    if args.stats:
+        show_stats(dataset_path, format_json)
+        return 0
+    
+    # Default: run replay
+    run_replay(
+        dataset_path=dataset_path,
+        use_mock=args.mock,
+        limit=args.limit,
+        format_json=format_json,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/src/bantz/router/misroute_collector.py
+++ b/src/bantz/router/misroute_collector.py
@@ -1,0 +1,648 @@
+"""Router Misroute Collection.
+
+Issue #238: Collect router misroutes/fallbacks for dataset improvement.
+
+This module provides:
+- JSONL logging of misroutes with PII redaction
+- Replay tool for testing router accuracy
+- Dataset management utilities
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterator, List, Literal, Optional
+
+from bantz.security.masking import DataMasker
+
+
+# ============================================================================
+# CONFIGURATION
+# ============================================================================
+
+DEFAULT_DATASET_PATH = os.getenv(
+    "BANTZ_MISROUTE_DATASET",
+    str(Path.home() / ".cache" / "bantz" / "datasets" / "router_misroutes.jsonl"),
+)
+
+
+# ============================================================================
+# DATA TYPES
+# ============================================================================
+
+MisrouteReason = Literal[
+    "wrong_route",      # Router chose wrong domain
+    "wrong_intent",     # Router chose wrong intent within domain
+    "missing_slot",     # Critical slot not extracted
+    "wrong_slot",       # Slot value incorrect
+    "fallback",         # Router returned fallback/unknown
+    "low_confidence",   # Confidence below threshold
+    "user_correction",  # User explicitly corrected
+    "other",            # Other misroute reason
+]
+
+
+@dataclass
+class MisrouteRecord:
+    """Record of a router misroute."""
+    
+    # Input
+    user_text: str
+    
+    # Router output
+    router_route: str
+    router_intent: str
+    router_slots: dict = field(default_factory=dict)
+    router_confidence: float = 0.0
+    router_raw_output: str = ""
+    
+    # Expected (if known from user correction)
+    expected_route: Optional[str] = None
+    expected_intent: Optional[str] = None
+    expected_slots: Optional[dict] = None
+    
+    # Metadata
+    reason: MisrouteReason = "other"
+    fallback_reason: Optional[str] = None
+    notes: str = ""
+    
+    # Timestamps
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    session_id: str = ""
+    
+    # Version tracking
+    model_name: str = ""
+    model_version: str = ""
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return asdict(self)
+    
+    @classmethod
+    def from_dict(cls, data: dict) -> "MisrouteRecord":
+        """Create from dictionary."""
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+# ============================================================================
+# PII MASKER
+# ============================================================================
+
+# Singleton masker for PII redaction
+_masker: Optional[DataMasker] = None
+
+
+def get_masker() -> DataMasker:
+    """Get or create the PII masker."""
+    global _masker
+    if _masker is None:
+        _masker = DataMasker()
+    return _masker
+
+
+def redact_pii(text: str) -> str:
+    """Redact PII from text using the masker."""
+    return get_masker().mask(text)
+
+
+def redact_record(record: MisrouteRecord) -> MisrouteRecord:
+    """Redact PII from all text fields in a record."""
+    return MisrouteRecord(
+        user_text=redact_pii(record.user_text),
+        router_route=record.router_route,
+        router_intent=record.router_intent,
+        router_slots={k: redact_pii(str(v)) if isinstance(v, str) else v 
+                      for k, v in record.router_slots.items()},
+        router_confidence=record.router_confidence,
+        router_raw_output=redact_pii(record.router_raw_output),
+        expected_route=record.expected_route,
+        expected_intent=record.expected_intent,
+        expected_slots={k: redact_pii(str(v)) if isinstance(v, str) else v 
+                        for k, v in (record.expected_slots or {}).items()},
+        reason=record.reason,
+        fallback_reason=record.fallback_reason,
+        notes=redact_pii(record.notes),
+        timestamp=record.timestamp,
+        session_id=record.session_id,
+        model_name=record.model_name,
+        model_version=record.model_version,
+    )
+
+
+# ============================================================================
+# DATASET WRITER
+# ============================================================================
+
+class MisrouteDataset:
+    """JSONL dataset for router misroutes."""
+    
+    def __init__(
+        self,
+        path: str = DEFAULT_DATASET_PATH,
+        redact: bool = True,
+    ):
+        """Initialize dataset.
+        
+        Args:
+            path: Path to JSONL file
+            redact: Whether to redact PII before writing
+        """
+        self.path = Path(path)
+        self.redact = redact
+        self._ensure_dir()
+    
+    def _ensure_dir(self) -> None:
+        """Ensure parent directory exists."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+    
+    def append(self, record: MisrouteRecord) -> None:
+        """Append a record to the dataset.
+        
+        Args:
+            record: Record to append (will be PII-redacted if self.redact)
+        """
+        if self.redact:
+            record = redact_record(record)
+        
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record.to_dict(), ensure_ascii=False) + "\n")
+    
+    def read_all(self) -> List[MisrouteRecord]:
+        """Read all records from dataset.
+        
+        Returns:
+            List of all records
+        """
+        records = []
+        if not self.path.exists():
+            return records
+        
+        with open(self.path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        data = json.loads(line)
+                        records.append(MisrouteRecord.from_dict(data))
+                    except json.JSONDecodeError:
+                        continue
+        
+        return records
+    
+    def iter_records(self) -> Iterator[MisrouteRecord]:
+        """Iterate over records without loading all into memory.
+        
+        Yields:
+            MisrouteRecord for each line
+        """
+        if not self.path.exists():
+            return
+        
+        with open(self.path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        data = json.loads(line)
+                        yield MisrouteRecord.from_dict(data)
+                    except json.JSONDecodeError:
+                        continue
+    
+    def count(self) -> int:
+        """Count records in dataset."""
+        if not self.path.exists():
+            return 0
+        
+        count = 0
+        with open(self.path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    count += 1
+        return count
+    
+    def clear(self) -> int:
+        """Clear all records. Returns number of records removed."""
+        count = self.count()
+        if self.path.exists():
+            self.path.unlink()
+        return count
+    
+    def export_json(self, output_path: str) -> int:
+        """Export to JSON array format.
+        
+        Args:
+            output_path: Path to output JSON file
+            
+        Returns:
+            Number of records exported
+        """
+        records = self.read_all()
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump([r.to_dict() for r in records], f, ensure_ascii=False, indent=2)
+        return len(records)
+
+
+# ============================================================================
+# LOGGING UTILITIES
+# ============================================================================
+
+# Global dataset instance
+_dataset: Optional[MisrouteDataset] = None
+
+
+def get_dataset() -> MisrouteDataset:
+    """Get or create the global dataset instance."""
+    global _dataset
+    if _dataset is None:
+        _dataset = MisrouteDataset()
+    return _dataset
+
+
+def log_misroute(
+    user_text: str,
+    router_route: str,
+    router_intent: str = "",
+    router_slots: Optional[dict] = None,
+    router_confidence: float = 0.0,
+    router_raw_output: str = "",
+    expected_route: Optional[str] = None,
+    expected_intent: Optional[str] = None,
+    expected_slots: Optional[dict] = None,
+    reason: MisrouteReason = "other",
+    fallback_reason: Optional[str] = None,
+    notes: str = "",
+    session_id: str = "",
+    model_name: str = "",
+    model_version: str = "",
+) -> MisrouteRecord:
+    """Log a misroute to the dataset.
+    
+    This is the main entry point for logging misroutes.
+    
+    Args:
+        user_text: Original user input
+        router_route: Route chosen by router
+        router_intent: Intent chosen by router
+        router_slots: Slots extracted by router
+        router_confidence: Router confidence score
+        router_raw_output: Raw router output (for debugging)
+        expected_route: Correct route (if known)
+        expected_intent: Correct intent (if known)
+        expected_slots: Correct slots (if known)
+        reason: Type of misroute
+        fallback_reason: Reason for fallback (if applicable)
+        notes: Additional notes
+        session_id: Session identifier
+        model_name: Model used
+        model_version: Model version
+        
+    Returns:
+        The logged record
+    """
+    record = MisrouteRecord(
+        user_text=user_text,
+        router_route=router_route,
+        router_intent=router_intent,
+        router_slots=router_slots or {},
+        router_confidence=router_confidence,
+        router_raw_output=router_raw_output,
+        expected_route=expected_route,
+        expected_intent=expected_intent,
+        expected_slots=expected_slots,
+        reason=reason,
+        fallback_reason=fallback_reason,
+        notes=notes,
+        session_id=session_id,
+        model_name=model_name,
+        model_version=model_version,
+    )
+    
+    get_dataset().append(record)
+    return record
+
+
+def log_fallback(
+    user_text: str,
+    fallback_reason: str,
+    router_raw_output: str = "",
+    session_id: str = "",
+    model_name: str = "",
+) -> MisrouteRecord:
+    """Convenience function for logging fallback events.
+    
+    Args:
+        user_text: Original user input
+        fallback_reason: Why fallback was triggered
+        router_raw_output: Raw output (if any)
+        session_id: Session identifier
+        model_name: Model used
+        
+    Returns:
+        The logged record
+    """
+    return log_misroute(
+        user_text=user_text,
+        router_route="unknown",
+        router_intent="fallback",
+        reason="fallback",
+        fallback_reason=fallback_reason,
+        router_raw_output=router_raw_output,
+        session_id=session_id,
+        model_name=model_name,
+    )
+
+
+def log_user_correction(
+    user_text: str,
+    router_route: str,
+    router_intent: str,
+    expected_route: str,
+    expected_intent: str = "",
+    router_slots: Optional[dict] = None,
+    expected_slots: Optional[dict] = None,
+    session_id: str = "",
+    model_name: str = "",
+) -> MisrouteRecord:
+    """Log when user explicitly corrects a routing decision.
+    
+    Args:
+        user_text: Original user input
+        router_route: Route chosen by router
+        router_intent: Intent chosen by router
+        expected_route: Correct route (from user)
+        expected_intent: Correct intent (from user)
+        router_slots: Slots extracted by router
+        expected_slots: Correct slots
+        session_id: Session identifier
+        model_name: Model used
+        
+    Returns:
+        The logged record
+    """
+    return log_misroute(
+        user_text=user_text,
+        router_route=router_route,
+        router_intent=router_intent,
+        router_slots=router_slots,
+        expected_route=expected_route,
+        expected_intent=expected_intent,
+        expected_slots=expected_slots,
+        reason="user_correction",
+        session_id=session_id,
+        model_name=model_name,
+    )
+
+
+# ============================================================================
+# REPLAY TYPES
+# ============================================================================
+
+@dataclass
+class ReplayResult:
+    """Result of replaying a single record."""
+    
+    record: MisrouteRecord
+    new_route: str
+    new_intent: str
+    new_slots: dict
+    new_confidence: float
+    
+    # Comparison
+    route_match: bool = False
+    intent_match: bool = False
+    improved: bool = False
+    regression: bool = False
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "user_text": self.record.user_text,
+            "original_route": self.record.router_route,
+            "new_route": self.new_route,
+            "expected_route": self.record.expected_route,
+            "route_match": self.route_match,
+            "improved": self.improved,
+            "regression": self.regression,
+        }
+
+
+@dataclass
+class ReplaySummary:
+    """Summary of replay run."""
+    
+    total: int = 0
+    improved: int = 0
+    regressed: int = 0
+    unchanged: int = 0
+    route_accuracy: float = 0.0
+    intent_accuracy: float = 0.0
+    
+    results: List[ReplayResult] = field(default_factory=list)
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "total": self.total,
+            "improved": self.improved,
+            "regressed": self.regressed,
+            "unchanged": self.unchanged,
+            "improvement_rate": self.improved / self.total if self.total > 0 else 0,
+            "regression_rate": self.regressed / self.total if self.total > 0 else 0,
+            "route_accuracy": self.route_accuracy,
+            "intent_accuracy": self.intent_accuracy,
+        }
+    
+    def format_markdown(self) -> str:
+        """Format as markdown report."""
+        lines = [
+            "# Router Replay Summary",
+            "",
+            f"**Total Records:** {self.total}",
+            f"**Improved:** {self.improved} ({self.improved/self.total*100:.1f}%)" if self.total else "**Improved:** 0",
+            f"**Regressed:** {self.regressed} ({self.regressed/self.total*100:.1f}%)" if self.total else "**Regressed:** 0",
+            f"**Unchanged:** {self.unchanged} ({self.unchanged/self.total*100:.1f}%)" if self.total else "**Unchanged:** 0",
+            "",
+            "## Accuracy",
+            f"- Route Accuracy: {self.route_accuracy*100:.1f}%",
+            f"- Intent Accuracy: {self.intent_accuracy*100:.1f}%",
+        ]
+        
+        # Show improvements
+        improved_results = [r for r in self.results if r.improved]
+        if improved_results:
+            lines.extend([
+                "",
+                "## Improvements",
+                "",
+            ])
+            for r in improved_results[:10]:
+                lines.append(f"- `{r.record.user_text[:50]}...` : {r.record.router_route} → {r.new_route}")
+        
+        # Show regressions
+        regressed_results = [r for r in self.results if r.regression]
+        if regressed_results:
+            lines.extend([
+                "",
+                "## Regressions",
+                "",
+            ])
+            for r in regressed_results[:10]:
+                lines.append(f"- `{r.record.user_text[:50]}...` : {r.record.router_route} → {r.new_route}")
+        
+        return "\n".join(lines)
+
+
+# ============================================================================
+# REPLAY FUNCTION
+# ============================================================================
+
+RouterFunction = Callable[[str], dict]
+
+
+def replay_dataset(
+    router_fn: RouterFunction,
+    dataset_path: str = DEFAULT_DATASET_PATH,
+    limit: Optional[int] = None,
+) -> ReplaySummary:
+    """Replay dataset through a router function.
+    
+    Args:
+        router_fn: Function that takes user_text and returns dict with
+                   route, intent, slots, confidence keys
+        dataset_path: Path to dataset JSONL
+        limit: Optional limit on number of records to replay
+        
+    Returns:
+        ReplaySummary with results
+    """
+    dataset = MisrouteDataset(path=dataset_path, redact=False)
+    records = dataset.read_all()
+    
+    if limit:
+        records = records[:limit]
+    
+    summary = ReplaySummary()
+    summary.total = len(records)
+    
+    route_correct = 0
+    intent_correct = 0
+    
+    for record in records:
+        try:
+            result = router_fn(record.user_text)
+            
+            new_route = result.get("route", "")
+            new_intent = result.get("intent", "")
+            new_slots = result.get("slots", {})
+            new_confidence = result.get("confidence", 0.0)
+            
+            # Determine expected route/intent
+            expected_route = record.expected_route or record.router_route
+            expected_intent = record.expected_intent or record.router_intent
+            
+            # Check matches
+            route_match = new_route == expected_route
+            intent_match = new_intent == expected_intent if expected_intent else True
+            
+            if route_match:
+                route_correct += 1
+            if intent_match:
+                intent_correct += 1
+            
+            # Determine improvement/regression
+            was_correct = record.router_route == expected_route
+            now_correct = route_match
+            
+            improved = not was_correct and now_correct
+            regressed = was_correct and not now_correct
+            
+            replay_result = ReplayResult(
+                record=record,
+                new_route=new_route,
+                new_intent=new_intent,
+                new_slots=new_slots,
+                new_confidence=new_confidence,
+                route_match=route_match,
+                intent_match=intent_match,
+                improved=improved,
+                regression=regressed,
+            )
+            
+            summary.results.append(replay_result)
+            
+            if improved:
+                summary.improved += 1
+            elif regressed:
+                summary.regressed += 1
+            else:
+                summary.unchanged += 1
+                
+        except Exception as e:
+            # Log error but continue
+            print(f"Error replaying record: {e}")
+            continue
+    
+    # Calculate accuracies
+    if summary.total > 0:
+        summary.route_accuracy = route_correct / summary.total
+        summary.intent_accuracy = intent_correct / summary.total
+    
+    return summary
+
+
+# ============================================================================
+# STATISTICS
+# ============================================================================
+
+def get_dataset_stats(dataset_path: str = DEFAULT_DATASET_PATH) -> dict:
+    """Get statistics about the misroute dataset.
+    
+    Args:
+        dataset_path: Path to dataset
+        
+    Returns:
+        Dictionary with statistics
+    """
+    dataset = MisrouteDataset(path=dataset_path, redact=False)
+    records = dataset.read_all()
+    
+    if not records:
+        return {
+            "total": 0,
+            "by_reason": {},
+            "by_route": {},
+            "by_model": {},
+        }
+    
+    # Count by reason
+    by_reason: dict[str, int] = {}
+    for r in records:
+        by_reason[r.reason] = by_reason.get(r.reason, 0) + 1
+    
+    # Count by route
+    by_route: dict[str, int] = {}
+    for r in records:
+        by_route[r.router_route] = by_route.get(r.router_route, 0) + 1
+    
+    # Count by model
+    by_model: dict[str, int] = {}
+    for r in records:
+        model = r.model_name or "unknown"
+        by_model[model] = by_model.get(model, 0) + 1
+    
+    # Time range
+    timestamps = [r.timestamp for r in records if r.timestamp]
+    
+    return {
+        "total": len(records),
+        "by_reason": by_reason,
+        "by_route": by_route,
+        "by_model": by_model,
+        "first_record": min(timestamps) if timestamps else None,
+        "last_record": max(timestamps) if timestamps else None,
+    }

--- a/tests/test_router_misroute.py
+++ b/tests/test_router_misroute.py
@@ -1,0 +1,635 @@
+"""Tests for Router Misroute Collector.
+
+Issue #238: Test misroute collection, PII redaction, and replay functionality.
+
+Test categories:
+1. MisrouteRecord dataclass
+2. PII redaction
+3. MisrouteDataset operations
+4. Logging utilities
+5. Replay functionality
+6. Statistics
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.router.misroute_collector import (
+    DEFAULT_DATASET_PATH,
+    MisrouteDataset,
+    MisrouteRecord,
+    ReplayResult,
+    ReplaySummary,
+    get_dataset_stats,
+    log_fallback,
+    log_misroute,
+    log_user_correction,
+    redact_pii,
+    redact_record,
+    replay_dataset,
+)
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+@pytest.fixture
+def temp_dataset_path() -> Generator[str, None, None]:
+    """Create a temporary dataset path."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
+        temp_path = f.name
+    
+    yield temp_path
+    
+    try:
+        os.unlink(temp_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def dataset(temp_dataset_path) -> MisrouteDataset:
+    """Create a test dataset."""
+    return MisrouteDataset(path=temp_dataset_path, redact=True)
+
+
+@pytest.fixture
+def sample_record() -> MisrouteRecord:
+    """Create a sample misroute record."""
+    return MisrouteRecord(
+        user_text="yarın saat 3te toplantı ekle",
+        router_route="calendar",
+        router_intent="create",
+        router_slots={"time": "15:00", "title": "toplantı"},
+        router_confidence=0.85,
+        expected_route="calendar",
+        expected_intent="create",
+        reason="wrong_slot",
+        notes="Time parsed incorrectly",
+    )
+
+
+# ============================================================================
+# MISROUTE RECORD TESTS
+# ============================================================================
+
+class TestMisrouteRecord:
+    """Test MisrouteRecord dataclass."""
+    
+    def test_create_record(self, sample_record):
+        """Test record creation."""
+        assert sample_record.user_text == "yarın saat 3te toplantı ekle"
+        assert sample_record.router_route == "calendar"
+        assert sample_record.reason == "wrong_slot"
+    
+    def test_record_to_dict(self, sample_record):
+        """Test dictionary conversion."""
+        data = sample_record.to_dict()
+        
+        assert data["user_text"] == "yarın saat 3te toplantı ekle"
+        assert data["router_route"] == "calendar"
+        assert data["router_slots"]["time"] == "15:00"
+    
+    def test_record_from_dict(self):
+        """Test creation from dictionary."""
+        data = {
+            "user_text": "test input",
+            "router_route": "gmail",
+            "router_intent": "read",
+            "router_slots": {},
+            "router_confidence": 0.9,
+            "reason": "fallback",
+            "timestamp": "2026-02-01T12:00:00Z",
+        }
+        
+        record = MisrouteRecord.from_dict(data)
+        
+        assert record.user_text == "test input"
+        assert record.router_route == "gmail"
+        assert record.reason == "fallback"
+    
+    def test_record_roundtrip(self, sample_record):
+        """Test dict roundtrip."""
+        data = sample_record.to_dict()
+        restored = MisrouteRecord.from_dict(data)
+        
+        assert restored.user_text == sample_record.user_text
+        assert restored.router_route == sample_record.router_route
+        assert restored.reason == sample_record.reason
+    
+    def test_record_default_timestamp(self):
+        """Test that timestamp is auto-generated."""
+        record = MisrouteRecord(
+            user_text="test",
+            router_route="test",
+            router_intent="test",
+        )
+        
+        assert record.timestamp
+        assert "202" in record.timestamp  # Year starts with 202x
+    
+    def test_record_with_expected_values(self):
+        """Test record with expected (correction) values."""
+        record = MisrouteRecord(
+            user_text="test",
+            router_route="gmail",
+            router_intent="read",
+            expected_route="calendar",
+            expected_intent="query",
+            reason="user_correction",
+        )
+        
+        assert record.expected_route == "calendar"
+        assert record.reason == "user_correction"
+
+
+# ============================================================================
+# PII REDACTION TESTS
+# ============================================================================
+
+class TestPIIRedaction:
+    """Test PII redaction functionality."""
+    
+    def test_redact_email(self):
+        """Test email redaction."""
+        text = "mail gönder john@example.com adresine"
+        result = redact_pii(text)
+        
+        assert "john@example.com" not in result
+        assert "@" in result  # Masked format still contains @
+    
+    def test_redact_phone(self):
+        """Test phone number redaction."""
+        text = "ara +90 555 123 4567"
+        result = redact_pii(text)
+        
+        assert "555 123 4567" not in result
+    
+    def test_redact_record_all_fields(self, sample_record):
+        """Test that record redaction covers all text fields."""
+        # Add PII to record
+        record = MisrouteRecord(
+            user_text="mail at test@email.com",
+            router_route="gmail",
+            router_intent="send",
+            router_slots={"to": "victim@example.com"},
+            router_raw_output='{"to": "victim@example.com"}',
+            notes="Contact test@email.com",
+            reason="other",
+        )
+        
+        redacted = redact_record(record)
+        
+        assert "test@email.com" not in redacted.user_text
+        assert "victim@example.com" not in str(redacted.router_slots)
+        assert "victim@example.com" not in redacted.router_raw_output
+        assert "test@email.com" not in redacted.notes
+    
+    def test_redact_preserves_non_pii(self):
+        """Test that non-PII text is preserved."""
+        text = "yarın saat 15:00'te toplantı"
+        result = redact_pii(text)
+        
+        assert result == text
+
+
+# ============================================================================
+# MISROUTE DATASET TESTS
+# ============================================================================
+
+class TestMisrouteDataset:
+    """Test MisrouteDataset operations."""
+    
+    def test_create_dataset(self, temp_dataset_path):
+        """Test dataset creation."""
+        dataset = MisrouteDataset(path=temp_dataset_path)
+        assert dataset.count() == 0
+    
+    def test_append_record(self, dataset, sample_record):
+        """Test appending a record."""
+        dataset.append(sample_record)
+        assert dataset.count() == 1
+    
+    def test_read_all(self, dataset, sample_record):
+        """Test reading all records."""
+        dataset.append(sample_record)
+        dataset.append(sample_record)
+        
+        records = dataset.read_all()
+        assert len(records) == 2
+    
+    def test_iter_records(self, dataset, sample_record):
+        """Test iterating over records."""
+        dataset.append(sample_record)
+        dataset.append(sample_record)
+        dataset.append(sample_record)
+        
+        count = sum(1 for _ in dataset.iter_records())
+        assert count == 3
+    
+    def test_clear(self, dataset, sample_record):
+        """Test clearing the dataset."""
+        dataset.append(sample_record)
+        dataset.append(sample_record)
+        
+        removed = dataset.clear()
+        
+        assert removed == 2
+        assert dataset.count() == 0
+    
+    def test_export_json(self, dataset, sample_record, tmp_path):
+        """Test JSON export."""
+        dataset.append(sample_record)
+        dataset.append(sample_record)
+        
+        output_path = str(tmp_path / "export.json")
+        count = dataset.export_json(output_path)
+        
+        assert count == 2
+        
+        with open(output_path) as f:
+            data = json.load(f)
+        
+        assert len(data) == 2
+        assert data[0]["user_text"] == sample_record.user_text
+    
+    def test_creates_directory(self, tmp_path):
+        """Test that nested directories are created."""
+        nested_path = tmp_path / "deep" / "nested" / "data.jsonl"
+        dataset = MisrouteDataset(path=str(nested_path))
+        
+        record = MisrouteRecord(
+            user_text="test",
+            router_route="test",
+            router_intent="test",
+        )
+        dataset.append(record)
+        
+        assert nested_path.exists()
+    
+    def test_redaction_enabled_by_default(self, temp_dataset_path):
+        """Test that PII redaction is enabled by default."""
+        dataset = MisrouteDataset(path=temp_dataset_path)
+        
+        record = MisrouteRecord(
+            user_text="mail at test@secret.com",
+            router_route="gmail",
+            router_intent="read",
+        )
+        
+        dataset.append(record)
+        
+        # Read back raw
+        with open(temp_dataset_path) as f:
+            line = f.readline()
+            data = json.loads(line)
+        
+        assert "test@secret.com" not in data["user_text"]
+    
+    def test_redaction_can_be_disabled(self, temp_dataset_path):
+        """Test that PII redaction can be disabled."""
+        dataset = MisrouteDataset(path=temp_dataset_path, redact=False)
+        
+        record = MisrouteRecord(
+            user_text="mail at test@visible.com",
+            router_route="gmail",
+            router_intent="read",
+        )
+        
+        dataset.append(record)
+        
+        records = dataset.read_all()
+        assert "test@visible.com" in records[0].user_text
+
+
+# ============================================================================
+# LOGGING UTILITY TESTS
+# ============================================================================
+
+class TestLoggingUtilities:
+    """Test logging convenience functions."""
+    
+    def test_log_misroute(self, temp_dataset_path):
+        """Test log_misroute function."""
+        with patch("bantz.router.misroute_collector._dataset", 
+                   MisrouteDataset(path=temp_dataset_path)):
+            record = log_misroute(
+                user_text="test input",
+                router_route="calendar",
+                router_intent="create",
+                reason="wrong_route",
+            )
+            
+            assert record.user_text == "test input"
+            assert record.reason == "wrong_route"
+    
+    def test_log_fallback(self, temp_dataset_path):
+        """Test log_fallback function."""
+        with patch("bantz.router.misroute_collector._dataset",
+                   MisrouteDataset(path=temp_dataset_path)):
+            record = log_fallback(
+                user_text="gibberish input",
+                fallback_reason="No matching intent",
+            )
+            
+            assert record.router_route == "unknown"
+            assert record.reason == "fallback"
+            assert record.fallback_reason == "No matching intent"
+    
+    def test_log_user_correction(self, temp_dataset_path):
+        """Test log_user_correction function."""
+        with patch("bantz.router.misroute_collector._dataset",
+                   MisrouteDataset(path=temp_dataset_path)):
+            record = log_user_correction(
+                user_text="yarın toplantım var mı",
+                router_route="smalltalk",
+                router_intent="greeting",
+                expected_route="calendar",
+                expected_intent="query",
+            )
+            
+            assert record.router_route == "smalltalk"
+            assert record.expected_route == "calendar"
+            assert record.reason == "user_correction"
+
+
+# ============================================================================
+# REPLAY TESTS
+# ============================================================================
+
+class TestReplay:
+    """Test replay functionality."""
+    
+    def test_replay_result_dataclass(self, sample_record):
+        """Test ReplayResult dataclass."""
+        result = ReplayResult(
+            record=sample_record,
+            new_route="calendar",
+            new_intent="create",
+            new_slots={},
+            new_confidence=0.9,
+            route_match=True,
+            improved=False,
+        )
+        
+        assert result.route_match is True
+        assert result.improved is False
+    
+    def test_replay_result_to_dict(self, sample_record):
+        """Test ReplayResult to_dict."""
+        result = ReplayResult(
+            record=sample_record,
+            new_route="calendar",
+            new_intent="create",
+            new_slots={},
+            new_confidence=0.9,
+            route_match=True,
+            improved=True,
+        )
+        
+        data = result.to_dict()
+        
+        assert data["new_route"] == "calendar"
+        assert data["improved"] is True
+    
+    def test_replay_summary_to_dict(self):
+        """Test ReplaySummary to_dict."""
+        summary = ReplaySummary(
+            total=10,
+            improved=3,
+            regressed=1,
+            unchanged=6,
+            route_accuracy=0.8,
+        )
+        
+        data = summary.to_dict()
+        
+        assert data["total"] == 10
+        assert data["improvement_rate"] == 0.3
+        assert data["route_accuracy"] == 0.8
+    
+    def test_replay_summary_format_markdown(self):
+        """Test ReplaySummary markdown formatting."""
+        summary = ReplaySummary(
+            total=10,
+            improved=3,
+            regressed=1,
+            unchanged=6,
+            route_accuracy=0.8,
+            intent_accuracy=0.9,
+        )
+        
+        md = summary.format_markdown()
+        
+        assert "# Router Replay Summary" in md
+        assert "Total Records:" in md
+        assert "Improved:" in md
+        assert "Route Accuracy:" in md
+    
+    def test_replay_dataset_basic(self, temp_dataset_path):
+        """Test basic replay functionality."""
+        # Create dataset with records
+        dataset = MisrouteDataset(path=temp_dataset_path, redact=False)
+        
+        dataset.append(MisrouteRecord(
+            user_text="saat kaç",
+            router_route="unknown",
+            router_intent="fallback",
+            expected_route="system",
+            reason="fallback",
+        ))
+        dataset.append(MisrouteRecord(
+            user_text="merhaba",
+            router_route="calendar",
+            router_intent="query",
+            expected_route="smalltalk",
+            reason="wrong_route",
+        ))
+        
+        # Mock router that returns correct routes
+        def mock_router(text: str) -> dict:
+            if "saat" in text:
+                return {"route": "system", "intent": "time", "slots": {}, "confidence": 0.9}
+            if "merhaba" in text:
+                return {"route": "smalltalk", "intent": "greeting", "slots": {}, "confidence": 0.9}
+            return {"route": "unknown", "intent": "fallback", "slots": {}, "confidence": 0.3}
+        
+        summary = replay_dataset(mock_router, temp_dataset_path)
+        
+        assert summary.total == 2
+        assert summary.improved == 2  # Both now route correctly
+        assert summary.route_accuracy == 1.0
+    
+    def test_replay_with_limit(self, temp_dataset_path):
+        """Test replay with record limit."""
+        dataset = MisrouteDataset(path=temp_dataset_path, redact=False)
+        
+        for i in range(10):
+            dataset.append(MisrouteRecord(
+                user_text=f"test {i}",
+                router_route="unknown",
+                router_intent="fallback",
+                reason="fallback",
+            ))
+        
+        def mock_router(text: str) -> dict:
+            return {"route": "unknown", "intent": "fallback", "slots": {}, "confidence": 0.5}
+        
+        summary = replay_dataset(mock_router, temp_dataset_path, limit=5)
+        
+        assert summary.total == 5
+    
+    def test_replay_detects_regression(self, temp_dataset_path):
+        """Test that replay detects regressions."""
+        dataset = MisrouteDataset(path=temp_dataset_path, redact=False)
+        
+        # Record where original was correct
+        dataset.append(MisrouteRecord(
+            user_text="merhaba",
+            router_route="smalltalk",  # Was correct
+            router_intent="greeting",
+            expected_route="smalltalk",
+            reason="low_confidence",  # Logged for confidence, not wrong route
+        ))
+        
+        # New router is wrong
+        def bad_router(text: str) -> dict:
+            return {"route": "calendar", "intent": "query", "slots": {}, "confidence": 0.9}
+        
+        summary = replay_dataset(bad_router, temp_dataset_path)
+        
+        assert summary.regressed == 1
+        assert summary.improved == 0
+
+
+# ============================================================================
+# STATISTICS TESTS
+# ============================================================================
+
+class TestStatistics:
+    """Test statistics functionality."""
+    
+    def test_empty_dataset_stats(self, temp_dataset_path):
+        """Test stats for empty dataset."""
+        stats = get_dataset_stats(temp_dataset_path)
+        
+        assert stats["total"] == 0
+        assert stats["by_reason"] == {}
+    
+    def test_dataset_stats(self, temp_dataset_path):
+        """Test stats calculation."""
+        dataset = MisrouteDataset(path=temp_dataset_path, redact=False)
+        
+        dataset.append(MisrouteRecord(
+            user_text="t1", router_route="calendar", router_intent="",
+            reason="wrong_route", model_name="model-a",
+        ))
+        dataset.append(MisrouteRecord(
+            user_text="t2", router_route="calendar", router_intent="",
+            reason="fallback", model_name="model-a",
+        ))
+        dataset.append(MisrouteRecord(
+            user_text="t3", router_route="gmail", router_intent="",
+            reason="fallback", model_name="model-b",
+        ))
+        
+        stats = get_dataset_stats(temp_dataset_path)
+        
+        assert stats["total"] == 3
+        assert stats["by_reason"]["fallback"] == 2
+        assert stats["by_reason"]["wrong_route"] == 1
+        assert stats["by_route"]["calendar"] == 2
+        assert stats["by_route"]["gmail"] == 1
+        assert stats["by_model"]["model-a"] == 2
+        assert stats["by_model"]["model-b"] == 1
+
+
+# ============================================================================
+# INTEGRATION TESTS
+# ============================================================================
+
+class TestIntegration:
+    """Integration tests for full workflow."""
+    
+    def test_full_workflow(self, temp_dataset_path):
+        """Test complete logging -> replay workflow."""
+        # Simulate misroute logging during conversation
+        dataset = MisrouteDataset(path=temp_dataset_path)
+        
+        # Log some misroutes
+        dataset.append(MisrouteRecord(
+            user_text="yarın toplantım var mı",
+            router_route="smalltalk",
+            router_intent="greeting",
+            expected_route="calendar",
+            expected_intent="query",
+            reason="wrong_route",
+            model_name="qwen-3b",
+        ))
+        
+        dataset.append(MisrouteRecord(
+            user_text="ahmet bey'e mail at",
+            router_route="unknown",
+            router_intent="fallback",
+            expected_route="gmail",
+            expected_intent="send",
+            reason="fallback",
+            fallback_reason="No matching pattern",
+            model_name="qwen-3b",
+        ))
+        
+        # Verify records are saved
+        assert dataset.count() == 2
+        
+        # Get stats
+        stats = get_dataset_stats(temp_dataset_path)
+        assert stats["total"] == 2
+        assert stats["by_reason"]["wrong_route"] == 1
+        assert stats["by_reason"]["fallback"] == 1
+        
+        # Simulate improved router
+        def improved_router(text: str) -> dict:
+            if "toplantı" in text or "yarın" in text:
+                return {"route": "calendar", "intent": "query", "slots": {}, "confidence": 0.9}
+            if "mail" in text:
+                return {"route": "gmail", "intent": "send", "slots": {}, "confidence": 0.85}
+            return {"route": "unknown", "intent": "fallback", "slots": {}, "confidence": 0.3}
+        
+        # Replay
+        summary = replay_dataset(improved_router, temp_dataset_path)
+        
+        # Both should be improved
+        assert summary.improved == 2
+        assert summary.regressed == 0
+        assert summary.route_accuracy == 1.0
+    
+    def test_pii_not_leaked(self, temp_dataset_path):
+        """Test that PII is never written to disk."""
+        dataset = MisrouteDataset(path=temp_dataset_path)
+        
+        # Log with PII
+        dataset.append(MisrouteRecord(
+            user_text="ahmet@secret.com adresine mail at",
+            router_route="gmail",
+            router_intent="send",
+            router_slots={"to": "ahmet@secret.com"},
+            notes="User email: ahmet@secret.com",
+            reason="wrong_slot",
+        ))
+        
+        # Read raw file
+        with open(temp_dataset_path, "r") as f:
+            content = f.read()
+        
+        # PII should be masked
+        assert "ahmet@secret.com" not in content


### PR DESCRIPTION
## Summary
Implements systematic collection of router misroutes for model improvement.

## Changes
- **`src/bantz/router/misroute_collector.py`**:
  - `MisrouteRecord`: Structured logging dataclass
  - `MisrouteDataset`: JSONL persistence with automatic PII redaction
  - `log_misroute()`, `log_fallback()`, `log_user_correction()`: Convenience functions
  - `replay_dataset()`: Test router accuracy against logged misroutes
  - `get_dataset_stats()`: Analyze misroute patterns

- **`scripts/replay_router.py`**:
  - CLI tool for replaying misroute dataset
  - `--stats`: Show dataset statistics
  - `--mock`: Use pattern-matching fallback router
  - `--export`: Export to JSON
  - `--limit`: Process subset of records

## Privacy
- PII redaction enabled by default using `bantz.security.masking`
- Email, phone, passwords automatically masked before write

## Tests
- **33 tests** covering:
  - Record dataclass operations
  - PII redaction
  - Dataset persistence
  - Logging utilities
  - Replay with improvement/regression detection
  - Statistics calculation

## Configuration
- Dataset path: `BANTZ_MISROUTE_DATASET` env var or `~/.cache/bantz/datasets/router_misroutes.jsonl`

Closes #238