### PR TITLE
feat(memory): preferences module for router/finalizer steering

### DIFF
--- a/src/bantz/memory/preferences.py
+++ b/src/bantz/memory/preferences.py
@@ -1,0 +1,546 @@
+"""User Preferences for Router and Finalizer Behavior.
+
+Issue #243: Use PROFILE preferences to steer router + finalizer.
+
+This module provides:
+- Preference schema (reply_length, confirm_writes, cloud_mode_default)
+- Preference injection into router prompts
+- BrainLoop config override based on preferences
+
+Preferences affect:
+- reply_length: short/normal/long -> controls max tokens
+- confirm_writes: always/ask/never -> write flow confirmation
+- cloud_mode_default: local/cloud -> finalizer gating
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class ReplyLength(Enum):
+    """User's preferred reply length."""
+    SHORT = "short"      # Kısa ve öz cevaplar
+    NORMAL = "normal"    # Normal uzunlukta cevaplar
+    LONG = "long"        # Detaylı, uzun cevaplar
+    
+    @property
+    def max_tokens(self) -> int:
+        """Get max tokens for this length preference."""
+        token_limits = {
+            ReplyLength.SHORT: 50,
+            ReplyLength.NORMAL: 150,
+            ReplyLength.LONG: 300,
+        }
+        return token_limits.get(self, 150)
+    
+    @property
+    def description_tr(self) -> str:
+        """Turkish description for prompts."""
+        descriptions = {
+            ReplyLength.SHORT: "Kısa ve öz cevaplar ver.",
+            ReplyLength.NORMAL: "Normal uzunlukta cevaplar ver.",
+            ReplyLength.LONG: "Detaylı ve kapsamlı cevaplar ver.",
+        }
+        return descriptions.get(self, "Normal uzunlukta cevaplar ver.")
+    
+    @classmethod
+    def from_str(cls, value: str) -> ReplyLength:
+        """Parse from string."""
+        value = value.strip().lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        return cls.NORMAL
+
+
+class ConfirmWrites(Enum):
+    """User's preference for write operation confirmations."""
+    ALWAYS = "always"    # Her zaman onay iste
+    ASK = "ask"          # Belirsizse sor
+    NEVER = "never"      # Hiç onay isteme
+    
+    @property
+    def requires_confirmation(self) -> bool:
+        """Check if confirmation is always required."""
+        return self == ConfirmWrites.ALWAYS
+    
+    @property
+    def description_tr(self) -> str:
+        """Turkish description for prompts."""
+        descriptions = {
+            ConfirmWrites.ALWAYS: "Yazma işlemlerinden önce HER ZAMAN kullanıcıdan onay al.",
+            ConfirmWrites.ASK: "Belirsiz durumlarda onay iste.",
+            ConfirmWrites.NEVER: "Onay istemeden işlemleri gerçekleştir.",
+        }
+        return descriptions.get(self, "Belirsiz durumlarda onay iste.")
+    
+    @classmethod
+    def from_str(cls, value: str) -> ConfirmWrites:
+        """Parse from string."""
+        value = value.strip().lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        return cls.ASK
+
+
+class CloudModeDefault(Enum):
+    """User's default cloud mode preference."""
+    LOCAL = "local"      # Varsayılan olarak yerel model
+    CLOUD = "cloud"      # Varsayılan olarak cloud (Gemini)
+    
+    @property
+    def is_cloud_enabled(self) -> bool:
+        """Check if cloud is enabled by default."""
+        return self == CloudModeDefault.CLOUD
+    
+    @property
+    def description_tr(self) -> str:
+        """Turkish description for prompts."""
+        descriptions = {
+            CloudModeDefault.LOCAL: "Yerel modeli kullan, cloud'a gönderme.",
+            CloudModeDefault.CLOUD: "Kaliteli cevap için cloud kullan.",
+        }
+        return descriptions.get(self, "Yerel modeli kullan.")
+    
+    @classmethod
+    def from_str(cls, value: str) -> CloudModeDefault:
+        """Parse from string."""
+        value = value.strip().lower()
+        for member in cls:
+            if member.value == value:
+                return member
+        return cls.LOCAL
+
+
+@dataclass(frozen=True)
+class UserPreferences:
+    """User preferences container.
+    
+    Stores user preferences that affect router and finalizer behavior.
+    """
+    reply_length: ReplyLength = ReplyLength.NORMAL
+    confirm_writes: ConfirmWrites = ConfirmWrites.ASK
+    cloud_mode_default: CloudModeDefault = CloudModeDefault.LOCAL
+    
+    # Additional preferences
+    language: str = "tr"
+    timezone: str = "Europe/Istanbul"
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "reply_length": self.reply_length.value,
+            "confirm_writes": self.confirm_writes.value,
+            "cloud_mode_default": self.cloud_mode_default.value,
+            "language": self.language,
+            "timezone": self.timezone,
+        }
+    
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> UserPreferences:
+        """Create from dictionary."""
+        return cls(
+            reply_length=ReplyLength.from_str(data.get("reply_length", "normal")),
+            confirm_writes=ConfirmWrites.from_str(data.get("confirm_writes", "ask")),
+            cloud_mode_default=CloudModeDefault.from_str(data.get("cloud_mode_default", "local")),
+            language=data.get("language", "tr"),
+            timezone=data.get("timezone", "Europe/Istanbul"),
+        )
+    
+    def to_prompt_block(self) -> str:
+        """Generate preference block for router prompt injection.
+        
+        Returns:
+            Formatted preference block for system prompt.
+        """
+        lines = [
+            "<PREFERENCES>",
+            f"- Cevap uzunluğu: {self.reply_length.description_tr}",
+            f"- Yazma onayı: {self.confirm_writes.description_tr}",
+            f"- Cloud modu: {self.cloud_mode_default.description_tr}",
+            f"- Dil: {self.language}",
+            "</PREFERENCES>",
+        ]
+        return "\n".join(lines)
+    
+    def get_max_tokens(self) -> int:
+        """Get max tokens based on reply length preference."""
+        return self.reply_length.max_tokens
+    
+    def should_confirm_write(self, is_ambiguous: bool = False) -> bool:
+        """Determine if write operation should be confirmed.
+        
+        Args:
+            is_ambiguous: Whether the operation is ambiguous.
+        
+        Returns:
+            True if confirmation should be requested.
+        """
+        if self.confirm_writes == ConfirmWrites.ALWAYS:
+            return True
+        elif self.confirm_writes == ConfirmWrites.NEVER:
+            return False
+        else:
+            return is_ambiguous
+    
+    def should_use_cloud(self, quality_requested: bool = False) -> bool:
+        """Determine if cloud should be used.
+        
+        Args:
+            quality_requested: Whether quality tier is explicitly requested.
+        
+        Returns:
+            True if cloud should be used.
+        """
+        if quality_requested:
+            return True
+        return self.cloud_mode_default.is_cloud_enabled
+
+
+# =============================================================================
+# Environment-based defaults
+# =============================================================================
+
+def _env_str(name: str, default: str = "") -> str:
+    """Get string from environment."""
+    return os.getenv(name, default).strip()
+
+
+def get_default_preferences() -> UserPreferences:
+    """Get default preferences from environment.
+    
+    Environment variables:
+    - BANTZ_REPLY_LENGTH: short/normal/long
+    - BANTZ_CONFIRM_WRITES: always/ask/never
+    - BANTZ_CLOUD_MODE: local/cloud
+    - BANTZ_LANGUAGE: tr/en
+    - BANTZ_TIMEZONE: Europe/Istanbul
+    """
+    return UserPreferences(
+        reply_length=ReplyLength.from_str(_env_str("BANTZ_REPLY_LENGTH", "normal")),
+        confirm_writes=ConfirmWrites.from_str(_env_str("BANTZ_CONFIRM_WRITES", "ask")),
+        cloud_mode_default=CloudModeDefault.from_str(_env_str("BANTZ_CLOUD_MODE", "local")),
+        language=_env_str("BANTZ_LANGUAGE", "tr"),
+        timezone=_env_str("BANTZ_TIMEZONE", "Europe/Istanbul"),
+    )
+
+
+# =============================================================================
+# Preference Store
+# =============================================================================
+
+@dataclass
+class PreferenceChange:
+    """Record of a preference change."""
+    key: str
+    old_value: Any
+    new_value: Any
+    source: str  # "user_stated", "inferred", "default"
+    confidence: float = 1.0
+
+
+class PreferenceStore:
+    """Store for user preferences with change tracking.
+    
+    Supports:
+    - Get/set individual preferences
+    - Track changes for learning
+    - Persist to file
+    """
+    
+    def __init__(self, preferences: Optional[UserPreferences] = None):
+        """Initialize preference store.
+        
+        Args:
+            preferences: Initial preferences (uses defaults if None).
+        """
+        self._preferences = preferences or get_default_preferences()
+        self._changes: list[PreferenceChange] = []
+    
+    @property
+    def preferences(self) -> UserPreferences:
+        """Get current preferences."""
+        return self._preferences
+    
+    @property
+    def changes(self) -> list[PreferenceChange]:
+        """Get change history."""
+        return list(self._changes)
+    
+    def update(
+        self,
+        reply_length: Optional[ReplyLength] = None,
+        confirm_writes: Optional[ConfirmWrites] = None,
+        cloud_mode_default: Optional[CloudModeDefault] = None,
+        language: Optional[str] = None,
+        timezone: Optional[str] = None,
+        source: str = "user_stated",
+    ) -> UserPreferences:
+        """Update preferences.
+        
+        Args:
+            reply_length: New reply length preference.
+            confirm_writes: New confirm writes preference.
+            cloud_mode_default: New cloud mode preference.
+            language: New language.
+            timezone: New timezone.
+            source: Source of the change.
+        
+        Returns:
+            Updated UserPreferences.
+        """
+        old = self._preferences
+        
+        new_prefs = UserPreferences(
+            reply_length=reply_length or old.reply_length,
+            confirm_writes=confirm_writes or old.confirm_writes,
+            cloud_mode_default=cloud_mode_default or old.cloud_mode_default,
+            language=language or old.language,
+            timezone=timezone or old.timezone,
+        )
+        
+        # Track changes
+        if reply_length and reply_length != old.reply_length:
+            self._changes.append(PreferenceChange(
+                key="reply_length",
+                old_value=old.reply_length.value,
+                new_value=reply_length.value,
+                source=source,
+            ))
+        
+        if confirm_writes and confirm_writes != old.confirm_writes:
+            self._changes.append(PreferenceChange(
+                key="confirm_writes",
+                old_value=old.confirm_writes.value,
+                new_value=confirm_writes.value,
+                source=source,
+            ))
+        
+        if cloud_mode_default and cloud_mode_default != old.cloud_mode_default:
+            self._changes.append(PreferenceChange(
+                key="cloud_mode_default",
+                old_value=old.cloud_mode_default.value,
+                new_value=cloud_mode_default.value,
+                source=source,
+            ))
+        
+        self._preferences = new_prefs
+        return new_prefs
+    
+    def set_short_replies(self, source: str = "user_stated") -> UserPreferences:
+        """Convenience: Set reply length to short."""
+        return self.update(reply_length=ReplyLength.SHORT, source=source)
+    
+    def set_always_confirm(self, source: str = "user_stated") -> UserPreferences:
+        """Convenience: Set confirm writes to always."""
+        return self.update(confirm_writes=ConfirmWrites.ALWAYS, source=source)
+    
+    def set_cloud_enabled(self, source: str = "user_stated") -> UserPreferences:
+        """Convenience: Enable cloud by default."""
+        return self.update(cloud_mode_default=CloudModeDefault.CLOUD, source=source)
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for persistence."""
+        return {
+            "preferences": self._preferences.to_dict(),
+            "changes": [
+                {
+                    "key": c.key,
+                    "old_value": c.old_value,
+                    "new_value": c.new_value,
+                    "source": c.source,
+                    "confidence": c.confidence,
+                }
+                for c in self._changes
+            ],
+        }
+    
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PreferenceStore:
+        """Create from dictionary."""
+        prefs = UserPreferences.from_dict(data.get("preferences", {}))
+        store = cls(prefs)
+        
+        for change_data in data.get("changes", []):
+            store._changes.append(PreferenceChange(
+                key=change_data["key"],
+                old_value=change_data["old_value"],
+                new_value=change_data["new_value"],
+                source=change_data.get("source", "unknown"),
+                confidence=change_data.get("confidence", 1.0),
+            ))
+        
+        return store
+
+
+# =============================================================================
+# Router Config Override
+# =============================================================================
+
+@dataclass
+class RouterConfigOverride:
+    """Configuration overrides for router based on preferences.
+    
+    Used to modify router behavior at runtime.
+    """
+    max_tokens: int = 150
+    require_confirmation: bool = False
+    cloud_enabled: bool = False
+    
+    @classmethod
+    def from_preferences(cls, prefs: UserPreferences) -> RouterConfigOverride:
+        """Create config override from user preferences."""
+        return cls(
+            max_tokens=prefs.get_max_tokens(),
+            require_confirmation=prefs.confirm_writes == ConfirmWrites.ALWAYS,
+            cloud_enabled=prefs.cloud_mode_default.is_cloud_enabled,
+        )
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "max_tokens": self.max_tokens,
+            "require_confirmation": self.require_confirmation,
+            "cloud_enabled": self.cloud_enabled,
+        }
+
+
+# =============================================================================
+# BrainLoop Config Override
+# =============================================================================
+
+@dataclass
+class BrainLoopConfigOverride:
+    """Configuration overrides for BrainLoop based on preferences.
+    
+    Passed to BrainLoop to modify behavior.
+    """
+    max_response_tokens: int = 150
+    always_confirm_writes: bool = False
+    enable_cloud_finalizer: bool = False
+    
+    @classmethod
+    def from_preferences(cls, prefs: UserPreferences) -> BrainLoopConfigOverride:
+        """Create BrainLoop config from user preferences."""
+        return cls(
+            max_response_tokens=prefs.get_max_tokens(),
+            always_confirm_writes=prefs.confirm_writes == ConfirmWrites.ALWAYS,
+            enable_cloud_finalizer=prefs.cloud_mode_default.is_cloud_enabled,
+        )
+    
+    def apply_to_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Apply overrides to a config dictionary.
+        
+        Args:
+            config: Original config dict.
+        
+        Returns:
+            Modified config dict.
+        """
+        result = dict(config)
+        result["max_response_tokens"] = self.max_response_tokens
+        result["always_confirm_writes"] = self.always_confirm_writes
+        result["enable_cloud_finalizer"] = self.enable_cloud_finalizer
+        return result
+
+
+# =============================================================================
+# Inference from user text
+# =============================================================================
+
+def infer_preferences_from_text(text: str) -> list[tuple[str, Any, float]]:
+    """Infer preference changes from user text.
+    
+    Args:
+        text: User's message.
+    
+    Returns:
+        List of (preference_key, value, confidence) tuples.
+    """
+    text_lower = text.lower()
+    inferences: list[tuple[str, Any, float]] = []
+    
+    # Reply length inference
+    short_phrases = ["kısa cevap", "kısa ver", "öz cevap", "kısa tut"]
+    long_phrases = ["detaylı cevap", "uzun cevap", "detaylı anlat", "kapsamlı"]
+    
+    for phrase in short_phrases:
+        if phrase in text_lower:
+            inferences.append(("reply_length", ReplyLength.SHORT, 0.9))
+            break
+    
+    for phrase in long_phrases:
+        if phrase in text_lower:
+            inferences.append(("reply_length", ReplyLength.LONG, 0.9))
+            break
+    
+    # Confirm writes inference
+    confirm_phrases = ["onay iste", "onay al", "sormadan yapma", "her zaman sor"]
+    no_confirm_phrases = ["onay isteme", "sormadan yap", "direkt yap"]
+    
+    for phrase in confirm_phrases:
+        if phrase in text_lower:
+            inferences.append(("confirm_writes", ConfirmWrites.ALWAYS, 0.9))
+            break
+    
+    for phrase in no_confirm_phrases:
+        if phrase in text_lower:
+            inferences.append(("confirm_writes", ConfirmWrites.NEVER, 0.8))
+            break
+    
+    # Cloud mode inference
+    cloud_phrases = ["kaliteli cevap", "gemini kullan", "cloud aç"]
+    local_phrases = ["yerel kullan", "cloud kapalı", "yerel model"]
+    
+    for phrase in cloud_phrases:
+        if phrase in text_lower:
+            inferences.append(("cloud_mode_default", CloudModeDefault.CLOUD, 0.9))
+            break
+    
+    for phrase in local_phrases:
+        if phrase in text_lower:
+            inferences.append(("cloud_mode_default", CloudModeDefault.LOCAL, 0.9))
+            break
+    
+    return inferences
+
+
+def apply_inferences(
+    store: PreferenceStore,
+    inferences: list[tuple[str, Any, float]],
+    min_confidence: float = 0.7,
+) -> list[PreferenceChange]:
+    """Apply inferred preferences to store.
+    
+    Args:
+        store: Preference store to update.
+        inferences: List of (key, value, confidence) tuples.
+        min_confidence: Minimum confidence to apply.
+    
+    Returns:
+        List of applied changes.
+    """
+    applied: list[PreferenceChange] = []
+    
+    for key, value, confidence in inferences:
+        if confidence < min_confidence:
+            continue
+        
+        if key == "reply_length" and isinstance(value, ReplyLength):
+            store.update(reply_length=value, source="inferred")
+            applied.append(PreferenceChange(key, None, value.value, "inferred", confidence))
+        
+        elif key == "confirm_writes" and isinstance(value, ConfirmWrites):
+            store.update(confirm_writes=value, source="inferred")
+            applied.append(PreferenceChange(key, None, value.value, "inferred", confidence))
+        
+        elif key == "cloud_mode_default" and isinstance(value, CloudModeDefault):
+            store.update(cloud_mode_default=value, source="inferred")
+            applied.append(PreferenceChange(key, None, value.value, "inferred", confidence))
+    
+    return applied

