### PR TITLE
feat(llm): add 3B model benchmark framework (#239)

### DIFF
--- a/scripts/bench_3b_models.py
+++ b/scripts/bench_3b_models.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""3B Model Benchmark CLI.
+
+Issue #239: Evaluate best 3B-class model for Turkish + router use case.
+
+Usage:
+    python scripts/bench_3b_models.py                  # Run with mock (no vLLM)
+    python scripts/bench_3b_models.py --live           # Run against live vLLM
+    python scripts/bench_3b_models.py --output report.md
+    python scripts/bench_3b_models.py --format json
+    python scripts/bench_3b_models.py --list-candidates
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bantz.llm.model_benchmark import (
+    DEFAULT_CANDIDATES,
+    DEFAULT_REPORT_PATH,
+    DEFAULT_VLLM_BASE,
+    ModelBenchmark,
+    ModelBenchmarkResult,
+    generate_report,
+    run_mock_benchmark,
+)
+
+
+def list_candidates() -> None:
+    """List available model candidates."""
+    print("Available Model Candidates:")
+    print("=" * 60)
+    
+    for i, c in enumerate(DEFAULT_CANDIDATES, 1):
+        print(f"\n{i}. {c.name}")
+        print(f"   HuggingFace: {c.hf_id}")
+        print(f"   Quantization: {c.quantization}")
+        print(f"   Notes: {c.notes}")
+
+
+def run_live_benchmark(
+    vllm_base: str,
+) -> list[ModelBenchmarkResult]:
+    """Run benchmark against live vLLM instance.
+    
+    Note: This only tests the currently loaded model.
+    For full comparison, models need to be loaded separately.
+    """
+    import requests
+    
+    # Check vLLM availability
+    try:
+        resp = requests.get(f"{vllm_base}/health", timeout=5)
+        if resp.status_code != 200:
+            print(f"vLLM not healthy at {vllm_base}")
+            return []
+    except Exception as e:
+        print(f"Cannot connect to vLLM at {vllm_base}: {e}")
+        return []
+    
+    # Get current model info
+    try:
+        resp = requests.get(f"{vllm_base}/v1/models", timeout=5)
+        models_data = resp.json()
+        model_id = models_data.get("data", [{}])[0].get("id", "unknown")
+    except Exception:
+        model_id = "unknown"
+    
+    print(f"Testing model: {model_id}")
+    print("-" * 40)
+    
+    # Create candidate for current model
+    from bantz.llm.model_benchmark import ModelCandidate
+    
+    current = ModelCandidate(
+        name=model_id.split("/")[-1] if "/" in model_id else model_id,
+        hf_id=model_id,
+        quantization="unknown",
+        notes="Currently loaded model",
+    )
+    
+    # Run benchmark
+    benchmark = ModelBenchmark(vllm_base=vllm_base)
+    result = benchmark.run_benchmark(current)
+    
+    return [result]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark 3B models for Turkish + router use case",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Run against live vLLM instance (tests current model only)",
+    )
+    parser.add_argument(
+        "--vllm-base",
+        default=DEFAULT_VLLM_BASE,
+        help=f"vLLM API base URL (default: {DEFAULT_VLLM_BASE})",
+    )
+    parser.add_argument(
+        "--output",
+        default=DEFAULT_REPORT_PATH,
+        help=f"Output report path (default: {DEFAULT_REPORT_PATH})",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json", "text"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--list-candidates",
+        action="store_true",
+        help="List available model candidates",
+    )
+    
+    args = parser.parse_args()
+    
+    if args.list_candidates:
+        list_candidates()
+        return 0
+    
+    # Run benchmark
+    if args.live:
+        print("Running live benchmark against vLLM...")
+        results = run_live_benchmark(args.vllm_base)
+        if not results:
+            print("No results - vLLM may not be available")
+            return 1
+    else:
+        print("Running mock benchmark (use --live for actual testing)...")
+        results = run_mock_benchmark()
+    
+    # Output results
+    if args.format == "json":
+        output = json.dumps([r.to_dict() for r in results], indent=2, ensure_ascii=False)
+        print(output)
+        
+        # Also save to file
+        json_path = args.output.replace(".md", ".json")
+        Path(json_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(json_path, "w", encoding="utf-8") as f:
+            f.write(output)
+        print(f"\nSaved to: {json_path}")
+        
+    elif args.format == "text":
+        print("\n" + "=" * 60)
+        print("BENCHMARK RESULTS")
+        print("=" * 60)
+        
+        for r in sorted(results, key=lambda x: x.overall_score, reverse=True):
+            print(f"\n{r.model.name}")
+            print(f"  JSON Compliance: {r.json_compliance_rate*100:.1f}%")
+            print(f"  Route Accuracy:  {r.route_accuracy*100:.1f}%")
+            print(f"  Smalltalk:       {r.smalltalk_quality*100:.1f}%")
+            print(f"  Latency:         {r.avg_latency_ms:.0f}ms (p95: {r.p95_latency_ms:.0f}ms)")
+            print(f"  Throughput:      {r.avg_tokens_per_sec:.0f} tok/s")
+            print(f"  Overall Score:   {r.overall_score*100:.1f}%")
+        
+        if results:
+            best = max(results, key=lambda x: x.overall_score)
+            print(f"\n✅ Recommended: {best.model.name}")
+    
+    else:  # markdown
+        report = generate_report(results, args.output)
+        print(report)
+        print(f"\nSaved to: {args.output}")
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/src/bantz/llm/model_benchmark.py
+++ b/src/bantz/llm/model_benchmark.py
@@ -1,0 +1,742 @@
+"""3B Model Benchmark Framework.
+
+Issue #239: Evaluate best 3B-class model for Turkish + router use case.
+
+This module provides:
+- Model evaluation framework
+- Router JSON compliance testing
+- Turkish smalltalk quality scoring
+- Latency and throughput measurement
+- Markdown report generation
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import statistics
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+import requests
+
+
+# ============================================================================
+# CONFIGURATION
+# ============================================================================
+
+DEFAULT_REPORT_PATH = str(
+    Path(__file__).resolve().parent.parent / "artifacts" / "results" / "3b_benchmark.md"
+)
+
+# vLLM default endpoint
+DEFAULT_VLLM_BASE = os.getenv("BANTZ_VLLM_BASE", "http://localhost:8001")
+
+
+# ============================================================================
+# CANDIDATE MODELS
+# ============================================================================
+
+@dataclass
+class ModelCandidate:
+    """A model candidate for evaluation."""
+    
+    name: str
+    hf_id: str
+    quantization: str = "awq"
+    notes: str = ""
+    
+    # vLLM settings
+    gpu_memory_utilization: float = 0.85
+    max_model_len: int = 4096
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+# Default candidates for evaluation
+DEFAULT_CANDIDATES = [
+    ModelCandidate(
+        name="Qwen2.5-3B-AWQ",
+        hf_id="Qwen/Qwen2.5-3B-Instruct-AWQ",
+        quantization="awq",
+        notes="Current default, good JSON compliance",
+    ),
+    ModelCandidate(
+        name="Qwen2.5-3B-GGUF-Q4",
+        hf_id="Qwen/Qwen2.5-3B-Instruct-GGUF",
+        quantization="gguf-q4",
+        notes="Smaller size, may trade quality",
+    ),
+    ModelCandidate(
+        name="Qwen2.5-3B-GPTQ",
+        hf_id="Qwen/Qwen2.5-3B-Instruct-GPTQ-Int4",
+        quantization="gptq-int4",
+        notes="Alternative quantization",
+    ),
+    ModelCandidate(
+        name="Phi-3.5-mini-instruct",
+        hf_id="microsoft/Phi-3.5-mini-instruct",
+        quantization="fp16",
+        notes="Strong reasoning, may need quantization",
+    ),
+    ModelCandidate(
+        name="Gemma-2-2B-Instruct",
+        hf_id="google/gemma-2-2b-it",
+        quantization="fp16",
+        notes="Smaller but efficient",
+    ),
+]
+
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+@dataclass
+class RouterTestCase:
+    """Test case for router JSON compliance."""
+    
+    user_text: str
+    expected_route: str
+    expected_intent: Optional[str] = None
+    expected_slots: Optional[dict] = None
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+@dataclass
+class SmalltalkTestCase:
+    """Test case for Turkish smalltalk quality."""
+    
+    user_text: str
+    expected_keywords: List[str] = field(default_factory=list)
+    min_length: int = 10
+    max_length: int = 500
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return asdict(self)
+
+
+# Router test cases
+ROUTER_TEST_CASES = [
+    RouterTestCase(
+        user_text="saat kaç",
+        expected_route="system",
+        expected_intent="time",
+    ),
+    RouterTestCase(
+        user_text="yarın toplantım var mı",
+        expected_route="calendar",
+        expected_intent="query",
+    ),
+    RouterTestCase(
+        user_text="yarın saat 3'te toplantı ekle",
+        expected_route="calendar",
+        expected_intent="create",
+        expected_slots={"time": "15:00"},
+    ),
+    RouterTestCase(
+        user_text="son mailimi oku",
+        expected_route="gmail",
+        expected_intent="read",
+    ),
+    RouterTestCase(
+        user_text="ahmet beye mail at",
+        expected_route="gmail",
+        expected_intent="send",
+    ),
+    RouterTestCase(
+        user_text="merhaba nasılsın",
+        expected_route="smalltalk",
+    ),
+    RouterTestCase(
+        user_text="teşekkür ederim",
+        expected_route="smalltalk",
+    ),
+    RouterTestCase(
+        user_text="cpu kullanımı ne",
+        expected_route="system",
+        expected_intent="status",
+    ),
+    RouterTestCase(
+        user_text="bugün hava nasıl",
+        expected_route="weather",
+    ),
+    RouterTestCase(
+        user_text="not defteri aç",
+        expected_route="system",
+        expected_intent="open_app",
+    ),
+]
+
+# Smalltalk test cases
+SMALLTALK_TEST_CASES = [
+    SmalltalkTestCase(
+        user_text="merhaba",
+        expected_keywords=["merhaba", "selam", "hoş geldin", "günaydın", "iyi"],
+    ),
+    SmalltalkTestCase(
+        user_text="nasılsın",
+        expected_keywords=["iyi", "teşekkür", "siz", "nasıl", "yardım"],
+    ),
+    SmalltalkTestCase(
+        user_text="iyi geceler",
+        expected_keywords=["iyi", "gece", "görüşürüz", "dinlen", "uyku"],
+    ),
+    SmalltalkTestCase(
+        user_text="teşekkür ederim çok yardımcı oldun",
+        expected_keywords=["rica", "teşekkür", "yardım", "memnun", "seve"],
+    ),
+    SmalltalkTestCase(
+        user_text="bugün çok yorgunum",
+        expected_keywords=["dinlen", "anlıyorum", "geçmiş", "yardım", "olsun"],
+    ),
+]
+
+
+# ============================================================================
+# ROUTER PROMPT
+# ============================================================================
+
+ROUTER_SYSTEM_PROMPT = """Sen Jarvis, akıllı bir asistansın. Kullanıcının isteğini analiz et ve JSON formatında yanıt ver.
+
+Çıktı formatı:
+{
+  "route": "calendar | gmail | system | smalltalk | weather | unknown",
+  "intent": "amaç (query, create, send, read, status, open_app, greeting, etc)",
+  "slots": {"slot_key": "value"},
+  "confidence": 0.0-1.0,
+  "assistant_reply": "smalltalk için doğrudan cevap"
+}
+
+Kurallar:
+1. JSON formatında yanıt ver, başka metin ekleme
+2. route mutlaka belirt
+3. smalltalk için assistant_reply dolu olmalı
+4. Slot değerlerini metinden çıkar (saat, tarih, isim vb)"""
+
+
+# ============================================================================
+# BENCHMARK RESULTS
+# ============================================================================
+
+@dataclass
+class RouterResult:
+    """Result of a single router test."""
+    
+    test_case: RouterTestCase
+    raw_output: str
+    parsed_output: Optional[dict] = None
+    parse_success: bool = False
+    route_correct: bool = False
+    intent_correct: bool = False
+    slots_correct: bool = False
+    latency_ms: float = 0.0
+    tokens_generated: int = 0
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "user_text": self.test_case.user_text,
+            "expected_route": self.test_case.expected_route,
+            "parsed_output": self.parsed_output,
+            "parse_success": self.parse_success,
+            "route_correct": self.route_correct,
+            "latency_ms": self.latency_ms,
+        }
+
+
+@dataclass
+class SmalltalkResult:
+    """Result of a single smalltalk test."""
+    
+    test_case: SmalltalkTestCase
+    response: str
+    keyword_hits: int = 0
+    length_ok: bool = False
+    quality_score: float = 0.0  # 0-1
+    latency_ms: float = 0.0
+    tokens_generated: int = 0
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "user_text": self.test_case.user_text,
+            "response": self.response[:100] + "..." if len(self.response) > 100 else self.response,
+            "quality_score": self.quality_score,
+            "latency_ms": self.latency_ms,
+        }
+
+
+@dataclass
+class ModelBenchmarkResult:
+    """Complete benchmark result for a model."""
+    
+    model: ModelCandidate
+    
+    # Router metrics
+    router_results: List[RouterResult] = field(default_factory=list)
+    json_compliance_rate: float = 0.0
+    route_accuracy: float = 0.0
+    intent_accuracy: float = 0.0
+    
+    # Smalltalk metrics
+    smalltalk_results: List[SmalltalkResult] = field(default_factory=list)
+    smalltalk_quality: float = 0.0
+    
+    # Latency metrics
+    avg_latency_ms: float = 0.0
+    p95_latency_ms: float = 0.0
+    avg_tokens_per_sec: float = 0.0
+    
+    # Overall
+    overall_score: float = 0.0
+    notes: str = ""
+    
+    def to_dict(self) -> dict:
+        """Convert to dictionary."""
+        return {
+            "model": self.model.to_dict(),
+            "json_compliance_rate": self.json_compliance_rate,
+            "route_accuracy": self.route_accuracy,
+            "intent_accuracy": self.intent_accuracy,
+            "smalltalk_quality": self.smalltalk_quality,
+            "avg_latency_ms": self.avg_latency_ms,
+            "p95_latency_ms": self.p95_latency_ms,
+            "avg_tokens_per_sec": self.avg_tokens_per_sec,
+            "overall_score": self.overall_score,
+        }
+
+
+# ============================================================================
+# BENCHMARK ENGINE
+# ============================================================================
+
+class ModelBenchmark:
+    """Benchmark engine for 3B models."""
+    
+    def __init__(
+        self,
+        vllm_base: str = DEFAULT_VLLM_BASE,
+        timeout: float = 30.0,
+    ):
+        """Initialize benchmark.
+        
+        Args:
+            vllm_base: vLLM API base URL
+            timeout: Request timeout in seconds
+        """
+        self.vllm_base = vllm_base
+        self.timeout = timeout
+    
+    def _call_vllm(
+        self,
+        prompt: str,
+        system_prompt: str = "",
+        max_tokens: int = 512,
+        temperature: float = 0.1,
+    ) -> tuple[str, float, int]:
+        """Call vLLM API.
+        
+        Returns:
+            (response_text, latency_ms, tokens_generated)
+        """
+        url = f"{self.vllm_base}/v1/chat/completions"
+        
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+        
+        payload = {
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        
+        start = time.perf_counter()
+        resp = requests.post(url, json=payload, timeout=self.timeout)
+        latency_ms = (time.perf_counter() - start) * 1000
+        
+        resp.raise_for_status()
+        data = resp.json()
+        
+        text = data["choices"][0]["message"]["content"]
+        tokens = data.get("usage", {}).get("completion_tokens", len(text.split()))
+        
+        return text, latency_ms, tokens
+    
+    def _parse_json(self, text: str) -> Optional[dict]:
+        """Try to parse JSON from response."""
+        # Try direct parse
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+        
+        # Try to extract JSON block
+        match = re.search(r'\{[^{}]*\}', text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())
+            except json.JSONDecodeError:
+                pass
+        
+        # Try nested JSON
+        match = re.search(r'\{.*\}', text, re.DOTALL)
+        if match:
+            try:
+                return json.loads(match.group())
+            except json.JSONDecodeError:
+                pass
+        
+        return None
+    
+    def run_router_tests(
+        self,
+        test_cases: List[RouterTestCase] = None,
+    ) -> List[RouterResult]:
+        """Run router compliance tests.
+        
+        Args:
+            test_cases: Test cases (default: ROUTER_TEST_CASES)
+            
+        Returns:
+            List of RouterResult
+        """
+        test_cases = test_cases or ROUTER_TEST_CASES
+        results = []
+        
+        for tc in test_cases:
+            try:
+                text, latency, tokens = self._call_vllm(
+                    prompt=tc.user_text,
+                    system_prompt=ROUTER_SYSTEM_PROMPT,
+                    max_tokens=256,
+                    temperature=0.1,
+                )
+                
+                parsed = self._parse_json(text)
+                
+                result = RouterResult(
+                    test_case=tc,
+                    raw_output=text,
+                    parsed_output=parsed,
+                    parse_success=parsed is not None,
+                    latency_ms=latency,
+                    tokens_generated=tokens,
+                )
+                
+                if parsed:
+                    result.route_correct = parsed.get("route") == tc.expected_route
+                    if tc.expected_intent:
+                        result.intent_correct = parsed.get("intent") == tc.expected_intent
+                    else:
+                        result.intent_correct = True  # No expectation
+                    
+                    # Slots check (partial)
+                    if tc.expected_slots:
+                        slots = parsed.get("slots", {})
+                        result.slots_correct = all(
+                            k in slots for k in tc.expected_slots
+                        )
+                    else:
+                        result.slots_correct = True
+                
+                results.append(result)
+                
+            except Exception as e:
+                results.append(RouterResult(
+                    test_case=tc,
+                    raw_output=str(e),
+                    parse_success=False,
+                ))
+        
+        return results
+    
+    def run_smalltalk_tests(
+        self,
+        test_cases: List[SmalltalkTestCase] = None,
+    ) -> List[SmalltalkResult]:
+        """Run Turkish smalltalk quality tests.
+        
+        Args:
+            test_cases: Test cases (default: SMALLTALK_TEST_CASES)
+            
+        Returns:
+            List of SmalltalkResult
+        """
+        test_cases = test_cases or SMALLTALK_TEST_CASES
+        results = []
+        
+        for tc in test_cases:
+            try:
+                text, latency, tokens = self._call_vllm(
+                    prompt=tc.user_text,
+                    system_prompt="Sen Jarvis, nazik ve yardımsever bir asistansın. Türkçe cevap ver.",
+                    max_tokens=200,
+                    temperature=0.7,
+                )
+                
+                # Score quality
+                response_lower = text.lower()
+                keyword_hits = sum(
+                    1 for kw in tc.expected_keywords 
+                    if kw.lower() in response_lower
+                )
+                
+                length_ok = tc.min_length <= len(text) <= tc.max_length
+                
+                # Quality score: keyword match + length + fluency heuristic
+                keyword_score = keyword_hits / len(tc.expected_keywords) if tc.expected_keywords else 0.5
+                length_score = 1.0 if length_ok else 0.5
+                
+                # Basic fluency: has Turkish chars, proper punctuation
+                has_turkish = any(c in text for c in "çğıöşüÇĞİÖŞÜ")
+                has_punctuation = any(c in text for c in ".,!?")
+                fluency_score = 0.5 + (0.25 if has_turkish else 0) + (0.25 if has_punctuation else 0)
+                
+                quality_score = (keyword_score + length_score + fluency_score) / 3
+                
+                results.append(SmalltalkResult(
+                    test_case=tc,
+                    response=text,
+                    keyword_hits=keyword_hits,
+                    length_ok=length_ok,
+                    quality_score=quality_score,
+                    latency_ms=latency,
+                    tokens_generated=tokens,
+                ))
+                
+            except Exception as e:
+                results.append(SmalltalkResult(
+                    test_case=tc,
+                    response=str(e),
+                    quality_score=0.0,
+                ))
+        
+        return results
+    
+    def run_benchmark(
+        self,
+        model: ModelCandidate,
+    ) -> ModelBenchmarkResult:
+        """Run full benchmark for a model.
+        
+        Note: This assumes the model is already loaded in vLLM.
+        
+        Args:
+            model: Model candidate info
+            
+        Returns:
+            ModelBenchmarkResult
+        """
+        result = ModelBenchmarkResult(model=model)
+        
+        # Run router tests
+        result.router_results = self.run_router_tests()
+        
+        if result.router_results:
+            parse_ok = [r for r in result.router_results if r.parse_success]
+            route_ok = [r for r in result.router_results if r.route_correct]
+            intent_ok = [r for r in result.router_results if r.intent_correct]
+            
+            result.json_compliance_rate = len(parse_ok) / len(result.router_results)
+            result.route_accuracy = len(route_ok) / len(result.router_results)
+            result.intent_accuracy = len(intent_ok) / len(result.router_results)
+        
+        # Run smalltalk tests
+        result.smalltalk_results = self.run_smalltalk_tests()
+        
+        if result.smalltalk_results:
+            result.smalltalk_quality = statistics.mean(
+                r.quality_score for r in result.smalltalk_results
+            )
+        
+        # Calculate latency metrics
+        all_latencies = [
+            r.latency_ms for r in result.router_results + result.smalltalk_results
+            if r.latency_ms > 0
+        ]
+        all_tokens = [
+            r.tokens_generated for r in result.router_results + result.smalltalk_results
+            if r.tokens_generated > 0
+        ]
+        
+        if all_latencies:
+            result.avg_latency_ms = statistics.mean(all_latencies)
+            sorted_lat = sorted(all_latencies)
+            idx = int(len(sorted_lat) * 0.95)
+            result.p95_latency_ms = sorted_lat[min(idx, len(sorted_lat) - 1)]
+        
+        if all_tokens and all_latencies:
+            total_tokens = sum(all_tokens)
+            total_time_s = sum(all_latencies) / 1000
+            if total_time_s > 0:
+                result.avg_tokens_per_sec = total_tokens / total_time_s
+        
+        # Overall score (weighted)
+        # 40% JSON compliance, 30% route accuracy, 20% smalltalk, 10% speed
+        speed_score = min(1.0, 50 / result.avg_latency_ms) if result.avg_latency_ms > 0 else 0
+        result.overall_score = (
+            0.40 * result.json_compliance_rate +
+            0.30 * result.route_accuracy +
+            0.20 * result.smalltalk_quality +
+            0.10 * speed_score
+        )
+        
+        return result
+
+
+# ============================================================================
+# REPORT GENERATION
+# ============================================================================
+
+def generate_report(
+    results: List[ModelBenchmarkResult],
+    output_path: str = DEFAULT_REPORT_PATH,
+) -> str:
+    """Generate markdown benchmark report.
+    
+    Args:
+        results: List of benchmark results
+        output_path: Path to write report
+        
+    Returns:
+        Markdown report string
+    """
+    lines = [
+        "# 3B Model Benchmark Report",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Summary",
+        "",
+        "| Model | JSON Compliance | Route Accuracy | Smalltalk | Latency (ms) | tok/s | Overall |",
+        "|-------|-----------------|----------------|-----------|--------------|-------|---------|",
+    ]
+    
+    # Sort by overall score
+    sorted_results = sorted(results, key=lambda r: r.overall_score, reverse=True)
+    
+    for r in sorted_results:
+        lines.append(
+            f"| {r.model.name} | {r.json_compliance_rate*100:.0f}% | "
+            f"{r.route_accuracy*100:.0f}% | {r.smalltalk_quality*100:.0f}% | "
+            f"{r.avg_latency_ms:.0f} | {r.avg_tokens_per_sec:.0f} | "
+            f"**{r.overall_score*100:.0f}%** |"
+        )
+    
+    lines.extend([
+        "",
+        "## Recommendation",
+        "",
+    ])
+    
+    if sorted_results:
+        best = sorted_results[0]
+        lines.append(f"**Recommended Model:** {best.model.name}")
+        lines.append(f"- HuggingFace ID: `{best.model.hf_id}`")
+        lines.append(f"- Quantization: {best.model.quantization}")
+        lines.append(f"- Notes: {best.model.notes}")
+        lines.append("")
+        lines.append("**Recommended vLLM Flags:**")
+        lines.append("```bash")
+        lines.append(f"--model {best.model.hf_id} \\")
+        lines.append(f"--quantization {best.model.quantization} \\")
+        lines.append(f"--gpu-memory-utilization {best.model.gpu_memory_utilization} \\")
+        lines.append(f"--max-model-len {best.model.max_model_len}")
+        lines.append("```")
+    
+    # Detailed results
+    lines.extend([
+        "",
+        "## Detailed Results",
+        "",
+    ])
+    
+    for r in sorted_results:
+        lines.extend([
+            f"### {r.model.name}",
+            "",
+            f"**JSON Compliance:** {r.json_compliance_rate*100:.1f}%",
+            f"**Route Accuracy:** {r.route_accuracy*100:.1f}%",
+            f"**Intent Accuracy:** {r.intent_accuracy*100:.1f}%",
+            f"**Smalltalk Quality:** {r.smalltalk_quality*100:.1f}%",
+            "",
+            f"**Latency:** avg={r.avg_latency_ms:.0f}ms, p95={r.p95_latency_ms:.0f}ms",
+            f"**Throughput:** {r.avg_tokens_per_sec:.0f} tok/s",
+            "",
+        ])
+        
+        # Router test details
+        if r.router_results:
+            lines.append("**Router Tests:**")
+            for rr in r.router_results:
+                status = "✅" if rr.route_correct else "❌"
+                lines.append(f"- {status} `{rr.test_case.user_text}` → {rr.parsed_output.get('route', 'N/A') if rr.parsed_output else 'PARSE_FAIL'}")
+            lines.append("")
+    
+    report = "\n".join(lines)
+    
+    # Write to file
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(report)
+    
+    return report
+
+
+# ============================================================================
+# MOCK BENCHMARK (for testing without vLLM)
+# ============================================================================
+
+def run_mock_benchmark() -> List[ModelBenchmarkResult]:
+    """Run mock benchmark for testing.
+    
+    Returns simulated results without actually calling vLLM.
+    """
+    results = []
+    
+    # Simulate results for candidates
+    mock_scores = [
+        (DEFAULT_CANDIDATES[0], 0.95, 0.90, 0.85, 45, 120),  # Qwen - best
+        (DEFAULT_CANDIDATES[1] if len(DEFAULT_CANDIDATES) > 1 else DEFAULT_CANDIDATES[0], 
+         0.88, 0.82, 0.80, 50, 100),
+        (DEFAULT_CANDIDATES[2] if len(DEFAULT_CANDIDATES) > 2 else DEFAULT_CANDIDATES[0],
+         0.90, 0.85, 0.75, 48, 110),
+    ]
+    
+    for model, json_rate, route_acc, smalltalk, latency, toks in mock_scores:
+        result = ModelBenchmarkResult(
+            model=model,
+            json_compliance_rate=json_rate,
+            route_accuracy=route_acc,
+            intent_accuracy=route_acc * 0.9,
+            smalltalk_quality=smalltalk,
+            avg_latency_ms=latency,
+            p95_latency_ms=latency * 1.5,
+            avg_tokens_per_sec=toks,
+        )
+        
+        # Calculate overall score
+        speed_score = min(1.0, 50 / latency) if latency > 0 else 0
+        result.overall_score = (
+            0.40 * json_rate +
+            0.30 * route_acc +
+            0.20 * smalltalk +
+            0.10 * speed_score
+        )
+        
+        results.append(result)
+    
+    return results

--- a/tests/test_model_benchmark.py
+++ b/tests/test_model_benchmark.py
@@ -1,0 +1,534 @@
+"""Tests for 3B Model Benchmark Framework.
+
+Issue #239: Test model benchmark, scoring, and report generation.
+
+Test categories:
+1. ModelCandidate dataclass
+2. Test case structures
+3. Result dataclasses
+4. Benchmark engine (with mock)
+5. Report generation
+6. Mock benchmark
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.llm.model_benchmark import (
+    DEFAULT_CANDIDATES,
+    ModelBenchmark,
+    ModelBenchmarkResult,
+    ModelCandidate,
+    ROUTER_TEST_CASES,
+    RouterResult,
+    RouterTestCase,
+    SMALLTALK_TEST_CASES,
+    SmalltalkResult,
+    SmalltalkTestCase,
+    generate_report,
+    run_mock_benchmark,
+)
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+@pytest.fixture
+def sample_model() -> ModelCandidate:
+    """Create a sample model candidate."""
+    return ModelCandidate(
+        name="Test-Model-3B",
+        hf_id="test/test-model-3b",
+        quantization="awq",
+        notes="Test model",
+    )
+
+
+@pytest.fixture
+def sample_router_test() -> RouterTestCase:
+    """Create a sample router test case."""
+    return RouterTestCase(
+        user_text="saat kaç",
+        expected_route="system",
+        expected_intent="time",
+    )
+
+
+@pytest.fixture
+def sample_smalltalk_test() -> SmalltalkTestCase:
+    """Create a sample smalltalk test case."""
+    return SmalltalkTestCase(
+        user_text="merhaba",
+        expected_keywords=["merhaba", "selam", "iyi"],
+    )
+
+
+@pytest.fixture
+def temp_report_path() -> Generator[str, None, None]:
+    """Create a temporary report path."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        temp_path = f.name
+    
+    yield temp_path
+    
+    try:
+        Path(temp_path).unlink()
+    except OSError:
+        pass
+
+
+# ============================================================================
+# MODEL CANDIDATE TESTS
+# ============================================================================
+
+class TestModelCandidate:
+    """Test ModelCandidate dataclass."""
+    
+    def test_create_candidate(self, sample_model):
+        """Test candidate creation."""
+        assert sample_model.name == "Test-Model-3B"
+        assert sample_model.hf_id == "test/test-model-3b"
+        assert sample_model.quantization == "awq"
+    
+    def test_candidate_defaults(self):
+        """Test default values."""
+        model = ModelCandidate(
+            name="Test",
+            hf_id="test/test",
+        )
+        
+        assert model.quantization == "awq"
+        assert model.gpu_memory_utilization == 0.85
+        assert model.max_model_len == 4096
+    
+    def test_candidate_to_dict(self, sample_model):
+        """Test dictionary conversion."""
+        data = sample_model.to_dict()
+        
+        assert data["name"] == "Test-Model-3B"
+        assert data["hf_id"] == "test/test-model-3b"
+    
+    def test_default_candidates_exist(self):
+        """Test that default candidates are defined."""
+        assert len(DEFAULT_CANDIDATES) >= 3
+        assert all(isinstance(c, ModelCandidate) for c in DEFAULT_CANDIDATES)
+
+
+# ============================================================================
+# TEST CASE TESTS
+# ============================================================================
+
+class TestRouterTestCase:
+    """Test RouterTestCase structure."""
+    
+    def test_create_test_case(self, sample_router_test):
+        """Test creation."""
+        assert sample_router_test.user_text == "saat kaç"
+        assert sample_router_test.expected_route == "system"
+        assert sample_router_test.expected_intent == "time"
+    
+    def test_optional_slots(self):
+        """Test optional expected_slots."""
+        tc = RouterTestCase(
+            user_text="test",
+            expected_route="test",
+            expected_slots={"key": "value"},
+        )
+        
+        assert tc.expected_slots["key"] == "value"
+    
+    def test_default_test_cases_exist(self):
+        """Test that default test cases are defined."""
+        assert len(ROUTER_TEST_CASES) >= 5
+        assert all(isinstance(tc, RouterTestCase) for tc in ROUTER_TEST_CASES)
+
+
+class TestSmalltalkTestCase:
+    """Test SmalltalkTestCase structure."""
+    
+    def test_create_test_case(self, sample_smalltalk_test):
+        """Test creation."""
+        assert sample_smalltalk_test.user_text == "merhaba"
+        assert "merhaba" in sample_smalltalk_test.expected_keywords
+    
+    def test_defaults(self):
+        """Test default values."""
+        tc = SmalltalkTestCase(user_text="test")
+        
+        assert tc.min_length == 10
+        assert tc.max_length == 500
+        assert tc.expected_keywords == []
+    
+    def test_default_test_cases_exist(self):
+        """Test that default test cases are defined."""
+        assert len(SMALLTALK_TEST_CASES) >= 3
+        assert all(isinstance(tc, SmalltalkTestCase) for tc in SMALLTALK_TEST_CASES)
+
+
+# ============================================================================
+# RESULT DATACLASS TESTS
+# ============================================================================
+
+class TestRouterResult:
+    """Test RouterResult dataclass."""
+    
+    def test_create_result(self, sample_router_test):
+        """Test result creation."""
+        result = RouterResult(
+            test_case=sample_router_test,
+            raw_output='{"route": "system"}',
+            parsed_output={"route": "system"},
+            parse_success=True,
+            route_correct=True,
+            latency_ms=45.5,
+            tokens_generated=10,
+        )
+        
+        assert result.parse_success is True
+        assert result.route_correct is True
+        assert result.latency_ms == 45.5
+    
+    def test_result_to_dict(self, sample_router_test):
+        """Test dictionary conversion."""
+        result = RouterResult(
+            test_case=sample_router_test,
+            raw_output="{}",
+            parse_success=True,
+            latency_ms=50,
+        )
+        
+        data = result.to_dict()
+        
+        assert data["user_text"] == "saat kaç"
+        assert data["latency_ms"] == 50
+
+
+class TestSmalltalkResult:
+    """Test SmalltalkResult dataclass."""
+    
+    def test_create_result(self, sample_smalltalk_test):
+        """Test result creation."""
+        result = SmalltalkResult(
+            test_case=sample_smalltalk_test,
+            response="Merhaba! Size nasıl yardımcı olabilirim?",
+            keyword_hits=1,
+            length_ok=True,
+            quality_score=0.85,
+            latency_ms=60,
+        )
+        
+        assert result.quality_score == 0.85
+        assert result.length_ok is True
+    
+    def test_result_to_dict(self, sample_smalltalk_test):
+        """Test dictionary conversion."""
+        result = SmalltalkResult(
+            test_case=sample_smalltalk_test,
+            response="Test response",
+            quality_score=0.7,
+            latency_ms=55,
+        )
+        
+        data = result.to_dict()
+        
+        assert data["quality_score"] == 0.7
+
+
+class TestModelBenchmarkResult:
+    """Test ModelBenchmarkResult dataclass."""
+    
+    def test_create_result(self, sample_model):
+        """Test result creation."""
+        result = ModelBenchmarkResult(
+            model=sample_model,
+            json_compliance_rate=0.95,
+            route_accuracy=0.90,
+            smalltalk_quality=0.85,
+            avg_latency_ms=50,
+            overall_score=0.88,
+        )
+        
+        assert result.json_compliance_rate == 0.95
+        assert result.overall_score == 0.88
+    
+    def test_result_to_dict(self, sample_model):
+        """Test dictionary conversion."""
+        result = ModelBenchmarkResult(
+            model=sample_model,
+            json_compliance_rate=0.90,
+            route_accuracy=0.85,
+            avg_tokens_per_sec=100,
+        )
+        
+        data = result.to_dict()
+        
+        assert data["json_compliance_rate"] == 0.90
+        assert data["avg_tokens_per_sec"] == 100
+        assert "model" in data
+
+
+# ============================================================================
+# BENCHMARK ENGINE TESTS
+# ============================================================================
+
+class TestModelBenchmark:
+    """Test ModelBenchmark engine."""
+    
+    def test_create_benchmark(self):
+        """Test benchmark creation."""
+        bench = ModelBenchmark(vllm_base="http://test:8001")
+        
+        assert bench.vllm_base == "http://test:8001"
+        assert bench.timeout == 30.0
+    
+    def test_parse_json_direct(self):
+        """Test direct JSON parsing."""
+        bench = ModelBenchmark()
+        
+        text = '{"route": "calendar", "intent": "create"}'
+        result = bench._parse_json(text)
+        
+        assert result is not None
+        assert result["route"] == "calendar"
+    
+    def test_parse_json_with_preamble(self):
+        """Test JSON parsing with extra text."""
+        bench = ModelBenchmark()
+        
+        text = 'Certainly! {"route": "system"}'
+        result = bench._parse_json(text)
+        
+        assert result is not None
+        assert result["route"] == "system"
+    
+    def test_parse_json_invalid(self):
+        """Test invalid JSON handling."""
+        bench = ModelBenchmark()
+        
+        text = "This is not JSON at all"
+        result = bench._parse_json(text)
+        
+        assert result is None
+    
+    def test_run_router_tests_mock(self):
+        """Test router tests with mocked vLLM."""
+        bench = ModelBenchmark()
+        
+        # Mock the _call_vllm method
+        def mock_call(prompt, **kwargs):
+            return '{"route": "system", "intent": "time"}', 50.0, 15
+        
+        bench._call_vllm = mock_call
+        
+        # Run with single test case
+        results = bench.run_router_tests([
+            RouterTestCase(
+                user_text="saat kaç",
+                expected_route="system",
+                expected_intent="time",
+            )
+        ])
+        
+        assert len(results) == 1
+        assert results[0].parse_success is True
+        assert results[0].route_correct is True
+    
+    def test_run_smalltalk_tests_mock(self):
+        """Test smalltalk tests with mocked vLLM."""
+        bench = ModelBenchmark()
+        
+        # Mock response with Turkish
+        def mock_call(prompt, **kwargs):
+            return "Merhaba! Size nasıl yardımcı olabilirim?", 60.0, 20
+        
+        bench._call_vllm = mock_call
+        
+        results = bench.run_smalltalk_tests([
+            SmalltalkTestCase(
+                user_text="merhaba",
+                expected_keywords=["merhaba", "yardım"],
+            )
+        ])
+        
+        assert len(results) == 1
+        assert results[0].quality_score > 0.5  # Should score well
+    
+    def test_run_full_benchmark_mock(self, sample_model):
+        """Test full benchmark with mocked vLLM."""
+        bench = ModelBenchmark()
+        
+        call_count = 0
+        
+        def mock_call(prompt, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            
+            # Alternate between router and smalltalk responses
+            if "JSON" in kwargs.get("system_prompt", ""):
+                return '{"route": "system", "intent": "time"}', 45.0, 10
+            else:
+                return "Merhaba efendim!", 55.0, 15
+        
+        bench._call_vllm = mock_call
+        
+        result = bench.run_benchmark(sample_model)
+        
+        assert result.model == sample_model
+        assert result.json_compliance_rate >= 0
+        assert result.route_accuracy >= 0
+        assert result.overall_score >= 0
+
+
+# ============================================================================
+# REPORT GENERATION TESTS
+# ============================================================================
+
+class TestReportGeneration:
+    """Test report generation."""
+    
+    def test_generate_empty_report(self, temp_report_path):
+        """Test report with no results."""
+        report = generate_report([], temp_report_path)
+        
+        assert "# 3B Model Benchmark Report" in report
+        assert "Summary" in report
+    
+    def test_generate_report_with_results(self, temp_report_path, sample_model):
+        """Test report with results."""
+        results = [
+            ModelBenchmarkResult(
+                model=sample_model,
+                json_compliance_rate=0.95,
+                route_accuracy=0.90,
+                smalltalk_quality=0.85,
+                avg_latency_ms=50,
+                avg_tokens_per_sec=100,
+                overall_score=0.88,
+            ),
+        ]
+        
+        report = generate_report(results, temp_report_path)
+        
+        assert "Test-Model-3B" in report
+        assert "95%" in report  # JSON compliance
+        assert "Recommendation" in report
+        assert Path(temp_report_path).exists()
+    
+    def test_report_contains_vllm_flags(self, temp_report_path, sample_model):
+        """Test that report includes vLLM flags."""
+        results = [
+            ModelBenchmarkResult(
+                model=sample_model,
+                json_compliance_rate=0.90,
+                overall_score=0.85,
+            ),
+        ]
+        
+        report = generate_report(results, temp_report_path)
+        
+        assert "--model" in report
+        assert "--quantization" in report
+
+
+# ============================================================================
+# MOCK BENCHMARK TESTS
+# ============================================================================
+
+class TestMockBenchmark:
+    """Test mock benchmark functionality."""
+    
+    def test_run_mock_benchmark(self):
+        """Test mock benchmark returns results."""
+        results = run_mock_benchmark()
+        
+        assert len(results) >= 3
+        assert all(isinstance(r, ModelBenchmarkResult) for r in results)
+    
+    def test_mock_results_have_scores(self):
+        """Test that mock results have realistic scores."""
+        results = run_mock_benchmark()
+        
+        for r in results:
+            assert 0 <= r.json_compliance_rate <= 1
+            assert 0 <= r.route_accuracy <= 1
+            assert 0 <= r.smalltalk_quality <= 1
+            assert 0 <= r.overall_score <= 1
+            assert r.avg_latency_ms > 0
+            assert r.avg_tokens_per_sec > 0
+    
+    def test_mock_results_sorted_by_score(self):
+        """Test that results can be sorted by overall score."""
+        results = run_mock_benchmark()
+        
+        sorted_results = sorted(results, key=lambda r: r.overall_score, reverse=True)
+        
+        # First should have highest score
+        assert sorted_results[0].overall_score >= sorted_results[-1].overall_score
+
+
+# ============================================================================
+# INTEGRATION TESTS
+# ============================================================================
+
+class TestIntegration:
+    """Integration tests for full workflow."""
+    
+    def test_full_workflow(self, temp_report_path, sample_model):
+        """Test complete benchmark -> report workflow."""
+        # Create mock benchmark
+        bench = ModelBenchmark()
+        
+        # Mock vLLM calls
+        def mock_call(prompt, **kwargs):
+            if "JSON" in str(kwargs):
+                return '{"route": "calendar", "intent": "query"}', 40.0, 12
+            return "Merhaba, size yardımcı olabilirim.", 50.0, 18
+        
+        bench._call_vllm = mock_call
+        
+        # Run benchmark
+        result = bench.run_benchmark(sample_model)
+        
+        # Generate report
+        report = generate_report([result], temp_report_path)
+        
+        # Verify
+        assert result.overall_score > 0
+        assert Path(temp_report_path).exists()
+        assert sample_model.name in report
+    
+    def test_multiple_models_ranking(self, temp_report_path):
+        """Test ranking of multiple models."""
+        models = [
+            ModelCandidate(name="Model-A", hf_id="a/a"),
+            ModelCandidate(name="Model-B", hf_id="b/b"),
+        ]
+        
+        results = [
+            ModelBenchmarkResult(
+                model=models[0],
+                json_compliance_rate=0.90,
+                route_accuracy=0.85,
+                overall_score=0.75,
+            ),
+            ModelBenchmarkResult(
+                model=models[1],
+                json_compliance_rate=0.95,
+                route_accuracy=0.92,
+                overall_score=0.88,
+            ),
+        ]
+        
+        report = generate_report(results, temp_report_path)
+        
+        # Model-B should be recommended (higher score)
+        assert "Model-B" in report
+        assert "Recommended Model" in report


### PR DESCRIPTION
## Summary
Framework for evaluating 3B-class models for Turkish + router use case.

## Changes
- **`src/bantz/llm/model_benchmark.py`**:
  - `ModelCandidate`: Model definition with HF ID, quantization, vLLM settings
  - `RouterTestCase`/`SmalltalkTestCase`: Test case structures
  - `ModelBenchmark`: Evaluation engine
  - Router JSON compliance testing (10 test cases)
  - Turkish smalltalk quality scoring (5 test cases)
  - Heuristic quality scoring (keyword matching, length, fluency)
  - Overall weighted score: 40% JSON, 30% routing, 20% smalltalk, 10% speed

- **`scripts/bench_3b_models.py`**:
  - `--live`: Run against live vLLM instance
  - `--list-candidates`: Show available models
  - `--format`: JSON/markdown/text output
  - Mock benchmark for testing without vLLM

## Default Candidates
1. Qwen/Qwen2.5-3B-Instruct-AWQ (current default)
2. Qwen/Qwen2.5-3B-Instruct-GPTQ-Int4
3. microsoft/Phi-3.5-mini-instruct
4. google/gemma-2-2b-it

## Tests
- **31 tests** covering all functionality

Closes #239