### PR TITLE
Fix #366: User-friendly error for missing tools

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -921,7 +921,18 @@ class OrchestratorLoop:
             try:
                 tool = self.tools.get(tool_name)
                 if tool is None:
-                    raise ValueError(f"Tool not found: {tool_name}")
+                    logger.error("[TOOLS] Tool not found in registry: %s", tool_name)
+                    self.event_bus.publish("tool.not_found", {
+                        "tool": tool_name,
+                        "route": output.route,
+                    })
+                    tool_results.append({
+                        "tool": tool_name,
+                        "success": False,
+                        "error": f"Efendim, '{tool_name}' işlemi şu an kullanılamıyor.",
+                        "user_message": f"Efendim, '{tool_name}' işlemi şu an kullanılamıyor.",
+                    })
+                    continue
                 
                 if tool.function is None:
                     raise ValueError(f"Tool {tool_name} has no function implementation")


### PR DESCRIPTION
## Issue
Closes #366

## Problem
Missing tools raise a ValueError, causing crashes and no user-friendly feedback.

## Solution
- Handle missing tool registry entries gracefully
- Log and emit `tool.not_found` event with tool/route
- Return user-facing error message in tool_results

## Tests
- Added test for missing tool handling

Command: pytest tests/test_orchestrator_loop.py -v