### PR TITLE
Fix #363: Default FlexibleHybrid finalizer to Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ orchestrator = create_gemini_hybrid_orchestrator(
     router_client=router,
     gemini_api_key=os.getenv("GEMINI_API_KEY", "")
 )
+
+**Flexible Hybrid defaults (Issue #363):**
+- Default finalizer is **Gemini** (3B router + Gemini finalizer)
+- Override with env vars if you prefer local 7B:
+    - `BANTZ_FINALIZER_TYPE=gemini|vllm_7b`
+    - `BANTZ_FINALIZER_MODEL=gemini-1.5-flash|Qwen/Qwen2.5-7B-Instruct`
 ```
 
 ### Architecture Benefits


### PR DESCRIPTION
## Issue
Closes #363

## Problem
FlexibleHybridConfig defaults to 7B vLLM finalizer even though the project defaults to 3B + Gemini. Users must override defaults and get errors if 7B is not running.

## Solution
- Default FlexibleHybridConfig to Gemini:
  - finalizer_type = "gemini"
  - finalizer_model = "gemini-1.5-flash"
- Add env-driven configuration:
  - BANTZ_FINALIZER_TYPE=gemini|vllm_7b
  - BANTZ_FINALIZER_MODEL=... (optional override)
- Use env-aware defaults when config is omitted
- Update README to document Gemini default + env overrides

## Tests
- Updated flexible hybrid tests for new defaults
- Added env-config tests

Command: pytest tests/test_flexible_hybrid_orchestrator.py -v