### PR TITLE
feat(#412): Unified HybridOrchestrator — consolidate 3 orchestrators

### DIFF
--- a/src/bantz/brain/flexible_hybrid_orchestrator.py
+++ b/src/bantz/brain/flexible_hybrid_orchestrator.py
@@ -134,6 +134,11 @@ class FlexibleHybridConfig:
 class FlexibleHybridOrchestrator:
     """Flexible hybrid orchestrator: 3B router + (Gemini OR 7B) finalizer.
     
+    .. deprecated::
+        Use ``bantz.brain.hybrid_orchestrator.HybridOrchestrator`` instead.
+        ``FlexibleHybridOrchestrator`` will be removed in a future release.
+        See Issue #412 for migration details.
+
     This implements Issue #157:
     - Phase 1: 3B router (fast planning)
     - Phase 2: Tool execution
@@ -164,6 +169,14 @@ class FlexibleHybridOrchestrator:
             finalizer: Finalizer LLM (Gemini or 7B vLLM) - optional for fallback mode
             config: Configuration (uses defaults if None)
         """
+        import warnings
+        warnings.warn(
+            "FlexibleHybridOrchestrator is deprecated. "
+            "Use bantz.brain.hybrid_orchestrator.HybridOrchestrator instead. "
+            "See Issue #412.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._router_orchestrator = router_orchestrator
         self._finalizer = finalizer
         self._config = config or FlexibleHybridConfig.from_env()

--- a/src/bantz/brain/gemini_hybrid_orchestrator.py
+++ b/src/bantz/brain/gemini_hybrid_orchestrator.py
@@ -204,6 +204,11 @@ class HybridOrchestratorConfig:
 class GeminiHybridOrchestrator:
     """Hybrid orchestrator: 3B router (local) + Gemini finalizer (cloud).
     
+    .. deprecated::
+        Use ``bantz.brain.hybrid_orchestrator.HybridOrchestrator`` instead.
+        ``GeminiHybridOrchestrator`` will be removed in a future release.
+        See Issue #412 for migration details.
+
     This implements the strategy from Issues #131, #134, #135:
     - Fast routing with local 3B model
     - Quality responses with Gemini
@@ -231,6 +236,14 @@ class GeminiHybridOrchestrator:
         gemini_client: GeminiClient,
         config: Optional[HybridOrchestratorConfig] = None,
     ):
+        import warnings
+        warnings.warn(
+            "GeminiHybridOrchestrator is deprecated. "
+            "Use bantz.brain.hybrid_orchestrator.HybridOrchestrator instead. "
+            "See Issue #412.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._router = router
         self._gemini = gemini_client
         self._config = config or HybridOrchestratorConfig()

--- a/src/bantz/brain/hybrid_orchestrator.py
+++ b/src/bantz/brain/hybrid_orchestrator.py
@@ -1,0 +1,531 @@
+"""Unified Hybrid Orchestrator — 3B Router + Quality Finalizer (Issue #412).
+
+Consolidates GeminiHybridOrchestrator and FlexibleHybridOrchestrator into
+a single ``HybridOrchestrator`` class.
+
+Features (best of both):
+  - From GeminiHybridOrchestrator: no-new-facts guard, smart tool result
+    summarisation (2KB cap), two-phase plan()+finalize() API
+  - From FlexibleHybridOrchestrator: env-based config, finalizer availability
+    check, 3B fallback, finalizer type selection (Gemini / vLLM 7B)
+
+Usage:
+    >>> orchestrator = HybridOrchestrator(
+    ...     router=router_client,
+    ...     finalizer=gemini_client,
+    ...     config=HybridConfig(finalizer_type="gemini"),
+    ... )
+    >>> plan_output = orchestrator.plan("bugün toplantılarım neler?")
+    >>> # ... execute tools ...
+    >>> final_output = orchestrator.finalize(plan_output, tool_results=[...])
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Literal, Optional, Protocol
+
+from bantz.brain.llm_router import JarvisLLMOrchestrator, OrchestratorOutput
+from bantz.llm.base import LLMClient, LLMMessage
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "HybridOrchestrator",
+    "HybridConfig",
+    "create_hybrid_orchestrator",
+]
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+class FinalizerProtocol(Protocol):
+    """Protocol for any finalizer LLM (Gemini, vLLM 7B, etc.)."""
+
+    def chat_detailed(
+        self,
+        messages: list[LLMMessage],
+        *,
+        temperature: float = 0.4,
+        max_tokens: int = 512,
+    ) -> Any: ...
+
+    def is_available(self, *, timeout_seconds: float = 1.5) -> bool: ...
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class HybridConfig:
+    """Configuration for unified HybridOrchestrator.
+
+    Attributes:
+        finalizer_type: ``"gemini"`` or ``"vllm_7b"``
+        finalizer_model: Model name (e.g. ``gemini-1.5-flash``)
+        finalizer_temperature: Sampling temperature for finalizer
+        finalizer_max_tokens: Max output tokens for finalizer
+        router_temperature: Temperature for 3B router (0.0 = deterministic)
+        router_max_tokens: Max output tokens for router
+        fallback_to_3b: Use 3B router reply when finalizer fails
+        confidence_threshold: Minimum confidence to execute tools
+        no_new_facts_guard: Enable hallucination guard retry (Issue #357)
+        tool_results_max_chars: Max chars for tool result context
+    """
+
+    finalizer_type: Literal["gemini", "vllm_7b"] = "gemini"
+    finalizer_model: str = "gemini-1.5-flash"
+    finalizer_temperature: float = 0.4
+    finalizer_max_tokens: int = 512
+
+    router_temperature: float = 0.0
+    router_max_tokens: int = 512
+
+    fallback_to_3b: bool = True
+    confidence_threshold: float = 0.7
+    no_new_facts_guard: bool = True
+    tool_results_max_chars: int = 2000
+
+    @classmethod
+    def from_env(cls) -> "HybridConfig":
+        """Create config from environment variables.
+
+        Env vars:
+          BANTZ_FINALIZER_TYPE: ``gemini`` | ``vllm_7b`` (default: gemini)
+          BANTZ_FINALIZER_MODEL: override model name
+          BANTZ_NO_NEW_FACTS_GUARD: ``0`` to disable
+        """
+        ft = os.getenv("BANTZ_FINALIZER_TYPE", "gemini").strip().lower()
+        if ft not in {"gemini", "vllm_7b"}:
+            logger.warning("[HYBRID] Invalid BANTZ_FINALIZER_TYPE=%s, defaulting to gemini", ft)
+            ft = "gemini"
+
+        model = os.getenv("BANTZ_FINALIZER_MODEL", "").strip()
+        if not model:
+            model = "gemini-1.5-flash" if ft == "gemini" else "Qwen/Qwen2.5-7B-Instruct"
+
+        guard_str = os.getenv("BANTZ_NO_NEW_FACTS_GUARD", "1").strip().lower()
+        guard = guard_str not in {"0", "false", "no", "off"}
+
+        return cls(
+            finalizer_type=ft,  # type: ignore[arg-type]
+            finalizer_model=model,
+            no_new_facts_guard=guard,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool result summarisation (from GeminiHybridOrchestrator)
+# ---------------------------------------------------------------------------
+
+def summarize_tool_results(
+    tool_results: list[dict[str, Any]],
+    max_chars: int = 2000,
+) -> tuple[str, bool]:
+    """Summarize tool results for finalizer context, preventing overflow.
+
+    Smart truncation strategy:
+      - Lists: first 5 items + metadata
+      - Dicts with ``events``: calendar-aware preview (5 events)
+      - Large strings/dicts: 500-char preview
+      - Fallback: keep only first 3 tools if still too large
+
+    Returns:
+        ``(summary_string, was_truncated)``
+    """
+    if not tool_results:
+        return "", False
+
+    def _truncate(result: Any, max_size: int = 500) -> tuple[Any, bool]:
+        if isinstance(result, list):
+            if len(result) > 5:
+                return {
+                    "_preview": result[:5],
+                    "_truncated": True,
+                    "_total_count": len(result),
+                    "_message": f"Showing first 5 of {len(result)} items",
+                }, True
+            return result, False
+        if isinstance(result, dict):
+            if "events" in result and isinstance(result["events"], list):
+                events = result["events"]
+                if len(events) > 5:
+                    return {
+                        "events": events[:5],
+                        "_preview": True,
+                        "_total_events": len(events),
+                        "_message": f"Showing first 5 of {len(events)} events",
+                        **{k: v for k, v in result.items() if k != "events"},
+                    }, True
+                return result, False
+            s = json.dumps(result, ensure_ascii=False)
+            if len(s) > max_size:
+                return f"{s[:max_size]}… (truncated from {len(s)} chars)", True
+            return result, False
+        if isinstance(result, str) and len(result) > max_size:
+            return f"{result[:max_size]}… (truncated from {len(result)} chars)", True
+        return result, False
+
+    summarized: list[dict] = []
+    truncated_any = False
+    for tr in tool_results:
+        row = dict(tr)
+        if "result" in row:
+            row["result"], t = _truncate(row["result"])
+            truncated_any = truncated_any or t
+        summarized.append(row)
+
+    try:
+        out = json.dumps(summarized, ensure_ascii=False)
+    except (TypeError, ValueError):
+        out = str(summarized)
+        truncated_any = True
+
+    if len(out) > max_chars:
+        truncated_any = True
+        agg: list[dict] = []
+        for tr in tool_results[:3]:
+            a: dict = {"tool_name": tr.get("tool_name", "?"), "status": tr.get("status", "?")}
+            if "result" in tr:
+                a["result"], _ = _truncate(tr["result"], 200)
+            agg.append(a)
+        try:
+            out = json.dumps(agg, ensure_ascii=False)
+        except (TypeError, ValueError):
+            out = str(agg)
+        if len(out) > max_chars:
+            out = out[:max_chars] + "… (truncated)"
+
+    return out, truncated_any
+
+
+# ---------------------------------------------------------------------------
+# No-new-facts guard (from GeminiHybridOrchestrator)
+# ---------------------------------------------------------------------------
+
+_NO_NEW_FACTS_SYSTEM = (
+    "Sadece verilen TOOL RESULTS bilgisine dayanarak cevap ver. "
+    "Eğer tool sonuçlarında olmayan yeni bilgiler üretirsen cevabın reddedilecek. "
+    "Bilinmeyen detayları uydurmak yerine 'bilmiyorum' de."
+)
+
+
+def _check_no_new_facts(response: str, tool_summary: str) -> bool:
+    """Heuristic: does the response appear to fabricate facts?
+
+    Very simple check — look for date/time patterns in the response that
+    don't appear in the tool summary.
+    """
+    import re
+
+    date_pattern = re.compile(r"\d{1,2}[./]\d{1,2}[./]\d{2,4}")
+    time_pattern = re.compile(r"\d{1,2}:\d{2}")
+
+    resp_dates = set(date_pattern.findall(response))
+    resp_times = set(time_pattern.findall(response))
+    tool_dates = set(date_pattern.findall(tool_summary))
+    tool_times = set(time_pattern.findall(tool_summary))
+
+    new_dates = resp_dates - tool_dates
+    new_times = resp_times - tool_times
+
+    if new_dates or new_times:
+        logger.warning(
+            "[HYBRID] No-new-facts violation: new_dates=%s new_times=%s",
+            new_dates,
+            new_times,
+        )
+        return False  # violated
+    return True  # ok
+
+
+# ---------------------------------------------------------------------------
+# HybridOrchestrator
+# ---------------------------------------------------------------------------
+
+class HybridOrchestrator:
+    """Unified hybrid orchestrator: 3B Router + Quality Finalizer.
+
+    Merges the capabilities of ``GeminiHybridOrchestrator`` and
+    ``FlexibleHybridOrchestrator`` into a single, well-tested class.
+
+    Two-phase API (recommended):
+      1. ``plan(user_input)`` → ``OrchestratorOutput`` (from 3B router)
+      2. Execute tools externally
+      3. ``finalize(plan_output, tool_results=...)`` → ``OrchestratorOutput``
+
+    Single-call API:
+      - ``orchestrate(user_input=..., tool_results=...)``
+    """
+
+    def __init__(
+        self,
+        *,
+        router: LLMClient,
+        finalizer: Optional[FinalizerProtocol] = None,
+        config: Optional[HybridConfig] = None,
+    ):
+        self._router_orchestrator = JarvisLLMOrchestrator(llm_client=router)
+        self._finalizer = finalizer
+        self._config = config or HybridConfig.from_env()
+        self._finalizer_available = self._check_finalizer()
+
+        logger.info(
+            "[HYBRID] finalizer=%s model=%s available=%s fallback=%s guard=%s",
+            self._config.finalizer_type,
+            self._config.finalizer_model,
+            self._finalizer_available,
+            self._config.fallback_to_3b,
+            self._config.no_new_facts_guard,
+        )
+
+    # ---- availability -------------------------------------------------
+
+    def _check_finalizer(self) -> bool:
+        if self._finalizer is None:
+            return False
+        try:
+            return self._finalizer.is_available(timeout_seconds=1.5)
+        except Exception:
+            return False
+
+    @property
+    def finalizer_available(self) -> bool:
+        return self._finalizer_available
+
+    # ---- two-phase API ------------------------------------------------
+
+    def plan(
+        self,
+        user_input: str,
+        *,
+        dialog_summary: str = "",
+    ) -> OrchestratorOutput:
+        """Phase 1: Route and extract intent/slots via 3B router."""
+        logger.info("[HYBRID] Phase-1 plan: '%s'", user_input[:60])
+        return self._router_orchestrator.route(
+            user_input=user_input,
+            dialog_summary=dialog_summary,
+        )
+
+    def finalize(
+        self,
+        plan_output: OrchestratorOutput,
+        *,
+        user_input: str = "",
+        dialog_summary: str = "",
+        tool_results: Optional[list[dict[str, Any]]] = None,
+    ) -> OrchestratorOutput:
+        """Phase 3: Generate natural-language response via finalizer.
+
+        If the finalizer is unavailable or fails, falls back to the 3B
+        router's ``assistant_reply`` (if ``fallback_to_3b`` is enabled).
+        """
+        final_text = self._do_finalize(
+            plan_output=plan_output,
+            user_input=user_input or plan_output.raw_output.get("user_input", ""),
+            dialog_summary=dialog_summary,
+            tool_results=tool_results,
+        )
+
+        return OrchestratorOutput(
+            route=plan_output.route,
+            calendar_intent=plan_output.calendar_intent,
+            slots=plan_output.slots,
+            confidence=plan_output.confidence,
+            tool_plan=plan_output.tool_plan,
+            assistant_reply=final_text,
+            ask_user=plan_output.ask_user,
+            question=plan_output.question,
+            requires_confirmation=plan_output.requires_confirmation,
+            confirmation_prompt=plan_output.confirmation_prompt,
+            memory_update=plan_output.memory_update,
+            reasoning_summary=plan_output.reasoning_summary,
+            raw_output={
+                "router": plan_output.raw_output,
+                "finalizer_type": self._active_finalizer_type,
+            },
+        )
+
+    # ---- single-call API (convenience) --------------------------------
+
+    def orchestrate(
+        self,
+        *,
+        user_input: str,
+        dialog_summary: str = "",
+        tool_results: Optional[list[dict[str, Any]]] = None,
+    ) -> OrchestratorOutput:
+        """Plan + finalize in one call."""
+        plan_out = self.plan(user_input, dialog_summary=dialog_summary)
+        return self.finalize(
+            plan_out,
+            user_input=user_input,
+            dialog_summary=dialog_summary,
+            tool_results=tool_results,
+        )
+
+    # ---- internals ----------------------------------------------------
+
+    def _do_finalize(
+        self,
+        *,
+        plan_output: OrchestratorOutput,
+        user_input: str,
+        dialog_summary: str,
+        tool_results: Optional[list[dict[str, Any]]],
+    ) -> str:
+        if not self._finalizer_available:
+            logger.warning("[HYBRID] Finalizer unavailable — 3B fallback")
+            return self._fallback(plan_output)
+
+        try:
+            return self._call_finalizer(
+                plan_output=plan_output,
+                user_input=user_input,
+                dialog_summary=dialog_summary,
+                tool_results=tool_results,
+            )
+        except Exception as exc:
+            logger.error("[HYBRID] Finalizer error: %s", exc)
+            if self._config.fallback_to_3b:
+                logger.warning("[HYBRID] Falling back to 3B router response")
+                return self._fallback(plan_output)
+            raise
+
+    def _call_finalizer(
+        self,
+        *,
+        plan_output: OrchestratorOutput,
+        user_input: str,
+        dialog_summary: str,
+        tool_results: Optional[list[dict[str, Any]]],
+    ) -> str:
+        # Build tool summary
+        tool_summary = ""
+        was_truncated = False
+        if tool_results:
+            tool_summary, was_truncated = summarize_tool_results(
+                tool_results, max_chars=self._config.tool_results_max_chars
+            )
+
+        # Build messages
+        system_prompt = self._build_system_prompt(
+            has_tool_results=bool(tool_results),
+            no_new_facts=self._config.no_new_facts_guard and bool(tool_results),
+        )
+        user_prompt = self._build_user_prompt(
+            plan_output=plan_output,
+            user_input=user_input,
+            dialog_summary=dialog_summary,
+            tool_summary=tool_summary,
+        )
+
+        messages = [
+            LLMMessage(role="system", content=system_prompt),
+            LLMMessage(role="user", content=user_prompt),
+        ]
+
+        response = self._finalizer.chat_detailed(
+            messages=messages,
+            temperature=self._config.finalizer_temperature,
+            max_tokens=self._config.finalizer_max_tokens,
+        )
+        text = (response.content or "").strip()
+
+        # No-new-facts guard
+        if self._config.no_new_facts_guard and tool_summary and text:
+            if not _check_no_new_facts(text, tool_summary):
+                logger.warning("[HYBRID] No-new-facts guard triggered — retrying with strict prompt")
+                strict_msgs = [
+                    LLMMessage(role="system", content=_NO_NEW_FACTS_SYSTEM),
+                    LLMMessage(role="user", content=user_prompt),
+                ]
+                retry_resp = self._finalizer.chat_detailed(
+                    messages=strict_msgs,
+                    temperature=max(0.1, self._config.finalizer_temperature - 0.2),
+                    max_tokens=self._config.finalizer_max_tokens,
+                )
+                text = (retry_resp.content or "").strip()
+
+        return text
+
+    @property
+    def _active_finalizer_type(self) -> str:
+        if not self._finalizer_available:
+            return "3b_fallback"
+        return self._config.finalizer_type
+
+    @staticmethod
+    def _fallback(plan_output: OrchestratorOutput) -> str:
+        return plan_output.assistant_reply or "Üzgünüm efendim, bir sorun oluştu."
+
+    @staticmethod
+    def _build_system_prompt(*, has_tool_results: bool, no_new_facts: bool) -> str:
+        base = (
+            "Sen BANTZ'sın — Jarvis tarzı Türkçe asistan.\n\n"
+            "Kurallar:\n"
+            "- \"Efendim\" hitabı kullan\n"
+            "- Nazik, profesyonel ama samimi\n"
+            "- Kısa ve öz cevaplar (1-2 cümle ideal)\n"
+            "- Türkçe doğal konuş\n"
+        )
+        if has_tool_results:
+            base += "\nTakvim/araç sonuçlarını kullanıcıya kısa ve öz aktar.\n"
+        if no_new_facts:
+            base += (
+                "\nÖNEMLİ: Sadece TOOL RESULTS bilgisine dayanarak cevap ver. "
+                "Yeni bilgi UYDURMAK YASAK.\n"
+            )
+        return base
+
+    @staticmethod
+    def _build_user_prompt(
+        *,
+        plan_output: OrchestratorOutput,
+        user_input: str,
+        dialog_summary: str,
+        tool_summary: str,
+    ) -> str:
+        parts: list[str] = []
+        if dialog_summary:
+            parts.append(f"Dialog Context:\n{dialog_summary}")
+        parts.append(f"User: {user_input}")
+        if plan_output.route == "calendar":
+            parts.append(f"Intent: {plan_output.calendar_intent}")
+            if plan_output.slots:
+                parts.append(f"Slots: {json.dumps(plan_output.slots, ensure_ascii=False)}")
+        if tool_summary:
+            parts.append(f"Tool Results:\n{tool_summary}")
+        parts.append("Yanıtını Türkçe ver:")
+        return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def create_hybrid_orchestrator(
+    *,
+    router: LLMClient,
+    finalizer: Optional[LLMClient] = None,
+    config: Optional[HybridConfig] = None,
+) -> HybridOrchestrator:
+    """Create a unified HybridOrchestrator.
+
+    Args:
+        router: 3B router LLM client.
+        finalizer: Finalizer LLM client (Gemini or 7B vLLM).
+        config: Optional configuration (falls back to env vars).
+    """
+    return HybridOrchestrator(
+        router=router,
+        finalizer=finalizer,
+        config=config or HybridConfig.from_env(),
+    )

--- a/tests/test_issue_412_orchestrator_consolidation.py
+++ b/tests/test_issue_412_orchestrator_consolidation.py
@@ -1,0 +1,460 @@
+"""Tests for Issue #412: Unified HybridOrchestrator.
+
+Tests cover:
+  - HybridConfig: defaults, from_env, env overrides
+  - HybridOrchestrator: plan, finalize, orchestrate, fallback, no-new-facts guard
+  - summarize_tool_results: truncation strategies
+  - Deprecation warnings for GeminiHybridOrchestrator & FlexibleHybridOrchestrator
+  - create_hybrid_orchestrator factory
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import warnings
+from dataclasses import dataclass
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.brain.hybrid_orchestrator import (
+    HybridOrchestrator,
+    HybridConfig,
+    create_hybrid_orchestrator,
+    summarize_tool_results,
+    _check_no_new_facts,
+)
+from bantz.brain.llm_router import OrchestratorOutput
+from bantz.llm.base import LLMClient, LLMMessage, LLMResponse
+
+
+# ======================================================================
+# Mock helpers
+# ======================================================================
+
+
+class MockRouterClient(LLMClient):
+    """Mock 3B router that returns a canned JSON plan."""
+
+    def __init__(self, route="calendar", intent="query_events"):
+        self._route = route
+        self._intent = intent
+
+    @property
+    def model_name(self) -> str:
+        return "mock-3b"
+
+    @property
+    def backend_name(self) -> str:
+        return "mock"
+
+    def is_available(self, *, timeout_seconds: float = 1.5) -> bool:
+        return True
+
+    def chat(self, messages, *, temperature=0.4, max_tokens=512) -> str:
+        return json.dumps({
+            "route": self._route,
+            "calendar_intent": self._intent,
+            "confidence": 0.9,
+            "assistant_reply": "Router cevabı efendim.",
+            "tool_plan": [],
+            "slots": {"date": "today"},
+        })
+
+    def chat_detailed(self, messages, *, temperature=0.4, max_tokens=512, seed=None) -> LLMResponse:
+        return LLMResponse(content=self.chat(messages), model="mock-3b", tokens_used=10)
+
+    def complete_text(self, *, prompt, temperature=0.0, max_tokens=200) -> str:
+        return self.chat([LLMMessage(role="user", content=prompt)])
+
+
+class MockFinalizer:
+    """Mock finalizer that returns a canned response."""
+
+    def __init__(self, response="Merhaba efendim!", available=True):
+        self._response = response
+        self._available = available
+        self.call_count = 0
+        self.last_messages = None
+
+    def chat_detailed(self, messages, *, temperature=0.4, max_tokens=512) -> LLMResponse:
+        self.call_count += 1
+        self.last_messages = messages
+        return LLMResponse(content=self._response, model="mock-finalizer", tokens_used=5, finish_reason="stop")
+
+    def is_available(self, *, timeout_seconds=1.5) -> bool:
+        return self._available
+
+
+class FailingFinalizer:
+    """Finalizer that always raises."""
+
+    def chat_detailed(self, messages, **kwargs):
+        raise RuntimeError("Finalizer crashed")
+
+    def is_available(self, **kwargs) -> bool:
+        return True
+
+
+# ======================================================================
+# HybridConfig Tests
+# ======================================================================
+
+
+class TestHybridConfig:
+    def test_defaults(self):
+        c = HybridConfig()
+        assert c.finalizer_type == "gemini"
+        assert c.finalizer_model == "gemini-1.5-flash"
+        assert c.fallback_to_3b is True
+        assert c.no_new_facts_guard is True
+        assert c.tool_results_max_chars == 2000
+
+    def test_from_env_gemini(self, monkeypatch):
+        monkeypatch.delenv("BANTZ_FINALIZER_TYPE", raising=False)
+        monkeypatch.delenv("BANTZ_FINALIZER_MODEL", raising=False)
+        c = HybridConfig.from_env()
+        assert c.finalizer_type == "gemini"
+        assert c.finalizer_model == "gemini-1.5-flash"
+
+    def test_from_env_vllm_7b(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_FINALIZER_TYPE", "vllm_7b")
+        monkeypatch.delenv("BANTZ_FINALIZER_MODEL", raising=False)
+        c = HybridConfig.from_env()
+        assert c.finalizer_type == "vllm_7b"
+        assert c.finalizer_model == "Qwen/Qwen2.5-7B-Instruct"
+
+    def test_from_env_custom_model(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_FINALIZER_TYPE", "gemini")
+        monkeypatch.setenv("BANTZ_FINALIZER_MODEL", "gemini-2.0-flash")
+        c = HybridConfig.from_env()
+        assert c.finalizer_model == "gemini-2.0-flash"
+
+    def test_from_env_invalid_type_defaults_gemini(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_FINALIZER_TYPE", "invalid")
+        c = HybridConfig.from_env()
+        assert c.finalizer_type == "gemini"
+
+    def test_from_env_guard_disabled(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_NO_NEW_FACTS_GUARD", "0")
+        c = HybridConfig.from_env()
+        assert c.no_new_facts_guard is False
+
+    def test_from_env_guard_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("BANTZ_NO_NEW_FACTS_GUARD", raising=False)
+        c = HybridConfig.from_env()
+        assert c.no_new_facts_guard is True
+
+
+# ======================================================================
+# HybridOrchestrator Tests
+# ======================================================================
+
+
+class TestHybridOrchestratorPlan:
+    def test_plan_returns_router_output(self):
+        router = MockRouterClient(route="calendar", intent="query_events")
+        o = HybridOrchestrator(router=router, config=HybridConfig())
+        out = o.plan("bugün toplantılarım neler?")
+        assert out.route == "calendar"
+        assert out.calendar_intent == "query_events"
+        assert out.confidence == 0.9
+
+    def test_plan_smalltalk(self):
+        router = MockRouterClient(route="smalltalk", intent="")
+        o = HybridOrchestrator(router=router, config=HybridConfig())
+        out = o.plan("nasılsın?")
+        assert out.route == "smalltalk"
+
+
+class TestHybridOrchestratorFinalize:
+    def test_finalize_uses_finalizer(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer(response="3 toplantınız var efendim.")
+        o = HybridOrchestrator(router=router, finalizer=finalizer, config=HybridConfig())
+        plan_out = o.plan("bugün toplantılarım?")
+        result = o.finalize(plan_out, user_input="bugün toplantılarım?")
+        assert result.assistant_reply == "3 toplantınız var efendim."
+        assert finalizer.call_count == 1
+
+    def test_finalize_with_tool_results(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer(response="3 etkinlik var efendim.")
+        o = HybridOrchestrator(router=router, finalizer=finalizer, config=HybridConfig())
+        plan_out = o.plan("bugün?")
+        tool_results = [{"tool_name": "calendar.list", "status": "success", "result": {"events": []}}]
+        result = o.finalize(plan_out, user_input="bugün?", tool_results=tool_results)
+        assert "etkinlik" in result.assistant_reply
+
+    def test_finalize_preserves_route_metadata(self):
+        router = MockRouterClient(route="calendar", intent="create_event")
+        finalizer = MockFinalizer(response="Tamam efendim.")
+        o = HybridOrchestrator(router=router, finalizer=finalizer, config=HybridConfig())
+        plan_out = o.plan("toplantı ekle")
+        result = o.finalize(plan_out, user_input="toplantı ekle")
+        assert result.route == "calendar"
+        assert result.calendar_intent == "create_event"
+        assert result.slots == {"date": "today"}
+
+    def test_finalize_fallback_on_error(self):
+        router = MockRouterClient()
+        finalizer = FailingFinalizer()
+        o = HybridOrchestrator(
+            router=router, finalizer=finalizer,
+            config=HybridConfig(fallback_to_3b=True),
+        )
+        plan_out = o.plan("test")
+        result = o.finalize(plan_out, user_input="test")
+        assert result.assistant_reply == "Router cevabı efendim."
+
+    def test_finalize_no_fallback_raises(self):
+        router = MockRouterClient()
+        finalizer = FailingFinalizer()
+        o = HybridOrchestrator(
+            router=router, finalizer=finalizer,
+            config=HybridConfig(fallback_to_3b=False),
+        )
+        plan_out = o.plan("test")
+        with pytest.raises(RuntimeError, match="Finalizer crashed"):
+            o.finalize(plan_out, user_input="test")
+
+    def test_finalize_unavailable_finalizer_fallback(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer(available=False)
+        o = HybridOrchestrator(
+            router=router, finalizer=finalizer,
+            config=HybridConfig(fallback_to_3b=True),
+        )
+        plan_out = o.plan("test")
+        result = o.finalize(plan_out, user_input="test")
+        assert result.assistant_reply == "Router cevabı efendim."
+        assert finalizer.call_count == 0
+
+    def test_finalize_no_finalizer_fallback(self):
+        router = MockRouterClient()
+        o = HybridOrchestrator(router=router, finalizer=None, config=HybridConfig())
+        plan_out = o.plan("test")
+        result = o.finalize(plan_out, user_input="test")
+        assert result.assistant_reply == "Router cevabı efendim."
+
+
+class TestHybridOrchestratorOrchestrate:
+    def test_orchestrate_combines_plan_and_finalize(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer(response="Tamam efendim.")
+        o = HybridOrchestrator(router=router, finalizer=finalizer, config=HybridConfig())
+        result = o.orchestrate(user_input="merhaba")
+        assert result.assistant_reply == "Tamam efendim."
+        assert result.route == "calendar"
+
+    def test_orchestrate_with_tool_results(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer(response="İşlem tamam.")
+        o = HybridOrchestrator(router=router, finalizer=finalizer, config=HybridConfig())
+        result = o.orchestrate(
+            user_input="test",
+            tool_results=[{"tool_name": "t", "status": "ok", "result": "done"}],
+        )
+        assert result.assistant_reply == "İşlem tamam."
+
+
+# ======================================================================
+# No-New-Facts Guard Tests
+# ======================================================================
+
+
+class TestNoNewFactsGuard:
+    def test_no_violation(self):
+        assert _check_no_new_facts("Toplantınız saat 14:00'te.", "14:00 meeting") is True
+
+    def test_date_violation(self):
+        assert _check_no_new_facts("25/12/2025 tarihinde.", "") is False
+
+    def test_time_violation(self):
+        assert _check_no_new_facts("Saat 09:30'da.", "") is False
+
+    def test_matching_date_ok(self):
+        assert _check_no_new_facts("25/12/2025 tarihinde.", "25/12/2025 event") is True
+
+    def test_guard_triggers_retry(self):
+        """When guard detects violation, finalizer should be called twice."""
+        router = MockRouterClient()
+        # First response has fabricated date, second is clean
+        call_count = 0
+
+        class GuardTestFinalizer:
+            def chat_detailed(self, messages, **kwargs) -> LLMResponse:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return LLMResponse(content="Toplantınız 31/12/2099'da.", model="m", tokens_used=5, finish_reason="stop")
+                return LLMResponse(content="Toplantınız var efendim.", model="m", tokens_used=5, finish_reason="stop")
+
+            def is_available(self, **kwargs) -> bool:
+                return True
+
+        o = HybridOrchestrator(
+            router=router,
+            finalizer=GuardTestFinalizer(),
+            config=HybridConfig(no_new_facts_guard=True),
+        )
+        plan_out = o.plan("test")
+        result = o.finalize(
+            plan_out, user_input="test",
+            tool_results=[{"tool_name": "cal", "status": "ok", "result": "events: []"}],
+        )
+        assert call_count == 2
+
+    def test_guard_disabled(self):
+        """With guard disabled, no retry even on fabricated content."""
+        router = MockRouterClient()
+        finalizer = MockFinalizer(response="31/12/2099 toplantı.")
+        o = HybridOrchestrator(
+            router=router, finalizer=finalizer,
+            config=HybridConfig(no_new_facts_guard=False),
+        )
+        plan_out = o.plan("test")
+        result = o.finalize(
+            plan_out, user_input="test",
+            tool_results=[{"tool_name": "cal", "status": "ok", "result": "empty"}],
+        )
+        assert finalizer.call_count == 1
+
+
+# ======================================================================
+# Tool Result Summarization Tests
+# ======================================================================
+
+
+class TestSummarizeToolResults:
+    def test_empty_list(self):
+        s, t = summarize_tool_results([])
+        assert s == ""
+        assert t is False
+
+    def test_simple_results(self):
+        results = [{"tool_name": "cal", "status": "ok", "result": "done"}]
+        s, t = summarize_tool_results(results)
+        assert "cal" in s
+        assert t is False
+
+    def test_list_truncation(self):
+        big_list = list(range(20))
+        results = [{"tool_name": "t", "result": big_list}]
+        s, t = summarize_tool_results(results)
+        assert t is True
+        assert "first 5" in s.lower() or "_truncated" in s
+
+    def test_calendar_event_truncation(self):
+        events = [{"title": f"Event {i}"} for i in range(10)]
+        results = [{"tool_name": "cal", "result": {"events": events}}]
+        s, t = summarize_tool_results(results)
+        assert t is True
+
+    def test_large_string_truncation(self):
+        results = [{"tool_name": "t", "result": "x" * 1000}]
+        s, t = summarize_tool_results(results)
+        assert t is True
+        assert "truncated" in s
+
+    def test_max_chars_respected(self):
+        results = [{"tool_name": f"t{i}", "result": "x" * 500} for i in range(10)]
+        s, t = summarize_tool_results(results, max_chars=500)
+        assert len(s) <= 600  # Allow small overshoot from JSON wrapping
+        assert t is True
+
+
+# ======================================================================
+# Deprecation Warning Tests
+# ======================================================================
+
+
+class TestDeprecationWarnings:
+    def test_gemini_hybrid_orchestrator_warns(self):
+        from bantz.brain.gemini_hybrid_orchestrator import GeminiHybridOrchestrator
+        router = MockRouterClient()
+        gemini = MockFinalizer()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            GeminiHybridOrchestrator(router=router, gemini_client=gemini)
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warnings) >= 1
+            assert "deprecated" in str(dep_warnings[0].message).lower()
+            assert "HybridOrchestrator" in str(dep_warnings[0].message)
+
+    def test_flexible_hybrid_orchestrator_warns(self):
+        from bantz.brain.flexible_hybrid_orchestrator import FlexibleHybridOrchestrator
+        from bantz.brain.llm_router import JarvisLLMOrchestrator
+        router = MockRouterClient()
+        jarvis = JarvisLLMOrchestrator(llm_client=router)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            FlexibleHybridOrchestrator(router_orchestrator=jarvis)
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warnings) >= 1
+            assert "deprecated" in str(dep_warnings[0].message).lower()
+            assert "HybridOrchestrator" in str(dep_warnings[0].message)
+
+
+# ======================================================================
+# Factory Tests
+# ======================================================================
+
+
+class TestCreateHybridOrchestrator:
+    def test_creates_with_defaults(self):
+        router = MockRouterClient()
+        o = create_hybrid_orchestrator(router=router)
+        assert isinstance(o, HybridOrchestrator)
+
+    def test_creates_with_config(self):
+        router = MockRouterClient()
+        config = HybridConfig(finalizer_type="vllm_7b", fallback_to_3b=False)
+        o = create_hybrid_orchestrator(router=router, config=config)
+        assert o._config.finalizer_type == "vllm_7b"
+        assert o._config.fallback_to_3b is False
+
+    def test_creates_with_finalizer(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer()
+        o = create_hybrid_orchestrator(router=router, finalizer=finalizer)
+        assert o.finalizer_available is True
+
+
+# ======================================================================
+# Property / Edge Case Tests
+# ======================================================================
+
+
+class TestEdgeCases:
+    def test_finalizer_available_property(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer(available=True)
+        o = HybridOrchestrator(router=router, finalizer=finalizer, config=HybridConfig())
+        assert o.finalizer_available is True
+
+    def test_finalizer_not_available_property(self):
+        router = MockRouterClient()
+        finalizer = MockFinalizer(available=False)
+        o = HybridOrchestrator(router=router, finalizer=finalizer, config=HybridConfig())
+        assert o.finalizer_available is False
+
+    def test_no_finalizer_property(self):
+        router = MockRouterClient()
+        o = HybridOrchestrator(router=router, finalizer=None, config=HybridConfig())
+        assert o.finalizer_available is False
+
+    def test_fallback_message_when_no_assistant_reply(self):
+        """When router output has empty assistant_reply, use default message."""
+        router = MockRouterClient()
+        # Override router to return empty assistant_reply
+        original_chat = router.chat
+        router.chat = lambda msgs, **kw: json.dumps({
+            "route": "unknown", "confidence": 0.5,
+            "assistant_reply": "", "tool_plan": [], "slots": {},
+        })
+        o = HybridOrchestrator(router=router, finalizer=None, config=HybridConfig())
+        result = o.orchestrate(user_input="test")
+        assert "sorun oluştu" in result.assistant_reply.lower() or result.assistant_reply


### PR DESCRIPTION
## Summary
Consolidates GeminiHybridOrchestrator and FlexibleHybridOrchestrator into a single unified HybridOrchestrator.

## Changes
- **New**: `src/bantz/brain/hybrid_orchestrator.py`
  - `HybridConfig`: frozen dataclass with `from_env()` for env-based configuration
  - `HybridOrchestrator`: two-phase `plan()`+`finalize()` API + single-call `orchestrate()`
  - `summarize_tool_results()`: smart truncation (lists→5 items, events→5, strings→500 chars)
  - `_check_no_new_facts()`: hallucination guard with retry (from GeminiHybrid)
  - `create_hybrid_orchestrator()`: factory function
  - Finalizer availability check with 3B fallback
- **Modified**: Added `DeprecationWarning` to both old orchestrator classes
- **Tests**: 39 tests covering config, plan, finalize, orchestrate, guard, deprecation, factory

## Test Results
```
39 passed in 0.18s
```

Closes #412