### PR TITLE
feat(brain): Issue #403 — UnifiedBrain facade + deprecation (Phase 1)

### DIFF
--- a/src/bantz/brain/__init__.py
+++ b/src/bantz/brain/__init__.py
@@ -9,8 +9,15 @@ from bantz.brain.brain_loop import (
     CallTool,
     Fail,
 )
+from bantz.brain.unified_loop import (
+    UnifiedBrain,
+    UnifiedConfig,
+    UnifiedResult,
+    create_brain,
+)
 
 __all__ = [
+    # Legacy — prefer UnifiedBrain / create_brain() for new code.
     "BrainLoop",
     "BrainLoopConfig",
     "BrainResult",
@@ -20,4 +27,9 @@ __all__ = [
     "AskUser",
     "CallTool",
     "Fail",
+    # Unified interface (Issue #403)
+    "UnifiedBrain",
+    "UnifiedConfig",
+    "UnifiedResult",
+    "create_brain",
 ]

--- a/src/bantz/brain/brain_loop.py
+++ b/src/bantz/brain/brain_loop.py
@@ -1477,6 +1477,16 @@ class BrainLoop:
         router: Optional[Any] = None,
         memory_manager: Optional[Any] = None,
     ):
+        # Issue #403: deprecation notice — prefer unified_loop.create_brain()
+        import warnings as _w
+        _w.warn(
+            "BrainLoop is deprecated and will be removed in a future release. "
+            "Use bantz.brain.create_brain(mode='jarvis', ...) instead. "
+            "See Issue #403 for migration details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         self._llm = llm
         self._tools = tools
         self._events = event_bus or get_event_bus()

--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -384,6 +384,16 @@ class OrchestratorLoop:
         finalizer_llm: Optional[Any] = None,
         audit_logger: Optional[Any] = None,
     ):
