### PR TITLE
feat(#410): Gemini rate-limit, quota management & circuit breaker

### DIFF
--- a/src/bantz/llm/quota_tracker.py
+++ b/src/bantz/llm/quota_tracker.py
@@ -1,0 +1,286 @@
+"""Gemini API quota tracker and circuit breaker (Issue #410).
+
+Tracks daily/monthly API usage, enforces quotas, and implements a
+circuit breaker to disable Gemini temporarily after repeated failures.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "QuotaTracker",
+    "QuotaExceeded",
+    "CircuitBreaker",
+    "CircuitOpen",
+]
+
+
+class QuotaExceeded(Exception):
+    """Raised when Gemini API quota has been exceeded."""
+
+    def __init__(self, message: str, daily_remaining: int = 0, monthly_remaining: int = 0):
+        super().__init__(message)
+        self.daily_remaining = daily_remaining
+        self.monthly_remaining = monthly_remaining
+
+
+class CircuitOpen(Exception):
+    """Raised when the circuit breaker is open (Gemini temporarily disabled)."""
+
+    def __init__(self, message: str, retry_after: float = 0.0):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+# ---------------------------------------------------------------------------
+# Quota Tracker
+# ---------------------------------------------------------------------------
+
+@dataclass
+class QuotaStats:
+    """Current quota usage statistics."""
+
+    daily_calls: int = 0
+    daily_tokens: int = 0
+    monthly_calls: int = 0
+    monthly_tokens: int = 0
+    daily_limit_calls: int = 1500
+    daily_limit_tokens: int = 1_000_000
+    monthly_limit_calls: int = 30000
+    monthly_limit_tokens: int = 20_000_000
+    current_date: str = ""
+    current_month: str = ""
+
+    @property
+    def daily_calls_remaining(self) -> int:
+        return max(0, self.daily_limit_calls - self.daily_calls)
+
+    @property
+    def monthly_calls_remaining(self) -> int:
+        return max(0, self.monthly_limit_calls - self.monthly_calls)
+
+    @property
+    def daily_tokens_remaining(self) -> int:
+        return max(0, self.daily_limit_tokens - self.daily_tokens)
+
+    @property
+    def is_daily_exceeded(self) -> bool:
+        return (
+            self.daily_calls >= self.daily_limit_calls
+            or self.daily_tokens >= self.daily_limit_tokens
+        )
+
+    @property
+    def is_monthly_exceeded(self) -> bool:
+        return (
+            self.monthly_calls >= self.monthly_limit_calls
+            or self.monthly_tokens >= self.monthly_limit_tokens
+        )
+
+
+class QuotaTracker:
+    """Track Gemini API call/token usage against configurable limits.
+
+    Thread-safe. Resets daily counters at midnight, monthly at month boundary.
+
+    Args:
+        daily_limit_calls: Max API calls per day (default 1500).
+        daily_limit_tokens: Max tokens per day (default 1M).
+        monthly_limit_calls: Max API calls per month (default 30000).
+        monthly_limit_tokens: Max tokens per month (default 20M).
+    """
+
+    def __init__(
+        self,
+        *,
+        daily_limit_calls: int = 1500,
+        daily_limit_tokens: int = 1_000_000,
+        monthly_limit_calls: int = 30000,
+        monthly_limit_tokens: int = 20_000_000,
+    ):
+        self._lock = threading.Lock()
+        self._daily_calls = 0
+        self._daily_tokens = 0
+        self._monthly_calls = 0
+        self._monthly_tokens = 0
+        self._daily_limit_calls = daily_limit_calls
+        self._daily_limit_tokens = daily_limit_tokens
+        self._monthly_limit_calls = monthly_limit_calls
+        self._monthly_limit_tokens = monthly_limit_tokens
+        self._current_date = date.today().isoformat()
+        self._current_month = date.today().strftime("%Y-%m")
+
+    def _maybe_reset(self) -> None:
+        """Reset counters if date/month has changed."""
+        today = date.today()
+        today_str = today.isoformat()
+        month_str = today.strftime("%Y-%m")
+
+        if today_str != self._current_date:
+            self._daily_calls = 0
+            self._daily_tokens = 0
+            self._current_date = today_str
+            logger.info("[QUOTA] Daily counters reset for %s", today_str)
+
+        if month_str != self._current_month:
+            self._monthly_calls = 0
+            self._monthly_tokens = 0
+            self._current_month = month_str
+            logger.info("[QUOTA] Monthly counters reset for %s", month_str)
+
+    def record(self, tokens_used: int = 0) -> None:
+        """Record a successful API call.
+
+        Args:
+            tokens_used: Total tokens consumed (prompt + completion).
+        """
+        with self._lock:
+            self._maybe_reset()
+            self._daily_calls += 1
+            self._daily_tokens += max(0, tokens_used)
+            self._monthly_calls += 1
+            self._monthly_tokens += max(0, tokens_used)
+
+    def check(self) -> None:
+        """Check if quota is exceeded. Raises QuotaExceeded if so."""
+        with self._lock:
+            self._maybe_reset()
+            if self._daily_calls >= self._daily_limit_calls:
+                raise QuotaExceeded(
+                    f"Daily call limit exceeded ({self._daily_calls}/{self._daily_limit_calls})",
+                    daily_remaining=0,
+                )
+            if self._daily_tokens >= self._daily_limit_tokens:
+                raise QuotaExceeded(
+                    f"Daily token limit exceeded ({self._daily_tokens}/{self._daily_limit_tokens})",
+                    daily_remaining=self._daily_limit_calls - self._daily_calls,
+                )
+            if self._monthly_calls >= self._monthly_limit_calls:
+                raise QuotaExceeded(
+                    f"Monthly call limit exceeded ({self._monthly_calls}/{self._monthly_limit_calls})",
+                    monthly_remaining=0,
+                )
+
+    def get_stats(self) -> QuotaStats:
+        """Get current quota usage snapshot."""
+        with self._lock:
+            self._maybe_reset()
+            return QuotaStats(
+                daily_calls=self._daily_calls,
+                daily_tokens=self._daily_tokens,
+                monthly_calls=self._monthly_calls,
+                monthly_tokens=self._monthly_tokens,
+                daily_limit_calls=self._daily_limit_calls,
+                daily_limit_tokens=self._daily_limit_tokens,
+                monthly_limit_calls=self._monthly_limit_calls,
+                monthly_limit_tokens=self._monthly_limit_tokens,
+                current_date=self._current_date,
+                current_month=self._current_month,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Circuit Breaker
+# ---------------------------------------------------------------------------
+
+class CircuitBreaker:
+    """Circuit breaker for Gemini API.
+
+    After ``failure_threshold`` consecutive failures, the circuit opens for
+    ``reset_timeout`` seconds.  During that window every call raises
+    ``CircuitOpen`` immediately (no API call attempted).
+
+    States:
+        CLOSED  — normal operation, failures are counted
+        OPEN    — Gemini disabled, raises immediately
+        HALF_OPEN — one probe call is allowed to test recovery
+
+    Args:
+        failure_threshold: Consecutive failures before opening (default 3).
+        reset_timeout: Seconds to stay open before half-open probe (default 60).
+    """
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int = 3,
+        reset_timeout: float = 60.0,
+    ):
+        self._lock = threading.Lock()
+        self._failure_threshold = failure_threshold
+        self._reset_timeout = reset_timeout
+        self._failure_count = 0
+        self._state = self.CLOSED
+        self._last_failure_time: float = 0.0
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            self._maybe_transition()
+            return self._state
+
+    def _maybe_transition(self) -> None:
+        """Transition from OPEN → HALF_OPEN if timeout has elapsed."""
+        if self._state == self.OPEN:
+            if time.monotonic() - self._last_failure_time >= self._reset_timeout:
+                self._state = self.HALF_OPEN
+                logger.info("[CIRCUIT] State: OPEN → HALF_OPEN (probe allowed)")
+
+    def check(self) -> None:
+        """Check if the circuit allows a call. Raises CircuitOpen if not."""
+        with self._lock:
+            self._maybe_transition()
+            if self._state == self.OPEN:
+                retry_after = self._reset_timeout - (
+                    time.monotonic() - self._last_failure_time
+                )
+                raise CircuitOpen(
+                    f"Circuit breaker OPEN — Gemini temporarily disabled "
+                    f"(retry in {max(0, retry_after):.0f}s)",
+                    retry_after=max(0.0, retry_after),
+                )
+            # CLOSED and HALF_OPEN allow calls
+
+    def record_success(self) -> None:
+        """Record a successful API call. Resets failure count."""
+        with self._lock:
+            if self._state == self.HALF_OPEN:
+                logger.info("[CIRCUIT] State: HALF_OPEN → CLOSED (probe succeeded)")
+            self._failure_count = 0
+            self._state = self.CLOSED
+
+    def record_failure(self) -> None:
+        """Record a failed API call. Opens circuit if threshold reached."""
+        with self._lock:
+            self._failure_count += 1
+            self._last_failure_time = time.monotonic()
+
+            if self._state == self.HALF_OPEN:
+                # Probe failed → back to OPEN
+                self._state = self.OPEN
+                logger.warning("[CIRCUIT] State: HALF_OPEN → OPEN (probe failed)")
+            elif self._failure_count >= self._failure_threshold:
+                self._state = self.OPEN
+                logger.warning(
+                    "[CIRCUIT] State: CLOSED → OPEN (%d consecutive failures)",
+                    self._failure_count,
+                )
+
+    def reset(self) -> None:
+        """Manually reset the circuit breaker to CLOSED."""
+        with self._lock:
+            self._failure_count = 0
+            self._state = self.CLOSED
+            logger.info("[CIRCUIT] Manually reset to CLOSED")

--- a/tests/test_issue_410_gemini_rate_limit.py
+++ b/tests/test_issue_410_gemini_rate_limit.py
@@ -1,0 +1,735 @@
+"""Tests for Issue #410: Gemini rate-limit + quota management.
+
+Tests cover:
+  - QuotaTracker: daily/monthly limits, auto-reset, thread safety
+  - CircuitBreaker: state transitions, threshold, timeout, probe
+  - GeminiClient retry: exponential backoff, retryable codes, non-retryable codes
+  - GeminiClient integration: circuit breaker + quota pre-flight checks
+  - Rate limit header parsing
+  - Backoff calculation
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import date
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+import requests
+
+from bantz.llm.quota_tracker import (
+    QuotaTracker,
+    QuotaExceeded,
+    QuotaStats,
+    CircuitBreaker,
+    CircuitOpen,
+)
+from bantz.llm.gemini_client import (
+    GeminiClient,
+    _calculate_backoff,
+    _parse_rate_limit_remaining,
+    _parse_retry_after,
+    RETRY_MAX_ATTEMPTS,
+    RETRY_BASE_DELAY,
+    RETRY_BACKOFF_FACTOR,
+    RETRY_MAX_DELAY,
+    RETRYABLE_STATUS_CODES,
+)
+from bantz.llm.base import (
+    LLMMessage,
+    LLMConnectionError,
+    LLMTimeoutError,
+    LLMModelNotFoundError,
+    LLMInvalidResponseError,
+)
+
+
+# ======================================================================
+# QuotaTracker Tests
+# ======================================================================
+
+
+class TestQuotaTracker:
+    """Tests for QuotaTracker daily/monthly limits."""
+
+    def test_record_and_check_within_limits(self):
+        qt = QuotaTracker(daily_limit_calls=10, monthly_limit_calls=100)
+        for _ in range(5):
+            qt.record(tokens_used=50)
+        qt.check()  # Should not raise
+
+    def test_daily_call_limit_exceeded(self):
+        qt = QuotaTracker(daily_limit_calls=3, monthly_limit_calls=100)
+        for _ in range(3):
+            qt.record(tokens_used=10)
+        with pytest.raises(QuotaExceeded, match="Daily call limit"):
+            qt.check()
+
+    def test_daily_token_limit_exceeded(self):
+        qt = QuotaTracker(daily_limit_calls=1000, daily_limit_tokens=100)
+        qt.record(tokens_used=100)
+        with pytest.raises(QuotaExceeded, match="Daily token limit"):
+            qt.check()
+
+    def test_monthly_call_limit_exceeded(self):
+        qt = QuotaTracker(daily_limit_calls=1000, monthly_limit_calls=2)
+        qt.record(tokens_used=1)
+        qt.record(tokens_used=1)
+        with pytest.raises(QuotaExceeded, match="Monthly call limit"):
+            qt.check()
+
+    def test_negative_tokens_clamped_to_zero(self):
+        qt = QuotaTracker()
+        qt.record(tokens_used=-100)
+        stats = qt.get_stats()
+        assert stats.daily_tokens == 0
+
+    def test_get_stats_snapshot(self):
+        qt = QuotaTracker(daily_limit_calls=50, daily_limit_tokens=5000)
+        qt.record(tokens_used=200)
+        qt.record(tokens_used=300)
+        stats = qt.get_stats()
+        assert stats.daily_calls == 2
+        assert stats.daily_tokens == 500
+        assert stats.monthly_calls == 2
+        assert stats.daily_calls_remaining == 48
+        assert stats.daily_tokens_remaining == 4500
+
+    def test_stats_properties(self):
+        stats = QuotaStats(
+            daily_calls=10,
+            daily_tokens=500,
+            daily_limit_calls=10,
+            daily_limit_tokens=1000,
+            monthly_calls=50,
+            monthly_limit_calls=100,
+        )
+        assert stats.is_daily_exceeded is True  # calls hit limit
+        assert stats.is_monthly_exceeded is False
+        assert stats.daily_calls_remaining == 0
+        assert stats.monthly_calls_remaining == 50
+
+    def test_daily_reset_on_date_change(self):
+        qt = QuotaTracker(daily_limit_calls=5)
+        qt.record(tokens_used=10)
+        qt.record(tokens_used=10)
+        assert qt.get_stats().daily_calls == 2
+
+        # Simulate date change
+        qt._current_date = "2020-01-01"
+        stats = qt.get_stats()
+        assert stats.daily_calls == 0  # Reset happened
+
+    def test_monthly_reset_on_month_change(self):
+        qt = QuotaTracker(monthly_limit_calls=5)
+        qt.record(tokens_used=10)
+        qt.record(tokens_used=10)
+        assert qt.get_stats().monthly_calls == 2
+
+        # Simulate month change
+        qt._current_month = "2020-01"
+        stats = qt.get_stats()
+        assert stats.monthly_calls == 0
+
+    def test_thread_safety(self):
+        """Concurrent record calls should not lose data."""
+        qt = QuotaTracker(daily_limit_calls=100_000, monthly_limit_calls=100_000)
+        n_threads = 10
+        n_per_thread = 100
+        barrier = threading.Barrier(n_threads)
+
+        def worker():
+            barrier.wait()
+            for _ in range(n_per_thread):
+                qt.record(tokens_used=1)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stats = qt.get_stats()
+        assert stats.daily_calls == n_threads * n_per_thread
+        assert stats.daily_tokens == n_threads * n_per_thread
+
+    def test_quota_exceeded_attributes(self):
+        exc = QuotaExceeded("test", daily_remaining=5, monthly_remaining=100)
+        assert exc.daily_remaining == 5
+        assert exc.monthly_remaining == 100
+        assert str(exc) == "test"
+
+
+# ======================================================================
+# CircuitBreaker Tests
+# ======================================================================
+
+
+class TestCircuitBreaker:
+    """Tests for CircuitBreaker state machine."""
+
+    def test_initial_state_closed(self):
+        cb = CircuitBreaker()
+        assert cb.state == CircuitBreaker.CLOSED
+
+    def test_check_passes_when_closed(self):
+        cb = CircuitBreaker()
+        cb.check()  # No exception
+
+    def test_opens_after_threshold_failures(self):
+        cb = CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.state == CircuitBreaker.CLOSED
+        cb.record_failure()
+        assert cb.state == CircuitBreaker.OPEN
+
+    def test_open_circuit_raises(self):
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=60)
+        cb.record_failure()
+        with pytest.raises(CircuitOpen, match="Circuit breaker OPEN"):
+            cb.check()
+
+    def test_circuit_open_retry_after(self):
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=60)
+        cb.record_failure()
+        try:
+            cb.check()
+        except CircuitOpen as e:
+            assert e.retry_after > 0
+            assert e.retry_after <= 60
+
+    def test_success_resets_failure_count(self):
+        cb = CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+        assert cb.state == CircuitBreaker.CLOSED
+        # One more failure should not open (count reset)
+        cb.record_failure()
+        assert cb.state == CircuitBreaker.CLOSED
+
+    def test_half_open_after_timeout(self):
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=0.05)
+        cb.record_failure()
+        assert cb.state == CircuitBreaker.OPEN
+        time.sleep(0.1)
+        assert cb.state == CircuitBreaker.HALF_OPEN
+
+    def test_half_open_success_closes(self):
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=0.05)
+        cb.record_failure()
+        time.sleep(0.1)
+        assert cb.state == CircuitBreaker.HALF_OPEN
+        cb.check()  # Should pass (half-open allows probe)
+        cb.record_success()
+        assert cb.state == CircuitBreaker.CLOSED
+
+    def test_half_open_failure_reopens(self):
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=0.05)
+        cb.record_failure()
+        time.sleep(0.1)
+        assert cb.state == CircuitBreaker.HALF_OPEN
+        cb.record_failure()
+        assert cb.state == CircuitBreaker.OPEN
+
+    def test_manual_reset(self):
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=999)
+        cb.record_failure()
+        assert cb.state == CircuitBreaker.OPEN
+        cb.reset()
+        assert cb.state == CircuitBreaker.CLOSED
+        cb.check()  # No exception
+
+    def test_thread_safety(self):
+        cb = CircuitBreaker(failure_threshold=100, reset_timeout=60)
+        barrier = threading.Barrier(10)
+
+        def worker():
+            barrier.wait()
+            for _ in range(10):
+                cb.record_failure()
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert cb.state == CircuitBreaker.OPEN
+
+
+# ======================================================================
+# Backoff & Header Parsing Tests
+# ======================================================================
+
+
+class TestBackoffCalculation:
+    """Tests for exponential backoff computation."""
+
+    def test_first_attempt_base_delay(self):
+        # With no retry-after, attempt 1 → ~base_delay (±25% jitter)
+        delays = [_calculate_backoff(1) for _ in range(20)]
+        for d in delays:
+            assert RETRY_BASE_DELAY * 0.7 <= d <= RETRY_BASE_DELAY * 1.3
+
+    def test_second_attempt_doubled(self):
+        delays = [_calculate_backoff(2) for _ in range(20)]
+        expected = RETRY_BASE_DELAY * RETRY_BACKOFF_FACTOR
+        for d in delays:
+            assert expected * 0.7 <= d <= expected * 1.3
+
+    def test_capped_at_max_delay(self):
+        # Very high attempt number should be capped
+        d = _calculate_backoff(100)
+        assert d <= RETRY_MAX_DELAY
+
+    def test_retry_after_header_honoured(self):
+        d = _calculate_backoff(1, retry_after_header=5.0)
+        assert d == 5.0
+
+    def test_retry_after_header_capped(self):
+        d = _calculate_backoff(1, retry_after_header=9999.0)
+        assert d == RETRY_MAX_DELAY
+
+
+class TestHeaderParsing:
+    """Tests for rate limit header parsers."""
+
+    def test_parse_remaining_standard(self):
+        assert _parse_rate_limit_remaining({"X-RateLimit-Remaining": "42"}) == 42
+
+    def test_parse_remaining_lowercase(self):
+        assert _parse_rate_limit_remaining({"x-ratelimit-remaining": "7"}) == 7
+
+    def test_parse_remaining_missing(self):
+        assert _parse_rate_limit_remaining({}) is None
+
+    def test_parse_remaining_invalid(self):
+        assert _parse_rate_limit_remaining({"X-RateLimit-Remaining": "abc"}) is None
+
+    def test_parse_retry_after_seconds(self):
+        assert _parse_retry_after({"Retry-After": "30"}) == 30.0
+
+    def test_parse_retry_after_float(self):
+        assert _parse_retry_after({"Retry-After": "2.5"}) == 2.5
+
+    def test_parse_retry_after_missing(self):
+        assert _parse_retry_after({}) is None
+
+
+# ======================================================================
+# GeminiClient Retry Integration Tests
+# ======================================================================
+
+
+def _make_client(
+    *,
+    quota_tracker=None,
+    circuit_breaker=None,
+    max_retries=3,
+) -> GeminiClient:
+    """Create a GeminiClient for testing."""
+    return GeminiClient(
+        api_key="test-key",
+        model="gemini-1.5-flash",
+        timeout_seconds=5.0,
+        quota_tracker=quota_tracker,
+        circuit_breaker=circuit_breaker,
+        max_retries=max_retries,
+    )
+
+
+def _mock_response(status_code=200, json_data=None, headers=None):
+    """Create a mock requests.Response."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.headers = headers or {}
+    if json_data is None:
+        json_data = {
+            "candidates": [
+                {
+                    "content": {"parts": [{"text": "Merhaba efendim!"}]},
+                    "finishReason": "STOP",
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15,
+            },
+        }
+    resp.json.return_value = json_data
+    return resp
+
+
+class TestGeminiRetry:
+    """Tests for retry logic in GeminiClient.chat_detailed."""
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_success_no_retry(self, mock_post):
+        """Successful call should not retry."""
+        mock_post.return_value = _mock_response(200)
+        client = _make_client()
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+        assert mock_post.call_count == 1
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_429_retries_then_succeeds(self, mock_post, mock_sleep):
+        """429 should trigger retry and succeed on second attempt."""
+        mock_post.side_effect = [
+            _mock_response(429, headers={"Retry-After": "1"}),
+            _mock_response(200),
+        ]
+        client = _make_client(max_retries=3)
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+        assert mock_post.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_500_retries_then_succeeds(self, mock_post, mock_sleep):
+        """500 should trigger retry."""
+        mock_post.side_effect = [
+            _mock_response(500),
+            _mock_response(200),
+        ]
+        client = _make_client(max_retries=3)
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+        assert mock_post.call_count == 2
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_503_retries_then_succeeds(self, mock_post, mock_sleep):
+        """503 should trigger retry."""
+        mock_post.side_effect = [
+            _mock_response(503),
+            _mock_response(503),
+            _mock_response(200),
+        ]
+        client = _make_client(max_retries=3)
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+        assert mock_post.call_count == 3
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_429_all_retries_exhausted(self, mock_post, mock_sleep):
+        """If all retries return 429, should raise LLMConnectionError."""
+        mock_post.return_value = _mock_response(429)
+        client = _make_client(max_retries=3)
+        with pytest.raises(LLMConnectionError, match="rate_limited"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 3
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_500_all_retries_exhausted(self, mock_post, mock_sleep):
+        """If all retries return 500, should raise LLMConnectionError."""
+        mock_post.return_value = _mock_response(500)
+        client = _make_client(max_retries=3)
+        with pytest.raises(LLMConnectionError, match="server_error"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 3
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_401_no_retry(self, mock_post):
+        """401 should not retry — immediate auth error."""
+        mock_post.return_value = _mock_response(401)
+        client = _make_client(max_retries=3)
+        with pytest.raises(LLMConnectionError, match="auth_error"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 1
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_404_no_retry(self, mock_post):
+        """404 should not retry — model not found."""
+        mock_post.return_value = _mock_response(404)
+        client = _make_client(max_retries=3)
+        with pytest.raises(LLMModelNotFoundError, match="model_not_found"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 1
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_400_no_retry(self, mock_post):
+        """400 should not retry — invalid request."""
+        mock_post.return_value = _mock_response(400)
+        client = _make_client(max_retries=3)
+        with pytest.raises(LLMInvalidResponseError, match="invalid_request"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 1
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_timeout_retries(self, mock_post, mock_sleep):
+        """Timeout should trigger retry."""
+        mock_post.side_effect = [
+            requests.Timeout("timed out"),
+            _mock_response(200),
+        ]
+        client = _make_client(max_retries=3)
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+        assert mock_post.call_count == 2
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_timeout_all_retries_exhausted(self, mock_post, mock_sleep):
+        """If all retries timeout, should raise LLMTimeoutError."""
+        mock_post.side_effect = requests.Timeout("timed out")
+        client = _make_client(max_retries=2)
+        with pytest.raises(LLMTimeoutError, match="timeout"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 2
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_connection_error_retries(self, mock_post, mock_sleep):
+        """Connection error should trigger retry."""
+        mock_post.side_effect = [
+            requests.ConnectionError("refused"),
+            _mock_response(200),
+        ]
+        client = _make_client(max_retries=3)
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_connection_error_all_retries_exhausted(self, mock_post, mock_sleep):
+        """All connection errors → LLMConnectionError."""
+        mock_post.side_effect = requests.ConnectionError("refused")
+        client = _make_client(max_retries=2)
+        with pytest.raises(LLMConnectionError, match="connection_error"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 2
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_retry_after_header_honoured(self, mock_post, mock_sleep):
+        """Retry-After header should set sleep delay."""
+        mock_post.side_effect = [
+            _mock_response(429, headers={"Retry-After": "5"}),
+            _mock_response(200),
+        ]
+        client = _make_client(max_retries=3)
+        client.chat_detailed([LLMMessage(role="user", content="test")])
+        # sleep should have been called with ~5.0
+        assert mock_sleep.call_count == 1
+        actual_delay = mock_sleep.call_args[0][0]
+        assert 4.5 <= actual_delay <= 5.5
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_max_retries_1_no_retry(self, mock_post):
+        """max_retries=1 means only one attempt, no retry."""
+        mock_post.return_value = _mock_response(429)
+        client = _make_client(max_retries=1)
+        with pytest.raises(LLMConnectionError, match="rate_limited"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 1
+
+
+# ======================================================================
+# Circuit Breaker Integration with GeminiClient
+# ======================================================================
+
+
+class TestGeminiCircuitBreaker:
+    """Tests for circuit breaker integration in GeminiClient."""
+
+    def test_circuit_open_blocks_call(self):
+        """When circuit is open, chat_detailed should not make HTTP call."""
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=60)
+        cb.record_failure()  # Opens circuit
+        client = _make_client(circuit_breaker=cb)
+        with pytest.raises(LLMConnectionError, match="circuit_open"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_success_resets_circuit(self, mock_post):
+        """Successful call should reset circuit breaker."""
+        cb = CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        client = _make_client(circuit_breaker=cb)
+        mock_post.return_value = _mock_response(200)
+        client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert cb.state == CircuitBreaker.CLOSED
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_retries_exhausted_opens_circuit(self, mock_post, mock_sleep):
+        """All retries failing should record circuit failure."""
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=60)
+        client = _make_client(circuit_breaker=cb, max_retries=2)
+        mock_post.return_value = _mock_response(500)
+        with pytest.raises(LLMConnectionError):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert cb.state == CircuitBreaker.OPEN
+
+    def test_circuit_open_turkish_message(self):
+        """User-facing error should include Turkish message."""
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=60)
+        cb.record_failure()
+        client = _make_client(circuit_breaker=cb)
+        with pytest.raises(LLMConnectionError, match="yerel model"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+
+
+# ======================================================================
+# Quota Tracker Integration with GeminiClient
+# ======================================================================
+
+
+class TestGeminiQuota:
+    """Tests for quota tracker integration in GeminiClient."""
+
+    def test_quota_exceeded_blocks_call(self):
+        """When quota exceeded, should not make HTTP call."""
+        qt = QuotaTracker(daily_limit_calls=1)
+        qt.record(tokens_used=10)  # Exhaust quota
+        client = _make_client(quota_tracker=qt)
+        with pytest.raises(LLMConnectionError, match="quota_exceeded"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_success_records_quota(self, mock_post):
+        """Successful call should record usage to quota tracker."""
+        qt = QuotaTracker(daily_limit_calls=100)
+        client = _make_client(quota_tracker=qt)
+        mock_post.return_value = _mock_response(200)
+        client.chat_detailed([LLMMessage(role="user", content="test")])
+        stats = qt.get_stats()
+        assert stats.daily_calls == 1
+        assert stats.daily_tokens == 15  # totalTokenCount from mock
+
+    def test_quota_exceeded_turkish_message(self):
+        """User-facing error should include Turkish message."""
+        qt = QuotaTracker(daily_limit_calls=0)
+        client = _make_client(quota_tracker=qt)
+        with pytest.raises(LLMConnectionError, match="yerel model"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_quota_not_recorded_on_failure(self, mock_post):
+        """Failed call should not count towards quota tokens."""
+        qt = QuotaTracker(daily_limit_calls=100)
+        client = _make_client(quota_tracker=qt, max_retries=1)
+        mock_post.return_value = _mock_response(401)
+        with pytest.raises(LLMConnectionError):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        stats = qt.get_stats()
+        assert stats.daily_calls == 0  # Not recorded for non-success
+
+
+# ======================================================================
+# Combined: Circuit Breaker + Quota + Retry
+# ======================================================================
+
+
+class TestGeminiFullIntegration:
+    """Full integration: CB checked first, then quota, then retry."""
+
+    def test_circuit_checked_before_quota(self):
+        """Circuit check happens before quota check."""
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=60)
+        cb.record_failure()
+        qt = QuotaTracker(daily_limit_calls=0)  # Also exceeded
+        client = _make_client(circuit_breaker=cb, quota_tracker=qt)
+        with pytest.raises(LLMConnectionError, match="circuit_open"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_quota_checked_before_http_call(self, mock_post):
+        """Quota check prevents HTTP call."""
+        qt = QuotaTracker(daily_limit_calls=0)
+        client = _make_client(quota_tracker=qt)
+        with pytest.raises(LLMConnectionError, match="quota_exceeded"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert mock_post.call_count == 0
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_retry_with_circuit_and_quota(self, mock_post, mock_sleep):
+        """Full flow: quota OK → retry on 503 → success → record both."""
+        cb = CircuitBreaker(failure_threshold=5)
+        qt = QuotaTracker(daily_limit_calls=100)
+        client = _make_client(circuit_breaker=cb, quota_tracker=qt, max_retries=3)
+        mock_post.side_effect = [
+            _mock_response(503),
+            _mock_response(200),
+        ]
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+        assert cb.state == CircuitBreaker.CLOSED
+        assert qt.get_stats().daily_calls == 1
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_no_tracker_no_breaker_still_works(self, mock_post):
+        """Client without tracker/breaker should work normally."""
+        client = _make_client()
+        mock_post.return_value = _mock_response(200)
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "Merhaba efendim!"
+
+
+# ======================================================================
+# Edge Cases
+# ======================================================================
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_missing_api_key_raises_immediately(self):
+        client = GeminiClient(api_key="", model="test")
+        with pytest.raises(LLMConnectionError, match="API key missing"):
+            client.chat_detailed([LLMMessage(role="user", content="x")])
+
+    def test_missing_model_raises_immediately(self):
+        client = GeminiClient(api_key="key", model="")
+        with pytest.raises(LLMInvalidResponseError, match="model not set"):
+            client.chat_detailed([LLMMessage(role="user", content="x")])
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_response_with_no_usage_metadata(self, mock_post):
+        """Response without usageMetadata should still work."""
+        mock_post.return_value = _mock_response(
+            200,
+            json_data={
+                "candidates": [
+                    {"content": {"parts": [{"text": "OK"}]}, "finishReason": "STOP"}
+                ]
+            },
+        )
+        client = _make_client()
+        result = client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert result.content == "OK"
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_rate_limit_warning_logged(self, mock_post, caplog):
+        """When X-RateLimit-Remaining is low, a warning should be logged."""
+        mock_post.return_value = _mock_response(
+            200, headers={"X-RateLimit-Remaining": "3"}
+        )
+        client = _make_client()
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="bantz.llm.gemini_client"):
+            client.chat_detailed([LLMMessage(role="user", content="test")])
+        assert "nearly exhausted" in caplog.text
+
+    def test_retryable_status_codes_constant(self):
+        """Ensure the retryable codes include expected values."""
+        assert 429 in RETRYABLE_STATUS_CODES
+        assert 500 in RETRYABLE_STATUS_CODES
+        assert 502 in RETRYABLE_STATUS_CODES
+        assert 503 in RETRYABLE_STATUS_CODES
+        assert 401 not in RETRYABLE_STATUS_CODES
+        assert 404 not in RETRYABLE_STATUS_CODES

--- a/tests/test_quality_finalizer_issue_215.py
+++ b/tests/test_quality_finalizer_issue_215.py
@@ -195,11 +195,13 @@ def test_gemini_client_emits_metrics_and_reason_codes(monkeypatch: pytest.Monkey
     # Rate-limited reason code
     class _Resp429:
         status_code = 429
+        headers = {}
 
         def json(self):
             return {}
 
     monkeypatch.setattr("requests.post", lambda *_a, **_k: _Resp429())
+    monkeypatch.setattr("bantz.llm.gemini_client.time.sleep", lambda _: None)
 
     with pytest.raises(LLMConnectionError) as ei:
         c.complete_text(prompt="hello", temperature=0.0, max_tokens=5)


### PR DESCRIPTION
## Summary

Implements Gemini API rate-limit handling, quota management, and circuit breaker (Issue #410).

## Changes

### New: `src/bantz/llm/quota_tracker.py`
- **QuotaTracker**: Daily/monthly API call + token tracking with automatic midnight/month reset
- **CircuitBreaker**: 3-state machine (CLOSED → OPEN → HALF_OPEN) with configurable failure threshold and reset timeout
- Thread-safe implementations with `threading.Lock`
- Custom exceptions: `QuotaExceeded`, `CircuitOpen`

### Updated: `src/bantz/llm/gemini_client.py`
- **Exponential backoff retry**: Max 3 attempts for retryable codes (429, 500, 502, 503) and timeouts
- **Retry-After header**: Honoured when present, capped at 30s
- **X-RateLimit-Remaining**: Parsed and logged as warning when ≤5 remaining
- **Circuit breaker pre-flight**: Blocks calls when Gemini is repeatedly failing → immediate fallback
- **Quota pre-flight**: Blocks calls when daily/monthly limits are exceeded
- **Turkish user messages**: "Gemini quota aşıldı, yerel model kullanılıyor" / "Gemini geçici olarak devre dışı"
- **Backoff jitter**: ±25% to prevent thundering herd

### Tests: `tests/test_issue_410_gemini_rate_limit.py` (65 tests)
- QuotaTracker: limits, auto-reset, thread safety, stats snapshots
- CircuitBreaker: state transitions, threshold, timeout, probe success/failure, manual reset
- Backoff: jitter range, exponential growth, cap, Retry-After honour
- Header parsing: X-RateLimit-Remaining, Retry-After (standard + lowercase + missing + invalid)
- GeminiClient retry: 429/500/503 retry-then-succeed, all-retries-exhausted, non-retryable (401/404/400)
- Circuit breaker integration: open blocks call, success resets, exhaustion opens circuit
- Quota integration: exceeded blocks call, success records usage, failure doesn't record
- Full integration: CB → Quota → HTTP ordering, combined retry+CB+quota flow

Closes #410
