### PR TITLE
Fix #367: Smalltalk-aware tiering

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -1275,6 +1275,7 @@ class OrchestratorLoop:
                         user_input,
                         tool_names=orchestrator_output.tool_plan,
                         requires_confirmation=bool(orchestrator_output.requires_confirmation),
+                        route=orchestrator_output.route,
                     )
 
                     if decision.reason == "tiering_disabled":

--- a/tests/test_tiered_smalltalk_issue_367.py
+++ b/tests/test_tiered_smalltalk_issue_367.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from bantz.llm.tiered import decide_tier
+
+
+@pytest.fixture(autouse=True)
+def _tiered_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("BANTZ_TIERED_MODE", "1")
+    monkeypatch.delenv("BANTZ_LLM_TIER", raising=False)
+
+
+def test_smalltalk_simple_greeting_uses_fast():
+    decision = decide_tier(
+        "Merhaba efendim",
+        route="smalltalk",
+        tool_names=[],
+        requires_confirmation=False,
+    )
+
+    assert decision.use_quality is False
+    assert decision.reason == "smalltalk_simple"
+
+
+def test_smalltalk_complex_question_uses_quality():
+    decision = decide_tier(
+        "Yapay zeka nedir, açıkla",
+        route="smalltalk",
+        tool_names=[],
+        requires_confirmation=False,
+    )
+
+    assert decision.use_quality is True
+    assert decision.reason == "smalltalk_complex"


### PR DESCRIPTION
## Issue
Closes #367

## Problem
Tiering logic ignores smalltalk route, so conversational queries always use fast tier (3B), reducing quality for complex questions.

## Solution
- Add route parameter to decide_tier()
- Smalltalk heuristics:
  - Simple greetings → fast tier
  - Complex questions (nedir/açıkla/anlat/nasıl/...) → quality tier
- Pass route from OrchestratorLoop

## Tests
- Added smalltalk tiering tests

Command: pytest tests/test_tiered_smalltalk_issue_367.py -v