--- a/tests/test_memory_preferences.py
+++ b/tests/test_memory_preferences.py
@@ -1,0 +1,728 @@
+"""Tests for memory preferences module.
+
+Issue #243: PROFILE preferences to steer router + finalizer.
+
+Tests cover:
+- Preference enums (ReplyLength, ConfirmWrites, CloudModeDefault)
+- UserPreferences dataclass
+- PreferenceStore with change tracking
+- Config overrides (Router, BrainLoop)
+- Preference inference from text
+"""
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bantz.memory.preferences import (
+    ReplyLength,
+    ConfirmWrites,
+    CloudModeDefault,
+    UserPreferences,
+    PreferenceChange,
+    PreferenceStore,
+    RouterConfigOverride,
+    BrainLoopConfigOverride,
+    get_default_preferences,
+    infer_preferences_from_text,
+    apply_inferences,
+)
+
+
+# =============================================================================
+# ReplyLength Tests
+# =============================================================================
+
+class TestReplyLength:
+    """Tests for ReplyLength enum."""
+    
+    def test_short_value(self) -> None:
+        """Test SHORT value."""
+        assert ReplyLength.SHORT.value == "short"
+    
+    def test_normal_value(self) -> None:
+        """Test NORMAL value."""
+        assert ReplyLength.NORMAL.value == "normal"
+    
+    def test_long_value(self) -> None:
+        """Test LONG value."""
+        assert ReplyLength.LONG.value == "long"
+    
+    def test_short_max_tokens(self) -> None:
+        """Test SHORT max tokens."""
+        assert ReplyLength.SHORT.max_tokens == 50
+    
+    def test_normal_max_tokens(self) -> None:
+        """Test NORMAL max tokens."""
+        assert ReplyLength.NORMAL.max_tokens == 150
+    
+    def test_long_max_tokens(self) -> None:
+        """Test LONG max tokens."""
+        assert ReplyLength.LONG.max_tokens == 300
+    
+    def test_short_description_tr(self) -> None:
+        """Test SHORT Turkish description."""
+        assert "Kısa" in ReplyLength.SHORT.description_tr
+    
+    def test_normal_description_tr(self) -> None:
+        """Test NORMAL Turkish description."""
+        assert "Normal" in ReplyLength.NORMAL.description_tr
+    
+    def test_long_description_tr(self) -> None:
+        """Test LONG Turkish description."""
+        assert "Detaylı" in ReplyLength.LONG.description_tr
+    
+    def test_from_str_short(self) -> None:
+        """Test parsing short."""
+        assert ReplyLength.from_str("short") == ReplyLength.SHORT
+    
+    def test_from_str_normal(self) -> None:
+        """Test parsing normal."""
+        assert ReplyLength.from_str("normal") == ReplyLength.NORMAL
+    
+    def test_from_str_long(self) -> None:
+        """Test parsing long."""
+        assert ReplyLength.from_str("long") == ReplyLength.LONG
+    
+    def test_from_str_case_insensitive(self) -> None:
+        """Test case insensitive parsing."""
+        assert ReplyLength.from_str("SHORT") == ReplyLength.SHORT
+        assert ReplyLength.from_str("Normal") == ReplyLength.NORMAL
+    
+    def test_from_str_whitespace(self) -> None:
+        """Test parsing with whitespace."""
+        assert ReplyLength.from_str("  short  ") == ReplyLength.SHORT
+    
+    def test_from_str_unknown(self) -> None:
+        """Test parsing unknown returns NORMAL."""
+        assert ReplyLength.from_str("unknown") == ReplyLength.NORMAL
+
+
+# =============================================================================
+# ConfirmWrites Tests
+# =============================================================================
+
+class TestConfirmWrites:
+    """Tests for ConfirmWrites enum."""
+    
+    def test_always_value(self) -> None:
+        """Test ALWAYS value."""
+        assert ConfirmWrites.ALWAYS.value == "always"
+    
+    def test_ask_value(self) -> None:
+        """Test ASK value."""
+        assert ConfirmWrites.ASK.value == "ask"
+    
+    def test_never_value(self) -> None:
+        """Test NEVER value."""
+        assert ConfirmWrites.NEVER.value == "never"
+    
+    def test_always_requires_confirmation(self) -> None:
+        """Test ALWAYS requires confirmation."""
+        assert ConfirmWrites.ALWAYS.requires_confirmation is True
+    
+    def test_ask_not_requires_confirmation(self) -> None:
+        """Test ASK does not require confirmation."""
+        assert ConfirmWrites.ASK.requires_confirmation is False
+    
+    def test_never_not_requires_confirmation(self) -> None:
+        """Test NEVER does not require confirmation."""
+        assert ConfirmWrites.NEVER.requires_confirmation is False
+    
+    def test_always_description_tr(self) -> None:
+        """Test ALWAYS Turkish description."""
+        assert "HER ZAMAN" in ConfirmWrites.ALWAYS.description_tr
+    
+    def test_from_str_always(self) -> None:
+        """Test parsing always."""
+        assert ConfirmWrites.from_str("always") == ConfirmWrites.ALWAYS
+    
+    def test_from_str_ask(self) -> None:
+        """Test parsing ask."""
+        assert ConfirmWrites.from_str("ask") == ConfirmWrites.ASK
+    
+    def test_from_str_never(self) -> None:
+        """Test parsing never."""
+        assert ConfirmWrites.from_str("never") == ConfirmWrites.NEVER
+    
+    def test_from_str_unknown(self) -> None:
+        """Test parsing unknown returns ASK."""
+        assert ConfirmWrites.from_str("unknown") == ConfirmWrites.ASK
+
+
+# =============================================================================
+# CloudModeDefault Tests
+# =============================================================================
+
+class TestCloudModeDefault:
+    """Tests for CloudModeDefault enum."""
+    
+    def test_local_value(self) -> None:
+        """Test LOCAL value."""
+        assert CloudModeDefault.LOCAL.value == "local"
+    
+    def test_cloud_value(self) -> None:
+        """Test CLOUD value."""
+        assert CloudModeDefault.CLOUD.value == "cloud"
+    
+    def test_local_not_cloud_enabled(self) -> None:
+        """Test LOCAL cloud not enabled."""
+        assert CloudModeDefault.LOCAL.is_cloud_enabled is False
+    
+    def test_cloud_is_cloud_enabled(self) -> None:
+        """Test CLOUD cloud enabled."""
+        assert CloudModeDefault.CLOUD.is_cloud_enabled is True
+    
+    def test_local_description_tr(self) -> None:
+        """Test LOCAL Turkish description."""
+        assert "Yerel" in CloudModeDefault.LOCAL.description_tr
+    
+    def test_cloud_description_tr(self) -> None:
+        """Test CLOUD Turkish description."""
+        assert "cloud" in CloudModeDefault.CLOUD.description_tr
+    
+    def test_from_str_local(self) -> None:
+        """Test parsing local."""
+        assert CloudModeDefault.from_str("local") == CloudModeDefault.LOCAL
+    
+    def test_from_str_cloud(self) -> None:
+        """Test parsing cloud."""
+        assert CloudModeDefault.from_str("cloud") == CloudModeDefault.CLOUD
+    
+    def test_from_str_unknown(self) -> None:
+        """Test parsing unknown returns LOCAL."""
+        assert CloudModeDefault.from_str("unknown") == CloudModeDefault.LOCAL
+
+
+# =============================================================================
+# UserPreferences Tests
+# =============================================================================
+
+class TestUserPreferences:
+    """Tests for UserPreferences dataclass."""
+    
+    def test_default_values(self) -> None:
+        """Test default preference values."""
+        prefs = UserPreferences()
+        assert prefs.reply_length == ReplyLength.NORMAL
+        assert prefs.confirm_writes == ConfirmWrites.ASK
+        assert prefs.cloud_mode_default == CloudModeDefault.LOCAL
+        assert prefs.language == "tr"
+        assert prefs.timezone == "Europe/Istanbul"
+    
+    def test_custom_values(self) -> None:
+        """Test custom preference values."""
+        prefs = UserPreferences(
+            reply_length=ReplyLength.SHORT,
+            confirm_writes=ConfirmWrites.ALWAYS,
+            cloud_mode_default=CloudModeDefault.CLOUD,
+        )
+        assert prefs.reply_length == ReplyLength.SHORT
+        assert prefs.confirm_writes == ConfirmWrites.ALWAYS
+        assert prefs.cloud_mode_default == CloudModeDefault.CLOUD
+    
+    def test_frozen(self) -> None:
+        """Test preferences are frozen."""
+        prefs = UserPreferences()
+        with pytest.raises(Exception):  # FrozenInstanceError
+            prefs.reply_length = ReplyLength.LONG  # type: ignore
+    
+    def test_to_dict(self) -> None:
+        """Test to_dict conversion."""
+        prefs = UserPreferences(
+            reply_length=ReplyLength.SHORT,
+            confirm_writes=ConfirmWrites.ALWAYS,
+            cloud_mode_default=CloudModeDefault.CLOUD,
+        )
+        d = prefs.to_dict()
+        assert d["reply_length"] == "short"
+        assert d["confirm_writes"] == "always"
+        assert d["cloud_mode_default"] == "cloud"
+        assert d["language"] == "tr"
+        assert d["timezone"] == "Europe/Istanbul"
+    
+    def test_from_dict(self) -> None:
+        """Test from_dict creation."""
+        data = {
+            "reply_length": "long",
+            "confirm_writes": "never",
+            "cloud_mode_default": "cloud",
+            "language": "en",
+            "timezone": "UTC",
+        }
+        prefs = UserPreferences.from_dict(data)
+        assert prefs.reply_length == ReplyLength.LONG
+        assert prefs.confirm_writes == ConfirmWrites.NEVER
+        assert prefs.cloud_mode_default == CloudModeDefault.CLOUD
+        assert prefs.language == "en"
+        assert prefs.timezone == "UTC"
+    
+    def test_from_dict_empty(self) -> None:
+        """Test from_dict with empty dict uses defaults."""
+        prefs = UserPreferences.from_dict({})
+        assert prefs.reply_length == ReplyLength.NORMAL
+        assert prefs.confirm_writes == ConfirmWrites.ASK
+    
+    def test_to_prompt_block(self) -> None:
+        """Test prompt block generation."""
+        prefs = UserPreferences(reply_length=ReplyLength.SHORT)
+        block = prefs.to_prompt_block()
+        assert "<PREFERENCES>" in block
+        assert "</PREFERENCES>" in block
+        assert "Kısa" in block
+    
+    def test_get_max_tokens(self) -> None:
+        """Test max tokens getter."""
+        prefs_short = UserPreferences(reply_length=ReplyLength.SHORT)
+        prefs_long = UserPreferences(reply_length=ReplyLength.LONG)
+        assert prefs_short.get_max_tokens() == 50
+        assert prefs_long.get_max_tokens() == 300
+    
+    def test_should_confirm_write_always(self) -> None:
+        """Test should_confirm_write with ALWAYS."""
+        prefs = UserPreferences(confirm_writes=ConfirmWrites.ALWAYS)
+        assert prefs.should_confirm_write() is True
+        assert prefs.should_confirm_write(is_ambiguous=False) is True
+    
+    def test_should_confirm_write_never(self) -> None:
+        """Test should_confirm_write with NEVER."""
+        prefs = UserPreferences(confirm_writes=ConfirmWrites.NEVER)
+        assert prefs.should_confirm_write() is False
+        assert prefs.should_confirm_write(is_ambiguous=True) is False
+    
+    def test_should_confirm_write_ask(self) -> None:
+        """Test should_confirm_write with ASK."""
+        prefs = UserPreferences(confirm_writes=ConfirmWrites.ASK)
+        assert prefs.should_confirm_write() is False
+        assert prefs.should_confirm_write(is_ambiguous=True) is True
+    
+    def test_should_use_cloud_default_local(self) -> None:
+        """Test should_use_cloud with LOCAL default."""
+        prefs = UserPreferences(cloud_mode_default=CloudModeDefault.LOCAL)
+        assert prefs.should_use_cloud() is False
+        assert prefs.should_use_cloud(quality_requested=True) is True
+    
+    def test_should_use_cloud_default_cloud(self) -> None:
+        """Test should_use_cloud with CLOUD default."""
+        prefs = UserPreferences(cloud_mode_default=CloudModeDefault.CLOUD)
+        assert prefs.should_use_cloud() is True
+
+
+# =============================================================================
+# PreferenceChange Tests
+# =============================================================================
+
+class TestPreferenceChange:
+    """Tests for PreferenceChange dataclass."""
+    
+    def test_creation(self) -> None:
+        """Test change creation."""
+        change = PreferenceChange(
+            key="reply_length",
+            old_value="normal",
+            new_value="short",
+            source="user_stated",
+        )
+        assert change.key == "reply_length"
+        assert change.old_value == "normal"
+        assert change.new_value == "short"
+        assert change.source == "user_stated"
+        assert change.confidence == 1.0
+    
+    def test_custom_confidence(self) -> None:
+        """Test change with custom confidence."""
+        change = PreferenceChange(
+            key="reply_length",
+            old_value="normal",
+            new_value="short",
+            source="inferred",
+            confidence=0.8,
+        )
+        assert change.confidence == 0.8
+
+
+# =============================================================================
+# PreferenceStore Tests
+# =============================================================================
+
+class TestPreferenceStore:
+    """Tests for PreferenceStore class."""
+    
+    def test_default_init(self) -> None:
+        """Test default initialization."""
+        store = PreferenceStore()
+        assert store.preferences.reply_length == ReplyLength.NORMAL
+        assert len(store.changes) == 0
+    
+    def test_custom_init(self) -> None:
+        """Test custom initialization."""
+        prefs = UserPreferences(reply_length=ReplyLength.SHORT)
+        store = PreferenceStore(prefs)
+        assert store.preferences.reply_length == ReplyLength.SHORT
+    
+    def test_update_reply_length(self) -> None:
+        """Test updating reply length."""
+        store = PreferenceStore()
+        new_prefs = store.update(reply_length=ReplyLength.SHORT)
+        assert new_prefs.reply_length == ReplyLength.SHORT
+        assert store.preferences.reply_length == ReplyLength.SHORT
+    
+    def test_update_tracks_change(self) -> None:
+        """Test that update tracks changes."""
+        store = PreferenceStore()
+        store.update(reply_length=ReplyLength.SHORT)
+        assert len(store.changes) == 1
+        assert store.changes[0].key == "reply_length"
+        assert store.changes[0].new_value == "short"
+    
+    def test_update_multiple_fields(self) -> None:
+        """Test updating multiple fields."""
+        store = PreferenceStore()
+        store.update(
+            reply_length=ReplyLength.SHORT,
+            confirm_writes=ConfirmWrites.ALWAYS,
+        )
+        assert len(store.changes) == 2
+    
+    def test_update_no_change_no_record(self) -> None:
+        """Test that no change is recorded if value same."""
+        prefs = UserPreferences(reply_length=ReplyLength.SHORT)
+        store = PreferenceStore(prefs)
+        store.update(reply_length=ReplyLength.SHORT)
+        assert len(store.changes) == 0
+    
+    def test_set_short_replies(self) -> None:
+        """Test convenience method for short replies."""
+        store = PreferenceStore()
+        store.set_short_replies()
+        assert store.preferences.reply_length == ReplyLength.SHORT
+    
+    def test_set_always_confirm(self) -> None:
+        """Test convenience method for always confirm."""
+        store = PreferenceStore()
+        store.set_always_confirm()
+        assert store.preferences.confirm_writes == ConfirmWrites.ALWAYS
+    
+    def test_set_cloud_enabled(self) -> None:
+        """Test convenience method for cloud enabled."""
+        store = PreferenceStore()
+        store.set_cloud_enabled()
+        assert store.preferences.cloud_mode_default == CloudModeDefault.CLOUD
+    
+    def test_to_dict(self) -> None:
+        """Test to_dict conversion."""
+        store = PreferenceStore()
+        store.update(reply_length=ReplyLength.SHORT)
+        d = store.to_dict()
+        assert "preferences" in d
+        assert "changes" in d
+        assert d["preferences"]["reply_length"] == "short"
+        assert len(d["changes"]) == 1
+    
+    def test_from_dict(self) -> None:
+        """Test from_dict creation."""
+        data = {
+            "preferences": {"reply_length": "short"},
+            "changes": [
+                {"key": "reply_length", "old_value": "normal", "new_value": "short", "source": "user", "confidence": 0.9}
+            ],
+        }
+        store = PreferenceStore.from_dict(data)
+        assert store.preferences.reply_length == ReplyLength.SHORT
+        assert len(store.changes) == 1
+
+
+# =============================================================================
+# RouterConfigOverride Tests
+# =============================================================================
+
+class TestRouterConfigOverride:
+    """Tests for RouterConfigOverride."""
+    
+    def test_default_values(self) -> None:
+        """Test default override values."""
+        override = RouterConfigOverride()
+        assert override.max_tokens == 150
+        assert override.require_confirmation is False
+        assert override.cloud_enabled is False
+    
+    def test_from_preferences_short(self) -> None:
+        """Test from preferences with short replies."""
+        prefs = UserPreferences(reply_length=ReplyLength.SHORT)
+        override = RouterConfigOverride.from_preferences(prefs)
+        assert override.max_tokens == 50
+    
+    def test_from_preferences_always_confirm(self) -> None:
+        """Test from preferences with always confirm."""
+        prefs = UserPreferences(confirm_writes=ConfirmWrites.ALWAYS)
+        override = RouterConfigOverride.from_preferences(prefs)
+        assert override.require_confirmation is True
+    
+    def test_from_preferences_cloud(self) -> None:
+        """Test from preferences with cloud enabled."""
+        prefs = UserPreferences(cloud_mode_default=CloudModeDefault.CLOUD)
+        override = RouterConfigOverride.from_preferences(prefs)
+        assert override.cloud_enabled is True
+    
+    def test_to_dict(self) -> None:
+        """Test to_dict conversion."""
+        override = RouterConfigOverride(max_tokens=50, require_confirmation=True, cloud_enabled=True)
+        d = override.to_dict()
+        assert d["max_tokens"] == 50
+        assert d["require_confirmation"] is True
+        assert d["cloud_enabled"] is True
+
+
+# =============================================================================
+# BrainLoopConfigOverride Tests
+# =============================================================================
+
+class TestBrainLoopConfigOverride:
+    """Tests for BrainLoopConfigOverride."""
+    
+    def test_default_values(self) -> None:
+        """Test default override values."""
+        override = BrainLoopConfigOverride()
+        assert override.max_response_tokens == 150
+        assert override.always_confirm_writes is False
+        assert override.enable_cloud_finalizer is False
+    
+    def test_from_preferences(self) -> None:
+        """Test from preferences."""
+        prefs = UserPreferences(
+            reply_length=ReplyLength.LONG,
+            confirm_writes=ConfirmWrites.ALWAYS,
+            cloud_mode_default=CloudModeDefault.CLOUD,
+        )
+        override = BrainLoopConfigOverride.from_preferences(prefs)
+        assert override.max_response_tokens == 300
+        assert override.always_confirm_writes is True
+        assert override.enable_cloud_finalizer is True
+    
+    def test_apply_to_config(self) -> None:
+        """Test applying to config dict."""
+        override = BrainLoopConfigOverride(
+            max_response_tokens=50,
+            always_confirm_writes=True,
+            enable_cloud_finalizer=True,
+        )
+        config = {"some_key": "value"}
+        result = override.apply_to_config(config)
+        assert result["some_key"] == "value"
+        assert result["max_response_tokens"] == 50
+        assert result["always_confirm_writes"] is True
+        assert result["enable_cloud_finalizer"] is True
+
+
+# =============================================================================
+# Environment Variable Tests
+# =============================================================================
+
+class TestGetDefaultPreferences:
+    """Tests for get_default_preferences function."""
+    
+    def test_default_without_env(self) -> None:
+        """Test defaults without environment variables."""
+        with patch.dict(os.environ, {}, clear=True):
+            prefs = get_default_preferences()
+            assert prefs.reply_length == ReplyLength.NORMAL
+    
+    def test_reply_length_from_env(self) -> None:
+        """Test reply length from environment."""
+        with patch.dict(os.environ, {"BANTZ_REPLY_LENGTH": "short"}):
+            prefs = get_default_preferences()
+            assert prefs.reply_length == ReplyLength.SHORT
+    
+    def test_confirm_writes_from_env(self) -> None:
+        """Test confirm writes from environment."""
+        with patch.dict(os.environ, {"BANTZ_CONFIRM_WRITES": "always"}):
+            prefs = get_default_preferences()
+            assert prefs.confirm_writes == ConfirmWrites.ALWAYS
+    
+    def test_cloud_mode_from_env(self) -> None:
+        """Test cloud mode from environment."""
+        with patch.dict(os.environ, {"BANTZ_CLOUD_MODE": "cloud"}):
+            prefs = get_default_preferences()
+            assert prefs.cloud_mode_default == CloudModeDefault.CLOUD
+    
+    def test_language_from_env(self) -> None:
+        """Test language from environment."""
+        with patch.dict(os.environ, {"BANTZ_LANGUAGE": "en"}):
+            prefs = get_default_preferences()
+            assert prefs.language == "en"
+    
+    def test_timezone_from_env(self) -> None:
+        """Test timezone from environment."""
+        with patch.dict(os.environ, {"BANTZ_TIMEZONE": "UTC"}):
+            prefs = get_default_preferences()
+            assert prefs.timezone == "UTC"
+
+
+# =============================================================================
+# Preference Inference Tests
+# =============================================================================
+
+class TestInferPreferencesFromText:
+    """Tests for infer_preferences_from_text function."""
+    
+    def test_infer_short_reply(self) -> None:
+        """Test inferring short reply preference."""
+        inferences = infer_preferences_from_text("Kısa cevap ver lütfen")
+        assert len(inferences) > 0
+        assert ("reply_length", ReplyLength.SHORT, 0.9) in inferences
+    
+    def test_infer_short_reply_variant(self) -> None:
+        """Test inferring short reply with variant phrase."""
+        inferences = infer_preferences_from_text("Cevapları kısa tut")
+        assert any(i[1] == ReplyLength.SHORT for i in inferences)
+    
+    def test_infer_long_reply(self) -> None:
+        """Test inferring long reply preference."""
+        inferences = infer_preferences_from_text("Detaylı cevap istiyorum")
+        assert any(i[1] == ReplyLength.LONG for i in inferences)
+    
+    def test_infer_always_confirm(self) -> None:
+        """Test inferring always confirm preference."""
+        inferences = infer_preferences_from_text("Her zaman sor bana")
+        assert any(i[1] == ConfirmWrites.ALWAYS for i in inferences)
+    
+    def test_infer_never_confirm(self) -> None:
+        """Test inferring never confirm preference."""
+        inferences = infer_preferences_from_text("Sormadan yap")
+        assert any(i[1] == ConfirmWrites.NEVER for i in inferences)
+    
+    def test_infer_cloud_enabled(self) -> None:
+        """Test inferring cloud enabled preference."""
+        inferences = infer_preferences_from_text("Gemini kullan kaliteli cevap için")
+        assert any(i[1] == CloudModeDefault.CLOUD for i in inferences)
+    
+    def test_infer_local_mode(self) -> None:
+        """Test inferring local mode preference."""
+        inferences = infer_preferences_from_text("Yerel model kullan")
+        assert any(i[1] == CloudModeDefault.LOCAL for i in inferences)
+    
+    def test_infer_multiple_preferences(self) -> None:
+        """Test inferring multiple preferences."""
+        inferences = infer_preferences_from_text("Kısa cevap ver ve onay iste")
+        assert len(inferences) >= 2
+    
+    def test_no_inference_generic_text(self) -> None:
+        """Test no inference for generic text."""
+        inferences = infer_preferences_from_text("Bugün hava nasıl?")
+        assert len(inferences) == 0
+
+
+# =============================================================================
+# Apply Inferences Tests
+# =============================================================================
+
+class TestApplyInferences:
+    """Tests for apply_inferences function."""
+    
+    def test_apply_high_confidence(self) -> None:
+        """Test applying high confidence inferences."""
+        store = PreferenceStore()
+        inferences = [("reply_length", ReplyLength.SHORT, 0.9)]
+        applied = apply_inferences(store, inferences)
+        assert len(applied) == 1
+        assert store.preferences.reply_length == ReplyLength.SHORT
+    
+    def test_skip_low_confidence(self) -> None:
+        """Test skipping low confidence inferences."""
+        store = PreferenceStore()
+        inferences = [("reply_length", ReplyLength.SHORT, 0.5)]
+        applied = apply_inferences(store, inferences, min_confidence=0.7)
+        assert len(applied) == 0
+        assert store.preferences.reply_length == ReplyLength.NORMAL
+    
+    def test_apply_multiple_inferences(self) -> None:
+        """Test applying multiple inferences."""
+        store = PreferenceStore()
+        inferences = [
+            ("reply_length", ReplyLength.SHORT, 0.9),
+            ("confirm_writes", ConfirmWrites.ALWAYS, 0.8),
+        ]
+        applied = apply_inferences(store, inferences)
+        assert len(applied) == 2
+        assert store.preferences.reply_length == ReplyLength.SHORT
+        assert store.preferences.confirm_writes == ConfirmWrites.ALWAYS
+    
+    def test_apply_cloud_mode(self) -> None:
+        """Test applying cloud mode inference."""
+        store = PreferenceStore()
+        inferences = [("cloud_mode_default", CloudModeDefault.CLOUD, 0.9)]
+        applied = apply_inferences(store, inferences)
+        assert store.preferences.cloud_mode_default == CloudModeDefault.CLOUD
+
+
+# =============================================================================
+# E2E Integration Tests
+# =============================================================================
+
+class TestPreferenceE2E:
+    """End-to-end integration tests."""
+    
+    def test_short_preference_to_config(self) -> None:
+        """Test short preference flows to config."""
+        # User says "kısa cevap ver"
+        inferences = infer_preferences_from_text("Kısa cevap ver")
+        
+        # Apply to store
+        store = PreferenceStore()
+        apply_inferences(store, inferences)
+        
+        # Get config override
+        override = BrainLoopConfigOverride.from_preferences(store.preferences)
+        
+        # Verify max tokens is 50 (short)
+        assert override.max_response_tokens == 50
+    
+    def test_cloud_preference_to_config(self) -> None:
+        """Test cloud preference flows to config."""
+        # User says "kaliteli cevap ver"
+        inferences = infer_preferences_from_text("Kaliteli cevap ver, gemini kullan")
+        
+        # Apply to store
+        store = PreferenceStore()
+        apply_inferences(store, inferences)
+        
+        # Get config override
+        override = BrainLoopConfigOverride.from_preferences(store.preferences)
+        
+        # Verify cloud is enabled
+        assert override.enable_cloud_finalizer is True
+    
+    def test_prompt_block_generation(self) -> None:
+        """Test prompt block is properly generated."""
+        prefs = UserPreferences(
+            reply_length=ReplyLength.SHORT,
+            confirm_writes=ConfirmWrites.ALWAYS,
+            cloud_mode_default=CloudModeDefault.CLOUD,
+        )
+        block = prefs.to_prompt_block()
+        
+        # Verify block structure
+        assert "<PREFERENCES>" in block
+        assert "</PREFERENCES>" in block
+        assert "Kısa" in block
+        assert "HER ZAMAN" in block
+        assert "cloud" in block
+    
+    def test_preference_persistence_round_trip(self) -> None:
+        """Test preferences can be persisted and restored."""
+        # Create and modify
+        store1 = PreferenceStore()
+        store1.set_short_replies()
+        store1.set_cloud_enabled()
+        
+        # Persist
+        data = store1.to_dict()
+        
+        # Restore
+        store2 = PreferenceStore.from_dict(data)
+        
+        # Verify
+        assert store2.preferences.reply_length == ReplyLength.SHORT
+        assert store2.preferences.cloud_mode_default == CloudModeDefault.CLOUD


### PR DESCRIPTION
## Summary
Implements Issue #243: PROFILE preferences to steer router + finalizer.

## Changes
- **Preference Schema**: ReplyLength (short/normal/long), ConfirmWrites (always/ask/never), CloudModeDefault (local/cloud)
- **UserPreferences**: Frozen dataclass with prompt block generation
- **PreferenceStore**: Store with change tracking and persistence
- **Config Overrides**: RouterConfigOverride and BrainLoopConfigOverride for runtime behavior
- **Environment Variables**: BANTZ_REPLY_LENGTH, BANTZ_CONFIRM_WRITES, BANTZ_CLOUD_MODE
- **Inference**: Preference detection from Turkish text

## Testing
- 92 comprehensive tests covering all functionality
- E2E tests for preference → config flow

Closes #243