### PR TITLE
Fix #369: Emit router JSON telemetry

### DIFF
--- a/tests/test_router_json_event_telemetry_issue_369.py
+++ b/tests/test_router_json_event_telemetry_issue_369.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from bantz.brain.llm_router import JarvisLLMOrchestrator
+from bantz.brain.json_protocol import JsonParseError
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    def publish(self, name: str, payload: dict[str, Any]) -> None:
+        self.events.append((name, payload))
+
+
+class DummyLLM:
+    def __init__(self) -> None:
+        self.event_bus = DummyEventBus()
+
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 512) -> str:  # noqa: ARG002
+        return "{}"
+
+
+def test_router_json_parse_failure_emits_event():
+    llm = DummyLLM()
+    orchestrator = JarvisLLMOrchestrator(llm=llm)
+
+    # Force parse failure
+    with pytest.raises(JsonParseError):
+        orchestrator._parse_json("this is not json")
+
+    events = [name for name, _payload in llm.event_bus.events]
+    assert "router.json.parse_failed" in events
+
+
+def test_router_json_validation_warning_emits_event():
+    llm = DummyLLM()
+    orchestrator = JarvisLLMOrchestrator(llm=llm)
+
+    # Valid JSON but invalid schema (missing required fields)
+    orchestrator._parse_json('{"route": "calendar"}')
+
+    events = [name for name, _payload in llm.event_bus.events]
+    assert "router.json.validation_warning" in events


### PR DESCRIPTION
## Issue
Closes #369

## Problem
Router JSON parse/validation failures only log debug messages; no telemetry is emitted.

## Solution
- Emit `router.json.parse_failed` with reason + phase
- Emit `router.json.validation_warning` with schema errors + phase
- Best-effort event bus publishing (if LLM has event_bus)

## Tests
- Added telemetry tests for parse failure and validation warning

Command: pytest tests/test_router_json_event_telemetry_issue_369.py -v