+        # Issue #403: deprecation notice — prefer unified_loop.create_brain()
+        import warnings as _w
+        _w.warn(
+            "OrchestratorLoop is deprecated and will be removed in a future release. "
+            "Use bantz.brain.create_brain(mode='orchestrator', ...) instead. "
+            "See Issue #403 for migration details.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         self.orchestrator = orchestrator
         self.tools = tools
         self.event_bus = event_bus or EventBus()

--- a/src/bantz/brain/unified_loop.py
+++ b/src/bantz/brain/unified_loop.py
@@ -1,0 +1,557 @@
+"""Unified Brain Loop — single entry point for all brain backends.
+
+Issue #403: Brain Consolidation EPIC — Phase 1 (Foundation).
+
+This module provides a unified interface over both:
+- **BrainLoop** (Jarvis mode — deterministic calendar UX, voice menus)
+- **OrchestratorLoop** (LLM-first — general purpose, multi-tool orchestration)
+
+The goal is to decouple callers from the backend implementation so that
+future PRs can gradually migrate BrainLoop features into OrchestratorLoop
+and eventually retire brain_loop.py.
+
+Usage::
+
+    # Factory (recommended)
+    brain = create_brain(
+        mode="orchestrator",
+        llm=my_llm,
+        tools=my_tools,
+        event_bus=bus,
+    )
+    result = brain.process("bugün takvimde ne var?")
+
+    # Jarvis mode (deterministic calendar UX)
+    brain = create_brain(
+        mode="jarvis",
+        llm=my_llm,
+        tools=my_tools,
+        event_bus=bus,
+        session_context=ctx,
+    )
+    result = brain.process("yarın 15:00'te toplantı ekle")
+
+    # Access the underlying backend when needed
+    if brain.mode == "orchestrator":
+        raw_state = brain.orchestrator_state
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "UnifiedBrain",
+    "UnifiedResult",
+    "UnifiedConfig",
+    "create_brain",
+]
+
+
+# ---------------------------------------------------------------------------
+# Unified result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UnifiedResult:
+    """Unified brain result — superset of BrainResult and OrchestratorOutput.
+
+    This normalises both backends into a single structure so callers never
+    need to know which backend produced the response.
+
+    Attributes:
+        kind: Result kind — ``"say"`` | ``"ask_user"`` | ``"fail"``.
+        text: The assistant reply or error message.
+        route: Detected route (``"calendar"`` | ``"gmail"`` | ``"smalltalk"``
+               | ``"unknown"`` | ``""``).
+        intent: Detected intent (``"create"`` | ``"query"`` | ``"none"`` …).
+        confidence: LLM confidence 0.0–1.0.
+        tool_plan: Tools that were planned (names).
+        tools_executed: Tools that actually ran successfully.
+        requires_confirmation: Whether the action needs user confirmation.
+        steps_used: Number of LLM steps consumed (BrainLoop) or 0.
+        metadata: Arbitrary backend-specific metadata / trace dict.
+        backend: Which backend produced this result
+                 (``"brain_loop"`` | ``"orchestrator"``).
+        state: Opaque state object to pass back on the next turn.
+    """
+
+    kind: str
+    text: str
+    route: str = ""
+    intent: str = ""
+    confidence: float = 0.0
+    tool_plan: list[str] = field(default_factory=list)
+    tools_executed: list[str] = field(default_factory=list)
+    requires_confirmation: bool = False
+    steps_used: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    backend: str = ""
+    state: Any = None
+
+
+# ---------------------------------------------------------------------------
+# Unified config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UnifiedConfig:
+    """Configuration for :class:`UnifiedBrain`.
+
+    Attributes:
+        mode: ``"orchestrator"`` (default, LLM-first) or ``"jarvis"``
+              (deterministic calendar UX).
+        max_steps: Maximum LLM reasoning steps per turn.
+        debug: Enable verbose logging.
+        enable_safety_guard: Enable tool safety checks (OrchestratorLoop).
+        memory_max_tokens: Token budget for memory-lite summaries.
+        memory_max_turns: Max turns kept in memory-lite.
+        require_confirmation_for: Tool names that require explicit confirmation.
+    """
+
+    mode: str = "orchestrator"
+    max_steps: int = 8
+    debug: bool = False
+    enable_safety_guard: bool = True
+    memory_max_tokens: int = 1000
+    memory_max_turns: int = 10
+    require_confirmation_for: Optional[list[str]] = None
+
+
+# ---------------------------------------------------------------------------
+# LLM protocol (union of both backends)
+# ---------------------------------------------------------------------------
+
+
+class LLMClientProtocol(Protocol):
+    """Minimal LLM protocol accepted by :func:`create_brain`.
+
+    At minimum the LLM must support ``complete_json`` (for BrainLoop) or
+    ``complete_text`` (for OrchestratorLoop).  Ideally it supports both.
+    """
+
+    def complete_json(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        schema_hint: str,
+    ) -> dict[str, Any]:
+        ...  # pragma: no cover
+
+    def complete_text(
+        self,
+        *,
+        prompt: str,
+        temperature: float = 0.0,
+        max_tokens: int = 200,
+    ) -> str:
+        ...  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Unified Brain
+# ---------------------------------------------------------------------------
+
+
+class UnifiedBrain:
+    """Single entry point for both BrainLoop and OrchestratorLoop.
+
+    Instead of importing either backend directly, callers should use this
+    class (or the :func:`create_brain` factory) to get a brain instance.
+    The underlying backend is selected by *mode* and is fully transparent
+    to the caller.
+
+    Parameters
+    ----------
+    mode:
+        ``"orchestrator"`` for LLM-first or ``"jarvis"`` for deterministic.
+    brain_loop:
+        A ``BrainLoop`` instance (required when *mode* is ``"jarvis"``).
+    orchestrator_loop:
+        An ``OrchestratorLoop`` instance (required when *mode* is ``"orchestrator"``).
+    config:
+        Unified configuration.
+    session_context:
+        Default session context passed on every turn (timezone, locale, …).
+    """
+
+    def __init__(
+        self,
+        *,
+        mode: str = "orchestrator",
+        brain_loop: Any = None,
+        orchestrator_loop: Any = None,
+        config: Optional[UnifiedConfig] = None,
+        session_context: Optional[dict[str, Any]] = None,
+    ) -> None:
+        if mode not in ("orchestrator", "jarvis"):
+            raise ValueError(f"Unknown mode: {mode!r}. Use 'orchestrator' or 'jarvis'.")
+
+        self.mode = mode
+        self._config = config or UnifiedConfig(mode=mode)
+        self._session_context = session_context or {}
+
+        # Backend instances
+        self._brain_loop = brain_loop
+        self._orchestrator_loop = orchestrator_loop
+
+        # Orchestrator state (persisted across turns)
+        self._orchestrator_state: Any = None
+
+        # Jarvis state dict (persisted across turns)
+        self._jarvis_state: dict[str, Any] = {}
+
+        # Validate the right backend is provided
+        if mode == "jarvis" and brain_loop is None:
+            raise ValueError("Jarvis mode requires a BrainLoop instance.")
+        if mode == "orchestrator" and orchestrator_loop is None:
+            raise ValueError("Orchestrator mode requires an OrchestratorLoop instance.")
+
+        logger.info(
+            "[UnifiedBrain] Initialized in %s mode (config=%s)",
+            mode,
+            self._config,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def process(
+        self,
+        user_input: str,
+        *,
+        session_context: Optional[dict[str, Any]] = None,
+        policy: Any = None,
+        state: Any = None,
+    ) -> UnifiedResult:
+        """Process a single user turn and return a unified result.
+
+        Parameters
+        ----------
+        user_input:
+            The user's text input.
+        session_context:
+            Per-turn session context (merged with default).
+        policy:
+            Optional policy engine (BrainLoop / Jarvis mode only).
+        state:
+            Opaque state object from a previous ``UnifiedResult.state``.
+            If *None*, the internal state is reused across turns.
+
+        Returns
+        -------
+        UnifiedResult
+            Normalised result regardless of backend.
+        """
+        user_input = (user_input or "").strip()
+        if not user_input:
+            return UnifiedResult(
+                kind="fail",
+                text="empty_input",
+                backend=self.mode,
+            )
+
+        if self.mode == "jarvis":
+            return self._process_jarvis(
+                user_input,
+                session_context=session_context,
+                policy=policy,
+                state=state,
+            )
+        else:
+            return self._process_orchestrator(
+                user_input,
+                session_context=session_context,
+                state=state,
+            )
+
+    def reset(self) -> None:
+        """Reset internal state (start a fresh conversation)."""
+        self._orchestrator_state = None
+        self._jarvis_state = {}
+        logger.debug("[UnifiedBrain] State reset")
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def orchestrator_state(self) -> Any:
+        """Access the raw OrchestratorState (orchestrator mode only)."""
+        return self._orchestrator_state
+
+    @property
+    def jarvis_state(self) -> dict[str, Any]:
+        """Access the raw Jarvis state dict (jarvis mode only)."""
+        return dict(self._jarvis_state)
+
+    @property
+    def backend(self) -> Any:
+        """Return the underlying backend instance."""
+        if self.mode == "jarvis":
+            return self._brain_loop
+        return self._orchestrator_loop
+
+    # ------------------------------------------------------------------
+    # Jarvis backend
+    # ------------------------------------------------------------------
+
+    def _process_jarvis(
+        self,
+        user_input: str,
+        *,
+        session_context: Optional[dict[str, Any]],
+        policy: Any,
+        state: Any,
+    ) -> UnifiedResult:
+        """Delegate to BrainLoop and normalise the result."""
+        from bantz.brain.brain_loop import BrainResult
+
+        # Merge session contexts
+        ctx = dict(self._session_context)
+        if isinstance(session_context, dict):
+            ctx.update(session_context)
+
+        # Restore state from caller or use internal
+        jarvis_ctx = state if isinstance(state, dict) else dict(self._jarvis_state)
+
+        result: BrainResult = self._brain_loop.run(
+            turn_input=user_input,
+            session_context=ctx,
+            policy=policy,
+            context=jarvis_ctx,
+        )
+
+        # Persist state
+        self._jarvis_state = jarvis_ctx
+
+        return self._from_brain_result(result, jarvis_ctx)
+
+    @staticmethod
+    def _from_brain_result(result: Any, state: Any = None) -> UnifiedResult:
+        """Convert BrainResult → UnifiedResult."""
+        metadata = result.metadata if isinstance(result.metadata, dict) else {}
+        trace = metadata.get("trace", {})
+
+        return UnifiedResult(
+            kind=result.kind,
+            text=result.text,
+            route=str(trace.get("llm_router_route") or metadata.get("route") or ""),
+            intent=str(trace.get("intent") or ""),
+            confidence=float(trace.get("llm_router_confidence") or 0.0),
+            tool_plan=list(trace.get("llm_router_tool_plan") or []),
+            tools_executed=[],  # BrainLoop doesn't expose this cleanly
+            requires_confirmation=bool(metadata.get("requires_confirmation", False)),
+            steps_used=result.steps_used,
+            metadata=metadata,
+            backend="brain_loop",
+            state=state,
+        )
+
+    # ------------------------------------------------------------------
+    # Orchestrator backend
+    # ------------------------------------------------------------------
+
+    def _process_orchestrator(
+        self,
+        user_input: str,
+        *,
+        session_context: Optional[dict[str, Any]],
+        state: Any,
+    ) -> UnifiedResult:
+        """Delegate to OrchestratorLoop and normalise the result."""
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        # Restore state
+        if isinstance(state, OrchestratorState):
+            orch_state = state
+        elif self._orchestrator_state is not None:
+            orch_state = self._orchestrator_state
+        else:
+            orch_state = OrchestratorState()
+
+        # Inject session context into state
+        if session_context or self._session_context:
+            merged_ctx = dict(self._session_context)
+            if isinstance(session_context, dict):
+                merged_ctx.update(session_context)
+            orch_state.session_context = merged_ctx
+
+        output, updated_state = self._orchestrator_loop.process_turn(
+            user_input=user_input,
+            state=orch_state,
+        )
+
+        # Persist state
+        self._orchestrator_state = updated_state
+
+        return self._from_orchestrator_output(output, updated_state)
+
+    @staticmethod
+    def _from_orchestrator_output(output: Any, state: Any = None) -> UnifiedResult:
+        """Convert (OrchestratorOutput, OrchestratorState) → UnifiedResult."""
+        # Determine kind
+        if output.ask_user and output.question:
+            kind = "ask_user"
+            text = output.question
+        elif output.assistant_reply:
+            kind = "say"
+            text = output.assistant_reply
+        else:
+            kind = "say"
+            text = output.assistant_reply or ""
+
+        # Extract executed tools from state trace
+        tools_executed: list[str] = []
+        if state is not None:
+            trace = getattr(state, "trace", {})
+            if isinstance(trace, dict):
+                ts = trace.get("tools_success")
+                if isinstance(ts, list):
+                    tools_executed = [str(t) for t in ts if isinstance(t, str)]
+
+        return UnifiedResult(
+            kind=kind,
+            text=text,
+            route=output.route or "",
+            intent=output.calendar_intent or "",
+            confidence=output.confidence,
+            tool_plan=list(output.tool_plan or []),
+            tools_executed=tools_executed,
+            requires_confirmation=bool(output.requires_confirmation),
+            steps_used=0,
+            metadata={
+                "trace": getattr(state, "trace", {}) if state else {},
+                "confirmation_prompt": output.confirmation_prompt or "",
+                "reasoning_summary": list(output.reasoning_summary or []),
+                "memory_update": output.memory_update or "",
+                "raw_output": output.raw_output or {},
+            },
+            backend="orchestrator",
+            state=state,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_brain(
+    *,
+    mode: str = "orchestrator",
+    llm: Any = None,
+    tools: Any = None,
+    event_bus: Any = None,
+    config: Optional[UnifiedConfig] = None,
+    session_context: Optional[dict[str, Any]] = None,
+    # OrchestratorLoop-specific
+    finalizer_llm: Any = None,
+    router_system_prompt: Optional[str] = None,
+    audit_logger: Any = None,
+    # BrainLoop-specific
+    router: Any = None,
+    memory_manager: Any = None,
+    policy: Any = None,
+) -> UnifiedBrain:
+    """Create a :class:`UnifiedBrain` with the appropriate backend.
+
+    This is the **recommended** way to get a brain instance.
+
+    Parameters
+    ----------
+    mode:
+        ``"orchestrator"`` (default, LLM-first) or ``"jarvis"``
+        (deterministic calendar UX).
+    llm:
+        LLM client — must support ``complete_json`` (Jarvis) and/or
+        ``complete_text`` (Orchestrator).
+    tools:
+        ``ToolRegistry`` instance with registered tools.
+    event_bus:
+        ``EventBus`` for publishing events.
+    config:
+        Optional unified configuration.
+    session_context:
+        Default session context for every turn.
+    finalizer_llm:
+        Separate LLM for response finalization (Orchestrator mode).
+    router_system_prompt:
+        Custom system prompt for the LLM router (Orchestrator mode).
+    audit_logger:
+        Audit logger for tool executions (Orchestrator mode).
+    router:
+        Optional LLM router (Jarvis mode).
+    memory_manager:
+        Optional memory manager (Jarvis mode).
+    policy:
+        Optional policy engine (Jarvis mode).
+
+    Returns
+    -------
+    UnifiedBrain
+        Ready-to-use brain instance.
+    """
+    cfg = config or UnifiedConfig(mode=mode)
+
+    brain_loop = None
+    orchestrator_loop = None
+
+    if mode == "jarvis":
+        from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+
+        bl_config = BrainLoopConfig(
+            max_steps=cfg.max_steps,
+            debug=cfg.debug,
+        )
+        brain_loop = BrainLoop(
+            llm=llm,
+            tools=tools,
+            event_bus=event_bus,
+            config=bl_config,
+            router=router,
+            memory_manager=memory_manager,
+        )
+
+    elif mode == "orchestrator":
+        from bantz.brain.llm_router import JarvisLLMOrchestrator
+        from bantz.brain.orchestrator_loop import OrchestratorConfig, OrchestratorLoop
+
+        orchestrator = JarvisLLMOrchestrator(
+            llm_client=llm,
+            system_prompt=router_system_prompt,
+        )
+
+        orch_config = OrchestratorConfig(
+            max_steps=cfg.max_steps,
+            debug=cfg.debug,
+            enable_safety_guard=cfg.enable_safety_guard,
+            memory_max_tokens=cfg.memory_max_tokens,
+            memory_max_turns=cfg.memory_max_turns,
+            require_confirmation_for=cfg.require_confirmation_for,
+        )
+
+        orchestrator_loop = OrchestratorLoop(
+            orchestrator=orchestrator,
+            tools=tools,
+            event_bus=event_bus,
+            config=orch_config,
+            finalizer_llm=finalizer_llm,
+            audit_logger=audit_logger,
+        )
+
+    return UnifiedBrain(
+        mode=mode,
+        brain_loop=brain_loop,
+        orchestrator_loop=orchestrator_loop,
+        config=cfg,
+        session_context=session_context,
+    )

--- a/tests/test_unified_loop.py
+++ b/tests/test_unified_loop.py
@@ -1,0 +1,619 @@
+"""Tests for UnifiedBrain — Issue #403 (Brain Consolidation Phase 1).
+
+Covers:
+- UnifiedBrain creation via factory
+- Jarvis mode delegating to BrainLoop
+- Orchestrator mode delegating to OrchestratorLoop
+- Result normalisation (UnifiedResult)
+- State persistence across turns
+- Empty input handling
+- Mode validation
+- Deprecation warnings
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Optional
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+from bantz.brain.unified_loop import (
+    UnifiedBrain,
+    UnifiedConfig,
+    UnifiedResult,
+    create_brain,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeLLM:
+    """Fake LLM that returns canned JSON outputs (for BrainLoop)."""
+
+    def __init__(self, outputs: list[dict] | None = None):
+        self._outputs = list(outputs or [])
+        self.calls: int = 0
+
+    def complete_json(
+        self, *, messages: list[dict[str, str]], schema_hint: str
+    ) -> dict:
+        self.calls += 1
+        if not self._outputs:
+            return {"type": "FAIL", "error": "no_more_outputs"}
+        return self._outputs.pop(0)
+
+    def complete_text(
+        self, *, prompt: str = "", temperature: float = 0.0, max_tokens: int = 200
+    ) -> str:
+        self.calls += 1
+        return "Tamam efendim."
+
+
+def _make_tool_registry():
+    """Create a minimal ToolRegistry with one tool."""
+    from bantz.agent.tools import Tool, ToolRegistry
+
+    tools = ToolRegistry()
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    tools.register(
+        Tool(
+            name="add",
+            description="Add two integers",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+            },
+            function=add,
+        )
+    )
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# UnifiedResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedResult:
+    def test_default_fields(self):
+        r = UnifiedResult(kind="say", text="Merhaba")
+        assert r.kind == "say"
+        assert r.text == "Merhaba"
+        assert r.route == ""
+        assert r.intent == ""
+        assert r.confidence == 0.0
+        assert r.tool_plan == []
+        assert r.tools_executed == []
+        assert r.requires_confirmation is False
+        assert r.steps_used == 0
+        assert r.metadata == {}
+        assert r.backend == ""
+        assert r.state is None
+
+    def test_all_fields(self):
+        r = UnifiedResult(
+            kind="ask_user",
+            text="Saat kaç?",
+            route="calendar",
+            intent="query",
+            confidence=0.9,
+            tool_plan=["calendar.list_events"],
+            tools_executed=["calendar.list_events"],
+            requires_confirmation=True,
+            steps_used=2,
+            metadata={"foo": "bar"},
+            backend="orchestrator",
+            state={"key": "val"},
+        )
+        assert r.kind == "ask_user"
+        assert r.route == "calendar"
+        assert r.confidence == 0.9
+        assert r.backend == "orchestrator"
+
+
+# ---------------------------------------------------------------------------
+# UnifiedConfig
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedConfig:
+    def test_defaults(self):
+        c = UnifiedConfig()
+        assert c.mode == "orchestrator"
+        assert c.max_steps == 8
+        assert c.debug is False
+        assert c.enable_safety_guard is True
+
+    def test_jarvis_mode(self):
+        c = UnifiedConfig(mode="jarvis", debug=True)
+        assert c.mode == "jarvis"
+        assert c.debug is True
+
+
+# ---------------------------------------------------------------------------
+# UnifiedBrain — constructor
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedBrainInit:
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Unknown mode"):
+            UnifiedBrain(mode="invalid")
+
+    def test_jarvis_requires_brain_loop(self):
+        with pytest.raises(ValueError, match="BrainLoop"):
+            UnifiedBrain(mode="jarvis")
+
+    def test_orchestrator_requires_orchestrator_loop(self):
+        with pytest.raises(ValueError, match="OrchestratorLoop"):
+            UnifiedBrain(mode="orchestrator")
+
+    def test_jarvis_mode_ok(self):
+        brain = UnifiedBrain(mode="jarvis", brain_loop=Mock())
+        assert brain.mode == "jarvis"
+        assert brain.backend is not None
+
+    def test_orchestrator_mode_ok(self):
+        brain = UnifiedBrain(mode="orchestrator", orchestrator_loop=Mock())
+        assert brain.mode == "orchestrator"
+        assert brain.backend is not None
+
+
+# ---------------------------------------------------------------------------
+# UnifiedBrain — empty input
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInput:
+    def test_empty_string(self):
+        brain = UnifiedBrain(mode="jarvis", brain_loop=Mock())
+        result = brain.process("")
+        assert result.kind == "fail"
+        assert result.text == "empty_input"
+
+    def test_whitespace_only(self):
+        brain = UnifiedBrain(mode="orchestrator", orchestrator_loop=Mock())
+        result = brain.process("   ")
+        assert result.kind == "fail"
+        assert result.text == "empty_input"
+
+    def test_none_input(self):
+        brain = UnifiedBrain(mode="jarvis", brain_loop=Mock())
+        result = brain.process(None)
+        assert result.kind == "fail"
+
+
+# ---------------------------------------------------------------------------
+# UnifiedBrain — Jarvis mode (BrainLoop delegation)
+# ---------------------------------------------------------------------------
+
+
+class TestJarvisMode:
+    def test_delegates_to_brain_loop(self):
+        """process() calls BrainLoop.run() and returns a UnifiedResult."""
+        from bantz.brain.brain_loop import BrainResult
+
+        mock_bl = Mock()
+        mock_bl.run.return_value = BrainResult(
+            kind="say",
+            text="Merhaba efendim",
+            steps_used=1,
+            metadata={"trace": {"intent": "smalltalk"}},
+        )
+
+        brain = UnifiedBrain(mode="jarvis", brain_loop=mock_bl)
+        result = brain.process("merhaba")
+
+        assert result.kind == "say"
+        assert result.text == "Merhaba efendim"
+        assert result.backend == "brain_loop"
+        assert result.steps_used == 1
+        mock_bl.run.assert_called_once()
+
+    def test_session_context_merge(self):
+        """Default + per-turn session_context merge correctly."""
+        from bantz.brain.brain_loop import BrainResult
+
+        mock_bl = Mock()
+        mock_bl.run.return_value = BrainResult(
+            kind="say", text="ok", steps_used=0, metadata={}
+        )
+
+        brain = UnifiedBrain(
+            mode="jarvis",
+            brain_loop=mock_bl,
+            session_context={"tz_name": "Europe/Istanbul"},
+        )
+        brain.process("test", session_context={"locale": "tr"})
+
+        call_kwargs = mock_bl.run.call_args
+        ctx = call_kwargs.kwargs.get("session_context") or call_kwargs[1].get("session_context")
+        assert ctx["tz_name"] == "Europe/Istanbul"
+        assert ctx["locale"] == "tr"
+
+    def test_state_persists_across_turns(self):
+        """Internal jarvis_state dict persists between turns."""
+        from bantz.brain.brain_loop import BrainResult
+
+        call_count = 0
+
+        def fake_run(*, turn_input, session_context, policy, context):
+            nonlocal call_count
+            call_count += 1
+            context["last_intent"] = "calendar"
+            return BrainResult(kind="say", text=f"turn {call_count}", steps_used=0, metadata={})
+
+        mock_bl = Mock()
+        mock_bl.run.side_effect = fake_run
+
+        brain = UnifiedBrain(mode="jarvis", brain_loop=mock_bl)
+        brain.process("first turn")
+        brain.process("second turn")
+
+        # The second call should see state from the first
+        second_call = mock_bl.run.call_args_list[1]
+        ctx_arg = second_call.kwargs.get("context") or second_call[1].get("context")
+        assert ctx_arg.get("last_intent") == "calendar"
+
+    def test_from_brain_result_with_trace(self):
+        """BrainResult with rich trace metadata is normalised properly."""
+        from bantz.brain.brain_loop import BrainResult
+
+        br = BrainResult(
+            kind="ask_user",
+            text="Saat kaç olsun?",
+            steps_used=0,
+            metadata={
+                "trace": {
+                    "intent": "calendar.create",
+                    "llm_router_route": "calendar",
+                    "llm_router_confidence": 0.85,
+                    "llm_router_tool_plan": ["calendar.create_event"],
+                },
+                "requires_confirmation": True,
+            },
+        )
+
+        result = UnifiedBrain._from_brain_result(br)
+        assert result.kind == "ask_user"
+        assert result.route == "calendar"
+        assert result.intent == "calendar.create"
+        assert result.confidence == 0.85
+        assert result.requires_confirmation is True
+        assert result.tool_plan == ["calendar.create_event"]
+
+
+# ---------------------------------------------------------------------------
+# UnifiedBrain — Orchestrator mode (OrchestratorLoop delegation)
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorMode:
+    def _make_mock_output(self, **overrides):
+        """Create a mock OrchestratorOutput."""
+        defaults = {
+            "route": "smalltalk",
+            "calendar_intent": "none",
+            "slots": {},
+            "confidence": 0.9,
+            "tool_plan": [],
+            "assistant_reply": "Merhaba efendim!",
+            "ask_user": False,
+            "question": "",
+            "requires_confirmation": False,
+            "confirmation_prompt": "",
+            "memory_update": "",
+            "reasoning_summary": [],
+            "raw_output": {},
+        }
+        defaults.update(overrides)
+
+        output = Mock()
+        for k, v in defaults.items():
+            setattr(output, k, v)
+        return output
+
+    def test_delegates_to_orchestrator_loop(self):
+        """process() calls OrchestratorLoop.process_turn() and normalises."""
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        mock_output = self._make_mock_output()
+        mock_state = OrchestratorState()
+
+        mock_orch = Mock()
+        mock_orch.process_turn.return_value = (mock_output, mock_state)
+
+        brain = UnifiedBrain(mode="orchestrator", orchestrator_loop=mock_orch)
+        result = brain.process("merhaba")
+
+        assert result.kind == "say"
+        assert result.text == "Merhaba efendim!"
+        assert result.route == "smalltalk"
+        assert result.backend == "orchestrator"
+        mock_orch.process_turn.assert_called_once()
+
+    def test_ask_user_normalisation(self):
+        """When ask_user=True and question is set, kind should be 'ask_user'."""
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        mock_output = self._make_mock_output(
+            ask_user=True,
+            question="Hangi gün efendim?",
+            assistant_reply="",
+        )
+        mock_state = OrchestratorState()
+
+        mock_orch = Mock()
+        mock_orch.process_turn.return_value = (mock_output, mock_state)
+
+        brain = UnifiedBrain(mode="orchestrator", orchestrator_loop=mock_orch)
+        result = brain.process("toplantı ekle")
+
+        assert result.kind == "ask_user"
+        assert result.text == "Hangi gün efendim?"
+
+    def test_state_persists_across_turns(self):
+        """OrchestratorState persists between turns."""
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        state_v1 = OrchestratorState()
+        state_v1.turn_count = 1
+
+        state_v2 = OrchestratorState()
+        state_v2.turn_count = 2
+
+        mock_orch = Mock()
+        mock_orch.process_turn.side_effect = [
+            (self._make_mock_output(assistant_reply="turn 1"), state_v1),
+            (self._make_mock_output(assistant_reply="turn 2"), state_v2),
+        ]
+
+        brain = UnifiedBrain(mode="orchestrator", orchestrator_loop=mock_orch)
+        brain.process("first")
+        brain.process("second")
+
+        # The second call should get state_v1 (returned from first call)
+        second_call = mock_orch.process_turn.call_args_list[1]
+        state_arg = second_call.kwargs.get("state") or second_call[0][1]
+        assert state_arg.turn_count == 1
+
+    def test_session_context_injected(self):
+        """session_context is injected into OrchestratorState."""
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        mock_state = OrchestratorState()
+        mock_orch = Mock()
+        mock_orch.process_turn.return_value = (
+            self._make_mock_output(),
+            mock_state,
+        )
+
+        brain = UnifiedBrain(
+            mode="orchestrator",
+            orchestrator_loop=mock_orch,
+            session_context={"tz_name": "Europe/Istanbul"},
+        )
+        brain.process("test", session_context={"locale": "tr"})
+
+        call_args = mock_orch.process_turn.call_args
+        state_arg = call_args.kwargs.get("state") or call_args[0][1]
+        assert state_arg.session_context["tz_name"] == "Europe/Istanbul"
+        assert state_arg.session_context["locale"] == "tr"
+
+    def test_from_orchestrator_output_with_tools(self):
+        """tools_executed extracted from state trace."""
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        mock_output = self._make_mock_output(
+            route="calendar",
+            calendar_intent="query",
+            tool_plan=["calendar.list_events"],
+            assistant_reply="2 etkinlik bulundu.",
+        )
+
+        state = OrchestratorState()
+        state.trace = {"tools_success": ["calendar.list_events"]}
+
+        result = UnifiedBrain._from_orchestrator_output(mock_output, state)
+        assert result.route == "calendar"
+        assert result.intent == "query"
+        assert result.tools_executed == ["calendar.list_events"]
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_clears_state(self):
+        brain = UnifiedBrain(mode="orchestrator", orchestrator_loop=Mock())
+        brain._orchestrator_state = "something"
+        brain._jarvis_state = {"key": "value"}
+
+        brain.reset()
+
+        assert brain._orchestrator_state is None
+        assert brain._jarvis_state == {}
+
+
+# ---------------------------------------------------------------------------
+# Factory — create_brain()
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_create_jarvis(self):
+        """create_brain(mode='jarvis') creates BrainLoop internally."""
+        llm = FakeLLM([{"type": "SAY", "text": "ok"}])
+        tools = _make_tool_registry()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            brain = create_brain(mode="jarvis", llm=llm, tools=tools)
+
+        assert brain.mode == "jarvis"
+        assert brain.backend is not None
+
+    def test_create_orchestrator(self):
+        """create_brain(mode='orchestrator') creates OrchestratorLoop internally."""
+        llm = FakeLLM()
+        tools = _make_tool_registry()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            brain = create_brain(mode="orchestrator", llm=llm, tools=tools)
+
+        assert brain.mode == "orchestrator"
+        assert brain.backend is not None
+
+    def test_create_with_finalizer(self):
+        """Finalizer LLM is passed to OrchestratorLoop."""
+        llm = FakeLLM()
+        finalizer = FakeLLM()
+        tools = _make_tool_registry()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            brain = create_brain(
+                mode="orchestrator",
+                llm=llm,
+                tools=tools,
+                finalizer_llm=finalizer,
+            )
+
+        assert brain.mode == "orchestrator"
+
+    def test_create_with_config(self):
+        """Custom config is applied to backend."""
+        llm = FakeLLM()
+        tools = _make_tool_registry()
+        config = UnifiedConfig(mode="orchestrator", max_steps=3, debug=True)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            brain = create_brain(mode="orchestrator", llm=llm, tools=tools, config=config)
+
+        assert brain._config.max_steps == 3
+        assert brain._config.debug is True
+
+
+# ---------------------------------------------------------------------------
+# Deprecation warnings on legacy constructors
+# ---------------------------------------------------------------------------
+
+
+class TestDeprecationWarnings:
+    def test_brain_loop_warns(self):
+        """BrainLoop() emits DeprecationWarning."""
+        from bantz.brain.brain_loop import BrainLoop, BrainLoopConfig
+
+        llm = FakeLLM()
+        tools = _make_tool_registry()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            BrainLoop(llm=llm, tools=tools, config=BrainLoopConfig(max_steps=1))
+
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) >= 1
+        assert "BrainLoop is deprecated" in str(dep_warnings[0].message)
+
+    def test_orchestrator_loop_warns(self):
+        """OrchestratorLoop() emits DeprecationWarning."""
+        from bantz.brain.orchestrator_loop import OrchestratorLoop, OrchestratorConfig
+        from bantz.brain.llm_router import JarvisLLMOrchestrator
+
+        llm = FakeLLM()
+        tools = _make_tool_registry()
+        orch = JarvisLLMOrchestrator(llm_client=llm)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            OrchestratorLoop(orch, tools, config=OrchestratorConfig())
+
+        dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(dep_warnings) >= 1
+        assert "OrchestratorLoop is deprecated" in str(dep_warnings[0].message)
+
+
+# ---------------------------------------------------------------------------
+# Integration: Jarvis mode end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestJarvisE2E:
+    def test_say_result(self):
+        """Full Jarvis flow: LLM says → UnifiedResult(kind='say')."""
+        llm = FakeLLM([{"type": "SAY", "text": "Sonuç 5."}])
+        tools = _make_tool_registry()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            brain = create_brain(mode="jarvis", llm=llm, tools=tools)
+
+        result = brain.process("iki artı üç")
+        assert result.kind == "say"
+        assert "5" in result.text
+        assert result.backend == "brain_loop"
+
+    def test_tool_then_say(self):
+        """Full Jarvis flow: LLM calls tool → says result → UnifiedResult."""
+        llm = FakeLLM(
+            [
+                {"type": "CALL_TOOL", "name": "add", "params": {"a": 2, "b": 3}},
+                {"type": "SAY", "text": "Sonuç 5."},
+            ]
+        )
+        tools = _make_tool_registry()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            brain = create_brain(
+                mode="jarvis",
+                llm=llm,
+                tools=tools,
+                config=UnifiedConfig(mode="jarvis", max_steps=4),
+            )
+
+        result = brain.process("2 ile 3 topla")
+        assert result.kind == "say"
+        assert "5" in result.text
+        assert result.steps_used == 2
+
+
+# ---------------------------------------------------------------------------
+# __init__.py exports
+# ---------------------------------------------------------------------------
+
+
+class TestPackageExports:
+    def test_imports_from_brain_package(self):
+        """UnifiedBrain and create_brain are importable from bantz.brain."""
+        from bantz.brain import UnifiedBrain, UnifiedConfig, UnifiedResult, create_brain
+
+        assert UnifiedBrain is not None
+        assert create_brain is not None
+        assert UnifiedConfig is not None
+        assert UnifiedResult is not None
+
+    def test_legacy_imports_still_work(self):
+        """BrainLoop and friends still importable from bantz.brain."""
+        from bantz.brain import BrainLoop, BrainLoopConfig, BrainResult, LLMClient
+
+        assert BrainLoop is not None
+        assert BrainLoopConfig is not None
+        assert BrainResult is not None


