### PR TITLE
Fix Gmail tool name inconsistency (Issue #348)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -104,7 +104,7 @@ class OrchestratorLoop:
             ("gmail", "list"): ["gmail.list_messages"],
             ("gmail", "query"): ["gmail.list_messages"],
             ("gmail", "read"): ["gmail.get_message"],
-            ("gmail", "send"): ["gmail.send_message"],
+            ("gmail", "send"): ["gmail.send"],
             ("gmail", "search"): ["gmail.smart_search"],  # Issue #317: Gmail label search
             # System routes
             ("system", "time"): ["time.now"],

--- a/tests/test_force_tool_plan.py
+++ b/tests/test_force_tool_plan.py
@@ -192,7 +192,7 @@ class TestForceToolPlanGmail:
         assert result.tool_plan == ["gmail.get_message"]
     
     def test_gmail_send_forces_send_message(self, loop):
-        """Gmail + send with empty tool_plan should force send_message."""
+        """Gmail + send with empty tool_plan should force gmail.send."""
         output = OrchestratorOutput(
             route="gmail",
             calendar_intent="send",
@@ -204,7 +204,7 @@ class TestForceToolPlanGmail:
         
         result = loop._force_tool_plan(output)
         
-        assert result.tool_plan == ["gmail.send_message"]
+        assert result.tool_plan == ["gmail.send"]
     
     def test_gmail_unknown_intent_fallback(self, loop):
         """Gmail with unknown intent should fallback to list_messages."""

--- a/tests/test_safe_tools_route_independent.py
+++ b/tests/test_safe_tools_route_independent.py
@@ -58,7 +58,7 @@ class TestRouteIndependentSafeToolsConstant:
         assert "calendar.create_event" not in ROUTE_INDEPENDENT_SAFE_TOOLS
         assert "calendar.delete_event" not in ROUTE_INDEPENDENT_SAFE_TOOLS
         assert "calendar.update_event" not in ROUTE_INDEPENDENT_SAFE_TOOLS
-        assert "gmail.send_message" not in ROUTE_INDEPENDENT_SAFE_TOOLS
+        assert "gmail.send" not in ROUTE_INDEPENDENT_SAFE_TOOLS
 
 
 # ============================================================================
@@ -160,10 +160,10 @@ class TestFilterToolPlanUnsafeTools:
         assert violations[0].tool_name == "calendar.delete_event"
     
     def test_gmail_send_blocked_on_route_unknown(self, guard):
-        """gmail.send_message should be blocked when route=unknown."""
+        """gmail.send should be blocked when route=unknown."""
         filtered, violations = guard.filter_tool_plan(
             route="unknown",
-            tool_plan=["gmail.send_message"],
+            tool_plan=["gmail.send"],
         )
         
         assert filtered == []
@@ -224,10 +224,10 @@ class TestFilterToolPlanAllowedRoutes:
         """route=gmail should allow all gmail tools."""
         filtered, violations = guard.filter_tool_plan(
             route="gmail",
-            tool_plan=["gmail.list_messages", "gmail.send_message"],
+            tool_plan=["gmail.list_messages", "gmail.send"],
         )
         
-        assert filtered == ["gmail.list_messages", "gmail.send_message"]
+        assert filtered == ["gmail.list_messages", "gmail.send"]
         assert len(violations) == 0
     
     def test_system_route_allows_system_tools(self, guard):
@@ -252,8 +252,8 @@ class TestFilterToolPlanEnforcementDisabled:
         """All tools should be allowed when enforcement is disabled."""
         filtered, violations = guard_no_enforcement.filter_tool_plan(
             route="unknown",
-            tool_plan=["calendar.create_event", "gmail.send_message"],
+            tool_plan=["calendar.create_event", "gmail.send"],
         )
         
-        assert filtered == ["calendar.create_event", "gmail.send_message"]
+        assert filtered == ["calendar.create_event", "gmail.send"]
         assert len(violations) == 0


### PR DESCRIPTION
## Summary
Standardize Gmail send tool name to `gmail.send` throughout codebase.

Fixes #348

## Problem
Inconsistent tool naming created confusion:
- **Line 107** (route intent map): `('gmail', 'send') → ['gmail.send_message']`
- **Line 121** (gmail intent map): `'send' → ['gmail.send']`
- **Actual tool**: `gmail.send`

This inconsistency could cause routing errors and makes code harder to maintain.

## Solution
Replaced all occurrences of `gmail.send_message` with `gmail.send`:
- [orchestrator_loop.py](src/bantz/brain/orchestrator_loop.py#L107) intent map
- [test_safe_tools_route_independent.py](tests/test_safe_tools_route_independent.py) (5 tests)
- [test_force_tool_plan.py](tests/test_force_tool_plan.py) (1 test)

## Changes
**Modified Files:**
- `src/bantz/brain/orchestrator_loop.py` (1 line)
- `tests/test_safe_tools_route_independent.py` (5 assertions)
- `tests/test_force_tool_plan.py` (1 assertion)

## Testing
```bash
$ python3 -m pytest tests/test_force_tool_plan.py -k gmail_send -xvs
tests/test_force_tool_plan.py::TestForceToolPlanGmail::test_gmail_send_forces_send_message PASSED

$ python3 -m pytest tests/test_safe_tools_route_independent.py -xvs  
20 passed in 0.11s
```

## Impact
✅ Gmail send intent correctly maps to `gmail.send` tool  
✅ Consistent naming improves code maintainability  
✅ No breaking changes (gmail.send was already the actual tool name)  
✅ All related tests passing