### PR TITLE
feat(gmail): add label/category support with Turkish keywords (#317)

### DIFF
--- a/src/bantz/google/gmail_labels.py
+++ b/src/bantz/google/gmail_labels.py
@@ -1,0 +1,392 @@
+"""Gmail label utilities with Turkish language support.
+
+Issue #317: Gmail label/kategori desteği
+
+Provides:
+- Gmail label enum with standard labels
+- Turkish keyword mapping for label detection
+- Label query builder for smart search
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+import re
+
+
+class GmailLabel(Enum):
+    """Standard Gmail labels with their IDs.
+    
+    Gmail uses specific label IDs for system labels.
+    User-created labels have IDs like "Label_123".
+    """
+    
+    # Primary categories
+    INBOX = "INBOX"
+    SENT = "SENT"
+    DRAFT = "DRAFT"
+    TRASH = "TRASH"
+    SPAM = "SPAM"
+    STARRED = "STARRED"
+    IMPORTANT = "IMPORTANT"
+    UNREAD = "UNREAD"
+    
+    # Category tabs
+    CATEGORY_PERSONAL = "CATEGORY_PERSONAL"
+    CATEGORY_SOCIAL = "CATEGORY_SOCIAL"
+    CATEGORY_PROMOTIONS = "CATEGORY_PROMOTIONS"
+    CATEGORY_UPDATES = "CATEGORY_UPDATES"
+    CATEGORY_FORUMS = "CATEGORY_FORUMS"
+    
+    @property
+    def label_id(self) -> str:
+        """Get the Gmail label ID."""
+        return self.value
+    
+    @property
+    def display_name_tr(self) -> str:
+        """Get Turkish display name."""
+        names = {
+            GmailLabel.INBOX: "Gelen Kutusu",
+            GmailLabel.SENT: "Gönderilenler",
+            GmailLabel.DRAFT: "Taslaklar",
+            GmailLabel.TRASH: "Çöp Kutusu",
+            GmailLabel.SPAM: "Spam",
+            GmailLabel.STARRED: "Yıldızlı",
+            GmailLabel.IMPORTANT: "Önemli",
+            GmailLabel.UNREAD: "Okunmamış",
+            GmailLabel.CATEGORY_PERSONAL: "Birincil",
+            GmailLabel.CATEGORY_SOCIAL: "Sosyal",
+            GmailLabel.CATEGORY_PROMOTIONS: "Promosyonlar",
+            GmailLabel.CATEGORY_UPDATES: "Güncellemeler",
+            GmailLabel.CATEGORY_FORUMS: "Forumlar",
+        }
+        return names.get(self, self.value)
+    
+    @property
+    def display_name_en(self) -> str:
+        """Get English display name."""
+        names = {
+            GmailLabel.INBOX: "Inbox",
+            GmailLabel.SENT: "Sent",
+            GmailLabel.DRAFT: "Drafts",
+            GmailLabel.TRASH: "Trash",
+            GmailLabel.SPAM: "Spam",
+            GmailLabel.STARRED: "Starred",
+            GmailLabel.IMPORTANT: "Important",
+            GmailLabel.UNREAD: "Unread",
+            GmailLabel.CATEGORY_PERSONAL: "Primary",
+            GmailLabel.CATEGORY_SOCIAL: "Social",
+            GmailLabel.CATEGORY_PROMOTIONS: "Promotions",
+            GmailLabel.CATEGORY_UPDATES: "Updates",
+            GmailLabel.CATEGORY_FORUMS: "Forums",
+        }
+        return names.get(self, self.value)
+    
+    @property
+    def query_filter(self) -> str:
+        """Get the Gmail query filter for this label."""
+        # For categories, use label: prefix
+        if self.value.startswith("CATEGORY_"):
+            return f"label:{self.value}"
+        # For system labels, use in: or is: prefix
+        elif self == GmailLabel.INBOX:
+            return "in:inbox"
+        elif self == GmailLabel.SENT:
+            return "in:sent"
+        elif self == GmailLabel.TRASH:
+            return "in:trash"
+        elif self == GmailLabel.SPAM:
+            return "in:spam"
+        elif self == GmailLabel.DRAFT:
+            return "in:drafts"
+        elif self == GmailLabel.STARRED:
+            return "is:starred"
+        elif self == GmailLabel.IMPORTANT:
+            return "is:important"
+        elif self == GmailLabel.UNREAD:
+            return "is:unread"
+        else:
+            return f"label:{self.value}"
+
+
+# Turkish keyword to label mapping
+TURKISH_LABEL_KEYWORDS: dict[str, GmailLabel] = {
+    # Gelen Kutusu
+    "gelen kutusu": GmailLabel.INBOX,
+    "gelen kutusundaki": GmailLabel.INBOX,
+    "inbox": GmailLabel.INBOX,
+    
+    # Gönderilenler
+    "gönderilenler": GmailLabel.SENT,
+    "gönderilen": GmailLabel.SENT,
+    "gönderdiğim": GmailLabel.SENT,
+    "gönderdiğim mailler": GmailLabel.SENT,
+    "sent": GmailLabel.SENT,
+    
+    # Taslaklar
+    "taslaklar": GmailLabel.DRAFT,
+    "taslak": GmailLabel.DRAFT,
+    "draft": GmailLabel.DRAFT,
+    "drafts": GmailLabel.DRAFT,
+    
+    # Çöp
+    "çöp": GmailLabel.TRASH,
+    "çöp kutusu": GmailLabel.TRASH,
+    "silinen": GmailLabel.TRASH,
+    "silinenler": GmailLabel.TRASH,
+    "trash": GmailLabel.TRASH,
+    
+    # Spam
+    "spam": GmailLabel.SPAM,
+    "istenmeyen": GmailLabel.SPAM,
+    "junk": GmailLabel.SPAM,
+    
+    # Yıldızlı
+    "yıldızlı": GmailLabel.STARRED,
+    "yildizli": GmailLabel.STARRED,  # ASCII variant
+    "starred": GmailLabel.STARRED,
+    "favoriler": GmailLabel.STARRED,
+    "favori": GmailLabel.STARRED,
+    
+    # Önemli
+    "önemli": GmailLabel.IMPORTANT,
+    "onemli": GmailLabel.IMPORTANT,  # ASCII variant
+    "important": GmailLabel.IMPORTANT,
+    
+    # Okunmamış
+    "okunmamış": GmailLabel.UNREAD,
+    "okunmamis": GmailLabel.UNREAD,  # ASCII variant
+    "unread": GmailLabel.UNREAD,
+    
+    # Categories - Sosyal
+    "sosyal": GmailLabel.CATEGORY_SOCIAL,
+    "social": GmailLabel.CATEGORY_SOCIAL,
+    "sosyal mailleri": GmailLabel.CATEGORY_SOCIAL,
+    
+    # Categories - Promosyonlar
+    "promosyon": GmailLabel.CATEGORY_PROMOTIONS,
+    "promosyonlar": GmailLabel.CATEGORY_PROMOTIONS,
+    "promotions": GmailLabel.CATEGORY_PROMOTIONS,
+    "reklam": GmailLabel.CATEGORY_PROMOTIONS,
+    "reklamlar": GmailLabel.CATEGORY_PROMOTIONS,
+    
+    # Categories - Güncellemeler
+    "güncelleme": GmailLabel.CATEGORY_UPDATES,
+    "güncellemeler": GmailLabel.CATEGORY_UPDATES,
+    "guncelleme": GmailLabel.CATEGORY_UPDATES,  # ASCII variant
+    "guncellemeler": GmailLabel.CATEGORY_UPDATES,  # ASCII variant
+    "updates": GmailLabel.CATEGORY_UPDATES,
+    "bildirimler": GmailLabel.CATEGORY_UPDATES,
+    
+    # Categories - Forumlar
+    "forum": GmailLabel.CATEGORY_FORUMS,
+    "forumlar": GmailLabel.CATEGORY_FORUMS,
+    "forums": GmailLabel.CATEGORY_FORUMS,
+    
+    # Categories - Birincil
+    "birincil": GmailLabel.CATEGORY_PERSONAL,
+    "primary": GmailLabel.CATEGORY_PERSONAL,
+    "ana": GmailLabel.CATEGORY_PERSONAL,
+    "ana kutu": GmailLabel.CATEGORY_PERSONAL,
+}
+
+
+@dataclass
+class LabelMatch:
+    """Result of label detection from text."""
+    
+    label: Optional[GmailLabel]
+    matched_keyword: Optional[str]
+    confidence: float
+    original_text: str
+    
+    @property
+    def detected(self) -> bool:
+        """Whether a label was detected."""
+        return self.label is not None
+    
+    @staticmethod
+    def no_match(text: str) -> "LabelMatch":
+        """Create a no-match result."""
+        return LabelMatch(
+            label=None,
+            matched_keyword=None,
+            confidence=0.0,
+            original_text=text,
+        )
+
+
+def detect_label_from_text(text: str) -> LabelMatch:
+    """Detect Gmail label from Turkish/English text.
+    
+    Args:
+        text: User input text (e.g., "güncellemeler kategorisindeki mailler")
+    
+    Returns:
+        LabelMatch with detected label or no match
+    
+    Examples:
+        >>> detect_label_from_text("sosyal mailleri göster")
+        LabelMatch(label=GmailLabel.CATEGORY_SOCIAL, ...)
+        
+        >>> detect_label_from_text("promosyonlar kategorisindeki mailleri oku")
+        LabelMatch(label=GmailLabel.CATEGORY_PROMOTIONS, ...)
+    """
+    text_lower = text.lower().strip()
+    
+    if not text_lower:
+        return LabelMatch.no_match(text)
+    
+    # Try longest matches first for better accuracy
+    sorted_keywords = sorted(TURKISH_LABEL_KEYWORDS.keys(), key=len, reverse=True)
+    
+    for keyword in sorted_keywords:
+        if keyword in text_lower:
+            return LabelMatch(
+                label=TURKISH_LABEL_KEYWORDS[keyword],
+                matched_keyword=keyword,
+                confidence=0.9,
+                original_text=text,
+            )
+    
+    return LabelMatch.no_match(text)
+
+
+def build_label_query(
+    label: GmailLabel,
+    *,
+    include_unread_only: bool = False,
+    additional_query: Optional[str] = None,
+) -> str:
+    """Build Gmail query string for a label.
+    
+    Args:
+        label: Gmail label to filter by
+        include_unread_only: Add is:unread filter
+        additional_query: Additional query terms to include
+    
+    Returns:
+        Gmail query string
+    
+    Examples:
+        >>> build_label_query(GmailLabel.CATEGORY_UPDATES)
+        'label:CATEGORY_UPDATES'
+        
+        >>> build_label_query(GmailLabel.INBOX, include_unread_only=True)
+        'in:inbox is:unread'
+    """
+    parts = [label.query_filter]
+    
+    if include_unread_only:
+        parts.append("is:unread")
+    
+    if additional_query:
+        parts.append(additional_query.strip())
+    
+    return " ".join(parts)
+
+
+def build_smart_query(
+    text: str,
+    *,
+    default_label: Optional[GmailLabel] = None,
+    include_unread_only: bool = False,
+) -> tuple[str, Optional[GmailLabel]]:
+    """Build Gmail query from natural language text.
+    
+    Detects labels from Turkish text and builds appropriate query.
+    Falls back to default_label if no label detected.
+    
+    Args:
+        text: Natural language text (Turkish/English)
+        default_label: Label to use if none detected (default: INBOX)
+        include_unread_only: Add is:unread filter
+    
+    Returns:
+        Tuple of (query_string, detected_label)
+    
+    Examples:
+        >>> build_smart_query("sosyal mailleri göster")
+        ('label:CATEGORY_SOCIAL', GmailLabel.CATEGORY_SOCIAL)
+        
+        >>> build_smart_query("son mailler")
+        ('in:inbox', None)  # Falls back to default
+    """
+    match = detect_label_from_text(text)
+    
+    if match.detected and match.label:
+        query = build_label_query(
+            match.label,
+            include_unread_only=include_unread_only,
+        )
+        return query, match.label
+    
+    # Fall back to default
+    if default_label:
+        query = build_label_query(
+            default_label,
+            include_unread_only=include_unread_only,
+        )
+        return query, default_label
+    
+    # No label - just basic inbox query
+    parts = ["in:inbox"]
+    if include_unread_only:
+        parts.append("is:unread")
+    return " ".join(parts), None
+
+
+def format_labels_summary(labels: list[GmailLabel], language: str = "tr") -> str:
+    """Format a list of labels for display.
+    
+    Args:
+        labels: List of Gmail labels
+        language: Display language ("tr" or "en")
+    
+    Returns:
+        Formatted string with label names
+    """
+    if not labels:
+        return ""
+    
+    names = []
+    for label in labels:
+        if language == "tr":
+            names.append(label.display_name_tr)
+        else:
+            names.append(label.display_name_en)
+    
+    return ", ".join(names)
+
+
+def get_all_labels() -> list[GmailLabel]:
+    """Get all available Gmail labels."""
+    return list(GmailLabel)
+
+
+def get_category_labels() -> list[GmailLabel]:
+    """Get Gmail category labels (tabs)."""
+    return [
+        GmailLabel.CATEGORY_PERSONAL,
+        GmailLabel.CATEGORY_SOCIAL,
+        GmailLabel.CATEGORY_PROMOTIONS,
+        GmailLabel.CATEGORY_UPDATES,
+        GmailLabel.CATEGORY_FORUMS,
+    ]
+
+
+def get_system_labels() -> list[GmailLabel]:
+    """Get Gmail system labels."""
+    return [
+        GmailLabel.INBOX,
+        GmailLabel.SENT,
+        GmailLabel.DRAFT,
+        GmailLabel.TRASH,
+        GmailLabel.SPAM,
+        GmailLabel.STARRED,
+        GmailLabel.IMPORTANT,
+        GmailLabel.UNREAD,
+    ]

--- a/tests/test_gmail_labels.py
+++ b/tests/test_gmail_labels.py
@@ -1,0 +1,406 @@
+"""Tests for Gmail label utilities.
+
+Issue #317: Gmail label/kategori desteği
+
+Tests cover:
+- GmailLabel enum
+- Turkish keyword detection
+- Query building
+- Smart search
+"""
+
+from typing import Any
+
+import pytest
+
+from bantz.google.gmail_labels import (
+    GmailLabel,
+    LabelMatch,
+    TURKISH_LABEL_KEYWORDS,
+    build_label_query,
+    build_smart_query,
+    detect_label_from_text,
+    format_labels_summary,
+    get_all_labels,
+    get_category_labels,
+    get_system_labels,
+)
+
+
+# =============================================================================
+# GmailLabel Enum Tests
+# =============================================================================
+
+class TestGmailLabel:
+    """Tests for GmailLabel enum."""
+    
+    def test_inbox_value(self) -> None:
+        """Test INBOX value."""
+        assert GmailLabel.INBOX.value == "INBOX"
+    
+    def test_category_social_value(self) -> None:
+        """Test CATEGORY_SOCIAL value."""
+        assert GmailLabel.CATEGORY_SOCIAL.value == "CATEGORY_SOCIAL"
+    
+    def test_label_id(self) -> None:
+        """Test label_id property."""
+        assert GmailLabel.INBOX.label_id == "INBOX"
+        assert GmailLabel.CATEGORY_UPDATES.label_id == "CATEGORY_UPDATES"
+    
+    def test_display_name_tr(self) -> None:
+        """Test Turkish display names."""
+        assert GmailLabel.INBOX.display_name_tr == "Gelen Kutusu"
+        assert GmailLabel.SENT.display_name_tr == "Gönderilenler"
+        assert GmailLabel.CATEGORY_SOCIAL.display_name_tr == "Sosyal"
+        assert GmailLabel.CATEGORY_PROMOTIONS.display_name_tr == "Promosyonlar"
+        assert GmailLabel.CATEGORY_UPDATES.display_name_tr == "Güncellemeler"
+    
+    def test_display_name_en(self) -> None:
+        """Test English display names."""
+        assert GmailLabel.INBOX.display_name_en == "Inbox"
+        assert GmailLabel.SENT.display_name_en == "Sent"
+        assert GmailLabel.CATEGORY_SOCIAL.display_name_en == "Social"
+    
+    def test_query_filter_inbox(self) -> None:
+        """Test query filter for INBOX."""
+        assert GmailLabel.INBOX.query_filter == "in:inbox"
+    
+    def test_query_filter_sent(self) -> None:
+        """Test query filter for SENT."""
+        assert GmailLabel.SENT.query_filter == "in:sent"
+    
+    def test_query_filter_starred(self) -> None:
+        """Test query filter for STARRED."""
+        assert GmailLabel.STARRED.query_filter == "is:starred"
+    
+    def test_query_filter_category(self) -> None:
+        """Test query filter for categories."""
+        assert GmailLabel.CATEGORY_SOCIAL.query_filter == "label:CATEGORY_SOCIAL"
+        assert GmailLabel.CATEGORY_UPDATES.query_filter == "label:CATEGORY_UPDATES"
+
+
+# =============================================================================
+# Turkish Keyword Mapping Tests
+# =============================================================================
+
+class TestTurkishKeywords:
+    """Tests for Turkish keyword mappings."""
+    
+    def test_gelen_kutusu_mapping(self) -> None:
+        """Test gelen kutusu maps to INBOX."""
+        assert TURKISH_LABEL_KEYWORDS["gelen kutusu"] == GmailLabel.INBOX
+    
+    def test_sosyal_mapping(self) -> None:
+        """Test sosyal maps to CATEGORY_SOCIAL."""
+        assert TURKISH_LABEL_KEYWORDS["sosyal"] == GmailLabel.CATEGORY_SOCIAL
+    
+    def test_promosyonlar_mapping(self) -> None:
+        """Test promosyonlar maps to CATEGORY_PROMOTIONS."""
+        assert TURKISH_LABEL_KEYWORDS["promosyonlar"] == GmailLabel.CATEGORY_PROMOTIONS
+    
+    def test_guncellemeler_mapping(self) -> None:
+        """Test güncellemeler maps to CATEGORY_UPDATES."""
+        assert TURKISH_LABEL_KEYWORDS["güncellemeler"] == GmailLabel.CATEGORY_UPDATES
+    
+    def test_ascii_variant_onemli(self) -> None:
+        """Test ASCII variant 'onemli' maps to IMPORTANT."""
+        assert TURKISH_LABEL_KEYWORDS["onemli"] == GmailLabel.IMPORTANT
+    
+    def test_yildizli_mapping(self) -> None:
+        """Test yıldızlı maps to STARRED."""
+        assert TURKISH_LABEL_KEYWORDS["yıldızlı"] == GmailLabel.STARRED
+
+
+# =============================================================================
+# LabelMatch Tests
+# =============================================================================
+
+class TestLabelMatch:
+    """Tests for LabelMatch dataclass."""
+    
+    def test_detected_true(self) -> None:
+        """Test detected property when label found."""
+        match = LabelMatch(
+            label=GmailLabel.INBOX,
+            matched_keyword="gelen kutusu",
+            confidence=0.9,
+            original_text="gelen kutusundaki mailler",
+        )
+        assert match.detected is True
+    
+    def test_detected_false(self) -> None:
+        """Test detected property when no label found."""
+        match = LabelMatch.no_match("random text")
+        assert match.detected is False
+    
+    def test_no_match_factory(self) -> None:
+        """Test no_match factory method."""
+        match = LabelMatch.no_match("some text")
+        assert match.label is None
+        assert match.matched_keyword is None
+        assert match.confidence == 0.0
+        assert match.original_text == "some text"
+
+
+# =============================================================================
+# Label Detection Tests
+# =============================================================================
+
+class TestDetectLabelFromText:
+    """Tests for detect_label_from_text function."""
+    
+    def test_detect_sosyal(self) -> None:
+        """Test detecting sosyal category."""
+        match = detect_label_from_text("sosyal mailleri göster")
+        assert match.detected is True
+        assert match.label == GmailLabel.CATEGORY_SOCIAL
+        # Longer keyword "sosyal mailleri" matches before "sosyal"
+        assert "sosyal" in match.matched_keyword
+    
+    def test_detect_promosyonlar(self) -> None:
+        """Test detecting promosyonlar category."""
+        match = detect_label_from_text("promosyonlar kategorisindeki mailler")
+        assert match.detected is True
+        assert match.label == GmailLabel.CATEGORY_PROMOTIONS
+    
+    def test_detect_guncellemeler(self) -> None:
+        """Test detecting güncellemeler category."""
+        match = detect_label_from_text("güncellemeler kategorisinde ne var")
+        assert match.detected is True
+        assert match.label == GmailLabel.CATEGORY_UPDATES
+    
+    def test_detect_gonderilenler(self) -> None:
+        """Test detecting gönderilenler."""
+        match = detect_label_from_text("gönderilen mailleri listele")
+        assert match.detected is True
+        assert match.label == GmailLabel.SENT
+    
+    def test_detect_yildizli(self) -> None:
+        """Test detecting yıldızlı."""
+        match = detect_label_from_text("yıldızlı mailleri göster")
+        assert match.detected is True
+        assert match.label == GmailLabel.STARRED
+    
+    def test_detect_gelen_kutusu(self) -> None:
+        """Test detecting gelen kutusu."""
+        match = detect_label_from_text("gelen kutusundaki maillerimi göster")
+        assert match.detected is True
+        assert match.label == GmailLabel.INBOX
+    
+    def test_no_detection_random_text(self) -> None:
+        """Test no detection for random text."""
+        match = detect_label_from_text("bugün hava nasıl")
+        assert match.detected is False
+    
+    def test_no_detection_empty(self) -> None:
+        """Test no detection for empty string."""
+        match = detect_label_from_text("")
+        assert match.detected is False
+    
+    def test_case_insensitive(self) -> None:
+        """Test case insensitive detection."""
+        match = detect_label_from_text("SOSYAL mailleri")
+        assert match.detected is True
+        assert match.label == GmailLabel.CATEGORY_SOCIAL
+    
+    def test_english_keyword(self) -> None:
+        """Test English keyword detection."""
+        match = detect_label_from_text("show me inbox emails")
+        assert match.detected is True
+        assert match.label == GmailLabel.INBOX
+
+
+# =============================================================================
+# Query Building Tests
+# =============================================================================
+
+class TestBuildLabelQuery:
+    """Tests for build_label_query function."""
+    
+    def test_inbox_query(self) -> None:
+        """Test INBOX query."""
+        query = build_label_query(GmailLabel.INBOX)
+        assert query == "in:inbox"
+    
+    def test_category_updates_query(self) -> None:
+        """Test CATEGORY_UPDATES query."""
+        query = build_label_query(GmailLabel.CATEGORY_UPDATES)
+        assert query == "label:CATEGORY_UPDATES"
+    
+    def test_with_unread_filter(self) -> None:
+        """Test with unread filter."""
+        query = build_label_query(GmailLabel.INBOX, include_unread_only=True)
+        assert query == "in:inbox is:unread"
+    
+    def test_with_additional_query(self) -> None:
+        """Test with additional query terms."""
+        query = build_label_query(
+            GmailLabel.CATEGORY_SOCIAL,
+            additional_query="from:twitter",
+        )
+        assert query == "label:CATEGORY_SOCIAL from:twitter"
+
+
+# =============================================================================
+# Smart Query Tests
+# =============================================================================
+
+class TestBuildSmartQuery:
+    """Tests for build_smart_query function."""
+    
+    def test_smart_query_sosyal(self) -> None:
+        """Test smart query for sosyal."""
+        query, label = build_smart_query("sosyal mailleri göster")
+        assert "CATEGORY_SOCIAL" in query
+        assert label == GmailLabel.CATEGORY_SOCIAL
+    
+    def test_smart_query_promosyonlar(self) -> None:
+        """Test smart query for promosyonlar."""
+        query, label = build_smart_query("promosyonlar kategorisindeki mailler")
+        assert "CATEGORY_PROMOTIONS" in query
+        assert label == GmailLabel.CATEGORY_PROMOTIONS
+    
+    def test_smart_query_no_label(self) -> None:
+        """Test smart query with no label detected."""
+        query, label = build_smart_query("son mailler")
+        assert query == "in:inbox"
+        assert label is None
+    
+    def test_smart_query_with_default(self) -> None:
+        """Test smart query with default label."""
+        query, label = build_smart_query(
+            "son mailler",
+            default_label=GmailLabel.INBOX,
+        )
+        assert query == "in:inbox"
+        assert label == GmailLabel.INBOX
+    
+    def test_smart_query_with_unread(self) -> None:
+        """Test smart query with unread filter."""
+        query, label = build_smart_query(
+            "sosyal mailleri",
+            include_unread_only=True,
+        )
+        assert "is:unread" in query
+        assert "CATEGORY_SOCIAL" in query
+
+
+# =============================================================================
+# Utility Function Tests
+# =============================================================================
+
+class TestUtilityFunctions:
+    """Tests for utility functions."""
+    
+    def test_format_labels_summary_tr(self) -> None:
+        """Test Turkish label summary."""
+        labels = [GmailLabel.CATEGORY_SOCIAL, GmailLabel.CATEGORY_UPDATES]
+        summary = format_labels_summary(labels, language="tr")
+        assert "Sosyal" in summary
+        assert "Güncellemeler" in summary
+    
+    def test_format_labels_summary_en(self) -> None:
+        """Test English label summary."""
+        labels = [GmailLabel.CATEGORY_SOCIAL, GmailLabel.CATEGORY_UPDATES]
+        summary = format_labels_summary(labels, language="en")
+        assert "Social" in summary
+        assert "Updates" in summary
+    
+    def test_format_labels_summary_empty(self) -> None:
+        """Test empty label summary."""
+        summary = format_labels_summary([])
+        assert summary == ""
+    
+    def test_get_all_labels(self) -> None:
+        """Test getting all labels."""
+        labels = get_all_labels()
+        assert len(labels) == len(GmailLabel)
+        assert GmailLabel.INBOX in labels
+    
+    def test_get_category_labels(self) -> None:
+        """Test getting category labels."""
+        labels = get_category_labels()
+        assert len(labels) == 5
+        assert GmailLabel.CATEGORY_SOCIAL in labels
+        assert GmailLabel.CATEGORY_PROMOTIONS in labels
+        assert GmailLabel.INBOX not in labels
+    
+    def test_get_system_labels(self) -> None:
+        """Test getting system labels."""
+        labels = get_system_labels()
+        assert GmailLabel.INBOX in labels
+        assert GmailLabel.SENT in labels
+        assert GmailLabel.CATEGORY_SOCIAL not in labels
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+class TestIntegration:
+    """Integration tests for Gmail labels."""
+    
+    def test_full_flow_updates_category(self) -> None:
+        """Test full flow for detecting and querying updates category."""
+        text = "güncellemeler kategorisindeki mailleri göster"
+        
+        # Detect label
+        match = detect_label_from_text(text)
+        assert match.detected is True
+        assert match.label == GmailLabel.CATEGORY_UPDATES
+        
+        # Build query
+        query = build_label_query(match.label)
+        assert query == "label:CATEGORY_UPDATES"
+    
+    def test_full_flow_promotions_category(self) -> None:
+        """Test full flow for promotions category."""
+        text = "promosyon mailleri"
+        
+        match = detect_label_from_text(text)
+        assert match.detected is True
+        assert match.label == GmailLabel.CATEGORY_PROMOTIONS
+        
+        query = build_label_query(match.label)
+        assert query == "label:CATEGORY_PROMOTIONS"
+    
+    def test_full_flow_starred(self) -> None:
+        """Test full flow for starred emails."""
+        text = "yıldızlı mailleri göster"
+        
+        match = detect_label_from_text(text)
+        assert match.detected is True
+        assert match.label == GmailLabel.STARRED
+        
+        query = build_label_query(match.label)
+        assert query == "is:starred"
+    
+    def test_turkish_social_email_request(self) -> None:
+        """Test realistic Turkish social email request."""
+        requests = [
+            "sosyal mailleri göster",
+            "sosyal kategorisindeki mailler",
+            "social mailleri",
+        ]
+        
+        for text in requests:
+            match = detect_label_from_text(text)
+            assert match.detected is True, f"Failed for: {text}"
+            assert match.label == GmailLabel.CATEGORY_SOCIAL, f"Wrong label for: {text}"
+    
+    def test_different_label_requests(self) -> None:
+        """Test various label requests."""
+        test_cases = [
+            ("gelen kutusu mailleri", GmailLabel.INBOX),
+            ("gönderilenler mailleri", GmailLabel.SENT),
+            ("taslaklar", GmailLabel.DRAFT),
+            ("çöp kutusu", GmailLabel.TRASH),
+            ("spam mailleri", GmailLabel.SPAM),
+            ("önemli mailler", GmailLabel.IMPORTANT),
+            ("forumlar kategorisi", GmailLabel.CATEGORY_FORUMS),
+        ]
+        
+        for text, expected_label in test_cases:
+            match = detect_label_from_text(text)
+            assert match.detected is True, f"Failed for: {text}"
+            assert match.label == expected_label, f"Wrong label for: {text}, got {match.label}"


### PR DESCRIPTION
## Problem
Gmail'de sadece LinkedIn maillerine bakıyor. Gmail'deki kategorileri/label'ları desteklemiyor.

## Solution
Turkish ve English keyword mapping ile Gmail label desteği.

## New Files
- `src/bantz/google/gmail_labels.py`: GmailLabel enum, keyword mapping, query builders
- `tests/test_gmail_labels.py`: 48 tests

## Implementation

### GmailLabel Enum
- System labels: INBOX, SENT, DRAFT, TRASH, SPAM, STARRED, IMPORTANT, UNREAD
- Category labels: CATEGORY_PERSONAL, CATEGORY_SOCIAL, CATEGORY_PROMOTIONS, CATEGORY_UPDATES, CATEGORY_FORUMS
- Turkish display names (display_name_tr)
- Gmail query filters (query_filter)

### Turkish Keyword Mapping
```
'sosyal' → CATEGORY_SOCIAL
'promosyonlar' → CATEGORY_PROMOTIONS
'güncellemeler' → CATEGORY_UPDATES
'gelen kutusu' → INBOX
'gönderilenler' → SENT
'yıldızlı' → STARRED
...
```

### New Tools
- `gmail_list_messages_tool`: Updated with category/label parameters
- `gmail_smart_search_tool`: Natural language search with label detection
- `gmail_list_categories_tool`: List available categories with Turkish names

## Usage Examples
```
> sosyal mailleri göster
> promosyonlar kategorisindeki mailler
> güncellemeler kategorisinde ne var
> gönderilen mailleri listele
```

Resolves #317