### PR TITLE
Fix #368: Configurable memory-lite settings

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -192,6 +192,9 @@ class OrchestratorConfig:
     require_confirmation_for: list[str] = None  # Tools requiring confirmation
     enable_safety_guard: bool = True  # Enable safety & policy checks (Issue #140)
     security_policy: Optional[ToolSecurityPolicy] = None  # Custom security policy
+    memory_max_tokens: int = 1000  # Memory-lite token budget (Issue #368)
+    memory_max_turns: int = 10  # Memory-lite max turns (Issue #368)
+    memory_pii_filter: bool = True  # Memory-lite PII filtering (Issue #368)
     
     def __post_init__(self):
         if self.require_confirmation_for is None:
@@ -236,9 +239,9 @@ class OrchestratorLoop:
         
         # Initialize memory-lite (Issue #141)
         self.memory = DialogSummaryManager(
-            max_tokens=500,
-            max_turns=5,
-            pii_filter_enabled=True,
+            max_tokens=self.config.memory_max_tokens,
+            max_turns=self.config.memory_max_turns,
+            pii_filter_enabled=self.config.memory_pii_filter,
         )
         
         # Initialize safety guard (Issue #140)

--- a/tests/test_orchestrator_memory_config_issue_368.py
+++ b/tests/test_orchestrator_memory_config_issue_368.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from bantz.brain.orchestrator_loop import OrchestratorConfig, OrchestratorLoop
+
+
+def test_memory_lite_config_defaults():
+    config = OrchestratorConfig()
+
+    assert config.memory_max_tokens == 1000
+    assert config.memory_max_turns == 10
+    assert config.memory_pii_filter is True
+
+
+def test_memory_lite_config_override_applied():
+    planner_llm = Mock()
+    planner_llm.complete_text = Mock(return_value="{}")
+    tools = Mock()
+
+    config = OrchestratorConfig(
+        memory_max_tokens=1500,
+        memory_max_turns=12,
+        memory_pii_filter=False,
+        enable_safety_guard=False,
+    )
+
+    loop = OrchestratorLoop(
+        orchestrator=Mock(),
+        tools=tools,
+        config=config,
+    )
+
+    assert loop.memory.max_tokens == 1500
+    assert loop.memory.max_turns == 12
+    assert loop.memory.pii_filter_enabled is False


### PR DESCRIPTION
## Issue
Closes #368

## Problem
OrchestratorLoop initializes memory-lite with fixed values (max_tokens=500, max_turns=5) and cannot be configured.

## Solution
- Add memory_max_tokens/memory_max_turns/memory_pii_filter to OrchestratorConfig
- Use config values when creating DialogSummaryManager
- Set defaults to 1000 tokens / 10 turns

## Tests
- Added tests for defaults and overrides

Command: pytest tests/test_orchestrator_memory_config_issue_368.py -v