### PR TITLE
Fix #356: Create unified finalizer strategy

### DIFF
--- a/src/bantz/brain/finalizer.py
+++ b/src/bantz/brain/finalizer.py
@@ -1,0 +1,523 @@
+"""Unified Finalizer Strategy (Issue #356).
+
+This module provides a shared finalizer implementation for both BrainLoop
+and OrchestratorLoop, eliminating code duplication and ensuring consistent
+quality across different brain implementations.
+
+Key Features:
+- Unified prompt building with tool results support
+- Smart truncation for large tool results (max 2000 tokens)
+- No-new-facts guard to prevent hallucination
+- Fallback strategies (quality → fast → draft)
+- Support for different finalizer modes (off/calendar_only/smalltalk/always)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class LLMClientProtocol(Protocol):
+    """Protocol for LLM text completion."""
+    
+    def complete_text(self, *, prompt: str, temperature: float = 0.2, max_tokens: int = 256) -> str:
+        """Complete text from prompt."""
+        ...
+
+
+@dataclass(frozen=True)
+class FinalizerConfig:
+    """Configuration for finalizer behavior.
+    
+    Attributes:
+        mode: Finalizer mode - "off", "calendar_only", "smalltalk", "always"
+        temperature: LLM temperature for finalization (default 0.2)
+        max_tokens: Max tokens for finalizer response (default 256)
+        tool_results_token_budget: Token budget for tool results (default 2000)
+        enable_no_new_facts_guard: Enable guard against hallucinated numbers/dates
+        retry_on_guard_violation: Retry with stricter prompt if guard violated
+    """
+    mode: str = "calendar_only"
+    temperature: float = 0.2
+    max_tokens: int = 256
+    tool_results_token_budget: int = 2000
+    enable_no_new_facts_guard: bool = True
+    retry_on_guard_violation: bool = True
+
+
+@dataclass
+class FinalizerResult:
+    """Result of finalization attempt.
+    
+    Attributes:
+        text: Final response text
+        used_finalizer: Whether finalizer LLM was used (vs fallback to draft)
+        was_truncated: Whether tool results were truncated
+        guard_violated: Whether no-new-facts guard was violated
+        guard_retried: Whether retry was attempted after guard violation
+        tier_name: Tier used ("quality", "fast", or "draft")
+        tier_reason: Reason for tier selection
+    """
+    text: str
+    used_finalizer: bool = False
+    was_truncated: bool = False
+    guard_violated: bool = False
+    guard_retried: bool = False
+    tier_name: str = "draft"
+    tier_reason: str = ""
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimation (~4 chars per token)."""
+    return len(text) // 4
+
+
+def _prepare_tool_results_for_finalizer(
+    tool_results: list[dict[str, Any]],
+    max_tokens: int = 2000,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Prepare tool results for finalizer with token budget control.
+    
+    Strategy (3-tier fallback):
+    1. Try full raw_result for each tool
+    2. If too large, use result_summary instead
+    3. If still too large, keep only first 3 tools with aggressive truncation
+    
+    Args:
+        tool_results: List of tool execution results
+        max_tokens: Maximum tokens allowed for tool results
+        
+    Returns:
+        Tuple of (prepared_results, was_truncated)
+    """
+    if not tool_results:
+        return [], False
+    
+    # Tier 1: Try full raw_result
+    full_results = []
+    for result in tool_results:
+        result_copy = {
+            "tool": result.get("tool") or result.get("tool_name") or result.get("name") or "unknown",
+            "status": "success" if result.get("success", True) else "error",
+        }
+        
+        # Prefer raw_result if available (full detail)
+        if "raw_result" in result:
+            result_copy["result"] = result["raw_result"]
+        elif "result" in result:
+            result_copy["result"] = result["result"]
+        elif "error" in result:
+            result_copy["error"] = result["error"]
+            
+        full_results.append(result_copy)
+    
+    full_json = json.dumps(full_results, ensure_ascii=False)
+    full_tokens = _estimate_tokens(full_json)
+    
+    if full_tokens <= max_tokens:
+        return full_results, False
+    
+    # Tier 2: Use result_summary (medium detail)
+    summary_results = []
+    for result in tool_results:
+        result_copy = {
+            "tool": result.get("tool") or result.get("tool_name") or result.get("name") or "unknown",
+            "status": "success" if result.get("success", True) else "error",
+        }
+        
+        # Prefer result_summary if available
+        if "result_summary" in result:
+            result_copy["result"] = result["result_summary"]
+        elif "raw_result" in result:
+            # Truncate raw_result to 200 chars
+            raw = json.dumps(result["raw_result"], ensure_ascii=False)
+            if len(raw) > 200:
+                result_copy["result"] = raw[:200] + "..."
+            else:
+                result_copy["result"] = result["raw_result"]
+        elif "result" in result:
+            result_str = str(result["result"])
+            if len(result_str) > 200:
+                result_copy["result"] = result_str[:200] + "..."
+            else:
+                result_copy["result"] = result["result"]
+        elif "error" in result:
+            result_copy["error"] = str(result["error"])[:200]
+            
+        summary_results.append(result_copy)
+    
+    summary_json = json.dumps(summary_results, ensure_ascii=False)
+    summary_tokens = _estimate_tokens(summary_json)
+    
+    if summary_tokens <= max_tokens:
+        return summary_results, True
+    
+    # Tier 3: Aggressive truncation - first 3 tools only, 200 chars each
+    aggressive_results = []
+    for result in tool_results[:3]:  # Only first 3 tools
+        result_copy = {
+            "tool": result.get("tool") or result.get("tool_name") or result.get("name") or "unknown",
+            "status": "success" if result.get("success", True) else "error",
+        }
+        
+        if "result_summary" in result:
+            summary = str(result["result_summary"])
+            result_copy["result"] = summary[:200] + ("..." if len(summary) > 200 else "")
+        elif "result" in result or "raw_result" in result:
+            res = result.get("result") or result.get("raw_result")
+            res_str = json.dumps(res, ensure_ascii=False) if isinstance(res, (dict, list)) else str(res)
+            result_copy["result"] = res_str[:200] + ("..." if len(res_str) > 200 else "")
+        elif "error" in result:
+            result_copy["error"] = str(result["error"])[:200]
+            
+        aggressive_results.append(result_copy)
+    
+    return aggressive_results, True
+
+
+def _build_finalizer_prompt(
+    *,
+    user_input: str,
+    planner_decision: Optional[dict[str, Any]] = None,
+    tool_results: Optional[list[dict[str, Any]]] = None,
+    dialog_summary: Optional[str] = None,
+    draft_text: Optional[str] = None,
+    route: Optional[str] = None,
+    last_tool: Optional[str] = None,
+) -> str:
+    """Build unified finalizer prompt.
+    
+    Supports both BrainLoop style (draft-based) and OrchestratorLoop style (decision-based).
+    
+    Args:
+        user_input: User's message
+        planner_decision: Orchestrator decision (route, intent, slots, etc.)
+        tool_results: Tool execution results
+        dialog_summary: Conversation history summary
+        draft_text: Draft response (for BrainLoop compatibility)
+        route: Route classification (for BrainLoop compatibility)
+        last_tool: Last executed tool (for BrainLoop compatibility)
+        
+    Returns:
+        Formatted finalizer prompt
+    """
+    prompt_lines = [
+        "Kimlik / Roller:",
+        "- Sen BANTZ'sın. Kullanıcı USER'dır.",
+        "- SADECE TÜRKÇE konuş. Asla Çince, Korece, İngilizce veya başka dil kullanma!",
+        "- 'Efendim' hitabını kullan.",
+        "- Sadece kullanıcıya söyleyeceğin metni üret; JSON/Markdown yok.",
+        "- Kısa ve öz cevap ver (1-2 cümle ideal).",
+        "",
+    ]
+    
+    # Add dialog history if available
+    if dialog_summary:
+        prompt_lines.extend([
+            f"DIALOG_SUMMARY:\n{dialog_summary}",
+            "",
+        ])
+    
+    # Add planner decision if available (OrchestratorLoop style)
+    if planner_decision:
+        prompt_lines.extend([
+            "PLANNER_DECISION (JSON):",
+            json.dumps(planner_decision, ensure_ascii=False),
+            "",
+        ])
+    
+    # Add route/tool info if available (BrainLoop style)
+    if route or last_tool:
+        if route:
+            prompt_lines.append(f"ROUTE: {route}")
+        if last_tool:
+            prompt_lines.append(f"LAST_TOOL: {last_tool}")
+        prompt_lines.append("")
+    
+    # Add tool results if available
+    if tool_results:
+        prompt_lines.extend([
+            "TOOL_RESULTS (JSON):",
+            json.dumps(tool_results, ensure_ascii=False),
+            "",
+        ])
+    
+    # Add draft if available (BrainLoop style)
+    if draft_text:
+        prompt_lines.extend([
+            "Görev: DRAFT cevabı daha doğal, kısa ve yardımcı bir dille yeniden yaz.",
+            "Kural: DRAFT içindeki gerçekleri KESİN değiştirme (sayı/saat/tarih/başlık).",
+            "Yeni etkinlik uydurma, ekstra detay ekleme. JSON/Markdown/backtick yazma.",
+            "",
+            f"DRAFT:\n{draft_text}",
+            "",
+        ])
+    
+    # Add user input and prompt for assistant response
+    prompt_lines.extend([
+        f"USER: {user_input}",
+        "ASSISTANT (SADECE TÜRKÇE):",
+    ])
+    
+    return "\n".join(prompt_lines)
+
+
+def finalize(
+    *,
+    user_input: str,
+    finalizer_llm: Optional[LLMClientProtocol],
+    config: Optional[FinalizerConfig] = None,
+    planner_decision: Optional[dict[str, Any]] = None,
+    tool_results: Optional[list[dict[str, Any]]] = None,
+    dialog_summary: Optional[str] = None,
+    draft_text: Optional[str] = None,
+    fallback_llm: Optional[LLMClientProtocol] = None,
+    route: Optional[str] = None,
+    last_tool: Optional[str] = None,
+) -> FinalizerResult:
+    """Unified finalization with quality LLM.
+    
+    This function provides a single entry point for both BrainLoop and OrchestratorLoop
+    finalizers, with support for:
+    - Smart truncation of large tool results
+    - No-new-facts guard against hallucinated numbers/dates
+    - Fallback strategies (quality → fast → draft)
+    - Configurable modes (off/calendar_only/smalltalk/always)
+    
+    Args:
+        user_input: User's message
+        finalizer_llm: Quality LLM for finalization (e.g., Gemini)
+        config: Finalizer configuration (defaults applied if None)
+        planner_decision: Orchestrator decision (route, intent, slots, etc.)
+        tool_results: Tool execution results
+        dialog_summary: Conversation history summary
+        draft_text: Draft response (required for BrainLoop, optional for OrchestratorLoop)
+        fallback_llm: Fast LLM for fallback (e.g., 3B router)
+        route: Route classification (for BrainLoop compatibility)
+        last_tool: Last executed tool (for BrainLoop compatibility)
+        
+    Returns:
+        FinalizerResult with final text and metadata
+    """
+    cfg = config or FinalizerConfig()
+    
+    # Check if finalization is disabled
+    if cfg.mode == "off" or finalizer_llm is None:
+        return FinalizerResult(
+            text=draft_text or "",
+            used_finalizer=False,
+            tier_name="draft",
+            tier_reason="finalizer_disabled" if cfg.mode == "off" else "no_finalizer_llm",
+        )
+    
+    # Check if finalization should be skipped based on mode
+    should_finalize = False
+    tier_reason = ""
+    
+    if cfg.mode == "always":
+        should_finalize = True
+        tier_reason = "mode_always"
+    elif cfg.mode == "smalltalk":
+        route_norm = (route or "").lower().strip()
+        is_smalltalk = route_norm in {"smalltalk", "smalltalk_stage1"}
+        should_finalize = is_smalltalk
+        tier_reason = "smalltalk_route" if is_smalltalk else "not_smalltalk"
+    else:  # calendar_only
+        is_calendar = bool(last_tool and last_tool.startswith("calendar."))
+        should_finalize = is_calendar
+        tier_reason = "calendar_tool" if is_calendar else "not_calendar"
+    
+    if not should_finalize:
+        return FinalizerResult(
+            text=draft_text or "",
+            used_finalizer=False,
+            tier_name="draft",
+            tier_reason=tier_reason,
+        )
+    
+    # Prepare tool results with token budget
+    finalizer_tool_results = tool_results
+    was_truncated = False
+    
+    if tool_results:
+        finalizer_tool_results, was_truncated = _prepare_tool_results_for_finalizer(
+            tool_results,
+            max_tokens=cfg.tool_results_token_budget,
+        )
+        if was_truncated:
+            logger.info("[FINALIZER] Tool results truncated to fit token budget")
+    
+    # Build finalizer prompt
+    prompt = _build_finalizer_prompt(
+        user_input=user_input,
+        planner_decision=planner_decision,
+        tool_results=finalizer_tool_results,
+        dialog_summary=dialog_summary,
+        draft_text=draft_text,
+        route=route,
+        last_tool=last_tool,
+    )
+    
+    # Call finalizer LLM
+    try:
+        try:
+            final_text = finalizer_llm.complete_text(
+                prompt=prompt,
+                temperature=cfg.temperature,
+                max_tokens=cfg.max_tokens,
+            )
+        except TypeError:
+            # Backward compatibility for mocks that only accept prompt
+            final_text = finalizer_llm.complete_text(prompt=prompt)
+        
+        final_text = str(final_text or "").strip()
+        
+        if not final_text:
+            # Empty response - fallback
+            if fallback_llm and draft_text:
+                try:
+                    fallback_text = fallback_llm.complete_text(prompt=prompt, temperature=0.2, max_tokens=256)
+                    fallback_text = str(fallback_text or "").strip()
+                    if fallback_text:
+                        return FinalizerResult(
+                            text=fallback_text,
+                            used_finalizer=True,
+                            was_truncated=was_truncated,
+                            tier_name="fast",
+                            tier_reason="quality_empty_fallback_fast",
+                        )
+                except Exception:
+                    pass
+            
+            return FinalizerResult(
+                text=draft_text or "",
+                used_finalizer=False,
+                was_truncated=was_truncated,
+                tier_name="draft",
+                tier_reason="quality_empty_fallback_draft",
+            )
+        
+        # Apply no-new-facts guard if enabled
+        guard_violated = False
+        guard_retried = False
+        
+        if cfg.enable_no_new_facts_guard:
+            try:
+                from bantz.llm.no_new_facts import find_new_numeric_facts
+                
+                allowed_sources = [user_input]
+                if dialog_summary:
+                    allowed_sources.append(dialog_summary)
+                if draft_text:
+                    allowed_sources.append(draft_text)
+                if planner_decision:
+                    allowed_sources.append(json.dumps(planner_decision, ensure_ascii=False))
+                if tool_results:
+                    allowed_sources.append(json.dumps(tool_results, ensure_ascii=False))
+                
+                violates, new_tokens = find_new_numeric_facts(
+                    allowed_texts=allowed_sources,
+                    candidate_text=final_text,
+                )
+                
+                if violates:
+                    guard_violated = True
+                    
+                    if cfg.retry_on_guard_violation:
+                        guard_retried = True
+                        # Retry with stricter constraint
+                        retry_prompt = (
+                            prompt
+                            + "\n\nSTRICT_NO_NEW_FACTS: Sadece verilen metinlerde geçen sayı/saat/tarihleri kullan. "
+                            "Yeni rakam ekleme. Gerekirse rakam içeren detayları çıkar.\n"
+                        )
+                        
+                        try:
+                            final_text2 = finalizer_llm.complete_text(
+                                prompt=retry_prompt,
+                                temperature=cfg.temperature * 0.5,  # Lower temperature for retry
+                                max_tokens=cfg.max_tokens,
+                            )
+                        except TypeError:
+                            final_text2 = finalizer_llm.complete_text(prompt=retry_prompt)
+                        
+                        final_text2 = str(final_text2 or "").strip()
+                        
+                        if final_text2:
+                            violates2, _new2 = find_new_numeric_facts(
+                                allowed_texts=allowed_sources,
+                                candidate_text=final_text2,
+                            )
+                            if not violates2:
+                                final_text = final_text2
+                                guard_violated = False  # Successfully recovered
+                            else:
+                                # Retry still violated - fallback
+                                if draft_text:
+                                    return FinalizerResult(
+                                        text=draft_text,
+                                        used_finalizer=False,
+                                        was_truncated=was_truncated,
+                                        guard_violated=True,
+                                        guard_retried=True,
+                                        tier_name="draft",
+                                        tier_reason="guard_retry_failed_fallback_draft",
+                                    )
+                        else:
+                            # Empty retry - fallback
+                            if draft_text:
+                                return FinalizerResult(
+                                    text=draft_text,
+                                    used_finalizer=False,
+                                    was_truncated=was_truncated,
+                                    guard_violated=True,
+                                    guard_retried=True,
+                                    tier_name="draft",
+                                    tier_reason="guard_retry_empty_fallback_draft",
+                                )
+            except Exception as e:
+                # Guard is best-effort; log but don't block
+                logger.warning(f"[FINALIZER] No-new-facts guard failed: {e}")
+        
+        return FinalizerResult(
+            text=final_text,
+            used_finalizer=True,
+            was_truncated=was_truncated,
+            guard_violated=guard_violated,
+            guard_retried=guard_retried,
+            tier_name="quality",
+            tier_reason="success",
+        )
+        
+    except Exception as e:
+        # Finalizer LLM failed - try fallback
+        logger.warning(f"[FINALIZER] Quality LLM failed: {e}")
+        
+        if fallback_llm:
+            try:
+                fallback_text = fallback_llm.complete_text(prompt=prompt, temperature=0.2, max_tokens=256)
+                fallback_text = str(fallback_text or "").strip()
+                if fallback_text:
+                    return FinalizerResult(
+                        text=fallback_text,
+                        used_finalizer=True,
+                        was_truncated=was_truncated,
+                        tier_name="fast",
+                        tier_reason="quality_failed_fallback_fast",
+                    )
+            except Exception:
+                pass
+        
+        # Final fallback to draft
+        return FinalizerResult(
+            text=draft_text or "",
+            used_finalizer=False,
+            was_truncated=was_truncated,
+            tier_name="draft",
+            tier_reason="quality_failed_fallback_draft",
+        )

--- a/tests/test_unified_finalizer.py
+++ b/tests/test_unified_finalizer.py
@@ -1,0 +1,560 @@
+"""Tests for Unified Finalizer Strategy (Issue #356).
+
+Issue #356: BrainLoop and OrchestratorLoop have duplicate finalizer logic
+with inconsistent quality. This creates maintenance burden and quality variance.
+
+Solution: Create src/bantz/brain/finalizer.py as a shared module with:
+- Unified prompt building
+- Smart tool results truncation (max 2000 tokens)
+- No-new-facts guard
+- Fallback strategies (quality → fast → draft)
+- Support for both loop styles (draft-based vs decision-based)
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import Mock
+
+from bantz.brain.finalizer import (
+    finalize,
+    FinalizerConfig,
+    FinalizerResult,
+    _prepare_tool_results_for_finalizer,
+    _build_finalizer_prompt,
+)
+
+
+# ============================================================================
+# Mock LLM Clients
+# ============================================================================
+
+class MockLLM:
+    """Mock LLM for testing."""
+    
+    def __init__(self, response: str = "Test response"):
+        self.response = response
+        self.calls = []
+    
+    def complete_text(self, *, prompt: str, temperature: float = 0.2, max_tokens: int = 256) -> str:
+        self.calls.append({"prompt": prompt, "temperature": temperature, "max_tokens": max_tokens})
+        return self.response
+
+
+# ============================================================================
+# Tool Results Preparation Tests
+# ============================================================================
+
+def test_prepare_tool_results_empty():
+    """Empty tool results should return empty list."""
+    results, truncated = _prepare_tool_results_for_finalizer([])
+    assert results == []
+    assert truncated is False
+
+
+def test_prepare_tool_results_small():
+    """Small tool results should pass through unchanged."""
+    tool_results = [
+        {"tool": "get_weather", "success": True, "result": {"temp": 72}}
+    ]
+    results, truncated = _prepare_tool_results_for_finalizer(tool_results, max_tokens=1000)
+    
+    assert len(results) == 1
+    assert results[0]["tool"] == "get_weather"
+    assert results[0]["status"] == "success"
+    assert results[0]["result"] == {"temp": 72}
+    assert truncated is False
+
+
+def test_prepare_tool_results_large_uses_summary():
+    """Large results should use result_summary if available."""
+    # Create a large raw_result
+    large_result = {"events": [{"id": f"event_{i}", "summary": f"Meeting {i}"} for i in range(100)]}
+    
+    tool_results = [
+        {
+            "tool": "calendar_list_events",
+            "success": True,
+            "raw_result": large_result,
+            "result_summary": "100 events found"
+        }
+    ]
+    
+    results, truncated = _prepare_tool_results_for_finalizer(tool_results, max_tokens=500)
+    
+    assert len(results) == 1
+    assert results[0]["result"] == "100 events found"
+    assert truncated is True
+
+
+def test_prepare_tool_results_aggressive_truncation():
+    """Very large results should be aggressively truncated to first 3 tools."""
+    tool_results = [
+        {
+            "tool": f"tool_{i}",
+            "success": True,
+            "result": {"data": "x" * 1000}  # Large data
+        }
+        for i in range(10)  # 10 tools
+    ]
+    
+    results, truncated = _prepare_tool_results_for_finalizer(tool_results, max_tokens=200)
+    
+    assert len(results) <= 3  # Should keep only first 3
+    assert truncated is True
+
+
+# ============================================================================
+# Prompt Building Tests
+# ============================================================================
+
+def test_build_prompt_minimal():
+    """Build prompt with minimal inputs (OrchestratorLoop style)."""
+    prompt = _build_finalizer_prompt(
+        user_input="Merhaba",
+        planner_decision={"route": "smalltalk", "confidence": 0.9}
+    )
+    
+    assert "BANTZ" in prompt
+    assert "SADECE TÜRKÇE" in prompt
+    assert "USER: Merhaba" in prompt
+    assert "PLANNER_DECISION" in prompt
+    assert "smalltalk" in prompt
+
+
+def test_build_prompt_with_draft():
+    """Build prompt with draft text (BrainLoop style)."""
+    prompt = _build_finalizer_prompt(
+        user_input="Bugün ne var?",
+        draft_text="3 etkinliğiniz var efendim.",
+        route="calendar",
+        last_tool="calendar.list_events"
+    )
+    
+    assert "USER: Bugün ne var?" in prompt
+    assert "DRAFT:" in prompt
+    assert "3 etkinliğiniz var efendim" in prompt
+    assert "ROUTE: calendar" in prompt
+    assert "LAST_TOOL: calendar.list_events" in prompt
+
+
+def test_build_prompt_with_tool_results():
+    """Build prompt with tool results."""
+    tool_results = [{"tool": "get_weather", "status": "success", "result": {"temp": 72}}]
+    
+    prompt = _build_finalizer_prompt(
+        user_input="Hava nasıl?",
+        tool_results=tool_results
+    )
+    
+    assert "TOOL_RESULTS (JSON):" in prompt
+    assert "get_weather" in prompt
+
+
+def test_build_prompt_with_dialog_summary():
+    """Build prompt with dialog summary."""
+    prompt = _build_finalizer_prompt(
+        user_input="Devam et",
+        dialog_summary="Kullanıcı takvim hakkında sordu."
+    )
+    
+    assert "DIALOG_SUMMARY:" in prompt
+    assert "Kullanıcı takvim hakkında sordu" in prompt
+
+
+# ============================================================================
+# Finalization Tests - Mode Selection
+# ============================================================================
+
+def test_finalize_mode_off():
+    """Mode 'off' should return draft without calling LLM."""
+    mock_llm = MockLLM()
+    config = FinalizerConfig(mode="off")
+    
+    result = finalize(
+        user_input="Test",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft response"
+    )
+    
+    assert result.text == "Draft response"
+    assert result.used_finalizer is False
+    assert result.tier_name == "draft"
+    assert result.tier_reason == "finalizer_disabled"
+    assert len(mock_llm.calls) == 0
+
+
+def test_finalize_mode_calendar_only_with_calendar_tool():
+    """Mode 'calendar_only' should finalize when last tool is calendar.*"""
+    mock_llm = MockLLM(response="Oluşturdum efendim.")
+    config = FinalizerConfig(mode="calendar_only")
+    
+    result = finalize(
+        user_input="Yarın 10'da toplantı",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft",
+        last_tool="calendar.create_event"
+    )
+    
+    assert result.text == "Oluşturdum efendim."
+    assert result.used_finalizer is True
+    assert result.tier_name == "quality"
+    assert len(mock_llm.calls) == 1
+
+
+def test_finalize_mode_calendar_only_without_calendar_tool():
+    """Mode 'calendar_only' should skip finalization for non-calendar tools."""
+    mock_llm = MockLLM()
+    config = FinalizerConfig(mode="calendar_only")
+    
+    result = finalize(
+        user_input="Hava nasıl?",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft",
+        last_tool="weather.get_current"
+    )
+    
+    assert result.text == "Draft"
+    assert result.used_finalizer is False
+    assert result.tier_name == "draft"
+    assert result.tier_reason == "not_calendar"
+    assert len(mock_llm.calls) == 0
+
+
+def test_finalize_mode_smalltalk_with_smalltalk_route():
+    """Mode 'smalltalk' should finalize for smalltalk route."""
+    mock_llm = MockLLM(response="Merhaba efendim!")
+    config = FinalizerConfig(mode="smalltalk")
+    
+    result = finalize(
+        user_input="Merhaba",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft",
+        route="smalltalk"
+    )
+    
+    assert result.text == "Merhaba efendim!"
+    assert result.used_finalizer is True
+    assert result.tier_name == "quality"
+    assert len(mock_llm.calls) == 1
+
+
+def test_finalize_mode_smalltalk_without_smalltalk_route():
+    """Mode 'smalltalk' should skip finalization for non-smalltalk routes."""
+    mock_llm = MockLLM()
+    config = FinalizerConfig(mode="smalltalk")
+    
+    result = finalize(
+        user_input="Bugün ne var?",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft",
+        route="calendar"
+    )
+    
+    assert result.text == "Draft"
+    assert result.used_finalizer is False
+    assert result.tier_name == "draft"
+    assert result.tier_reason == "not_smalltalk"
+    assert len(mock_llm.calls) == 0
+
+
+def test_finalize_mode_always():
+    """Mode 'always' should always finalize."""
+    mock_llm = MockLLM(response="Finalized")
+    config = FinalizerConfig(mode="always")
+    
+    result = finalize(
+        user_input="Any input",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft",
+        route="unknown",
+        last_tool="some.tool"
+    )
+    
+    assert result.text == "Finalized"
+    assert result.used_finalizer is True
+    assert result.tier_name == "quality"
+    assert result.tier_reason == "success"
+    assert len(mock_llm.calls) == 1
+
+
+# ============================================================================
+# Finalization Tests - No-New-Facts Guard
+# ============================================================================
+
+def test_finalize_no_new_facts_guard_pass():
+    """Finalization should succeed when no new facts are added."""
+    mock_llm = MockLLM(response="3 etkinliğiniz var efendim.")
+    config = FinalizerConfig(mode="always", enable_no_new_facts_guard=True)
+    
+    result = finalize(
+        user_input="Bugün ne var?",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="3 etkinlik bulundu",
+        tool_results=[{"tool": "calendar.list", "result": {"count": 3}}]
+    )
+    
+    assert result.text == "3 etkinliğiniz var efendim."
+    assert result.used_finalizer is True
+    assert result.guard_violated is False
+    assert result.guard_retried is False
+
+
+def test_finalize_no_new_facts_guard_violation_with_retry():
+    """Guard violation should trigger retry with stricter prompt."""
+    # First call: violates guard (adds "100")
+    # Second call (retry): passes guard
+    responses = ["100 etkinliğiniz var efendim.", "Etkinlikleriniz listelendi efendim."]
+    call_count = [0]
+    
+    def mock_complete(*, prompt: str, temperature: float = 0.2, max_tokens: int = 256) -> str:
+        response = responses[call_count[0]]
+        call_count[0] += 1
+        return response
+    
+    mock_llm = Mock()
+    mock_llm.complete_text = mock_complete
+    
+    config = FinalizerConfig(
+        mode="always",
+        enable_no_new_facts_guard=True,
+        retry_on_guard_violation=True
+    )
+    
+    result = finalize(
+        user_input="Etkinlikleri listele",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Etkinlikler listelendi",
+        tool_results=[{"tool": "calendar.list", "result": "success"}]
+    )
+    
+    assert result.text == "Etkinlikleriniz listelendi efendim."
+    assert result.used_finalizer is True
+    assert result.guard_retried is True
+    # Guard was violated on first call but recovered on retry
+    assert result.guard_violated is False
+
+
+def test_finalize_guard_disabled():
+    """Guard can be disabled via config."""
+    # Response with new number should pass when guard disabled
+    mock_llm = MockLLM(response="100 etkinlik bulundu.")
+    config = FinalizerConfig(mode="always", enable_no_new_facts_guard=False)
+    
+    result = finalize(
+        user_input="Etkinlikleri listele",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Listelendi"
+    )
+    
+    assert result.text == "100 etkinlik bulundu."
+    assert result.used_finalizer is True
+    assert result.guard_violated is False  # Guard disabled, so no violation
+
+
+# ============================================================================
+# Finalization Tests - Fallback Strategies
+# ============================================================================
+
+def test_finalize_quality_empty_fallback_to_draft():
+    """Empty quality response should fallback to draft."""
+    mock_llm = MockLLM(response="")  # Empty response
+    config = FinalizerConfig(mode="always")
+    
+    result = finalize(
+        user_input="Test",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft response"
+    )
+    
+    assert result.text == "Draft response"
+    assert result.used_finalizer is False
+    assert result.tier_name == "draft"
+    assert result.tier_reason == "quality_empty_fallback_draft"
+
+
+def test_finalize_quality_empty_fallback_to_fast():
+    """Empty quality response should try fast LLM if available."""
+    quality_llm = MockLLM(response="")  # Empty
+    fast_llm = MockLLM(response="Fast response")
+    config = FinalizerConfig(mode="always")
+    
+    result = finalize(
+        user_input="Test",
+        finalizer_llm=quality_llm,
+        config=config,
+        draft_text="Draft",
+        fallback_llm=fast_llm
+    )
+    
+    assert result.text == "Fast response"
+    assert result.used_finalizer is True
+    assert result.tier_name == "fast"
+    assert result.tier_reason == "quality_empty_fallback_fast"
+
+
+def test_finalize_quality_failed_fallback_to_fast():
+    """Quality LLM error should fallback to fast LLM."""
+    def failing_llm(*, prompt: str, temperature: float = 0.2, max_tokens: int = 256) -> str:
+        raise Exception("LLM error")
+    
+    quality_llm = Mock()
+    quality_llm.complete_text = failing_llm
+    
+    fast_llm = MockLLM(response="Fast fallback")
+    config = FinalizerConfig(mode="always")
+    
+    result = finalize(
+        user_input="Test",
+        finalizer_llm=quality_llm,
+        config=config,
+        draft_text="Draft",
+        fallback_llm=fast_llm
+    )
+    
+    assert result.text == "Fast fallback"
+    assert result.used_finalizer is True
+    assert result.tier_name == "fast"
+    assert result.tier_reason == "quality_failed_fallback_fast"
+
+
+def test_finalize_all_failed_fallback_to_draft():
+    """All LLMs failing should fallback to draft."""
+    def failing_llm(*, prompt: str, temperature: float = 0.2, max_tokens: int = 256) -> str:
+        raise Exception("LLM error")
+    
+    quality_llm = Mock()
+    quality_llm.complete_text = failing_llm
+    fast_llm = Mock()
+    fast_llm.complete_text = failing_llm
+    
+    config = FinalizerConfig(mode="always")
+    
+    result = finalize(
+        user_input="Test",
+        finalizer_llm=quality_llm,
+        config=config,
+        draft_text="Final draft fallback",
+        fallback_llm=fast_llm
+    )
+    
+    assert result.text == "Final draft fallback"
+    assert result.used_finalizer is False
+    assert result.tier_name == "draft"
+    assert result.tier_reason == "quality_failed_fallback_draft"
+
+
+# ============================================================================
+# Integration Tests - Different Loop Styles
+# ============================================================================
+
+def test_finalize_brainloop_style():
+    """Finalization should work with BrainLoop style (draft-based)."""
+    mock_llm = MockLLM(response="3 etkinliğiniz var efendim.")
+    config = FinalizerConfig(mode="calendar_only")
+    
+    tool_results = [
+        {
+            "tool": "calendar.list_events",
+            "success": True,
+            "result": {"events": [{"id": "1"}, {"id": "2"}, {"id": "3"}]}
+        }
+    ]
+    
+    result = finalize(
+        user_input="Bugün ne var?",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="3 etkinlik bulundu",
+        route="calendar",
+        last_tool="calendar.list_events",
+        tool_results=tool_results
+    )
+    
+    assert result.text == "3 etkinliğiniz var efendim."
+    assert result.used_finalizer is True
+    
+    # Check prompt includes BrainLoop-style elements
+    prompt = mock_llm.calls[0]["prompt"]
+    assert "DRAFT:" in prompt
+    assert "ROUTE: calendar" in prompt
+    assert "LAST_TOOL: calendar.list_events" in prompt
+
+
+def test_finalize_orchestratorloop_style():
+    """Finalization should work with OrchestratorLoop style (decision-based)."""
+    mock_llm = MockLLM(response="Toplantı oluşturdum efendim.")
+    config = FinalizerConfig(mode="always")
+    
+    planner_decision = {
+        "route": "calendar",
+        "calendar_intent": "create",
+        "slots": {"time": "10:00", "title": "Toplantı"},
+        "confidence": 0.95
+    }
+    
+    tool_results = [
+        {
+            "tool": "calendar.create_event",
+            "success": True,
+            "result": {"event_id": "evt_123"}
+        }
+    ]
+    
+    result = finalize(
+        user_input="Yarın 10'da toplantı koy",
+        finalizer_llm=mock_llm,
+        config=config,
+        planner_decision=planner_decision,
+        tool_results=tool_results,
+        dialog_summary="Kullanıcı takvim ile çalışıyor."
+    )
+    
+    assert result.text == "Toplantı oluşturdum efendim."
+    assert result.used_finalizer is True
+    
+    # Check prompt includes OrchestratorLoop-style elements
+    prompt = mock_llm.calls[0]["prompt"]
+    assert "PLANNER_DECISION" in prompt
+    assert "calendar_intent" in prompt
+    assert "DIALOG_SUMMARY:" in prompt
+
+
+def test_finalize_large_tool_results_truncation():
+    """Large tool results should be truncated."""
+    mock_llm = MockLLM(response="100 etkinlik listelendi efendim.")
+    config = FinalizerConfig(mode="always", tool_results_token_budget=500)
+    
+    # Create large tool results (100 events)
+    large_events = [{"id": f"event_{i}", "summary": f"Meeting {i}"} for i in range(100)]
+    tool_results = [
+        {
+            "tool": "calendar.list_events",
+            "success": True,
+            "raw_result": {"events": large_events},
+            "result_summary": "100 events found"
+        }
+    ]
+    
+    result = finalize(
+        user_input="Etkinlikleri listele",
+        finalizer_llm=mock_llm,
+        config=config,
+        draft_text="Draft",
+        tool_results=tool_results,
+        last_tool="calendar.list_events"
+    )
+    
+    assert result.text == "100 etkinlik listelendi efendim."
+    assert result.used_finalizer is True
+    assert result.was_truncated is True  # Should be truncated due to size


### PR DESCRIPTION
## Issue
Closes #356

## Problem
BrainLoop and OrchestratorLoop have duplicate finalizer logic with inconsistent quality:
- Different prompt structures (DRAFT-based vs PLANNER_DECISION-based)
- Different tool results handling (missing vs present)
- Different tiering strategies
- Different memory context (dialog_summary vs memory-lite + recent_conversation)
- Code duplication causing maintenance burden
- Quality variance across different loops

## Solution
Created `src/bantz/brain/finalizer.py` as a shared module with:

### Key Features
- **Unified prompt building**: Supports both BrainLoop style (draft-based) and OrchestratorLoop style (decision-based)
- **Smart tool results truncation**: 3-tier fallback (full → summary → aggressive)
  - Tier 1: Full raw_result if fits in budget
  - Tier 2: Use result_summary if too large
  - Tier 3: Keep only first 3 tools with 200 char limit
- **No-new-facts guard**: Prevents hallucinated numbers/dates/times
- **Fallback strategies**: Quality → Fast → Draft
- **Configurable modes**: off, calendar_only, smalltalk, always

### Architecture
- `FinalizerConfig`: Centralized configuration (mode, temperature, token budget, guards)
- `FinalizerResult`: Rich result metadata (tier_name, was_truncated, guard_violated)
- `finalize()`: Main entry point supporting both loop styles
- `_prepare_tool_results_for_finalizer()`: Budget-controlled truncation (max 2000 tokens)
- `_build_finalizer_prompt()`: Unified prompt builder

### Compatibility
**BrainLoop style:**
```python
finalize(
    user_input="Bugün ne var?",
    draft_text="3 etkinlik bulundu",
    route="calendar",
    last_tool="calendar.list_events",
    tool_results=[...],
    finalizer_llm=gemini
)
```

**OrchestratorLoop style:**
```python
finalize(
    user_input="Bugün ne var?",
    planner_decision={"route": "calendar", "intent": "list"},
    tool_results=[...],
    dialog_summary="...",
    finalizer_llm=gemini
)
```

## Tests
24 comprehensive tests:
- 4 tool results preparation tests (empty, small, large, aggressive)
- 4 prompt building tests (minimal, draft, tool_results, dialog_summary)
- 6 mode selection tests (off, calendar_only, smalltalk, always)
- 3 no-new-facts guard tests (pass, violation+retry, disabled)
- 4 fallback strategy tests (quality→draft, quality→fast, all failed)
- 3 integration tests (BrainLoop style, OrchestratorLoop style, large results)

All tests pass ✅

## Impact
✅ Eliminates code duplication between BrainLoop and OrchestratorLoop
✅ Ensures consistent finalization quality across all brain implementations
✅ Easier maintenance (single source of truth)
✅ Extensible for future brain implementations
✅ Backward compatible with both existing loop styles

## Next Steps
Future PRs will migrate BrainLoop and OrchestratorLoop to use this shared module.