### PR DESCRIPTION
## Issue #403: Brain Consolidation EPIC — Phase 1 (Foundation)

### Sorun
Projede iki paralel brain sistemi var:
- **BrainLoop** (5846 satır) — Jarvis modu, deterministik takvim UX, sesli menüler
- **OrchestratorLoop** (1854 satır) — LLM-first mimari, genel amaçlı

İkisi farklı API'ler sunuyor, ayrı state yönetiyor ve bakım yükü ikiye katlıyor.

### Çözüm (Phase 1)
Tek giriş noktası oluşturan **UnifiedBrain** facade pattern:

- `src/bantz/brain/unified_loop.py`:
  - `UnifiedBrain`: her iki backend'i saran tek arayüz
  - `UnifiedResult`: normalize edilmiş sonuç tipi (BrainResult + OrchestratorOutput üst kümesi)
  - `UnifiedConfig`: birleşik konfigürasyon
  - `create_brain()` factory: önerilen kullanım şekli
  - Jarvis modu → BrainLoop'a delege eder
  - Orchestrator modu → OrchestratorLoop'a delege eder
  - Her iki modda da turn'ler arası state kalıcılığı

- `brain/__init__.py`: UnifiedBrain, UnifiedConfig, UnifiedResult, create_brain export

- BrainLoop ve OrchestratorLoop'a `DeprecationWarning` eklendi

### Testler
- 32 yeni test (`tests/test_unified_loop.py`)
- 61/61 brain-related test geçiyor
- 4849 test'lik süitte regresyon yok

### Sonraki adımlar (Phase 2+)
- [ ] Takvim state machine'i brain_loop.py'dan çıkart → calendar_state_machine.py
- [ ] OrchestratorLoop'a calendar handler entegrasyonu
- [ ] cli.py ve terminal_jarvis.py'yi create_brain() kullanacak şekilde güncelle
- [ ] brain_loop.py'yi tamamen retire et

Closes #403 (Phase 1)