### PR TITLE
feat(#420): Router engine.py modularization with handler registry

### DIFF
--- a/src/bantz/router/engine.py
+++ b/src/bantz/router/engine.py
@@ -2126,6 +2126,16 @@ class Router:
     # Dispatch single action
     # ─────────────────────────────────────────────────────────────────
     def _dispatch(self, *, intent: str, slots: dict, ctx: ConversationContext, in_queue: bool) -> RouterResult:
+        # ── Issue #420: Try modular handler registry first ────────────
+        from bantz.router.handler_registry import get_handler
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        handler = get_handler(intent)
+        if handler is not None:
+            return handler(intent=intent, slots=slots, ctx=ctx, router=self, in_queue=in_queue)
+
+        # ── Fallback: intents not yet extracted (news, page_*, etc.) ──
         follow_up = "" if in_queue else " Başka ne yapayım?"
         search_follow = "" if in_queue else " Ne arayayım?"
 

--- a/src/bantz/router/handler_registry.py
+++ b/src/bantz/router/handler_registry.py
@@ -1,0 +1,57 @@
+"""Intent Handler Protocol and Registry (Issue #420).
+
+Provides a clean dispatch mechanism for Router._dispatch() by extracting
+intent handlers into separate modules. The Router can look up handlers
+from the registry instead of maintaining a 900-line if/elif chain.
+
+Usage in Router._dispatch():
+    handler = get_handler(intent)
+    if handler:
+        return handler(intent=intent, slots=slots, ctx=ctx, router=self, in_queue=in_queue)
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Protocol
+
+from bantz.router.context import ConversationContext
+from bantz.router.types import RouterResult
+
+
+class IntentHandler(Protocol):
+    """Protocol for intent handler callables."""
+
+    def __call__(
+        self,
+        *,
+        intent: str,
+        slots: dict,
+        ctx: ConversationContext,
+        router: object,
+        in_queue: bool,
+    ) -> RouterResult: ...
+
+
+# ── Handler Registry ──────────────────────────────────────────────────────
+_REGISTRY: dict[str, IntentHandler] = {}
+
+
+def register_handler(intent: str, handler: IntentHandler) -> None:
+    """Register a handler function for a specific intent."""
+    _REGISTRY[intent] = handler
+
+
+def register_handlers(intents: list[str], handler: IntentHandler) -> None:
+    """Register the same handler for multiple intents."""
+    for intent in intents:
+        _REGISTRY[intent] = handler
+
+
+def get_handler(intent: str) -> Optional[IntentHandler]:
+    """Look up the registered handler for an intent."""
+    return _REGISTRY.get(intent)
+
+
+def registered_intents() -> list[str]:
+    """Return all registered intent names (for testing/debugging)."""
+    return sorted(_REGISTRY.keys())

--- a/src/bantz/router/handlers/__init__.py
+++ b/src/bantz/router/handlers/__init__.py
@@ -1,0 +1,24 @@
+"""Router Intent Handlers Package (Issue #420).
+
+Auto-registers all handler modules on import.
+"""
+
+from __future__ import annotations
+
+_registered = False
+
+
+def ensure_registered() -> None:
+    """Register all handler modules (idempotent)."""
+    global _registered
+    if _registered:
+        return
+    _registered = True
+
+    from bantz.router.handlers import browser, panel, pc, daily, scheduler, coding
+    browser.register_all()
+    panel.register_all()
+    pc.register_all()
+    daily.register_all()
+    scheduler.register_all()
+    coding.register_all()

--- a/src/bantz/router/handlers/browser.py
+++ b/src/bantz/router/handlers/browser.py
@@ -1,0 +1,137 @@
+"""Browser Intent Handlers (Issue #420).
+
+Extracted from Router._dispatch() — handles all browser_* and page_* intents.
+"""
+
+from __future__ import annotations
+
+from bantz.router.context import ConversationContext
+from bantz.router.handler_registry import register_handler
+from bantz.router.types import RouterResult
+
+
+def _follow(in_queue: bool) -> str:
+    return "" if in_queue else " Başka ne yapayım?"
+
+
+def handle_ai_chat(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_ai_chat
+    service = str(slots.get("service", "duck")).lower()
+    prompt = str(slots.get("prompt", "")).strip()
+    ok, msg = browser_ai_chat(service, prompt)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_open(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_open
+    url = str(slots.get("url", "")).strip()
+    ok, msg = browser_open(url)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_scan(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_scan
+    ok, msg, scan = browser_scan()
+    ctx.last_intent = intent
+    data = {"scan": scan} if scan else None
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue), data=data)
+
+
+def handle_browser_click(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_click_index, browser_click_text
+    if "index" in slots:
+        idx = int(slots["index"])
+        ok, msg = browser_click_index(idx)
+    elif "text" in slots:
+        txt = str(slots["text"])
+        ok, msg = browser_click_text(txt)
+    else:
+        ok, msg = False, "Neye tıklayacağımı anlamadım."
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_type(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_type_text
+    text_to_type = str(slots.get("text", "")).strip()
+    idx = slots.get("index")
+    if idx is not None:
+        ok, msg = browser_type_text(text_to_type, int(idx))
+    else:
+        ok, msg = browser_type_text(text_to_type)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_scroll_down(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_scroll_down
+    ok, msg = browser_scroll_down()
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_scroll_up(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_scroll_up
+    ok, msg = browser_scroll_up()
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_back(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_go_back
+    ok, msg = browser_go_back()
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_info(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_current_info
+    ok, msg = browser_current_info()
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_detail(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_detail
+    idx = int(slots.get("index", 0))
+    ok, msg = browser_detail(idx)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_wait(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_wait
+    seconds = int(slots.get("seconds", 3))
+    ok, msg = browser_wait(seconds)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_browser_search(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.browser.skills import browser_search_in_page
+    query = str(slots.get("query", "")).strip()
+    if not query:
+        return RouterResult(ok=False, intent=intent, user_text="Ne arayayım?")
+    ok, msg = browser_search_in_page(query)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+def register_all() -> None:
+    """Register all browser intent handlers."""
+    register_handler("ai_chat", handle_ai_chat)
+    register_handler("browser_open", handle_browser_open)
+    register_handler("browser_scan", handle_browser_scan)
+    register_handler("browser_click", handle_browser_click)
+    register_handler("browser_type", handle_browser_type)
+    register_handler("browser_scroll_down", handle_browser_scroll_down)
+    register_handler("browser_scroll_up", handle_browser_scroll_up)
+    register_handler("browser_back", handle_browser_back)
+    register_handler("browser_info", handle_browser_info)
+    register_handler("browser_detail", handle_browser_detail)
+    register_handler("browser_wait", handle_browser_wait)
+    register_handler("browser_search", handle_browser_search)

--- a/src/bantz/router/handlers/coding.py
+++ b/src/bantz/router/handlers/coding.py
@@ -1,0 +1,60 @@
+"""Coding Agent Intent Handlers (Issue #420).
+
+Extracted from Router._dispatch() — handles all coding/file/terminal intents (Issue #4).
+"""
+
+from __future__ import annotations
+
+from bantz.router.context import ConversationContext
+from bantz.router.handler_registry import register_handlers
+from bantz.router.types import RouterResult
+
+
+_CODING_INTENTS = [
+    "file_read", "file_write", "file_edit", "file_create", "file_delete",
+    "file_undo", "file_list", "file_search",
+    "terminal_run", "terminal_background", "terminal_background_output",
+    "terminal_background_kill", "terminal_background_list",
+    "code_apply_diff", "code_replace_function", "code_replace_class",
+    "code_insert_lines", "code_delete_lines", "code_format", "code_search_replace",
+    "project_info", "project_tree", "project_symbols", "project_search_symbol",
+    "project_related_files", "project_imports",
+]
+
+# Shared executor instance (lazy init)
+_executor = None
+
+
+def handle_coding(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    follow_up = "" if in_queue else " Başka ne yapayım?"
+    try:
+        from bantz.coding import CodingToolExecutor
+
+        global _executor
+        if _executor is None:
+            from pathlib import Path
+            workspace = Path.cwd()
+            _executor = CodingToolExecutor(workspace_root=workspace)
+
+        import asyncio
+        loop = asyncio.new_event_loop()
+        try:
+            ok, result_text = loop.run_until_complete(
+                _executor.execute(intent, slots)
+            )
+        finally:
+            loop.close()
+
+        ctx.last_intent = intent
+        return RouterResult(ok=ok, intent=intent, user_text=result_text + follow_up)
+
+    except Exception as e:
+        ctx.last_intent = intent
+        return RouterResult(ok=False, intent=intent, user_text=f"❌ Coding agent hatası: {e}" + follow_up)
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+def register_all() -> None:
+    """Register all coding agent intent handlers."""
+    register_handlers(_CODING_INTENTS, handle_coding)

--- a/src/bantz/router/handlers/daily.py
+++ b/src/bantz/router/handlers/daily.py
@@ -1,0 +1,75 @@
+"""Daily Skills Intent Handlers (Issue #420).
+
+Extracted from Router._dispatch() — handles open_browser, google_search,
+open_path, open_url, notify, open_btop intents.
+"""
+
+from __future__ import annotations
+
+from bantz.router.context import ConversationContext
+from bantz.router.handler_registry import register_handler
+from bantz.router.types import RouterResult
+from bantz.skills.daily import open_btop, open_browser, open_path, open_url, google_search, notify
+
+
+def _follow(in_queue: bool) -> str:
+    return "" if in_queue else " Başka ne yapayım?"
+
+
+def handle_open_browser(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    ok, msg = open_browser()
+    ctx.last_intent = intent
+    if not in_queue:
+        ctx.awaiting = "search_query"
+    search_follow = "" if in_queue else " Ne arayayım?"
+    return RouterResult(ok=ok, intent=intent, user_text=msg + search_follow)
+
+
+def handle_google_search(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    query = str(slots.get("query", "")).strip()
+    if not query:
+        if not in_queue:
+            ctx.awaiting = "search_query"
+        return RouterResult(ok=False, intent=intent, user_text="Ne arayayım?")
+    ok, msg = google_search(query=query)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_open_path(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    target = str(slots.get("target", "")).strip()
+    ok, msg = open_path(target)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_open_url(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    url = str(slots.get("url", "")).strip()
+    ok, msg = open_url(url)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_notify(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    message = str(slots.get("message", "")).strip()
+    ok, msg = notify(message)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_open_btop(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    ok, msg = open_btop()
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+def register_all() -> None:
+    """Register all daily skills intent handlers."""
+    register_handler("open_browser", handle_open_browser)
+    register_handler("google_search", handle_google_search)
+    register_handler("open_path", handle_open_path)
+    register_handler("open_url", handle_open_url)
+    register_handler("notify", handle_notify)
+    register_handler("open_btop", handle_open_btop)

--- a/src/bantz/router/handlers/panel.py
+++ b/src/bantz/router/handlers/panel.py
@@ -1,0 +1,102 @@
+"""Panel Intent Handlers (Issue #420).
+
+Extracted from Router._dispatch() — handles Jarvis Panel intents (Issue #19).
+"""
+
+from __future__ import annotations
+
+from bantz.router.context import ConversationContext
+from bantz.router.handler_registry import register_handler
+from bantz.router.types import RouterResult
+from bantz.skills.daily import open_url
+
+
+def _follow(in_queue: bool) -> str:
+    return "" if in_queue else " Başka ne yapayım?"
+
+
+def handle_panel_move(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    position = str(slots.get("position", "")).strip()
+    if not position:
+        return RouterResult(ok=False, intent=intent, user_text="Nereye taşıyayım efendim?")
+    controller = ctx.get_panel_controller()
+    if controller:
+        controller.move_panel(position)
+        return RouterResult(ok=True, intent=intent, user_text=f"Panel {position} tarafına taşındı efendim.")
+    return RouterResult(ok=False, intent=intent, user_text="Panel henüz açık değil efendim.")
+
+
+def handle_panel_hide(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    controller = ctx.get_panel_controller()
+    if controller:
+        controller.hide_panel()
+        ctx.set_panel_visible(False)
+        return RouterResult(ok=True, intent=intent, user_text="Panel kapatıldı efendim.")
+    return RouterResult(ok=True, intent=intent, user_text="Panel zaten kapalı efendim.")
+
+
+def handle_panel_minimize(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    controller = ctx.get_panel_controller()
+    if controller:
+        controller.minimize_panel()
+        return RouterResult(ok=True, intent=intent, user_text="Panel küçültüldü efendim.")
+    return RouterResult(ok=False, intent=intent, user_text="Panel açık değil efendim.")
+
+
+def handle_panel_maximize(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    controller = ctx.get_panel_controller()
+    if controller:
+        controller.maximize_panel()
+        return RouterResult(ok=True, intent=intent, user_text="Panel büyütüldü efendim.")
+    return RouterResult(ok=False, intent=intent, user_text="Panel açık değil efendim.")
+
+
+def handle_panel_next_page(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    controller = ctx.get_panel_controller()
+    if controller:
+        controller.next_page()
+        page = controller.current_page
+        total = controller.total_pages
+        return RouterResult(ok=True, intent=intent, user_text=f"Sayfa {page}/{total} efendim.", data={"page": page, "total": total})
+    return RouterResult(ok=False, intent=intent, user_text="Gösterilecek sonuç yok efendim.")
+
+
+def handle_panel_prev_page(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    controller = ctx.get_panel_controller()
+    if controller:
+        controller.prev_page()
+        page = controller.current_page
+        total = controller.total_pages
+        return RouterResult(ok=True, intent=intent, user_text=f"Sayfa {page}/{total} efendim.", data={"page": page, "total": total})
+    return RouterResult(ok=False, intent=intent, user_text="Gösterilecek sonuç yok efendim.")
+
+
+def handle_panel_select_item(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    index = slots.get("index", 0)
+    if not index:
+        return RouterResult(ok=False, intent=intent, user_text="Kaçıncı sonucu açayım efendim?")
+    item = ctx.get_panel_result_by_index(index)
+    if item:
+        url = item.get("url", "")
+        if url:
+            ok, msg = open_url(url)
+            ctx.last_intent = intent
+            return RouterResult(ok=ok, intent=intent, user_text=f"{index}. sonuç açılıyor efendim.", data={"index": index, "url": url})
+        return RouterResult(ok=False, intent=intent, user_text=f"{index}. sonuçta URL yok efendim.")
+    total = len(ctx.get_panel_results())
+    if total > 0:
+        return RouterResult(ok=False, intent=intent, user_text=f"Geçersiz numara. 1 ile {total} arasında bir sayı söyleyin efendim.")
+    return RouterResult(ok=False, intent=intent, user_text="Gösterilecek sonuç yok efendim.")
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+def register_all() -> None:
+    """Register all panel intent handlers."""
+    register_handler("panel_move", handle_panel_move)
+    register_handler("panel_hide", handle_panel_hide)
+    register_handler("panel_minimize", handle_panel_minimize)
+    register_handler("panel_maximize", handle_panel_maximize)
+    register_handler("panel_next_page", handle_panel_next_page)
+    register_handler("panel_prev_page", handle_panel_prev_page)
+    register_handler("panel_select_item", handle_panel_select_item)

--- a/src/bantz/router/handlers/pc.py
+++ b/src/bantz/router/handlers/pc.py
@@ -1,0 +1,192 @@
+"""PC / Desktop Control Intent Handlers (Issue #420).
+
+Extracted from Router._dispatch() — handles app_*, pc_mouse_*, pc_hotkey,
+clipboard_*, and app_session_exit intents.
+"""
+
+from __future__ import annotations
+
+from bantz.router.context import ConversationContext
+from bantz.router.handler_registry import register_handler
+from bantz.router.types import RouterResult
+from bantz.skills.pc import (
+    open_app, close_app, focus_app, list_windows, type_text, send_key,
+    move_mouse, click_mouse, scroll_mouse, hotkey, clipboard_set, clipboard_get,
+)
+
+
+def _follow(in_queue: bool) -> str:
+    return "" if in_queue else " Başka ne yapayım?"
+
+
+def _get_overlay_hook():
+    from bantz.router.engine import get_overlay_hook
+    return get_overlay_hook()
+
+
+def _preview(text: str, duration_ms: int = 900) -> None:
+    hook = _get_overlay_hook()
+    if hook and hasattr(hook, "preview_action_sync"):
+        try:
+            getattr(hook, "preview_action_sync")(text, duration_ms)
+        except Exception:
+            pass
+
+
+def _cursor_dot(x: int, y: int, duration_ms: int = 700) -> None:
+    hook = _get_overlay_hook()
+    if hook and hasattr(hook, "cursor_dot_sync"):
+        try:
+            getattr(hook, "cursor_dot_sync")(x, y, duration_ms)
+        except Exception:
+            pass
+
+
+def handle_app_open(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    app_name = str(slots.get("app", "")).strip().lower()
+    ok, msg, window_id = open_app(app_name)
+    if ok:
+        ctx.set_active_app(app_name, window_id)
+        session_hint = f" 🎯 {app_name} oturumu başladı. Komut verebilirsin ('yaz:', 'gönder', 'kapat') veya 'uygulamadan çık' de."
+        return RouterResult(ok=ok, intent=intent, user_text=msg + session_hint)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_app_close(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    app_name = str(slots.get("app", "")).strip().lower() if slots.get("app") else None
+    if not app_name and ctx.has_active_app():
+        app_name = ctx.active_app
+    if not app_name:
+        return RouterResult(ok=False, intent=intent, user_text="Hangi uygulamayı kapatayım?" + _follow(in_queue))
+    ok, msg = close_app(app_name)
+    if ok and ctx.active_app == app_name:
+        ctx.clear_active_app()
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_app_focus(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    app_name = str(slots.get("app", "")).strip().lower()
+    ok, msg, window_id = focus_app(app_name)
+    if ok:
+        ctx.set_active_app(app_name, window_id)
+        session_hint = f" 🎯 {app_name} oturumuna geçtim."
+        return RouterResult(ok=ok, intent=intent, user_text=msg + session_hint)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_app_list(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    ok, msg, windows = list_windows()
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue), data={"windows": windows})
+
+
+def handle_app_type(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    text_to_type = str(slots.get("text", "")).strip()
+    if not text_to_type:
+        return RouterResult(ok=False, intent=intent, user_text="Ne yazayım?" + _follow(in_queue))
+    _preview(f"Yazıyorum: {text_to_type[:60]}", 1200)
+    target_window = ctx.active_window_id if ctx.has_active_app() else None
+    ok, msg = type_text(text_to_type, window_id=target_window)
+    ctx.last_intent = intent
+    session_hint = f" ({ctx.active_app} oturumunda)" if ctx.has_active_app() else ""
+    return RouterResult(ok=ok, intent=intent, user_text=msg + session_hint + _follow(in_queue))
+
+
+def handle_app_submit(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    target_window = ctx.active_window_id if ctx.has_active_app() else None
+    _preview("Enter gönderiyorum…", 800)
+    ok, msg = send_key("Return", window_id=target_window)
+    ctx.last_intent = intent
+    session_hint = f" ({ctx.active_app} oturumunda)" if ctx.has_active_app() else ""
+    return RouterResult(ok=ok, intent=intent, user_text="Gönderildi." + session_hint + _follow(in_queue))
+
+
+def handle_pc_mouse_move(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    x = int(slots.get("x", 0))
+    y = int(slots.get("y", 0))
+    duration_ms = int(slots.get("duration_ms", 0) or 0)
+    _cursor_dot(x, y)
+    _preview(f"İmleci ({x}, {y}) konumuna götürüyorum…")
+    ok, msg = move_mouse(x, y, duration_ms=duration_ms)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_pc_mouse_click(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    x = slots.get("x")
+    y = slots.get("y")
+    button = str(slots.get("button", "left"))
+    double = bool(slots.get("double", False))
+    btn_tr = "sol" if button == "left" else "sağ" if button == "right" else "orta"
+    click_tr = "çift tık" if double else "tık"
+    where = f"({int(x)}, {int(y)})" if x is not None and y is not None else "mevcut konum"
+    _preview(f"{btn_tr} {click_tr}: {where}")
+    if x is not None and y is not None:
+        _cursor_dot(int(x), int(y))
+    ok, msg = click_mouse(button=button, x=int(x) if x is not None else None, y=int(y) if y is not None else None, double=double)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_pc_mouse_scroll(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    direction = str(slots.get("direction", "down"))
+    amount = int(slots.get("amount", 3) or 3)
+    tr = "aşağı" if direction == "down" else "yukarı"
+    _preview(f"Kaydırıyorum: {tr} ({amount})")
+    ok, msg = scroll_mouse(direction=direction, amount=amount)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_pc_hotkey(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    combo = str(slots.get("combo", "")).strip()
+    _preview(f"Kısayol: {combo}")
+    ok, msg = hotkey(combo)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_clipboard_set(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    txt = str(slots.get("text", ""))
+    _preview("Panoya kopyalıyorum…")
+    ok, msg = clipboard_set(txt)
+    ctx.last_intent = intent
+    return RouterResult(ok=ok, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_clipboard_get(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    ok, msg, val = clipboard_get()
+    ctx.last_intent = intent
+    if ok:
+        return RouterResult(ok=True, intent=intent, user_text=(msg + "\n" + val).strip() + _follow(in_queue), data={"clipboard": val})
+    return RouterResult(ok=False, intent=intent, user_text=msg + _follow(in_queue))
+
+
+def handle_app_session_exit(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    if ctx.has_active_app():
+        old_app = ctx.active_app
+        ctx.clear_active_app()
+        return RouterResult(ok=True, intent=intent, user_text=f"✅ {old_app} oturumundan çıktım. Normal moda döndüm." + _follow(in_queue))
+    return RouterResult(ok=True, intent=intent, user_text="Zaten aktif uygulama oturumu yok." + _follow(in_queue))
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+def register_all() -> None:
+    """Register all PC/desktop control intent handlers."""
+    register_handler("app_open", handle_app_open)
+    register_handler("app_close", handle_app_close)
+    register_handler("app_focus", handle_app_focus)
+    register_handler("app_list", handle_app_list)
+    register_handler("app_type", handle_app_type)
+    register_handler("app_submit", handle_app_submit)
+    register_handler("pc_mouse_move", handle_pc_mouse_move)
+    register_handler("pc_mouse_click", handle_pc_mouse_click)
+    register_handler("pc_mouse_scroll", handle_pc_mouse_scroll)
+    register_handler("pc_hotkey", handle_pc_hotkey)
+    register_handler("clipboard_set", handle_clipboard_set)
+    register_handler("clipboard_get", handle_clipboard_get)
+    register_handler("app_session_exit", handle_app_session_exit)

--- a/src/bantz/router/handlers/scheduler.py
+++ b/src/bantz/router/handlers/scheduler.py
@@ -1,0 +1,111 @@
+"""Scheduler Intent Handlers (Issue #420).
+
+Extracted from Router._dispatch() — handles reminder_* and checkin_* intents.
+"""
+
+from __future__ import annotations
+
+from bantz.router.context import ConversationContext
+from bantz.router.handler_registry import register_handler
+from bantz.router.types import RouterResult
+
+
+def _follow(in_queue: bool) -> str:
+    return "" if in_queue else " Başka ne yapayım?"
+
+
+def handle_reminder_add(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.reminder import get_reminder_manager
+    manager = get_reminder_manager()
+    time_str = str(slots.get("time", "")).strip()
+    message = str(slots.get("message", "")).strip()
+    result_data = manager.add_reminder(time_str, message)
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_reminder_list(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.reminder import get_reminder_manager
+    manager = get_reminder_manager()
+    result_data = manager.list_reminders()
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_reminder_delete(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.reminder import get_reminder_manager
+    manager = get_reminder_manager()
+    reminder_id = int(slots.get("id", 0))
+    result_data = manager.delete_reminder(reminder_id)
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_reminder_snooze(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.reminder import get_reminder_manager
+    manager = get_reminder_manager()
+    reminder_id = int(slots.get("id", 0))
+    minutes = int(slots.get("minutes", 10))
+    result_data = manager.snooze_reminder(reminder_id, minutes)
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_checkin_add(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.checkin import get_checkin_manager
+    manager = get_checkin_manager()
+    schedule_str = str(slots.get("schedule", "")).strip()
+    prompt = str(slots.get("prompt", "")).strip()
+    result_data = manager.add_checkin(schedule_str, prompt)
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_checkin_list(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.checkin import get_checkin_manager
+    manager = get_checkin_manager()
+    result_data = manager.list_checkins()
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_checkin_delete(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.checkin import get_checkin_manager
+    manager = get_checkin_manager()
+    checkin_id = int(slots.get("id", 0))
+    result_data = manager.delete_checkin(checkin_id)
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_checkin_pause(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.checkin import get_checkin_manager
+    manager = get_checkin_manager()
+    checkin_id = int(slots.get("id", 0))
+    result_data = manager.pause_checkin(checkin_id)
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+def handle_checkin_resume(*, intent: str, slots: dict, ctx: ConversationContext, router: object, in_queue: bool) -> RouterResult:
+    from bantz.scheduler.checkin import get_checkin_manager
+    manager = get_checkin_manager()
+    checkin_id = int(slots.get("id", 0))
+    result_data = manager.resume_checkin(checkin_id)
+    ctx.last_intent = intent
+    return RouterResult(ok=result_data["ok"], intent=intent, user_text=result_data["text"] + _follow(in_queue))
+
+
+# ── Registration ──────────────────────────────────────────────────────────
+
+def register_all() -> None:
+    """Register all scheduler intent handlers."""
+    register_handler("reminder_add", handle_reminder_add)
+    register_handler("reminder_list", handle_reminder_list)
+    register_handler("reminder_delete", handle_reminder_delete)
+    register_handler("reminder_snooze", handle_reminder_snooze)
+    register_handler("checkin_add", handle_checkin_add)
+    register_handler("checkin_list", handle_checkin_list)
+    register_handler("checkin_delete", handle_checkin_delete)
+    register_handler("checkin_pause", handle_checkin_pause)
+    register_handler("checkin_resume", handle_checkin_resume)

--- a/tests/test_issue_420_router_modularization.py
+++ b/tests/test_issue_420_router_modularization.py
@@ -1,0 +1,453 @@
+"""Tests for Issue #420: Router Engine Modularization.
+
+Tests the handler registry, individual handler modules, and the
+dispatch integration in Router._dispatch().
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from bantz.router.handler_registry import (
+    register_handler,
+    register_handlers,
+    get_handler,
+    registered_intents,
+    _REGISTRY,
+)
+from bantz.router.types import RouterResult
+
+
+# ============================================================================
+# Handler Registry
+# ============================================================================
+
+class TestHandlerRegistry:
+    """Test the handler registry mechanism."""
+
+    def test_register_and_get(self):
+        """Register a handler and retrieve it."""
+        def my_handler(*, intent, slots, ctx, router, in_queue):
+            return RouterResult(ok=True, intent=intent, user_text="test")
+
+        register_handler("test_intent_420", my_handler)
+        assert get_handler("test_intent_420") is my_handler
+        # Cleanup
+        _REGISTRY.pop("test_intent_420", None)
+
+    def test_register_handlers_bulk(self):
+        """Register multiple intents to same handler."""
+        def bulk_handler(*, intent, slots, ctx, router, in_queue):
+            return RouterResult(ok=True, intent=intent, user_text="bulk")
+
+        register_handlers(["bulk_a_420", "bulk_b_420"], bulk_handler)
+        assert get_handler("bulk_a_420") is bulk_handler
+        assert get_handler("bulk_b_420") is bulk_handler
+        # Cleanup
+        _REGISTRY.pop("bulk_a_420", None)
+        _REGISTRY.pop("bulk_b_420", None)
+
+    def test_get_unknown_returns_none(self):
+        """Unknown intent returns None."""
+        assert get_handler("nonexistent_intent_xyz_420") is None
+
+    def test_registered_intents_sorted(self):
+        """registered_intents() returns sorted list."""
+        intents = registered_intents()
+        assert intents == sorted(intents)
+
+
+# ============================================================================
+# Handler Module Registration
+# ============================================================================
+
+class TestHandlerModuleRegistration:
+    """Test that all handler modules register correctly."""
+
+    def test_ensure_registered_idempotent(self):
+        """ensure_registered() can be called multiple times."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+        ensure_registered()  # no error
+
+    def test_browser_intents_registered(self):
+        """Browser handler intents should be registered."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        browser_intents = [
+            "ai_chat", "browser_open", "browser_scan", "browser_click",
+            "browser_type", "browser_scroll_down", "browser_scroll_up",
+            "browser_back", "browser_info", "browser_detail", "browser_wait",
+            "browser_search",
+        ]
+        for intent in browser_intents:
+            assert get_handler(intent) is not None, f"Browser intent '{intent}' not registered"
+
+    def test_panel_intents_registered(self):
+        """Panel handler intents should be registered."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        panel_intents = [
+            "panel_move", "panel_hide", "panel_minimize", "panel_maximize",
+            "panel_next_page", "panel_prev_page", "panel_select_item",
+        ]
+        for intent in panel_intents:
+            assert get_handler(intent) is not None, f"Panel intent '{intent}' not registered"
+
+    def test_pc_intents_registered(self):
+        """PC/desktop handler intents should be registered."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        pc_intents = [
+            "app_open", "app_close", "app_focus", "app_list", "app_type",
+            "app_submit", "pc_mouse_move", "pc_mouse_click", "pc_mouse_scroll",
+            "pc_hotkey", "clipboard_set", "clipboard_get", "app_session_exit",
+        ]
+        for intent in pc_intents:
+            assert get_handler(intent) is not None, f"PC intent '{intent}' not registered"
+
+    def test_daily_intents_registered(self):
+        """Daily skills handler intents should be registered."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        daily_intents = [
+            "open_browser", "google_search", "open_path", "open_url",
+            "notify", "open_btop",
+        ]
+        for intent in daily_intents:
+            assert get_handler(intent) is not None, f"Daily intent '{intent}' not registered"
+
+    def test_scheduler_intents_registered(self):
+        """Scheduler handler intents should be registered."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        scheduler_intents = [
+            "reminder_add", "reminder_list", "reminder_delete", "reminder_snooze",
+            "checkin_add", "checkin_list", "checkin_delete", "checkin_pause", "checkin_resume",
+        ]
+        for intent in scheduler_intents:
+            assert get_handler(intent) is not None, f"Scheduler intent '{intent}' not registered"
+
+    def test_coding_intents_registered(self):
+        """Coding agent intents should be registered."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        coding_intents = [
+            "file_read", "file_write", "file_edit", "file_create", "file_delete",
+            "terminal_run", "code_apply_diff", "project_info", "project_tree",
+        ]
+        for intent in coding_intents:
+            assert get_handler(intent) is not None, f"Coding intent '{intent}' not registered"
+
+    def test_total_registered_count(self):
+        """At least 60 intents should be registered."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        count = len(registered_intents())
+        assert count >= 60, f"Expected ≥60 registered intents, got {count}"
+
+
+# ============================================================================
+# Individual Handler Behavior
+# ============================================================================
+
+class TestBrowserHandlers:
+    """Test browser handler functions directly."""
+
+    def _mock_ctx(self):
+        ctx = MagicMock()
+        ctx.last_intent = None
+        return ctx
+
+    @patch("bantz.browser.skills.browser_ai_chat", return_value=(True, "AI chat açıldı"))
+    def test_ai_chat(self, mock_chat):
+        from bantz.router.handlers.browser import handle_ai_chat
+        ctx = self._mock_ctx()
+        result = handle_ai_chat(intent="ai_chat", slots={"service": "duck", "prompt": "test"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        assert "AI chat" in result.user_text
+
+    @patch("bantz.browser.skills.browser_open", return_value=(True, "Açıldı"))
+    def test_browser_open(self, mock_open):
+        from bantz.router.handlers.browser import handle_browser_open
+        ctx = self._mock_ctx()
+        result = handle_browser_open(intent="browser_open", slots={"url": "google.com"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+
+    @patch("bantz.browser.skills.browser_click_index", return_value=(True, "Tıklandı"))
+    def test_browser_click_index(self, mock_click):
+        from bantz.router.handlers.browser import handle_browser_click
+        ctx = self._mock_ctx()
+        result = handle_browser_click(intent="browser_click", slots={"index": 3}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        mock_click.assert_called_once_with(3)
+
+    @patch("bantz.browser.skills.browser_click_text", return_value=(True, "Tıklandı"))
+    def test_browser_click_text(self, mock_click):
+        from bantz.router.handlers.browser import handle_browser_click
+        ctx = self._mock_ctx()
+        result = handle_browser_click(intent="browser_click", slots={"text": "Login"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        mock_click.assert_called_once_with("Login")
+
+    def test_browser_click_no_target(self):
+        from bantz.router.handlers.browser import handle_browser_click
+        ctx = self._mock_ctx()
+        result = handle_browser_click(intent="browser_click", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is False
+        assert "anlamadım" in result.user_text
+
+    @patch("bantz.browser.skills.browser_search_in_page", return_value=(True, "Arandı"))
+    def test_browser_search(self, mock_search):
+        from bantz.router.handlers.browser import handle_browser_search
+        ctx = self._mock_ctx()
+        result = handle_browser_search(intent="browser_search", slots={"query": "test"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+
+    def test_browser_search_empty(self):
+        from bantz.router.handlers.browser import handle_browser_search
+        ctx = self._mock_ctx()
+        result = handle_browser_search(intent="browser_search", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is False
+        assert "Ne arayayım" in result.user_text
+
+
+class TestPanelHandlers:
+    """Test panel handler functions directly."""
+
+    def _mock_ctx(self, has_controller=True):
+        ctx = MagicMock()
+        if not has_controller:
+            ctx.get_panel_controller.return_value = None
+        return ctx
+
+    def test_panel_move_no_position(self):
+        from bantz.router.handlers.panel import handle_panel_move
+        ctx = self._mock_ctx()
+        result = handle_panel_move(intent="panel_move", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is False
+        assert "Nereye" in result.user_text
+
+    def test_panel_move_with_position(self):
+        from bantz.router.handlers.panel import handle_panel_move
+        ctx = self._mock_ctx()
+        result = handle_panel_move(intent="panel_move", slots={"position": "sağ"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        assert "sağ" in result.user_text
+
+    def test_panel_hide_no_controller(self):
+        from bantz.router.handlers.panel import handle_panel_hide
+        ctx = self._mock_ctx(has_controller=False)
+        result = handle_panel_hide(intent="panel_hide", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        assert "zaten" in result.user_text.lower()
+
+    def test_panel_select_no_index(self):
+        from bantz.router.handlers.panel import handle_panel_select_item
+        ctx = self._mock_ctx()
+        result = handle_panel_select_item(intent="panel_select_item", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is False
+
+
+class TestDailyHandlers:
+    """Test daily skills handler functions."""
+
+    def _mock_ctx(self):
+        ctx = MagicMock()
+        ctx.last_intent = None
+        ctx.awaiting = None
+        return ctx
+
+    @patch("bantz.skills.daily.google_search", return_value=(True, "Arandı"))
+    def test_google_search(self, mock_search):
+        from bantz.router.handlers.daily import handle_google_search
+        ctx = self._mock_ctx()
+        result = handle_google_search(intent="google_search", slots={"query": "python"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+
+    def test_google_search_empty(self):
+        from bantz.router.handlers.daily import handle_google_search
+        ctx = self._mock_ctx()
+        result = handle_google_search(intent="google_search", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is False
+        assert "Ne arayayım" in result.user_text
+
+
+class TestPCHandlers:
+    """Test PC control handler functions."""
+
+    def _mock_ctx(self, has_active_app=False):
+        ctx = MagicMock()
+        ctx.last_intent = None
+        ctx.has_active_app.return_value = has_active_app
+        ctx.active_app = "test_app" if has_active_app else None
+        ctx.active_window_id = "win123" if has_active_app else None
+        return ctx
+
+    def test_app_type_empty(self):
+        from bantz.router.handlers.pc import handle_app_type
+        ctx = self._mock_ctx()
+        result = handle_app_type(intent="app_type", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is False
+        assert "Ne yazayım" in result.user_text
+
+    def test_app_session_exit_no_session(self):
+        from bantz.router.handlers.pc import handle_app_session_exit
+        ctx = self._mock_ctx(has_active_app=False)
+        result = handle_app_session_exit(intent="app_session_exit", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        assert "Zaten" in result.user_text
+
+    def test_app_session_exit_with_session(self):
+        from bantz.router.handlers.pc import handle_app_session_exit
+        ctx = self._mock_ctx(has_active_app=True)
+        result = handle_app_session_exit(intent="app_session_exit", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        assert "çıktım" in result.user_text
+        ctx.clear_active_app.assert_called_once()
+
+    def test_app_close_no_app_no_session(self):
+        from bantz.router.handlers.pc import handle_app_close
+        ctx = self._mock_ctx(has_active_app=False)
+        result = handle_app_close(intent="app_close", slots={}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is False
+        assert "Hangi" in result.user_text
+
+
+class TestSchedulerHandlers:
+    """Test scheduler handler functions."""
+
+    @patch("bantz.scheduler.reminder.get_reminder_manager")
+    def test_reminder_add(self, mock_mgr_fn):
+        mock_mgr = MagicMock()
+        mock_mgr.add_reminder.return_value = {"ok": True, "text": "Hatırlatıcı eklendi"}
+        mock_mgr_fn.return_value = mock_mgr
+
+        from bantz.router.handlers.scheduler import handle_reminder_add
+        ctx = MagicMock()
+        result = handle_reminder_add(intent="reminder_add", slots={"time": "17:00", "message": "test"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        assert "eklendi" in result.user_text
+
+
+# ============================================================================
+# Integration: Router._dispatch() uses registry
+# ============================================================================
+
+class TestDispatchIntegration:
+    """Test that Router._dispatch() delegates to the handler registry."""
+
+    @patch("bantz.browser.skills.browser_open", return_value=(True, "Açıldı"))
+    def test_dispatch_browser_open_via_registry(self, mock_open):
+        """_dispatch should route browser_open through the handler registry."""
+        from bantz.router.engine import Router
+        from bantz.router.context import ConversationContext
+
+        mock_logger = MagicMock()
+        mock_policy = MagicMock()
+        router = Router(policy=mock_policy, logger=mock_logger)
+
+        ctx = MagicMock(spec=ConversationContext)
+        ctx.last_intent = None
+
+        result = router._dispatch(intent="browser_open", slots={"url": "test.com"}, ctx=ctx, in_queue=False)
+        assert result.ok is True
+        assert result.intent == "browser_open"
+        mock_open.assert_called_once()
+
+    def test_dispatch_unknown_intent(self):
+        """Unknown intent should fall through to default."""
+        from bantz.router.engine import Router
+
+        mock_logger = MagicMock()
+        mock_policy = MagicMock()
+        router = Router(policy=mock_policy, logger=mock_logger)
+
+        ctx = MagicMock()
+        ctx.last_intent = None
+
+        result = router._dispatch(intent="totally_unknown_xyz", slots={}, ctx=ctx, in_queue=False)
+        assert result.ok is False
+        assert result.intent == "unknown"
+
+    def test_follow_up_in_queue(self):
+        """When in_queue=True, follow-up text should be empty."""
+        from bantz.router.handlers.browser import handle_browser_search
+        ctx = MagicMock()
+        result = handle_browser_search(intent="browser_search", slots={}, ctx=ctx, router=None, in_queue=True)
+        assert result.ok is False
+        # Should NOT have "Başka ne yapayım?"
+        assert "Başka" not in result.user_text
+
+    def test_follow_up_not_in_queue(self):
+        """When in_queue=False, handler still returns clean result."""
+        from bantz.router.handlers.panel import handle_panel_move
+        ctx = MagicMock()
+        result = handle_panel_move(intent="panel_move", slots={"position": "sol"}, ctx=ctx, router=None, in_queue=False)
+        assert result.ok is True
+        assert "sol" in result.user_text
+
+
+# ============================================================================
+# Architecture: Module counts and structure
+# ============================================================================
+
+class TestArchitecture:
+    """Test the architectural properties of the modularization."""
+
+    def test_handler_modules_exist(self):
+        """All expected handler modules should be importable."""
+        from bantz.router.handlers import browser, panel, pc, daily, scheduler, coding
+        assert hasattr(browser, "register_all")
+        assert hasattr(panel, "register_all")
+        assert hasattr(pc, "register_all")
+        assert hasattr(daily, "register_all")
+        assert hasattr(scheduler, "register_all")
+        assert hasattr(coding, "register_all")
+
+    def test_handler_protocol_signature(self):
+        """All handlers should accept the standard kwargs."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        import inspect
+        for intent_name in registered_intents():
+            handler = get_handler(intent_name)
+            sig = inspect.signature(handler)
+            params = set(sig.parameters.keys())
+            required = {"intent", "slots", "ctx", "router", "in_queue"}
+            assert required.issubset(params), f"Handler for '{intent_name}' missing params: {required - params}"
+
+    def test_no_handler_returns_none_result(self):
+        """All handlers should return RouterResult, not None."""
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+
+        # Spot-check a few handlers with minimal mocks
+        ctx = MagicMock()
+        ctx.last_intent = None
+        ctx.has_active_app.return_value = False
+        ctx.active_app = None
+
+        handlers_to_check = [
+            ("browser_search", {"query": ""}),
+            ("panel_move", {}),
+            ("app_type", {}),
+        ]
+        for intent_name, slots in handlers_to_check:
+            handler = get_handler(intent_name)
+            result = handler(intent=intent_name, slots=slots, ctx=ctx, router=None, in_queue=False)
+            assert isinstance(result, RouterResult), f"Handler '{intent_name}' returned {type(result)}"
+
+    def test_registry_is_not_empty_after_ensure(self):
+        from bantz.router.handlers import ensure_registered
+        ensure_registered()
+        assert len(registered_intents()) > 0


### PR DESCRIPTION
## Summary
Extracts 73 intents from the monolithic 878-line `_dispatch()` if/elif chain into 6 handler modules with a clean registry pattern.

## Changes
- **handler_registry.py**: `IntentHandler` Protocol, `register_handler()`, `get_handler()` registry
- **handlers/browser.py**: 12 browser intents (ai_chat, browser_open/scan/click/type/scroll/back/info/detail/wait/search)
- **handlers/panel.py**: 7 panel intents (panel_move/hide/minimize/maximize/next_page/prev_page/select_item)
- **handlers/pc.py**: 13 PC control intents (app_open/close/focus/list/type/submit, pc_mouse_*, clipboard_*, app_session_exit)
- **handlers/daily.py**: 6 daily skills (open_browser, google_search, open_path, open_url, notify, open_btop)
- **handlers/scheduler.py**: 9 scheduler intents (reminder_add/list/delete/snooze, checkin_add/list/delete/pause/resume)
- **handlers/coding.py**: 26 coding agent intents via single handler
- **engine.py**: registry-first lookup at top of `_dispatch()`, fallback to original if/elif for 7 complex news/page intents

## Backward Compatible
- News/page intents remain in engine.py (complex async state management)
- Registry lookup first → original if/elif fallback → clean migration path

## Tests
- 38 tests covering registry, handler registration, handler behavior, dispatch integration, architecture validation

Closes #420