### PR TITLE
fix(calendar): add event cache for immediate visibility (#315)

### DIFF
--- a/src/bantz/google/calendar_cache.py
+++ b/src/bantz/google/calendar_cache.py
@@ -1,0 +1,330 @@
+"""Calendar event cache for immediate visibility of new events.
+
+Issue #315: Yeni eklenen etkinlik list_events'te görünmüyor
+
+Problem:
+- Google Calendar API'de create sonrası list'te görünme gecikmesi olabiliyor
+- Kullanıcı "toplantı koy" dedikten hemen sonra "bugün için planım var mı" dediğinde
+  yeni etkinlik görünmeyebiliyor
+
+Çözüm:
+- Yeni oluşturulan event'leri in-memory cache'de tutuyoruz
+- list_events sonuçlarına cache'deki event'leri merge ediyoruz
+- Cache TTL: 5 dakika (API sync edilince gereksiz hale gelir)
+- Session-scoped: Terminal kapanınca cache temizlenir
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+import threading
+
+
+# Default cache TTL in seconds
+DEFAULT_CACHE_TTL_SECONDS = 300  # 5 minutes
+
+
+@dataclass
+class CachedEvent:
+    """A recently created calendar event held in cache."""
+    
+    event_id: str
+    summary: str
+    start: str  # ISO format
+    end: str    # ISO format
+    location: Optional[str] = None
+    description: Optional[str] = None
+    calendar_id: str = "primary"
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    status: str = "confirmed"
+    
+    def is_expired(self, ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS) -> bool:
+        """Check if this cached event has expired."""
+        age = datetime.now(timezone.utc) - self.created_at
+        return age.total_seconds() > ttl_seconds
+    
+    def to_event_dict(self) -> dict[str, Any]:
+        """Convert to standard event dict format for merging."""
+        return {
+            "id": self.event_id,
+            "summary": self.summary,
+            "start": self.start,
+            "end": self.end,
+            "location": self.location,
+            "status": self.status,
+            "htmlLink": None,  # Won't have link until API sync
+            "_cached": True,  # Flag for debugging
+        }
+    
+    def is_in_window(self, time_min: Optional[str], time_max: Optional[str]) -> bool:
+        """Check if event falls within a time window."""
+        if not time_min:
+            return True  # No filter
+        
+        try:
+            event_start = _parse_datetime(self.start)
+            window_min = _parse_datetime(time_min)
+            
+            if event_start < window_min:
+                return False
+            
+            if time_max:
+                window_max = _parse_datetime(time_max)
+                if event_start >= window_max:
+                    return False
+            
+            return True
+        except (ValueError, TypeError):
+            # If parsing fails, include event to be safe
+            return True
+
+
+def _parse_datetime(value: str) -> datetime:
+    """Parse ISO datetime string."""
+    v = (value or "").strip()
+    if not v:
+        raise ValueError("empty datetime")
+    
+    # Handle all-day dates (YYYY-MM-DD)
+    if len(v) == 10 and v[4] == "-" and v[7] == "-":
+        from datetime import date
+        d = date.fromisoformat(v)
+        return datetime.combine(d, datetime.min.time(), tzinfo=timezone.utc)
+    
+    # Handle Z suffix
+    if v.endswith("Z"):
+        v = v[:-1] + "+00:00"
+    
+    dt = datetime.fromisoformat(v)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+class CalendarEventCache:
+    """Thread-safe cache for recently created calendar events.
+    
+    This cache ensures that newly created events appear immediately in
+    list_events results, even before the Google Calendar API syncs.
+    
+    Usage:
+        cache = get_calendar_cache()
+        
+        # After creating an event
+        cache.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        
+        # When listing events
+        api_events = [...]  # From Google API
+        merged = cache.merge_with_api_events(api_events, time_min=..., time_max=...)
+    """
+    
+    def __init__(self, ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS) -> None:
+        self._events: dict[str, CachedEvent] = {}
+        self._lock = threading.RLock()
+        self._ttl_seconds = ttl_seconds
+    
+    def add_event(
+        self,
+        *,
+        event_id: str,
+        summary: str,
+        start: str,
+        end: str,
+        location: Optional[str] = None,
+        description: Optional[str] = None,
+        calendar_id: str = "primary",
+    ) -> CachedEvent:
+        """Add a newly created event to cache."""
+        with self._lock:
+            event = CachedEvent(
+                event_id=event_id,
+                summary=summary,
+                start=start,
+                end=end,
+                location=location,
+                description=description,
+                calendar_id=calendar_id,
+            )
+            self._events[event_id] = event
+            self._cleanup_expired()
+            return event
+    
+    def remove_event(self, event_id: str) -> bool:
+        """Remove an event from cache (e.g., after deletion)."""
+        with self._lock:
+            if event_id in self._events:
+                del self._events[event_id]
+                return True
+            return False
+    
+    def get_events_in_window(
+        self,
+        *,
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        calendar_id: str = "primary",
+    ) -> list[CachedEvent]:
+        """Get cached events within a time window."""
+        with self._lock:
+            self._cleanup_expired()
+            
+            result = []
+            for event in self._events.values():
+                if event.calendar_id != calendar_id:
+                    continue
+                if event.is_in_window(time_min, time_max):
+                    result.append(event)
+            
+            return result
+    
+    def merge_with_api_events(
+        self,
+        api_events: list[dict[str, Any]],
+        *,
+        time_min: Optional[str] = None,
+        time_max: Optional[str] = None,
+        calendar_id: str = "primary",
+    ) -> list[dict[str, Any]]:
+        """Merge API events with cached events, deduplicating by ID.
+        
+        Cached events are added if they:
+        1. Fall within the time window
+        2. Are not already in API results (by ID)
+        3. Are not expired
+        
+        Returns events sorted by start time.
+        """
+        # Get API event IDs for deduplication
+        api_ids = {e.get("id") for e in api_events if e.get("id")}
+        
+        # Get cached events in window
+        cached = self.get_events_in_window(
+            time_min=time_min,
+            time_max=time_max,
+            calendar_id=calendar_id,
+        )
+        
+        # Add cached events not in API results
+        result = list(api_events)
+        for event in cached:
+            if event.event_id not in api_ids:
+                result.append(event.to_event_dict())
+        
+        # Sort by start time
+        def sort_key(e: dict) -> str:
+            start = e.get("start", "")
+            if isinstance(start, dict):
+                start = start.get("dateTime") or start.get("date") or ""
+            return start or ""
+        
+        result.sort(key=sort_key)
+        return result
+    
+    def clear(self) -> int:
+        """Clear all cached events. Returns count cleared."""
+        with self._lock:
+            count = len(self._events)
+            self._events.clear()
+            return count
+    
+    def _cleanup_expired(self) -> int:
+        """Remove expired events. Returns count removed."""
+        expired_ids = [
+            eid for eid, event in self._events.items()
+            if event.is_expired(self._ttl_seconds)
+        ]
+        for eid in expired_ids:
+            del self._events[eid]
+        return len(expired_ids)
+    
+    @property
+    def size(self) -> int:
+        """Number of events in cache."""
+        with self._lock:
+            return len(self._events)
+    
+    def get_stats(self) -> dict[str, Any]:
+        """Get cache statistics."""
+        with self._lock:
+            self._cleanup_expired()
+            return {
+                "size": len(self._events),
+                "ttl_seconds": self._ttl_seconds,
+                "events": [
+                    {
+                        "id": e.event_id,
+                        "summary": e.summary,
+                        "start": e.start,
+                        "age_seconds": (datetime.now(timezone.utc) - e.created_at).total_seconds(),
+                    }
+                    for e in self._events.values()
+                ],
+            }
+
+
+# Singleton instance
+_calendar_cache: Optional[CalendarEventCache] = None
+_cache_lock = threading.Lock()
+
+
+def get_calendar_cache() -> CalendarEventCache:
+    """Get the singleton calendar event cache."""
+    global _calendar_cache
+    with _cache_lock:
+        if _calendar_cache is None:
+            _calendar_cache = CalendarEventCache()
+        return _calendar_cache
+
+
+def reset_calendar_cache() -> None:
+    """Reset the calendar cache (for testing)."""
+    global _calendar_cache
+    with _cache_lock:
+        _calendar_cache = None
+
+
+def cache_created_event(
+    *,
+    event_id: str,
+    summary: str,
+    start: str,
+    end: str,
+    location: Optional[str] = None,
+    description: Optional[str] = None,
+    calendar_id: str = "primary",
+) -> CachedEvent:
+    """Convenience function to cache a newly created event."""
+    cache = get_calendar_cache()
+    return cache.add_event(
+        event_id=event_id,
+        summary=summary,
+        start=start,
+        end=end,
+        location=location,
+        description=description,
+        calendar_id=calendar_id,
+    )
+
+
+def get_merged_events(
+    api_events: list[dict[str, Any]],
+    *,
+    time_min: Optional[str] = None,
+    time_max: Optional[str] = None,
+    calendar_id: str = "primary",
+) -> list[dict[str, Any]]:
+    """Convenience function to merge API events with cache."""
+    cache = get_calendar_cache()
+    return cache.merge_with_api_events(
+        api_events,
+        time_min=time_min,
+        time_max=time_max,
+        calendar_id=calendar_id,
+    )

--- a/tests/test_calendar_cache.py
+++ b/tests/test_calendar_cache.py
@@ -1,0 +1,523 @@
+"""Tests for calendar event cache module.
+
+Issue #315: Yeni eklenen etkinlik list_events'te görünmüyor
+
+Tests cover:
+- CachedEvent creation and expiration
+- CalendarEventCache operations
+- Event merging with API results
+- Time window filtering
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bantz.google.calendar_cache import (
+    CachedEvent,
+    CalendarEventCache,
+    DEFAULT_CACHE_TTL_SECONDS,
+    cache_created_event,
+    get_calendar_cache,
+    get_merged_events,
+    reset_calendar_cache,
+)
+
+
+# =============================================================================
+# CachedEvent Tests
+# =============================================================================
+
+class TestCachedEvent:
+    """Tests for CachedEvent dataclass."""
+    
+    def test_creation(self) -> None:
+        """Test creating a cached event."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        assert event.event_id == "abc123"
+        assert event.summary == "Meeting"
+        assert event.status == "confirmed"
+        assert event.calendar_id == "primary"
+    
+    def test_is_expired_false(self) -> None:
+        """Test event is not expired when fresh."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        assert event.is_expired() is False
+    
+    def test_is_expired_true(self) -> None:
+        """Test event is expired after TTL."""
+        old_time = datetime.now(timezone.utc) - timedelta(seconds=DEFAULT_CACHE_TTL_SECONDS + 10)
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+            created_at=old_time,
+        )
+        assert event.is_expired() is True
+    
+    def test_to_event_dict(self) -> None:
+        """Test conversion to event dict."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+            location="Office",
+        )
+        d = event.to_event_dict()
+        assert d["id"] == "abc123"
+        assert d["summary"] == "Meeting"
+        assert d["start"] == "2026-02-05T17:00:00+03:00"
+        assert d["end"] == "2026-02-05T18:00:00+03:00"
+        assert d["location"] == "Office"
+        assert d["_cached"] is True
+    
+    def test_is_in_window_no_filter(self) -> None:
+        """Test in window with no time filter."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        assert event.is_in_window(None, None) is True
+    
+    def test_is_in_window_inside(self) -> None:
+        """Test event inside window."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        assert event.is_in_window(
+            "2026-02-05T00:00:00+03:00",
+            "2026-02-05T23:59:00+03:00",
+        ) is True
+    
+    def test_is_in_window_before(self) -> None:
+        """Test event before window."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-04T17:00:00+03:00",
+            end="2026-02-04T18:00:00+03:00",
+        )
+        assert event.is_in_window(
+            "2026-02-05T00:00:00+03:00",
+            "2026-02-05T23:59:00+03:00",
+        ) is False
+    
+    def test_is_in_window_after(self) -> None:
+        """Test event after window."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-06T17:00:00+03:00",
+            end="2026-02-06T18:00:00+03:00",
+        )
+        assert event.is_in_window(
+            "2026-02-05T00:00:00+03:00",
+            "2026-02-05T23:59:00+03:00",
+        ) is False
+    
+    def test_is_in_window_all_day_event(self) -> None:
+        """Test all-day event in window."""
+        event = CachedEvent(
+            event_id="abc123",
+            summary="Conference",
+            start="2026-02-05",
+            end="2026-02-06",
+        )
+        assert event.is_in_window(
+            "2026-02-05T00:00:00+03:00",
+            "2026-02-05T23:59:00+03:00",
+        ) is True
+
+
+# =============================================================================
+# CalendarEventCache Tests
+# =============================================================================
+
+class TestCalendarEventCache:
+    """Tests for CalendarEventCache class."""
+    
+    def setup_method(self) -> None:
+        """Reset cache before each test."""
+        reset_calendar_cache()
+    
+    def test_add_event(self) -> None:
+        """Test adding an event to cache."""
+        cache = CalendarEventCache()
+        event = cache.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        assert event.event_id == "abc123"
+        assert cache.size == 1
+    
+    def test_add_multiple_events(self) -> None:
+        """Test adding multiple events."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="abc123",
+            summary="Meeting 1",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        cache.add_event(
+            event_id="def456",
+            summary="Meeting 2",
+            start="2026-02-05T19:00:00+03:00",
+            end="2026-02-05T20:00:00+03:00",
+        )
+        assert cache.size == 2
+    
+    def test_remove_event(self) -> None:
+        """Test removing an event from cache."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        assert cache.remove_event("abc123") is True
+        assert cache.size == 0
+    
+    def test_remove_nonexistent_event(self) -> None:
+        """Test removing non-existent event."""
+        cache = CalendarEventCache()
+        assert cache.remove_event("nonexistent") is False
+    
+    def test_get_events_in_window(self) -> None:
+        """Test getting events in a time window."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        events = cache.get_events_in_window(
+            time_min="2026-02-05T00:00:00+03:00",
+            time_max="2026-02-05T23:59:00+03:00",
+        )
+        assert len(events) == 1
+        assert events[0].event_id == "abc123"
+    
+    def test_get_events_outside_window(self) -> None:
+        """Test getting events outside window returns empty."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        events = cache.get_events_in_window(
+            time_min="2026-02-06T00:00:00+03:00",
+            time_max="2026-02-06T23:59:00+03:00",
+        )
+        assert len(events) == 0
+    
+    def test_merge_with_api_events(self) -> None:
+        """Test merging with API events."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="cached123",
+            summary="Cached Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        
+        api_events = [
+            {
+                "id": "api456",
+                "summary": "API Meeting",
+                "start": "2026-02-05T10:00:00+03:00",
+                "end": "2026-02-05T11:00:00+03:00",
+            }
+        ]
+        
+        merged = cache.merge_with_api_events(
+            api_events,
+            time_min="2026-02-05T00:00:00+03:00",
+            time_max="2026-02-05T23:59:00+03:00",
+        )
+        
+        assert len(merged) == 2
+        assert merged[0]["id"] == "api456"  # Earlier event first
+        assert merged[1]["id"] == "cached123"
+    
+    def test_merge_deduplicates_by_id(self) -> None:
+        """Test that merge deduplicates by ID."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="same123",
+            summary="Cached Version",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        
+        api_events = [
+            {
+                "id": "same123",
+                "summary": "API Version",
+                "start": "2026-02-05T17:00:00+03:00",
+                "end": "2026-02-05T18:00:00+03:00",
+            }
+        ]
+        
+        merged = cache.merge_with_api_events(
+            api_events,
+            time_min="2026-02-05T00:00:00+03:00",
+            time_max="2026-02-05T23:59:00+03:00",
+        )
+        
+        # Should have only 1 event (API version takes precedence)
+        assert len(merged) == 1
+        assert merged[0]["id"] == "same123"
+        assert merged[0]["summary"] == "API Version"
+    
+    def test_clear(self) -> None:
+        """Test clearing cache."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        count = cache.clear()
+        assert count == 1
+        assert cache.size == 0
+    
+    def test_get_stats(self) -> None:
+        """Test getting cache stats."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        stats = cache.get_stats()
+        assert stats["size"] == 1
+        assert len(stats["events"]) == 1
+        assert stats["events"][0]["id"] == "abc123"
+    
+    def test_custom_ttl(self) -> None:
+        """Test custom TTL setting."""
+        cache = CalendarEventCache(ttl_seconds=60)
+        assert cache._ttl_seconds == 60
+
+
+# =============================================================================
+# Singleton and Convenience Function Tests
+# =============================================================================
+
+class TestSingletonAndConvenienceFunctions:
+    """Tests for singleton and convenience functions."""
+    
+    def setup_method(self) -> None:
+        """Reset cache before each test."""
+        reset_calendar_cache()
+    
+    def test_get_calendar_cache_singleton(self) -> None:
+        """Test that get_calendar_cache returns singleton."""
+        cache1 = get_calendar_cache()
+        cache2 = get_calendar_cache()
+        assert cache1 is cache2
+    
+    def test_reset_calendar_cache(self) -> None:
+        """Test resetting the singleton."""
+        cache1 = get_calendar_cache()
+        cache1.add_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        reset_calendar_cache()
+        cache2 = get_calendar_cache()
+        assert cache2.size == 0
+    
+    def test_cache_created_event(self) -> None:
+        """Test convenience function to cache event."""
+        event = cache_created_event(
+            event_id="abc123",
+            summary="Meeting",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        assert event.event_id == "abc123"
+        assert get_calendar_cache().size == 1
+    
+    def test_get_merged_events(self) -> None:
+        """Test convenience function to merge events."""
+        cache_created_event(
+            event_id="cached123",
+            summary="Cached",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        
+        api_events: list[dict[str, Any]] = []
+        merged = get_merged_events(
+            api_events,
+            time_min="2026-02-05T00:00:00+03:00",
+            time_max="2026-02-05T23:59:00+03:00",
+        )
+        
+        assert len(merged) == 1
+        assert merged[0]["id"] == "cached123"
+
+
+# =============================================================================
+# Thread Safety Tests
+# =============================================================================
+
+class TestThreadSafety:
+    """Tests for thread safety."""
+    
+    def setup_method(self) -> None:
+        """Reset cache before each test."""
+        reset_calendar_cache()
+    
+    def test_concurrent_add(self) -> None:
+        """Test concurrent add operations."""
+        import threading
+        
+        cache = CalendarEventCache()
+        
+        def add_events(start_id: int) -> None:
+            for i in range(10):
+                cache.add_event(
+                    event_id=f"event_{start_id}_{i}",
+                    summary=f"Meeting {start_id}_{i}",
+                    start="2026-02-05T17:00:00+03:00",
+                    end="2026-02-05T18:00:00+03:00",
+                )
+        
+        threads = [threading.Thread(target=add_events, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        
+        assert cache.size == 50
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+class TestIntegration:
+    """Integration tests for calendar cache."""
+    
+    def setup_method(self) -> None:
+        """Reset cache before each test."""
+        reset_calendar_cache()
+    
+    def test_create_then_list_scenario(self) -> None:
+        """Test the create-then-list scenario from issue #315."""
+        # Simulate creating an event
+        cache_created_event(
+            event_id="new_meeting_123",
+            summary="toplantı",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        
+        # Simulate API returning empty (hasn't synced yet)
+        api_events: list[dict[str, Any]] = []
+        
+        # Merge should include cached event
+        merged = get_merged_events(
+            api_events,
+            time_min="2026-02-05T00:00:00+03:00",
+            time_max="2026-02-05T23:59:00+03:00",
+        )
+        
+        assert len(merged) == 1
+        assert merged[0]["summary"] == "toplantı"
+    
+    def test_delete_removes_from_cache(self) -> None:
+        """Test that deleting an event removes it from cache."""
+        cache = get_calendar_cache()
+        cache_created_event(
+            event_id="to_delete_123",
+            summary="Will be deleted",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        
+        # Remove from cache
+        cache.remove_event("to_delete_123")
+        
+        # Should not appear in merged
+        merged = get_merged_events(
+            [],
+            time_min="2026-02-05T00:00:00+03:00",
+            time_max="2026-02-05T23:59:00+03:00",
+        )
+        
+        assert len(merged) == 0
+    
+    def test_cache_expires_after_ttl(self) -> None:
+        """Test that cached events expire after TTL."""
+        cache = CalendarEventCache(ttl_seconds=1)  # 1 second TTL
+        cache.add_event(
+            event_id="short_lived",
+            summary="Will expire",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+        )
+        
+        import time
+        time.sleep(1.5)  # Wait for expiration
+        
+        events = cache.get_events_in_window()
+        assert len(events) == 0
+    
+    def test_multiple_calendars(self) -> None:
+        """Test events on different calendars are separated."""
+        cache = CalendarEventCache()
+        cache.add_event(
+            event_id="primary_event",
+            summary="Primary Calendar Event",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+            calendar_id="primary",
+        )
+        cache.add_event(
+            event_id="work_event",
+            summary="Work Calendar Event",
+            start="2026-02-05T17:00:00+03:00",
+            end="2026-02-05T18:00:00+03:00",
+            calendar_id="work@example.com",
+        )
+        
+        primary_events = cache.get_events_in_window(calendar_id="primary")
+        work_events = cache.get_events_in_window(calendar_id="work@example.com")
+        
+        assert len(primary_events) == 1
+        assert len(work_events) == 1
+        assert primary_events[0].event_id == "primary_event"
+        assert work_events[0].event_id == "work_event"


### PR DESCRIPTION
## Problem
Etkinlik başarıyla oluşturuluyor ama hemen ardından 'bugün için planım var mı' diye sorulduğunda 'planınız yok' diyor.

## Root Cause
Google Calendar API'de yazma-okuma gecikmesi olabiliyor. Yeni oluşturulan etkinlik henüz API'de sync edilmeden list_events çağrılınca görünmüyor.

## Solution
- **CalendarEventCache**: In-memory cache for newly created events
- create_event sonrası event'i cache'e ekliyoruz
- list_events sonuçlarına cache'deki event'leri merge ediyoruz
- delete_event'te cache'den siliyoruz

## Implementation Details
- Cache TTL: 5 dakika (API sync'i için yeterli süre)
- Thread-safe with RLock
- Deduplication: Event ID'ye göre (API versiyonu öncelikli)
- Time window filtering
- Session-scoped (terminal kapanınca cache temizlenir)

## Files Changed
- `src/bantz/google/calendar_cache.py` (new): Cache implementation
- `src/bantz/google/calendar.py`: create_event, list_events, delete_event cache entegrasyonu
- `tests/test_calendar_cache.py` (new): 29 tests

Resolves #315