### PR TITLE
feat(#413): SQLite-backed memory persistence

### DIFF
--- a/src/bantz/brain/memory_store.py
+++ b/src/bantz/brain/memory_store.py
@@ -1,0 +1,558 @@
+"""Persistent memory store for DialogSummaryManager (Issue #413).
+
+Provides SQLite-backed persistence so that dialog summaries survive
+across session restarts.
+
+Features:
+  - SQLite storage (thread-safe, single file)
+  - Session-aware: each boot creates a new session_id
+  - Configurable via ``MemoryStoreConfig``
+  - PII filter applied before persist
+  - Boot reload: load last N sessions' summaries
+  - JSONL export/import for backup & migration
+
+Usage:
+    >>> store = SQLiteMemoryStore.from_config(MemoryStoreConfig())
+    >>> store.save_turn(session_id, summary)
+    >>> summaries = store.load_recent(max_sessions=3)
+
+Design:
+    - One row per ``CompactSummary`` turn
+    - ``sessions`` table tracks session metadata
+    - ``turns`` table stores individual turn data
+    - ``store.close()`` or context-manager for cleanup
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, Optional
+
+from bantz.brain.memory_lite import CompactSummary, PIIFilter
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MemoryStoreConfig",
+    "SQLiteMemoryStore",
+    "PersistentDialogSummaryManager",
+]
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MemoryStoreConfig:
+    """Configuration for persistent memory store.
+
+    Attributes:
+        db_path: Path to SQLite database file.
+        max_sessions: Max number of past sessions to load on boot.
+        max_turns_per_session: Max turns to keep per session.
+        pii_filter_enabled: Apply PII filter before persisting.
+    """
+
+    db_path: str = "~/.bantz/memory.db"
+    max_sessions: int = 5
+    max_turns_per_session: int = 20
+    pii_filter_enabled: bool = True
+
+    @classmethod
+    def from_env(cls) -> "MemoryStoreConfig":
+        """Create config from environment variables.
+
+        Env vars:
+          BANTZ_MEMORY_DB_PATH: path to SQLite DB (default: ~/.bantz/memory.db)
+          BANTZ_MEMORY_MAX_SESSIONS: max sessions to load (default: 5)
+          BANTZ_MEMORY_MAX_TURNS: max turns per session (default: 20)
+          BANTZ_MEMORY_PII_FILTER: "0" to disable (default: enabled)
+        """
+        db_path = os.getenv("BANTZ_MEMORY_DB_PATH", "~/.bantz/memory.db").strip()
+        max_sessions = int(os.getenv("BANTZ_MEMORY_MAX_SESSIONS", "5"))
+        max_turns = int(os.getenv("BANTZ_MEMORY_MAX_TURNS", "20"))
+        pii_str = os.getenv("BANTZ_MEMORY_PII_FILTER", "1").strip().lower()
+        pii = pii_str not in {"0", "false", "no", "off"}
+        return cls(
+            db_path=db_path,
+            max_sessions=max(1, max_sessions),
+            max_turns_per_session=max(1, max_turns),
+            pii_filter_enabled=pii,
+        )
+
+
+# ---------------------------------------------------------------------------
+# SQLite Memory Store
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id  TEXT PRIMARY KEY,
+    started_at  TEXT NOT NULL,
+    ended_at    TEXT,
+    turn_count  INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS turns (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id      TEXT NOT NULL,
+    turn_number     INTEGER NOT NULL,
+    user_intent     TEXT NOT NULL,
+    action_taken    TEXT NOT NULL,
+    pending_items   TEXT NOT NULL DEFAULT '[]',
+    timestamp       TEXT NOT NULL,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_turns_session ON turns(session_id);
+CREATE INDEX IF NOT EXISTS idx_turns_created ON turns(created_at);
+"""
+
+
+class SQLiteMemoryStore:
+    """SQLite-backed persistent memory store for dialog summaries.
+
+    Thread-safe via ``check_same_thread=False`` and WAL journal mode.
+    """
+
+    def __init__(self, db_path: str):
+        """Initialize store and create schema.
+
+        Args:
+            db_path: Path to SQLite database file. ``~`` is expanded.
+                     Parent directories are created automatically.
+        """
+        self._db_path = str(Path(db_path).expanduser())
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        self._conn = sqlite3.connect(
+            self._db_path,
+            check_same_thread=False,
+            isolation_level="DEFERRED",
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA_SQL)
+        self._conn.commit()
+        logger.info("[MEMORY_STORE] Opened SQLite store at %s", self._db_path)
+
+    @classmethod
+    def from_config(cls, config: MemoryStoreConfig) -> "SQLiteMemoryStore":
+        """Create from config."""
+        return cls(db_path=config.db_path)
+
+    # ---- session management -------------------------------------------
+
+    def create_session(self) -> str:
+        """Create a new session and return its ID."""
+        session_id = str(uuid.uuid4())[:12]
+        now = datetime.now().isoformat()
+        self._conn.execute(
+            "INSERT INTO sessions (session_id, started_at) VALUES (?, ?)",
+            (session_id, now),
+        )
+        self._conn.commit()
+        logger.info("[MEMORY_STORE] Created session %s", session_id)
+        return session_id
+
+    def end_session(self, session_id: str) -> None:
+        """Mark a session as ended."""
+        now = datetime.now().isoformat()
+        self._conn.execute(
+            "UPDATE sessions SET ended_at = ? WHERE session_id = ?",
+            (now, session_id),
+        )
+        self._conn.commit()
+
+    # ---- turn persistence ---------------------------------------------
+
+    def save_turn(
+        self,
+        session_id: str,
+        summary: CompactSummary,
+        *,
+        pii_filter: bool = True,
+    ) -> None:
+        """Persist a single turn summary.
+
+        Args:
+            session_id: Current session ID.
+            summary: The turn summary to save.
+            pii_filter: Apply PII filter before saving.
+        """
+        user_intent = summary.user_intent
+        action_taken = summary.action_taken
+        pending = list(summary.pending_items)
+
+        if pii_filter:
+            user_intent = PIIFilter.filter(user_intent)
+            action_taken = PIIFilter.filter(action_taken)
+            pending = [PIIFilter.filter(p) for p in pending]
+
+        self._conn.execute(
+            """INSERT INTO turns
+               (session_id, turn_number, user_intent, action_taken, pending_items, timestamp)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                session_id,
+                summary.turn_number,
+                user_intent,
+                action_taken,
+                json.dumps(pending, ensure_ascii=False),
+                summary.timestamp.isoformat(),
+            ),
+        )
+        self._conn.execute(
+            "UPDATE sessions SET turn_count = turn_count + 1 WHERE session_id = ?",
+            (session_id,),
+        )
+        self._conn.commit()
+
+    # ---- loading ------------------------------------------------------
+
+    def load_session_turns(self, session_id: str) -> list[CompactSummary]:
+        """Load all turns for a specific session."""
+        cursor = self._conn.execute(
+            """SELECT turn_number, user_intent, action_taken, pending_items, timestamp
+               FROM turns WHERE session_id = ? ORDER BY turn_number ASC""",
+            (session_id,),
+        )
+        return [self._row_to_summary(row) for row in cursor.fetchall()]
+
+    def load_recent(
+        self,
+        max_sessions: int = 5,
+        max_turns_per_session: int = 20,
+    ) -> list[tuple[str, list[CompactSummary]]]:
+        """Load recent sessions with their turns.
+
+        Returns list of ``(session_id, [summaries])`` ordered by most recent first.
+        """
+        cursor = self._conn.execute(
+            """SELECT session_id FROM sessions
+               ORDER BY started_at DESC LIMIT ?""",
+            (max_sessions,),
+        )
+        sessions = [row[0] for row in cursor.fetchall()]
+
+        result: list[tuple[str, list[CompactSummary]]] = []
+        for sid in sessions:
+            turns_cursor = self._conn.execute(
+                """SELECT turn_number, user_intent, action_taken, pending_items, timestamp
+                   FROM turns WHERE session_id = ?
+                   ORDER BY turn_number ASC LIMIT ?""",
+                (sid, max_turns_per_session),
+            )
+            turns = [self._row_to_summary(row) for row in turns_cursor.fetchall()]
+            if turns:
+                result.append((sid, turns))
+        return result
+
+    def load_all_turns_flat(
+        self,
+        max_sessions: int = 5,
+        max_turns_per_session: int = 20,
+    ) -> list[CompactSummary]:
+        """Load all recent turns as a flat list (oldest first).
+
+        Useful for bootstrapping DialogSummaryManager at boot.
+        """
+        sessions = self.load_recent(max_sessions, max_turns_per_session)
+        # Reverse so oldest sessions come first
+        all_turns: list[CompactSummary] = []
+        for _sid, turns in reversed(sessions):
+            all_turns.extend(turns)
+        return all_turns
+
+    # ---- maintenance --------------------------------------------------
+
+    def prune_old_sessions(self, keep_sessions: int = 10) -> int:
+        """Delete old sessions beyond keep limit.
+
+        Returns number of sessions deleted.
+        """
+        cursor = self._conn.execute(
+            """SELECT session_id FROM sessions
+               ORDER BY started_at DESC LIMIT -1 OFFSET ?""",
+            (keep_sessions,),
+        )
+        old_ids = [row[0] for row in cursor.fetchall()]
+        if not old_ids:
+            return 0
+
+        placeholders = ",".join("?" * len(old_ids))
+        self._conn.execute(
+            f"DELETE FROM turns WHERE session_id IN ({placeholders})", old_ids
+        )
+        self._conn.execute(
+            f"DELETE FROM sessions WHERE session_id IN ({placeholders})", old_ids
+        )
+        self._conn.commit()
+        logger.info("[MEMORY_STORE] Pruned %d old sessions", len(old_ids))
+        return len(old_ids)
+
+    def session_count(self) -> int:
+        """Count total sessions in store."""
+        cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
+        return cursor.fetchone()[0]
+
+    def turn_count(self, session_id: Optional[str] = None) -> int:
+        """Count turns, optionally filtered by session."""
+        if session_id:
+            cursor = self._conn.execute(
+                "SELECT COUNT(*) FROM turns WHERE session_id = ?", (session_id,)
+            )
+        else:
+            cursor = self._conn.execute("SELECT COUNT(*) FROM turns")
+        return cursor.fetchone()[0]
+
+    # ---- JSONL export/import -----------------------------------------
+
+    def export_jsonl(self, file_path: str) -> int:
+        """Export all turns as JSONL for backup.
+
+        Returns number of records exported.
+        """
+        path = Path(file_path).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        cursor = self._conn.execute(
+            """SELECT t.session_id, t.turn_number, t.user_intent,
+                      t.action_taken, t.pending_items, t.timestamp,
+                      s.started_at
+               FROM turns t JOIN sessions s ON t.session_id = s.session_id
+               ORDER BY s.started_at ASC, t.turn_number ASC"""
+        )
+        count = 0
+        with open(path, "w", encoding="utf-8") as f:
+            for row in cursor:
+                record = {
+                    "session_id": row[0],
+                    "turn_number": row[1],
+                    "user_intent": row[2],
+                    "action_taken": row[3],
+                    "pending_items": json.loads(row[4]),
+                    "timestamp": row[5],
+                    "session_started_at": row[6],
+                }
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+                count += 1
+        logger.info("[MEMORY_STORE] Exported %d records to %s", count, path)
+        return count
+
+    def import_jsonl(self, file_path: str) -> int:
+        """Import turns from JSONL backup.
+
+        Returns number of records imported.
+        """
+        path = Path(file_path).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(f"JSONL file not found: {path}")
+
+        count = 0
+        seen_sessions: set[str] = set()
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                sid = record["session_id"]
+
+                # Create session if not seen
+                if sid not in seen_sessions:
+                    existing = self._conn.execute(
+                        "SELECT 1 FROM sessions WHERE session_id = ?", (sid,)
+                    ).fetchone()
+                    if not existing:
+                        self._conn.execute(
+                            "INSERT INTO sessions (session_id, started_at) VALUES (?, ?)",
+                            (sid, record.get("session_started_at", datetime.now().isoformat())),
+                        )
+                    seen_sessions.add(sid)
+
+                self._conn.execute(
+                    """INSERT INTO turns
+                       (session_id, turn_number, user_intent, action_taken, pending_items, timestamp)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        sid,
+                        record["turn_number"],
+                        record["user_intent"],
+                        record["action_taken"],
+                        json.dumps(record.get("pending_items", []), ensure_ascii=False),
+                        record["timestamp"],
+                    ),
+                )
+                count += 1
+
+        self._conn.commit()
+        logger.info("[MEMORY_STORE] Imported %d records from %s", count, path)
+        return count
+
+    # ---- cleanup ------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self._conn:
+            self._conn.close()
+            logger.info("[MEMORY_STORE] Closed SQLite store")
+
+    def __enter__(self) -> "SQLiteMemoryStore":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+    # ---- helpers ------------------------------------------------------
+
+    @staticmethod
+    def _row_to_summary(row: tuple) -> CompactSummary:
+        """Convert a DB row to CompactSummary."""
+        turn_number, user_intent, action_taken, pending_json, ts = row
+        try:
+            pending = json.loads(pending_json)
+        except (json.JSONDecodeError, TypeError):
+            pending = []
+        try:
+            timestamp = datetime.fromisoformat(ts)
+        except (ValueError, TypeError):
+            timestamp = datetime.now()
+        return CompactSummary(
+            turn_number=turn_number,
+            user_intent=user_intent,
+            action_taken=action_taken,
+            pending_items=pending,
+            timestamp=timestamp,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PersistentDialogSummaryManager — extends in-memory with persistence
+# ---------------------------------------------------------------------------
+
+
+class PersistentDialogSummaryManager:
+    """DialogSummaryManager with SQLite persistence (Issue #413).
+
+    Drop-in extension: wraps the in-memory DialogSummaryManager and
+    mirrors all turns to SQLite.  On boot, loads recent sessions.
+
+    Usage:
+        >>> manager = PersistentDialogSummaryManager.create()
+        >>> manager.add_turn(summary)  # saves to memory + SQLite
+        >>> # On next boot:
+        >>> manager2 = PersistentDialogSummaryManager.create()
+        >>> # manager2 already has past sessions loaded
+    """
+
+    def __init__(
+        self,
+        store: SQLiteMemoryStore,
+        config: MemoryStoreConfig,
+        *,
+        max_tokens: int = 500,
+        max_turns: int = 5,
+    ):
+        from bantz.brain.memory_lite import DialogSummaryManager
+
+        self._store = store
+        self._config = config
+        self._session_id = store.create_session()
+        self._manager = DialogSummaryManager(
+            max_tokens=max_tokens,
+            max_turns=max_turns,
+            pii_filter_enabled=config.pii_filter_enabled,
+        )
+        # Boot reload
+        self._boot_reload()
+        logger.info(
+            "[MEMORY_PERSIST] Session %s started, loaded %d past turns",
+            self._session_id, len(self._manager),
+        )
+
+    @classmethod
+    def create(
+        cls,
+        config: Optional[MemoryStoreConfig] = None,
+        *,
+        max_tokens: int = 500,
+        max_turns: int = 5,
+    ) -> "PersistentDialogSummaryManager":
+        """Factory: create with config (defaults to env vars)."""
+        config = config or MemoryStoreConfig.from_env()
+        store = SQLiteMemoryStore.from_config(config)
+        return cls(store, config, max_tokens=max_tokens, max_turns=max_turns)
+
+    def _boot_reload(self) -> None:
+        """Load summaries from past sessions into in-memory manager."""
+        past_turns = self._store.load_all_turns_flat(
+            max_sessions=self._config.max_sessions,
+            max_turns_per_session=self._config.max_turns_per_session,
+        )
+        for summary in past_turns:
+            # Add directly without re-persisting
+            self._manager.add_turn(summary)
+
+    # ---- delegated API (mirrors DialogSummaryManager) -----------------
+
+    @property
+    def session_id(self) -> str:
+        """Current session ID."""
+        return self._session_id
+
+    def add_turn(self, summary: CompactSummary) -> None:
+        """Add turn to in-memory manager and persist to SQLite."""
+        self._manager.add_turn(summary)
+        self._store.save_turn(
+            self._session_id, summary,
+            pii_filter=self._config.pii_filter_enabled,
+        )
+
+    def to_prompt_block(self) -> str:
+        """Generate prompt block from in-memory summaries."""
+        return self._manager.to_prompt_block()
+
+    def clear(self) -> None:
+        """Clear in-memory summaries (SQLite data preserved)."""
+        self._manager.clear()
+
+    def get_latest(self) -> Optional[CompactSummary]:
+        """Get most recent in-memory summary."""
+        return self._manager.get_latest()
+
+    @property
+    def store(self) -> SQLiteMemoryStore:
+        """Access underlying store for advanced operations."""
+        return self._store
+
+    def end_session(self) -> None:
+        """End current session in SQLite."""
+        self._store.end_session(self._session_id)
+
+    def close(self) -> None:
+        """End session and close store."""
+        self.end_session()
+        self._store.close()
+
+    def __len__(self) -> int:
+        return len(self._manager)
+
+    def __str__(self) -> str:
+        return self._manager.to_prompt_block()
+
+    def __enter__(self) -> "PersistentDialogSummaryManager":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()

--- a/tests/test_issue_413_memory_persistence.py
+++ b/tests/test_issue_413_memory_persistence.py
@@ -1,0 +1,495 @@
+"""Tests for Issue #413: Memory persistence via SQLite.
+
+Tests cover:
+  - MemoryStoreConfig: defaults, from_env, env overrides
+  - SQLiteMemoryStore: CRUD, session management, pruning, JSONL export/import
+  - PersistentDialogSummaryManager: boot reload, add_turn, prompt_block
+  - PII filtering on persist
+  - Edge cases: empty DB, missing file, concurrent sessions
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from bantz.brain.memory_lite import CompactSummary, PIIFilter, DialogSummaryManager
+from bantz.brain.memory_store import (
+    MemoryStoreConfig,
+    SQLiteMemoryStore,
+    PersistentDialogSummaryManager,
+)
+
+
+# ======================================================================
+# Fixtures
+# ======================================================================
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Create a temporary SQLite DB path."""
+    return str(tmp_path / "test_memory.db")
+
+
+@pytest.fixture
+def store(tmp_db):
+    """Create a temporary SQLiteMemoryStore."""
+    s = SQLiteMemoryStore(db_path=tmp_db)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def sample_summary():
+    """Create a sample CompactSummary."""
+    return CompactSummary(
+        turn_number=1,
+        user_intent="asked about calendar",
+        action_taken="listed events",
+        pending_items=["waiting for confirmation"],
+        timestamp=datetime(2025, 1, 15, 10, 30, 0),
+    )
+
+
+def _make_summary(turn: int, intent: str = "test", action: str = "tested") -> CompactSummary:
+    return CompactSummary(
+        turn_number=turn,
+        user_intent=intent,
+        action_taken=action,
+        timestamp=datetime(2025, 1, 15, 10, 0, 0),
+    )
+
+
+# ======================================================================
+# MemoryStoreConfig Tests
+# ======================================================================
+
+
+class TestMemoryStoreConfig:
+    def test_defaults(self):
+        c = MemoryStoreConfig()
+        assert c.db_path == "~/.bantz/memory.db"
+        assert c.max_sessions == 5
+        assert c.max_turns_per_session == 20
+        assert c.pii_filter_enabled is True
+
+    def test_from_env_defaults(self, monkeypatch):
+        for k in ["BANTZ_MEMORY_DB_PATH", "BANTZ_MEMORY_MAX_SESSIONS",
+                   "BANTZ_MEMORY_MAX_TURNS", "BANTZ_MEMORY_PII_FILTER"]:
+            monkeypatch.delenv(k, raising=False)
+        c = MemoryStoreConfig.from_env()
+        assert c.db_path == "~/.bantz/memory.db"
+        assert c.max_sessions == 5
+
+    def test_from_env_custom(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_MEMORY_DB_PATH", "/tmp/custom.db")
+        monkeypatch.setenv("BANTZ_MEMORY_MAX_SESSIONS", "10")
+        monkeypatch.setenv("BANTZ_MEMORY_MAX_TURNS", "50")
+        monkeypatch.setenv("BANTZ_MEMORY_PII_FILTER", "0")
+        c = MemoryStoreConfig.from_env()
+        assert c.db_path == "/tmp/custom.db"
+        assert c.max_sessions == 10
+        assert c.max_turns_per_session == 50
+        assert c.pii_filter_enabled is False
+
+    def test_from_env_min_clamp(self, monkeypatch):
+        monkeypatch.setenv("BANTZ_MEMORY_MAX_SESSIONS", "0")
+        monkeypatch.setenv("BANTZ_MEMORY_MAX_TURNS", "-5")
+        c = MemoryStoreConfig.from_env()
+        assert c.max_sessions >= 1
+        assert c.max_turns_per_session >= 1
+
+
+# ======================================================================
+# SQLiteMemoryStore Tests
+# ======================================================================
+
+
+class TestSQLiteMemoryStoreBasic:
+    def test_create_store(self, tmp_db):
+        store = SQLiteMemoryStore(db_path=tmp_db)
+        assert Path(tmp_db).exists()
+        store.close()
+
+    def test_creates_parent_dirs(self, tmp_path):
+        nested = str(tmp_path / "a" / "b" / "c" / "memory.db")
+        store = SQLiteMemoryStore(db_path=nested)
+        assert Path(nested).exists()
+        store.close()
+
+    def test_context_manager(self, tmp_db):
+        with SQLiteMemoryStore(db_path=tmp_db) as store:
+            sid = store.create_session()
+            assert sid
+
+    def test_tilde_expansion(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        store = SQLiteMemoryStore(db_path="~/test_memory.db")
+        assert Path(tmp_path / "test_memory.db").exists()
+        store.close()
+
+
+class TestSQLiteMemoryStoreSession:
+    def test_create_session(self, store):
+        sid = store.create_session()
+        assert isinstance(sid, str)
+        assert len(sid) > 0
+
+    def test_multiple_sessions(self, store):
+        s1 = store.create_session()
+        s2 = store.create_session()
+        assert s1 != s2
+        assert store.session_count() == 2
+
+    def test_end_session(self, store):
+        sid = store.create_session()
+        store.end_session(sid)
+        # Should not raise
+
+
+class TestSQLiteMemoryStoreTurns:
+    def test_save_and_load_turn(self, store, sample_summary):
+        sid = store.create_session()
+        store.save_turn(sid, sample_summary)
+        turns = store.load_session_turns(sid)
+        assert len(turns) == 1
+        assert turns[0].turn_number == 1
+        assert turns[0].user_intent == "asked about calendar"
+        assert turns[0].action_taken == "listed events"
+        assert turns[0].pending_items == ["waiting for confirmation"]
+
+    def test_save_multiple_turns(self, store):
+        sid = store.create_session()
+        for i in range(5):
+            store.save_turn(sid, _make_summary(i + 1, f"intent-{i}", f"action-{i}"))
+        turns = store.load_session_turns(sid)
+        assert len(turns) == 5
+        assert turns[0].turn_number == 1
+        assert turns[4].turn_number == 5
+
+    def test_turn_count(self, store):
+        sid = store.create_session()
+        assert store.turn_count(sid) == 0
+        store.save_turn(sid, _make_summary(1))
+        assert store.turn_count(sid) == 1
+        store.save_turn(sid, _make_summary(2))
+        assert store.turn_count(sid) == 2
+        assert store.turn_count() >= 2  # total across all sessions
+
+    def test_pii_filter_on_save(self, store):
+        sid = store.create_session()
+        summary = CompactSummary(
+            turn_number=1,
+            user_intent="emailed user@test.com",
+            action_taken="sent to 555-123-4567",
+        )
+        store.save_turn(sid, summary, pii_filter=True)
+        turns = store.load_session_turns(sid)
+        assert "<EMAIL>" in turns[0].user_intent
+        assert "<PHONE>" in turns[0].action_taken
+
+    def test_pii_filter_disabled(self, store):
+        sid = store.create_session()
+        summary = CompactSummary(
+            turn_number=1,
+            user_intent="emailed user@test.com",
+            action_taken="called 555-123-4567",
+        )
+        store.save_turn(sid, summary, pii_filter=False)
+        turns = store.load_session_turns(sid)
+        assert "user@test.com" in turns[0].user_intent
+
+    def test_pending_items_roundtrip(self, store):
+        sid = store.create_session()
+        summary = CompactSummary(
+            turn_number=1,
+            user_intent="test",
+            action_taken="test",
+            pending_items=["confirmation", "review"],
+        )
+        store.save_turn(sid, summary, pii_filter=False)
+        turns = store.load_session_turns(sid)
+        assert turns[0].pending_items == ["confirmation", "review"]
+
+
+class TestSQLiteMemoryStoreRecent:
+    def test_load_recent_sessions(self, store):
+        # Create 3 sessions with turns
+        for _ in range(3):
+            sid = store.create_session()
+            store.save_turn(sid, _make_summary(1))
+            store.save_turn(sid, _make_summary(2))
+
+        recent = store.load_recent(max_sessions=2)
+        assert len(recent) == 2
+        for sid, turns in recent:
+            assert len(turns) == 2
+
+    def test_load_recent_empty_db(self, store):
+        recent = store.load_recent()
+        assert recent == []
+
+    def test_load_all_turns_flat(self, store):
+        s1 = store.create_session()
+        store.save_turn(s1, _make_summary(1, "s1-intent"))
+        store.save_turn(s1, _make_summary(2, "s1-intent2"))
+
+        s2 = store.create_session()
+        store.save_turn(s2, _make_summary(1, "s2-intent"))
+
+        flat = store.load_all_turns_flat(max_sessions=5)
+        assert len(flat) == 3
+        # Oldest sessions first
+        assert flat[0].user_intent == "s1-intent"
+        assert flat[2].user_intent == "s2-intent"
+
+    def test_max_turns_per_session_limit(self, store):
+        sid = store.create_session()
+        for i in range(10):
+            store.save_turn(sid, _make_summary(i + 1))
+        recent = store.load_recent(max_turns_per_session=3)
+        for _, turns in recent:
+            assert len(turns) <= 3
+
+
+class TestSQLiteMemoryStorePrune:
+    def test_prune_old_sessions(self, store):
+        for _ in range(10):
+            sid = store.create_session()
+            store.save_turn(sid, _make_summary(1))
+
+        deleted = store.prune_old_sessions(keep_sessions=3)
+        assert deleted == 7
+        assert store.session_count() == 3
+
+    def test_prune_no_op_when_under_limit(self, store):
+        store.create_session()
+        deleted = store.prune_old_sessions(keep_sessions=10)
+        assert deleted == 0
+
+    def test_prune_deletes_turns(self, store):
+        sids = []
+        for _ in range(5):
+            sid = store.create_session()
+            sids.append(sid)
+            store.save_turn(sid, _make_summary(1))
+            store.save_turn(sid, _make_summary(2))
+
+        assert store.turn_count() == 10
+        store.prune_old_sessions(keep_sessions=2)
+        # Should have only 4 turns left (2 sessions × 2 turns)
+        assert store.turn_count() == 4
+
+
+class TestSQLiteMemoryStoreJSONL:
+    def test_export_import_roundtrip(self, store, tmp_path):
+        sid = store.create_session()
+        store.save_turn(sid, _make_summary(1, "hello", "greeted"))
+        store.save_turn(sid, _make_summary(2, "calendar", "listed"))
+
+        jsonl_path = str(tmp_path / "export.jsonl")
+        exported = store.export_jsonl(jsonl_path)
+        assert exported == 2
+
+        # Verify JSONL content
+        with open(jsonl_path) as f:
+            lines = [json.loads(l) for l in f if l.strip()]
+        assert len(lines) == 2
+        assert lines[0]["user_intent"] == "hello"
+        assert lines[1]["user_intent"] == "calendar"
+
+    def test_import_into_fresh_db(self, tmp_path):
+        # First: create and export
+        db1 = str(tmp_path / "db1.db")
+        jsonl_path = str(tmp_path / "backup.jsonl")
+        with SQLiteMemoryStore(db_path=db1) as s1:
+            sid = s1.create_session()
+            s1.save_turn(sid, _make_summary(1, "i1", "a1"), pii_filter=False)
+            s1.save_turn(sid, _make_summary(2, "i2", "a2"), pii_filter=False)
+            s1.export_jsonl(jsonl_path)
+
+        # Second: import into fresh DB
+        db2 = str(tmp_path / "db2.db")
+        with SQLiteMemoryStore(db_path=db2) as s2:
+            imported = s2.import_jsonl(jsonl_path)
+            assert imported == 2
+            flat = s2.load_all_turns_flat()
+            assert len(flat) == 2
+
+    def test_import_missing_file(self, store, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            store.import_jsonl(str(tmp_path / "nonexistent.jsonl"))
+
+    def test_export_empty_db(self, store, tmp_path):
+        jsonl_path = str(tmp_path / "empty.jsonl")
+        exported = store.export_jsonl(jsonl_path)
+        assert exported == 0
+
+
+# ======================================================================
+# PersistentDialogSummaryManager Tests
+# ======================================================================
+
+
+class TestPersistentDialogSummaryManager:
+    def test_create(self, tmp_path):
+        config = MemoryStoreConfig(db_path=str(tmp_path / "mem.db"))
+        manager = PersistentDialogSummaryManager.create(config)
+        assert manager.session_id
+        assert len(manager) == 0
+        manager.close()
+
+    def test_add_turn_persists(self, tmp_path):
+        db = str(tmp_path / "mem.db")
+        config = MemoryStoreConfig(db_path=db)
+
+        # Session 1: add turns
+        m1 = PersistentDialogSummaryManager.create(config)
+        m1.add_turn(_make_summary(1, "greet", "greeted"))
+        m1.add_turn(_make_summary(2, "calendar", "listed"))
+        assert len(m1) == 2
+        m1.close()
+
+        # Session 2: boot reload should load past turns
+        m2 = PersistentDialogSummaryManager.create(config)
+        assert len(m2) >= 2
+        m2.close()
+
+    def test_prompt_block(self, tmp_path):
+        config = MemoryStoreConfig(db_path=str(tmp_path / "mem.db"))
+        manager = PersistentDialogSummaryManager.create(config)
+        manager.add_turn(_make_summary(1, "asked about weather", "said sunny"))
+        block = manager.to_prompt_block()
+        assert "DIALOG_SUMMARY" in block
+        assert "weather" in block
+        manager.close()
+
+    def test_clear_only_in_memory(self, tmp_path):
+        db = str(tmp_path / "mem.db")
+        config = MemoryStoreConfig(db_path=db)
+
+        m1 = PersistentDialogSummaryManager.create(config)
+        m1.add_turn(_make_summary(1, "test", "tested"))
+        m1.clear()
+        assert len(m1) == 0  # In-memory cleared
+        m1.close()
+
+        # But SQLite still has the data
+        with SQLiteMemoryStore(db_path=db) as store:
+            assert store.turn_count() >= 1
+
+    def test_get_latest(self, tmp_path):
+        config = MemoryStoreConfig(db_path=str(tmp_path / "mem.db"))
+        manager = PersistentDialogSummaryManager.create(config)
+        assert manager.get_latest() is None
+        manager.add_turn(_make_summary(1, "first", "did first"))
+        manager.add_turn(_make_summary(2, "second", "did second"))
+        latest = manager.get_latest()
+        assert latest.turn_number == 2
+        assert latest.user_intent == "second"
+        manager.close()
+
+    def test_context_manager(self, tmp_path):
+        config = MemoryStoreConfig(db_path=str(tmp_path / "mem.db"))
+        with PersistentDialogSummaryManager.create(config) as m:
+            m.add_turn(_make_summary(1))
+            assert len(m) == 1
+
+    def test_boot_reload_respects_max_turns(self, tmp_path):
+        db = str(tmp_path / "mem.db")
+        config = MemoryStoreConfig(db_path=db)
+
+        # Session 1: add many turns
+        m1 = PersistentDialogSummaryManager.create(config, max_turns=3)
+        for i in range(10):
+            m1.add_turn(_make_summary(i + 1, f"intent-{i}", f"action-{i}"))
+        m1.close()
+
+        # Session 2: boot reload, but max_turns=3 limits in-memory
+        m2 = PersistentDialogSummaryManager.create(config, max_turns=3)
+        assert len(m2) <= 3  # In-memory limited by max_turns
+        m2.close()
+
+    def test_pii_filter_on_persist(self, tmp_path):
+        db = str(tmp_path / "mem.db")
+        config = MemoryStoreConfig(db_path=db, pii_filter_enabled=True)
+        m = PersistentDialogSummaryManager.create(config)
+        m.add_turn(CompactSummary(
+            turn_number=1,
+            user_intent="sent email to user@test.com",
+            action_taken="forwarded to 555-123-4567",
+        ))
+        m.close()
+
+        # Check SQLite directly
+        with SQLiteMemoryStore(db_path=db) as store:
+            turns = store.load_all_turns_flat()
+            assert "<EMAIL>" in turns[-1].user_intent
+            assert "<PHONE>" in turns[-1].action_taken
+
+    def test_str_delegation(self, tmp_path):
+        config = MemoryStoreConfig(db_path=str(tmp_path / "mem.db"))
+        m = PersistentDialogSummaryManager.create(config)
+        m.add_turn(_make_summary(1, "test", "tested"))
+        assert "DIALOG_SUMMARY" in str(m)
+        m.close()
+
+    def test_store_property(self, tmp_path):
+        config = MemoryStoreConfig(db_path=str(tmp_path / "mem.db"))
+        m = PersistentDialogSummaryManager.create(config)
+        assert isinstance(m.store, SQLiteMemoryStore)
+        m.close()
+
+
+# ======================================================================
+# Cross-session persistence test
+# ======================================================================
+
+
+class TestCrossSessionPersistence:
+    def test_three_sessions_reload(self, tmp_path):
+        """Simulate 3 session restarts and verify context carries over."""
+        db = str(tmp_path / "mem.db")
+        config = MemoryStoreConfig(db_path=db, max_sessions=5)
+
+        # Session 1
+        m1 = PersistentDialogSummaryManager.create(config)
+        m1.add_turn(_make_summary(1, "greeting", "greeted back"))
+        m1.add_turn(_make_summary(2, "asked about meeting", "listed 3 events"))
+        m1.close()
+
+        # Session 2
+        m2 = PersistentDialogSummaryManager.create(config)
+        block2 = m2.to_prompt_block()
+        assert "greeting" in block2 or "meeting" in block2
+        m2.add_turn(_make_summary(1, "asked about email", "showed inbox"))
+        m2.close()
+
+        # Session 3
+        m3 = PersistentDialogSummaryManager.create(config)
+        block3 = m3.to_prompt_block()
+        # Should have context from sessions 1 and 2
+        assert "DIALOG_SUMMARY" in block3
+        assert len(m3) > 0
+        m3.close()
+
+    def test_session_id_changes_each_boot(self, tmp_path):
+        db = str(tmp_path / "mem.db")
+        config = MemoryStoreConfig(db_path=db)
+
+        m1 = PersistentDialogSummaryManager.create(config)
+        sid1 = m1.session_id
+        m1.close()
+
+        m2 = PersistentDialogSummaryManager.create(config)
+        sid2 = m2.session_id
+        m2.close()
+
+        assert sid1 != sid2


### PR DESCRIPTION
## Summary
Adds SQLite-backed persistence for DialogSummaryManager so dialog history survives across session restarts.

## Changes
- **New**: `src/bantz/brain/memory_store.py`
  - `MemoryStoreConfig`: frozen dataclass with `from_env()`
  - `SQLiteMemoryStore`: WAL-mode SQLite with session/turn CRUD, pruning, JSONL export/import
  - `PersistentDialogSummaryManager`: wraps DialogSummaryManager + SQLite persistence + boot reload
- PII filter applied before persisting
- Configurable: `BANTZ_MEMORY_DB_PATH`, `BANTZ_MEMORY_MAX_SESSIONS`, `BANTZ_MEMORY_MAX_TURNS`, `BANTZ_MEMORY_PII_FILTER`
- **Tests**: 40 tests covering config, CRUD, sessions, pruning, JSONL, boot reload, cross-session persistence

## Test Results
```
40 passed in 0.61s
```

Closes #413