### PR TITLE
feat(debug): tier debug info for router/finalizer decisions

### DIFF
--- a/src/bantz/debug/tier_info.py
+++ b/src/bantz/debug/tier_info.py
@@ -1,0 +1,683 @@
+"""Debug Tier Information for Router and Finalizer Decisions.
+
+Issue #244: Debug tier decisions + quality hit/miss.
+
+This module provides:
+- Debug output for tier routing decisions
+- --debug flag and BANTZ_DEBUG_TIERS=1 env support
+- Show router_backend, finalizer_backend, quality called
+- Performance timing metrics
+
+Usage:
+    # Enable via environment
+    export BANTZ_DEBUG_TIERS=1
+    
+    # Or programmatically
+    from bantz.debug.tier_info import TierDebugger
+    debugger = TierDebugger(enabled=True)
+    debugger.log_router_decision(...)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Callable, Optional, TextIO
+
+
+# =============================================================================
+# Enums
+# =============================================================================
+
+class TierBackend(Enum):
+    """Backend tier for routing."""
+    VLLM_LOCAL = "vllm_local"      # Local Qwen2.5-3B
+    GEMINI_CLOUD = "gemini_cloud"  # Gemini 1.5 Flash
+    OPENAI_CLOUD = "openai_cloud"  # OpenAI fallback
+    MOCK = "mock"                  # Mock for testing
+    UNKNOWN = "unknown"
+
+
+class TierDecisionType(Enum):
+    """Type of tier decision."""
+    ROUTER = "router"              # Initial routing decision
+    FINALIZER = "finalizer"        # Finalizer selection
+    QUALITY_CHECK = "quality"      # Quality assessment
+    FALLBACK = "fallback"          # Fallback triggered
+    BYPASS = "bypass"              # Rule-based bypass
+
+
+class QualityResult(Enum):
+    """Quality check result."""
+    PASS = "pass"                  # Quality met threshold
+    FAIL = "fail"                  # Quality below threshold
+    SKIP = "skip"                  # Quality check skipped
+    PENDING = "pending"            # Not yet checked
+
+
+# =============================================================================
+# Debug Configuration
+# =============================================================================
+
+def is_debug_enabled() -> bool:
+    """Check if tier debug mode is enabled.
+    
+    Enabled by:
+    - BANTZ_DEBUG_TIERS=1 environment variable
+    - BANTZ_DEBUG=1 environment variable
+    - --debug CLI flag (sets env var)
+    """
+    debug_tiers = os.getenv("BANTZ_DEBUG_TIERS", "").strip().lower()
+    debug_main = os.getenv("BANTZ_DEBUG", "").strip().lower()
+    
+    return debug_tiers in ("1", "true", "yes") or debug_main in ("1", "true", "yes")
+
+
+def enable_debug() -> None:
+    """Enable tier debug mode."""
+    os.environ["BANTZ_DEBUG_TIERS"] = "1"
+
+
+def disable_debug() -> None:
+    """Disable tier debug mode."""
+    os.environ.pop("BANTZ_DEBUG_TIERS", None)
+
+
+# =============================================================================
+# Decision Records
+# =============================================================================
+
+@dataclass
+class TierDecision:
+    """Record of a tier decision.
+    
+    Captures what decision was made, when, and why.
+    """
+    decision_type: TierDecisionType
+    backend: TierBackend
+    timestamp: datetime = field(default_factory=datetime.now)
+    duration_ms: float = 0.0
+    reason: str = ""
+    confidence: float = 1.0
+    quality_result: QualityResult = QualityResult.PENDING
+    metadata: dict[str, Any] = field(default_factory=dict)
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "decision_type": self.decision_type.value,
+            "backend": self.backend.value,
+            "timestamp": self.timestamp.isoformat(),
+            "duration_ms": self.duration_ms,
+            "reason": self.reason,
+            "confidence": self.confidence,
+            "quality_result": self.quality_result.value,
+            "metadata": self.metadata,
+        }
+    
+    def format_short(self) -> str:
+        """Format as short one-line string."""
+        return (
+            f"[{self.decision_type.value.upper():10}] "
+            f"{self.backend.value:15} "
+            f"({self.duration_ms:6.1f}ms) "
+            f"{self.reason}"
+        )
+    
+    def format_detailed(self) -> str:
+        """Format as detailed multi-line string."""
+        lines = [
+            f"=== Tier Decision: {self.decision_type.value.upper()} ===",
+            f"  Backend: {self.backend.value}",
+            f"  Time: {self.timestamp.strftime('%H:%M:%S.%f')[:-3]}",
+            f"  Duration: {self.duration_ms:.1f}ms",
+            f"  Confidence: {self.confidence:.2f}",
+            f"  Reason: {self.reason}",
+        ]
+        
+        if self.quality_result != QualityResult.PENDING:
+            lines.append(f"  Quality: {self.quality_result.value}")
+        
+        if self.metadata:
+            lines.append("  Metadata:")
+            for key, value in self.metadata.items():
+                lines.append(f"    {key}: {value}")
+        
+        return "\n".join(lines)
+
+
+@dataclass
+class TierSession:
+    """Session of tier decisions for a single request.
+    
+    Groups related decisions together for analysis.
+    """
+    session_id: str
+    start_time: datetime = field(default_factory=datetime.now)
+    decisions: list[TierDecision] = field(default_factory=list)
+    user_query: str = ""
+    final_response: str = ""
+    total_duration_ms: float = 0.0
+    
+    def add_decision(self, decision: TierDecision) -> None:
+        """Add a decision to the session."""
+        self.decisions.append(decision)
+    
+    def get_router_backend(self) -> Optional[TierBackend]:
+        """Get the router backend used."""
+        for d in self.decisions:
+            if d.decision_type == TierDecisionType.ROUTER:
+                return d.backend
+        return None
+    
+    def get_finalizer_backend(self) -> Optional[TierBackend]:
+        """Get the finalizer backend used."""
+        for d in self.decisions:
+            if d.decision_type == TierDecisionType.FINALIZER:
+                return d.backend
+        return None
+    
+    def was_quality_called(self) -> bool:
+        """Check if quality check was called."""
+        return any(
+            d.decision_type == TierDecisionType.QUALITY_CHECK
+            for d in self.decisions
+        )
+    
+    def quality_passed(self) -> bool:
+        """Check if quality check passed."""
+        for d in self.decisions:
+            if d.decision_type == TierDecisionType.QUALITY_CHECK:
+                return d.quality_result == QualityResult.PASS
+        return False
+    
+    def format_summary(self) -> str:
+        """Format session summary."""
+        router = self.get_router_backend()
+        finalizer = self.get_finalizer_backend()
+        quality = "called" if self.was_quality_called() else "skipped"
+        
+        return (
+            f"[TIER DEBUG] session={self.session_id} "
+            f"router={router.value if router else 'none'} "
+            f"finalizer={finalizer.value if finalizer else 'none'} "
+            f"quality={quality} "
+            f"total={self.total_duration_ms:.1f}ms"
+        )
+    
+    def format_full(self) -> str:
+        """Format full session details."""
+        lines = [
+            "=" * 60,
+            f"TIER DEBUG SESSION: {self.session_id}",
+            "=" * 60,
+            f"Query: {self.user_query[:50]}..." if len(self.user_query) > 50 else f"Query: {self.user_query}",
+            f"Start: {self.start_time.strftime('%H:%M:%S.%f')[:-3]}",
+            "",
+            "Decisions:",
+        ]
+        
+        for i, decision in enumerate(self.decisions, 1):
+            lines.append(f"  {i}. {decision.format_short()}")
+        
+        lines.extend([
+            "",
+            f"Total Duration: {self.total_duration_ms:.1f}ms",
+            "=" * 60,
+        ])
+        
+        return "\n".join(lines)
+    
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "session_id": self.session_id,
+            "start_time": self.start_time.isoformat(),
+            "user_query": self.user_query,
+            "decisions": [d.to_dict() for d in self.decisions],
+            "total_duration_ms": self.total_duration_ms,
+            "router_backend": self.get_router_backend().value if self.get_router_backend() else None,
+            "finalizer_backend": self.get_finalizer_backend().value if self.get_finalizer_backend() else None,
+            "quality_called": self.was_quality_called(),
+        }
+
+
+# =============================================================================
+# Timer Context Manager
+# =============================================================================
+
+class TierTimer:
+    """Context manager for timing tier operations."""
+    
+    def __init__(self) -> None:
+        self._start: float = 0.0
+        self._end: float = 0.0
+    
+    def __enter__(self) -> "TierTimer":
+        self._start = time.perf_counter()
+        return self
+    
+    def __exit__(self, *args: Any) -> None:
+        self._end = time.perf_counter()
+    
+    @property
+    def duration_ms(self) -> float:
+        """Get duration in milliseconds."""
+        return (self._end - self._start) * 1000
+
+
+# =============================================================================
+# Tier Debugger
+# =============================================================================
+
+class TierDebugger:
+    """Main debugger for tier decisions.
+    
+    Tracks and logs tier routing decisions for debugging.
+    
+    Usage:
+        debugger = TierDebugger()
+        
+        with debugger.session("req-123", "Bugün hava nasıl?") as session:
+            with debugger.timer() as t:
+                # Do routing
+                result = router.route(query)
+            debugger.log_router_decision(
+                session, TierBackend.VLLM_LOCAL,
+                duration_ms=t.duration_ms, reason="local capable"
+            )
+    """
+    
+    def __init__(
+        self,
+        enabled: Optional[bool] = None,
+        output: Optional[TextIO] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        """Initialize tier debugger.
+        
+        Args:
+            enabled: Override for debug enabled (uses env if None).
+            output: Output stream (uses stderr if None).
+            logger: Logger to use (creates one if None).
+        """
+        self._enabled = enabled if enabled is not None else is_debug_enabled()
+        self._output = output or sys.stderr
+        self._logger = logger or logging.getLogger("bantz.tier_debug")
+        self._sessions: dict[str, TierSession] = {}
+        self._current_session: Optional[TierSession] = None
+    
+    @property
+    def enabled(self) -> bool:
+        """Check if debugging is enabled."""
+        return self._enabled
+    
+    def enable(self) -> None:
+        """Enable debugging."""
+        self._enabled = True
+    
+    def disable(self) -> None:
+        """Disable debugging."""
+        self._enabled = False
+    
+    def timer(self) -> TierTimer:
+        """Create a timer for measuring operations."""
+        return TierTimer()
+    
+    def session(
+        self,
+        session_id: str,
+        user_query: str = "",
+    ) -> "TierDebugSession":
+        """Create a debug session context.
+        
+        Args:
+            session_id: Unique session identifier.
+            user_query: User's query text.
+        
+        Returns:
+            Context manager for the session.
+        """
+        return TierDebugSession(self, session_id, user_query)
+    
+    def _start_session(self, session_id: str, user_query: str) -> TierSession:
+        """Start a new debug session."""
+        session = TierSession(session_id=session_id, user_query=user_query)
+        self._sessions[session_id] = session
+        self._current_session = session
+        return session
+    
+    def _end_session(self, session_id: str) -> None:
+        """End a debug session."""
+        if session_id in self._sessions:
+            session = self._sessions[session_id]
+            session.total_duration_ms = (
+                datetime.now() - session.start_time
+            ).total_seconds() * 1000
+            
+            if self._enabled:
+                self._output.write(session.format_summary() + "\n")
+                self._output.flush()
+            
+            if self._current_session and self._current_session.session_id == session_id:
+                self._current_session = None
+    
+    def log_router_decision(
+        self,
+        session: TierSession,
+        backend: TierBackend,
+        duration_ms: float = 0.0,
+        reason: str = "",
+        confidence: float = 1.0,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> TierDecision:
+        """Log a router decision.
+        
+        Args:
+            session: The debug session.
+            backend: Backend selected.
+            duration_ms: Time taken for decision.
+            reason: Reason for selection.
+            confidence: Confidence score.
+            metadata: Additional metadata.
+        
+        Returns:
+            The logged decision.
+        """
+        decision = TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=backend,
+            duration_ms=duration_ms,
+            reason=reason,
+            confidence=confidence,
+            metadata=metadata or {},
+        )
+        session.add_decision(decision)
+        
+        if self._enabled:
+            self._log_decision(decision)
+        
+        return decision
+    
+    def log_finalizer_decision(
+        self,
+        session: TierSession,
+        backend: TierBackend,
+        duration_ms: float = 0.0,
+        reason: str = "",
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> TierDecision:
+        """Log a finalizer decision.
+        
+        Args:
+            session: The debug session.
+            backend: Backend selected.
+            duration_ms: Time taken for decision.
+            reason: Reason for selection.
+            metadata: Additional metadata.
+        
+        Returns:
+            The logged decision.
+        """
+        decision = TierDecision(
+            decision_type=TierDecisionType.FINALIZER,
+            backend=backend,
+            duration_ms=duration_ms,
+            reason=reason,
+            metadata=metadata or {},
+        )
+        session.add_decision(decision)
+        
+        if self._enabled:
+            self._log_decision(decision)
+        
+        return decision
+    
+    def log_quality_check(
+        self,
+        session: TierSession,
+        result: QualityResult,
+        score: float = 0.0,
+        threshold: float = 0.0,
+        duration_ms: float = 0.0,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> TierDecision:
+        """Log a quality check result.
+        
+        Args:
+            session: The debug session.
+            result: Quality result (pass/fail/skip).
+            score: Quality score achieved.
+            threshold: Required threshold.
+            duration_ms: Time taken for check.
+            metadata: Additional metadata.
+        
+        Returns:
+            The logged decision.
+        """
+        meta = metadata or {}
+        meta.update({"score": score, "threshold": threshold})
+        
+        decision = TierDecision(
+            decision_type=TierDecisionType.QUALITY_CHECK,
+            backend=TierBackend.UNKNOWN,
+            duration_ms=duration_ms,
+            reason=f"score={score:.2f} threshold={threshold:.2f}",
+            quality_result=result,
+            metadata=meta,
+        )
+        session.add_decision(decision)
+        
+        if self._enabled:
+            self._log_decision(decision)
+        
+        return decision
+    
+    def log_fallback(
+        self,
+        session: TierSession,
+        from_backend: TierBackend,
+        to_backend: TierBackend,
+        reason: str = "",
+        duration_ms: float = 0.0,
+    ) -> TierDecision:
+        """Log a fallback event.
+        
+        Args:
+            session: The debug session.
+            from_backend: Original backend.
+            to_backend: Fallback backend.
+            reason: Reason for fallback.
+            duration_ms: Time taken.
+        
+        Returns:
+            The logged decision.
+        """
+        decision = TierDecision(
+            decision_type=TierDecisionType.FALLBACK,
+            backend=to_backend,
+            duration_ms=duration_ms,
+            reason=f"{from_backend.value} -> {to_backend.value}: {reason}",
+            metadata={"from_backend": from_backend.value},
+        )
+        session.add_decision(decision)
+        
+        if self._enabled:
+            self._log_decision(decision)
+        
+        return decision
+    
+    def log_bypass(
+        self,
+        session: TierSession,
+        reason: str,
+        rule_name: str = "",
+    ) -> TierDecision:
+        """Log a rule-based bypass.
+        
+        Args:
+            session: The debug session.
+            reason: Reason for bypass.
+            rule_name: Name of the rule that triggered bypass.
+        
+        Returns:
+            The logged decision.
+        """
+        decision = TierDecision(
+            decision_type=TierDecisionType.BYPASS,
+            backend=TierBackend.VLLM_LOCAL,
+            duration_ms=0.0,
+            reason=reason,
+            metadata={"rule_name": rule_name},
+        )
+        session.add_decision(decision)
+        
+        if self._enabled:
+            self._log_decision(decision)
+        
+        return decision
+    
+    def _log_decision(self, decision: TierDecision) -> None:
+        """Log a decision to output."""
+        self._output.write(f"[TIER] {decision.format_short()}\n")
+        self._output.flush()
+    
+    def get_session(self, session_id: str) -> Optional[TierSession]:
+        """Get a session by ID."""
+        return self._sessions.get(session_id)
+    
+    def get_all_sessions(self) -> list[TierSession]:
+        """Get all recorded sessions."""
+        return list(self._sessions.values())
+    
+    def clear_sessions(self) -> None:
+        """Clear all recorded sessions."""
+        self._sessions.clear()
+        self._current_session = None
+    
+    def get_stats(self) -> dict[str, Any]:
+        """Get aggregated statistics."""
+        if not self._sessions:
+            return {"total_sessions": 0}
+        
+        sessions = list(self._sessions.values())
+        
+        router_backends = [s.get_router_backend() for s in sessions]
+        finalizer_backends = [s.get_finalizer_backend() for s in sessions]
+        quality_calls = sum(1 for s in sessions if s.was_quality_called())
+        
+        # Count backend usage
+        router_counts: dict[str, int] = {}
+        for b in router_backends:
+            if b:
+                router_counts[b.value] = router_counts.get(b.value, 0) + 1
+        
+        finalizer_counts: dict[str, int] = {}
+        for b in finalizer_backends:
+            if b:
+                finalizer_counts[b.value] = finalizer_counts.get(b.value, 0) + 1
+        
+        # Average duration
+        total_duration = sum(s.total_duration_ms for s in sessions)
+        avg_duration = total_duration / len(sessions) if sessions else 0
+        
+        return {
+            "total_sessions": len(sessions),
+            "router_backends": router_counts,
+            "finalizer_backends": finalizer_counts,
+            "quality_calls": quality_calls,
+            "quality_call_rate": quality_calls / len(sessions) if sessions else 0,
+            "avg_duration_ms": avg_duration,
+            "total_duration_ms": total_duration,
+        }
+
+
+class TierDebugSession:
+    """Context manager for a debug session."""
+    
+    def __init__(
+        self,
+        debugger: TierDebugger,
+        session_id: str,
+        user_query: str,
+    ) -> None:
+        self._debugger = debugger
+        self._session_id = session_id
+        self._user_query = user_query
+        self._session: Optional[TierSession] = None
+    
+    def __enter__(self) -> TierSession:
+        self._session = self._debugger._start_session(
+            self._session_id, self._user_query
+        )
+        return self._session
+    
+    def __exit__(self, *args: Any) -> None:
+        self._debugger._end_session(self._session_id)
+
+
+# =============================================================================
+# Global Debugger Instance
+# =============================================================================
+
+_global_debugger: Optional[TierDebugger] = None
+
+
+def get_tier_debugger() -> TierDebugger:
+    """Get or create the global tier debugger."""
+    global _global_debugger
+    if _global_debugger is None:
+        _global_debugger = TierDebugger()
+    return _global_debugger
+
+
+def reset_tier_debugger() -> None:
+    """Reset the global tier debugger."""
+    global _global_debugger
+    _global_debugger = None
+
+
+# =============================================================================
+# CLI Integration Helpers
+# =============================================================================
+
+def setup_debug_from_cli(args: Any) -> None:
+    """Setup debugging from CLI arguments.
+    
+    Args:
+        args: Parsed CLI arguments (expects args.debug attribute).
+    """
+    if hasattr(args, "debug") and args.debug:
+        enable_debug()
+        debugger = get_tier_debugger()
+        debugger.enable()
+
+
+def print_tier_stats() -> None:
+    """Print tier statistics to stderr."""
+    debugger = get_tier_debugger()
+    stats = debugger.get_stats()
+    
+    if stats["total_sessions"] == 0:
+        return
+    
+    sys.stderr.write("\n")
+    sys.stderr.write("=" * 50 + "\n")
+    sys.stderr.write("TIER DEBUG STATISTICS\n")
+    sys.stderr.write("=" * 50 + "\n")
+    sys.stderr.write(f"Total Sessions: {stats['total_sessions']}\n")
+    sys.stderr.write(f"Average Duration: {stats['avg_duration_ms']:.1f}ms\n")
+    sys.stderr.write(f"Quality Call Rate: {stats['quality_call_rate']:.1%}\n")
+    sys.stderr.write("\nRouter Backends:\n")
+    for backend, count in stats.get("router_backends", {}).items():
+        sys.stderr.write(f"  {backend}: {count}\n")
+    sys.stderr.write("\nFinalizer Backends:\n")
+    for backend, count in stats.get("finalizer_backends", {}).items():
+        sys.stderr.write(f"  {backend}: {count}\n")
+    sys.stderr.write("=" * 50 + "\n")
+    sys.stderr.flush()

--- a/tests/test_debug_tier_info.py
+++ b/tests/test_debug_tier_info.py
@@ -1,0 +1,832 @@
+"""Tests for debug tier info module.
+
+Issue #244: Debug tier decisions + quality hit/miss.
+
+Tests cover:
+- TierBackend, TierDecisionType, QualityResult enums
+- TierDecision and TierSession dataclasses
+- TierDebugger and session management
+- Debug enable/disable via environment
+- Timer functionality
+- Statistics aggregation
+"""
+
+import os
+import io
+import time
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+from bantz.debug.tier_info import (
+    TierBackend,
+    TierDecisionType,
+    QualityResult,
+    TierDecision,
+    TierSession,
+    TierTimer,
+    TierDebugger,
+    TierDebugSession,
+    is_debug_enabled,
+    enable_debug,
+    disable_debug,
+    get_tier_debugger,
+    reset_tier_debugger,
+    setup_debug_from_cli,
+    print_tier_stats,
+)
+
+
+# =============================================================================
+# TierBackend Tests
+# =============================================================================
+
+class TestTierBackend:
+    """Tests for TierBackend enum."""
+    
+    def test_vllm_local_value(self) -> None:
+        """Test VLLM_LOCAL value."""
+        assert TierBackend.VLLM_LOCAL.value == "vllm_local"
+    
+    def test_gemini_cloud_value(self) -> None:
+        """Test GEMINI_CLOUD value."""
+        assert TierBackend.GEMINI_CLOUD.value == "gemini_cloud"
+    
+    def test_openai_cloud_value(self) -> None:
+        """Test OPENAI_CLOUD value."""
+        assert TierBackend.OPENAI_CLOUD.value == "openai_cloud"
+    
+    def test_mock_value(self) -> None:
+        """Test MOCK value."""
+        assert TierBackend.MOCK.value == "mock"
+    
+    def test_unknown_value(self) -> None:
+        """Test UNKNOWN value."""
+        assert TierBackend.UNKNOWN.value == "unknown"
+
+
+# =============================================================================
+# TierDecisionType Tests
+# =============================================================================
+
+class TestTierDecisionType:
+    """Tests for TierDecisionType enum."""
+    
+    def test_router_value(self) -> None:
+        """Test ROUTER value."""
+        assert TierDecisionType.ROUTER.value == "router"
+    
+    def test_finalizer_value(self) -> None:
+        """Test FINALIZER value."""
+        assert TierDecisionType.FINALIZER.value == "finalizer"
+    
+    def test_quality_value(self) -> None:
+        """Test QUALITY_CHECK value."""
+        assert TierDecisionType.QUALITY_CHECK.value == "quality"
+    
+    def test_fallback_value(self) -> None:
+        """Test FALLBACK value."""
+        assert TierDecisionType.FALLBACK.value == "fallback"
+    
+    def test_bypass_value(self) -> None:
+        """Test BYPASS value."""
+        assert TierDecisionType.BYPASS.value == "bypass"
+
+
+# =============================================================================
+# QualityResult Tests
+# =============================================================================
+
+class TestQualityResult:
+    """Tests for QualityResult enum."""
+    
+    def test_pass_value(self) -> None:
+        """Test PASS value."""
+        assert QualityResult.PASS.value == "pass"
+    
+    def test_fail_value(self) -> None:
+        """Test FAIL value."""
+        assert QualityResult.FAIL.value == "fail"
+    
+    def test_skip_value(self) -> None:
+        """Test SKIP value."""
+        assert QualityResult.SKIP.value == "skip"
+    
+    def test_pending_value(self) -> None:
+        """Test PENDING value."""
+        assert QualityResult.PENDING.value == "pending"
+
+
+# =============================================================================
+# TierDecision Tests
+# =============================================================================
+
+class TestTierDecision:
+    """Tests for TierDecision dataclass."""
+    
+    def test_creation(self) -> None:
+        """Test decision creation."""
+        decision = TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+        )
+        assert decision.decision_type == TierDecisionType.ROUTER
+        assert decision.backend == TierBackend.VLLM_LOCAL
+        assert decision.duration_ms == 0.0
+        assert decision.reason == ""
+        assert decision.confidence == 1.0
+    
+    def test_creation_with_all_fields(self) -> None:
+        """Test decision creation with all fields."""
+        decision = TierDecision(
+            decision_type=TierDecisionType.FINALIZER,
+            backend=TierBackend.GEMINI_CLOUD,
+            duration_ms=150.5,
+            reason="quality requested",
+            confidence=0.95,
+            quality_result=QualityResult.PASS,
+            metadata={"model": "gemini-1.5-flash"},
+        )
+        assert decision.duration_ms == 150.5
+        assert decision.reason == "quality requested"
+        assert decision.confidence == 0.95
+        assert decision.quality_result == QualityResult.PASS
+        assert decision.metadata["model"] == "gemini-1.5-flash"
+    
+    def test_to_dict(self) -> None:
+        """Test to_dict conversion."""
+        decision = TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+            duration_ms=25.0,
+            reason="local capable",
+        )
+        d = decision.to_dict()
+        assert d["decision_type"] == "router"
+        assert d["backend"] == "vllm_local"
+        assert d["duration_ms"] == 25.0
+        assert d["reason"] == "local capable"
+    
+    def test_format_short(self) -> None:
+        """Test short format."""
+        decision = TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+            duration_ms=25.0,
+            reason="local capable",
+        )
+        formatted = decision.format_short()
+        assert "ROUTER" in formatted
+        assert "vllm_local" in formatted
+        assert "25.0" in formatted
+        assert "local capable" in formatted
+    
+    def test_format_detailed(self) -> None:
+        """Test detailed format."""
+        decision = TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+            duration_ms=25.0,
+            reason="local capable",
+            metadata={"model": "qwen2.5-3b"},
+        )
+        formatted = decision.format_detailed()
+        assert "ROUTER" in formatted
+        assert "vllm_local" in formatted
+        assert "25.0" in formatted
+        assert "model" in formatted
+        assert "qwen2.5-3b" in formatted
+
+
+# =============================================================================
+# TierSession Tests
+# =============================================================================
+
+class TestTierSession:
+    """Tests for TierSession dataclass."""
+    
+    def test_creation(self) -> None:
+        """Test session creation."""
+        session = TierSession(session_id="test-123")
+        assert session.session_id == "test-123"
+        assert len(session.decisions) == 0
+    
+    def test_add_decision(self) -> None:
+        """Test adding decision to session."""
+        session = TierSession(session_id="test-123")
+        decision = TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+        )
+        session.add_decision(decision)
+        assert len(session.decisions) == 1
+        assert session.decisions[0] == decision
+    
+    def test_get_router_backend(self) -> None:
+        """Test getting router backend."""
+        session = TierSession(session_id="test-123")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+        ))
+        assert session.get_router_backend() == TierBackend.VLLM_LOCAL
+    
+    def test_get_router_backend_none(self) -> None:
+        """Test getting router backend when none."""
+        session = TierSession(session_id="test-123")
+        assert session.get_router_backend() is None
+    
+    def test_get_finalizer_backend(self) -> None:
+        """Test getting finalizer backend."""
+        session = TierSession(session_id="test-123")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.FINALIZER,
+            backend=TierBackend.GEMINI_CLOUD,
+        ))
+        assert session.get_finalizer_backend() == TierBackend.GEMINI_CLOUD
+    
+    def test_was_quality_called_true(self) -> None:
+        """Test quality called check when true."""
+        session = TierSession(session_id="test-123")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.QUALITY_CHECK,
+            backend=TierBackend.UNKNOWN,
+            quality_result=QualityResult.PASS,
+        ))
+        assert session.was_quality_called() is True
+    
+    def test_was_quality_called_false(self) -> None:
+        """Test quality called check when false."""
+        session = TierSession(session_id="test-123")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+        ))
+        assert session.was_quality_called() is False
+    
+    def test_quality_passed_true(self) -> None:
+        """Test quality passed when true."""
+        session = TierSession(session_id="test-123")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.QUALITY_CHECK,
+            backend=TierBackend.UNKNOWN,
+            quality_result=QualityResult.PASS,
+        ))
+        assert session.quality_passed() is True
+    
+    def test_quality_passed_false(self) -> None:
+        """Test quality passed when failed."""
+        session = TierSession(session_id="test-123")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.QUALITY_CHECK,
+            backend=TierBackend.UNKNOWN,
+            quality_result=QualityResult.FAIL,
+        ))
+        assert session.quality_passed() is False
+    
+    def test_format_summary(self) -> None:
+        """Test format summary."""
+        session = TierSession(session_id="test-123")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+        ))
+        session.total_duration_ms = 150.5
+        
+        summary = session.format_summary()
+        assert "TIER DEBUG" in summary
+        assert "test-123" in summary
+        assert "vllm_local" in summary
+    
+    def test_format_full(self) -> None:
+        """Test format full."""
+        session = TierSession(
+            session_id="test-123",
+            user_query="Bugün hava nasıl?",
+        )
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+            reason="local capable",
+        ))
+        session.total_duration_ms = 150.5
+        
+        full = session.format_full()
+        assert "test-123" in full
+        assert "Bugün hava nasıl?" in full
+        assert "ROUTER" in full
+        assert "150.5" in full
+    
+    def test_to_dict(self) -> None:
+        """Test to_dict conversion."""
+        session = TierSession(session_id="test-123", user_query="test")
+        session.add_decision(TierDecision(
+            decision_type=TierDecisionType.ROUTER,
+            backend=TierBackend.VLLM_LOCAL,
+        ))
+        
+        d = session.to_dict()
+        assert d["session_id"] == "test-123"
+        assert d["router_backend"] == "vllm_local"
+        assert len(d["decisions"]) == 1
+
+
+# =============================================================================
+# TierTimer Tests
+# =============================================================================
+
+class TestTierTimer:
+    """Tests for TierTimer context manager."""
+    
+    def test_timer_basic(self) -> None:
+        """Test basic timer functionality."""
+        with TierTimer() as timer:
+            time.sleep(0.01)  # 10ms
+        
+        assert timer.duration_ms >= 9  # At least 9ms (accounting for precision)
+        assert timer.duration_ms < 100  # Less than 100ms
+    
+    def test_timer_very_short(self) -> None:
+        """Test timer for very short operation."""
+        with TierTimer() as timer:
+            pass
+        
+        assert timer.duration_ms >= 0
+        assert timer.duration_ms < 10
+
+
+# =============================================================================
+# Debug Enable/Disable Tests
+# =============================================================================
+
+class TestDebugEnableDisable:
+    """Tests for debug enable/disable functions."""
+    
+    def test_is_debug_enabled_default(self) -> None:
+        """Test default debug state."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_debug_enabled() is False
+    
+    def test_is_debug_enabled_via_bantz_debug_tiers(self) -> None:
+        """Test enabling via BANTZ_DEBUG_TIERS."""
+        with patch.dict(os.environ, {"BANTZ_DEBUG_TIERS": "1"}):
+            assert is_debug_enabled() is True
+    
+    def test_is_debug_enabled_via_bantz_debug(self) -> None:
+        """Test enabling via BANTZ_DEBUG."""
+        with patch.dict(os.environ, {"BANTZ_DEBUG": "1"}):
+            assert is_debug_enabled() is True
+    
+    def test_is_debug_enabled_true_string(self) -> None:
+        """Test enabling with 'true' string."""
+        with patch.dict(os.environ, {"BANTZ_DEBUG_TIERS": "true"}):
+            assert is_debug_enabled() is True
+    
+    def test_is_debug_enabled_yes_string(self) -> None:
+        """Test enabling with 'yes' string."""
+        with patch.dict(os.environ, {"BANTZ_DEBUG_TIERS": "yes"}):
+            assert is_debug_enabled() is True
+    
+    def test_enable_debug(self) -> None:
+        """Test enable_debug function."""
+        with patch.dict(os.environ, {}, clear=True):
+            enable_debug()
+            assert os.environ.get("BANTZ_DEBUG_TIERS") == "1"
+    
+    def test_disable_debug(self) -> None:
+        """Test disable_debug function."""
+        with patch.dict(os.environ, {"BANTZ_DEBUG_TIERS": "1"}):
+            disable_debug()
+            assert os.environ.get("BANTZ_DEBUG_TIERS") is None
+
+
+# =============================================================================
+# TierDebugger Tests
+# =============================================================================
+
+class TestTierDebugger:
+    """Tests for TierDebugger class."""
+    
+    def test_creation_disabled(self) -> None:
+        """Test creation with debugging disabled."""
+        debugger = TierDebugger(enabled=False)
+        assert debugger.enabled is False
+    
+    def test_creation_enabled(self) -> None:
+        """Test creation with debugging enabled."""
+        debugger = TierDebugger(enabled=True)
+        assert debugger.enabled is True
+    
+    def test_enable_disable(self) -> None:
+        """Test enable/disable methods."""
+        debugger = TierDebugger(enabled=False)
+        assert debugger.enabled is False
+        
+        debugger.enable()
+        assert debugger.enabled is True
+        
+        debugger.disable()
+        assert debugger.enabled is False
+    
+    def test_timer_creation(self) -> None:
+        """Test timer method."""
+        debugger = TierDebugger(enabled=False)
+        timer = debugger.timer()
+        assert isinstance(timer, TierTimer)
+    
+    def test_session_context(self) -> None:
+        """Test session context manager."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("test-123", "hello") as session:
+            assert session.session_id == "test-123"
+            assert session.user_query == "hello"
+        
+        # Summary should be written
+        assert "test-123" in output.getvalue()
+    
+    def test_log_router_decision(self) -> None:
+        """Test logging router decision."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("test-123", "hello") as session:
+            decision = debugger.log_router_decision(
+                session,
+                TierBackend.VLLM_LOCAL,
+                duration_ms=25.0,
+                reason="local capable",
+            )
+            assert decision.decision_type == TierDecisionType.ROUTER
+            assert decision.backend == TierBackend.VLLM_LOCAL
+        
+        assert "ROUTER" in output.getvalue()
+        assert "vllm_local" in output.getvalue()
+    
+    def test_log_finalizer_decision(self) -> None:
+        """Test logging finalizer decision."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("test-123", "hello") as session:
+            decision = debugger.log_finalizer_decision(
+                session,
+                TierBackend.GEMINI_CLOUD,
+                duration_ms=150.0,
+                reason="quality tier",
+            )
+            assert decision.decision_type == TierDecisionType.FINALIZER
+            assert decision.backend == TierBackend.GEMINI_CLOUD
+        
+        assert "FINALIZER" in output.getvalue()
+    
+    def test_log_quality_check(self) -> None:
+        """Test logging quality check."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("test-123", "hello") as session:
+            decision = debugger.log_quality_check(
+                session,
+                QualityResult.PASS,
+                score=0.85,
+                threshold=0.7,
+                duration_ms=50.0,
+            )
+            assert decision.decision_type == TierDecisionType.QUALITY_CHECK
+            assert decision.quality_result == QualityResult.PASS
+            assert decision.metadata["score"] == 0.85
+            assert decision.metadata["threshold"] == 0.7
+        
+        assert "QUALITY" in output.getvalue()
+    
+    def test_log_fallback(self) -> None:
+        """Test logging fallback."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("test-123", "hello") as session:
+            decision = debugger.log_fallback(
+                session,
+                from_backend=TierBackend.VLLM_LOCAL,
+                to_backend=TierBackend.GEMINI_CLOUD,
+                reason="timeout",
+            )
+            assert decision.decision_type == TierDecisionType.FALLBACK
+            assert decision.backend == TierBackend.GEMINI_CLOUD
+        
+        assert "FALLBACK" in output.getvalue()
+    
+    def test_log_bypass(self) -> None:
+        """Test logging bypass."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("test-123", "hello") as session:
+            decision = debugger.log_bypass(
+                session,
+                reason="smalltalk detected",
+                rule_name="smalltalk_rule",
+            )
+            assert decision.decision_type == TierDecisionType.BYPASS
+            assert decision.metadata["rule_name"] == "smalltalk_rule"
+        
+        assert "BYPASS" in output.getvalue()
+    
+    def test_no_output_when_disabled(self) -> None:
+        """Test no output when disabled."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=False, output=output)
+        
+        with debugger.session("test-123", "hello") as session:
+            debugger.log_router_decision(
+                session,
+                TierBackend.VLLM_LOCAL,
+            )
+        
+        assert output.getvalue() == ""
+    
+    def test_get_session(self) -> None:
+        """Test getting session by ID."""
+        debugger = TierDebugger(enabled=False)
+        
+        with debugger.session("test-123", "hello") as session:
+            pass
+        
+        retrieved = debugger.get_session("test-123")
+        assert retrieved is not None
+        assert retrieved.session_id == "test-123"
+    
+    def test_get_session_not_found(self) -> None:
+        """Test getting non-existent session."""
+        debugger = TierDebugger(enabled=False)
+        assert debugger.get_session("nonexistent") is None
+    
+    def test_get_all_sessions(self) -> None:
+        """Test getting all sessions."""
+        debugger = TierDebugger(enabled=False)
+        
+        with debugger.session("test-1", "hello1") as s1:
+            pass
+        with debugger.session("test-2", "hello2") as s2:
+            pass
+        
+        sessions = debugger.get_all_sessions()
+        assert len(sessions) == 2
+    
+    def test_clear_sessions(self) -> None:
+        """Test clearing sessions."""
+        debugger = TierDebugger(enabled=False)
+        
+        with debugger.session("test-123", "hello") as session:
+            pass
+        
+        assert len(debugger.get_all_sessions()) == 1
+        debugger.clear_sessions()
+        assert len(debugger.get_all_sessions()) == 0
+    
+    def test_get_stats_empty(self) -> None:
+        """Test stats with no sessions."""
+        debugger = TierDebugger(enabled=False)
+        stats = debugger.get_stats()
+        assert stats["total_sessions"] == 0
+    
+    def test_get_stats_with_sessions(self) -> None:
+        """Test stats with sessions."""
+        debugger = TierDebugger(enabled=False)
+        
+        with debugger.session("test-1", "hello1") as s1:
+            debugger.log_router_decision(s1, TierBackend.VLLM_LOCAL)
+            debugger.log_quality_check(s1, QualityResult.PASS, score=0.9, threshold=0.7)
+        
+        with debugger.session("test-2", "hello2") as s2:
+            debugger.log_router_decision(s2, TierBackend.GEMINI_CLOUD)
+        
+        stats = debugger.get_stats()
+        assert stats["total_sessions"] == 2
+        assert stats["router_backends"]["vllm_local"] == 1
+        assert stats["router_backends"]["gemini_cloud"] == 1
+        assert stats["quality_calls"] == 1
+        assert stats["quality_call_rate"] == 0.5
+
+
+# =============================================================================
+# Global Debugger Tests
+# =============================================================================
+
+class TestGlobalDebugger:
+    """Tests for global debugger functions."""
+    
+    def test_get_tier_debugger(self) -> None:
+        """Test getting global debugger."""
+        reset_tier_debugger()
+        debugger = get_tier_debugger()
+        assert debugger is not None
+        assert isinstance(debugger, TierDebugger)
+    
+    def test_get_tier_debugger_singleton(self) -> None:
+        """Test global debugger is singleton."""
+        reset_tier_debugger()
+        debugger1 = get_tier_debugger()
+        debugger2 = get_tier_debugger()
+        assert debugger1 is debugger2
+    
+    def test_reset_tier_debugger(self) -> None:
+        """Test resetting global debugger."""
+        reset_tier_debugger()
+        debugger1 = get_tier_debugger()
+        reset_tier_debugger()
+        debugger2 = get_tier_debugger()
+        assert debugger1 is not debugger2
+
+
+# =============================================================================
+# CLI Integration Tests
+# =============================================================================
+
+class TestCLIIntegration:
+    """Tests for CLI integration helpers."""
+    
+    def test_setup_debug_from_cli_enabled(self) -> None:
+        """Test setup from CLI with debug enabled."""
+        reset_tier_debugger()
+        
+        class Args:
+            debug = True
+        
+        with patch.dict(os.environ, {}, clear=True):
+            setup_debug_from_cli(Args())
+            assert is_debug_enabled() is True
+            debugger = get_tier_debugger()
+            assert debugger.enabled is True
+    
+    def test_setup_debug_from_cli_disabled(self) -> None:
+        """Test setup from CLI with debug disabled."""
+        reset_tier_debugger()
+        
+        class Args:
+            debug = False
+        
+        with patch.dict(os.environ, {}, clear=True):
+            setup_debug_from_cli(Args())
+            # Should not enable
+            assert os.environ.get("BANTZ_DEBUG_TIERS") is None
+    
+    def test_setup_debug_from_cli_no_attr(self) -> None:
+        """Test setup from CLI without debug attribute."""
+        class Args:
+            pass
+        
+        # Should not raise
+        setup_debug_from_cli(Args())
+
+
+# =============================================================================
+# E2E Integration Tests
+# =============================================================================
+
+class TestE2EIntegration:
+    """End-to-end integration tests."""
+    
+    def test_full_request_flow(self) -> None:
+        """Test full request flow with all decisions."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("req-001", "Bugün hava nasıl?") as session:
+            # Router decision
+            with debugger.timer() as t1:
+                time.sleep(0.01)
+            debugger.log_router_decision(
+                session,
+                TierBackend.VLLM_LOCAL,
+                duration_ms=t1.duration_ms,
+                reason="smalltalk - local capable",
+            )
+            
+            # Quality check
+            with debugger.timer() as t2:
+                time.sleep(0.01)
+            debugger.log_quality_check(
+                session,
+                QualityResult.PASS,
+                score=0.88,
+                threshold=0.7,
+                duration_ms=t2.duration_ms,
+            )
+            
+            # Finalizer decision
+            debugger.log_finalizer_decision(
+                session,
+                TierBackend.VLLM_LOCAL,
+                reason="quality passed",
+            )
+        
+        # Verify session data
+        assert session.get_router_backend() == TierBackend.VLLM_LOCAL
+        assert session.get_finalizer_backend() == TierBackend.VLLM_LOCAL
+        assert session.was_quality_called() is True
+        assert session.quality_passed() is True
+        
+        # Verify output
+        output_text = output.getvalue()
+        assert "ROUTER" in output_text
+        assert "QUALITY" in output_text
+        assert "FINALIZER" in output_text
+    
+    def test_fallback_flow(self) -> None:
+        """Test fallback flow."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("req-002", "Karmaşık soru") as session:
+            # Router decision to local
+            debugger.log_router_decision(
+                session,
+                TierBackend.VLLM_LOCAL,
+                reason="initial attempt",
+            )
+            
+            # Quality fails
+            debugger.log_quality_check(
+                session,
+                QualityResult.FAIL,
+                score=0.45,
+                threshold=0.7,
+            )
+            
+            # Fallback to cloud
+            debugger.log_fallback(
+                session,
+                from_backend=TierBackend.VLLM_LOCAL,
+                to_backend=TierBackend.GEMINI_CLOUD,
+                reason="quality below threshold",
+            )
+            
+            # Finalizer with cloud
+            debugger.log_finalizer_decision(
+                session,
+                TierBackend.GEMINI_CLOUD,
+                reason="fallback triggered",
+            )
+        
+        # Verify
+        assert session.get_finalizer_backend() == TierBackend.GEMINI_CLOUD
+        assert "FALLBACK" in output.getvalue()
+    
+    def test_bypass_flow(self) -> None:
+        """Test rule-based bypass flow."""
+        output = io.StringIO()
+        debugger = TierDebugger(enabled=True, output=output)
+        
+        with debugger.session("req-003", "Merhaba") as session:
+            # Bypass router entirely
+            debugger.log_bypass(
+                session,
+                reason="greeting detected",
+                rule_name="greeting_rule",
+            )
+            
+            # Direct to local finalizer
+            debugger.log_finalizer_decision(
+                session,
+                TierBackend.VLLM_LOCAL,
+                reason="bypass - no router needed",
+            )
+        
+        # Verify no router decision
+        assert session.get_router_backend() is None
+        assert session.get_finalizer_backend() == TierBackend.VLLM_LOCAL
+        assert "BYPASS" in output.getvalue()
+    
+    def test_stats_aggregation(self) -> None:
+        """Test statistics aggregation across sessions."""
+        debugger = TierDebugger(enabled=False)
+        
+        # Session 1: local, quality pass
+        with debugger.session("req-1", "q1") as s1:
+            debugger.log_router_decision(s1, TierBackend.VLLM_LOCAL)
+            debugger.log_quality_check(s1, QualityResult.PASS, score=0.9, threshold=0.7)
+            debugger.log_finalizer_decision(s1, TierBackend.VLLM_LOCAL)
+        
+        # Session 2: local, quality fail, fallback to cloud
+        with debugger.session("req-2", "q2") as s2:
+            debugger.log_router_decision(s2, TierBackend.VLLM_LOCAL)
+            debugger.log_quality_check(s2, QualityResult.FAIL, score=0.5, threshold=0.7)
+            debugger.log_fallback(s2, TierBackend.VLLM_LOCAL, TierBackend.GEMINI_CLOUD, "quality fail")
+            debugger.log_finalizer_decision(s2, TierBackend.GEMINI_CLOUD)
+        
+        # Session 3: cloud direct
+        with debugger.session("req-3", "q3") as s3:
+            debugger.log_router_decision(s3, TierBackend.GEMINI_CLOUD)
+            debugger.log_finalizer_decision(s3, TierBackend.GEMINI_CLOUD)
+        
+        stats = debugger.get_stats()
+        
+        assert stats["total_sessions"] == 3
+        assert stats["router_backends"]["vllm_local"] == 2
+        assert stats["router_backends"]["gemini_cloud"] == 1
+        assert stats["quality_calls"] == 2
+        assert stats["quality_call_rate"] == pytest.approx(2/3)


### PR DESCRIPTION
## Summary
Implements Issue #244: Debug tier decisions + quality hit/miss.

## Changes
- **TierDebugger**: Main debugger class with session tracking
- **TierDecision**: Records for router, finalizer, quality, fallback, bypass decisions
- **TierSession**: Groups related decisions for analysis
- **Environment Variables**: BANTZ_DEBUG_TIERS=1, BANTZ_DEBUG=1
- **CLI Integration**: setup_debug_from_cli() for --debug flag
- **TierTimer**: Performance measurement context manager
- **Statistics**: Aggregated stats across sessions

## Usage
```bash
export BANTZ_DEBUG_TIERS=1
# Or
jarvis --debug
```

## Testing
- 67 comprehensive tests
- E2E tests for full request flow, fallback, bypass

Closes #244