### PR TITLE
feat(#422): Rule-based Gmail intent detection for Turkish

### DIFF
--- a/src/bantz/brain/gmail_intent.py
+++ b/src/bantz/brain/gmail_intent.py
@@ -1,0 +1,179 @@
+"""Rule-based Gmail intent detection for Turkish (Issue #422).
+
+When the 3B model returns gmail_intent='none' or misroutes 'mail at' vs 'mail oku',
+this module provides a keyword-based fallback that resolves the intent from the
+user's original Turkish text.
+
+Keyword patterns:
+- send: gönder, at, yolla, yaz (mail context)
+- read: oku, aç, göster, bak
+- list: listele, sırala, göster (without specific email target)
+- search: ara, bul, filtrele
+"""
+
+from __future__ import annotations
+
+import re
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Keyword → intent mapping (ordered by specificity) ───────────────────────
+
+# Send indicators (Turkish conjugation-aware)
+_SEND_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b(?:gönder|yolla|ilet)\b", re.IGNORECASE),
+    # "mail at" / "e-posta at" — "at" is ambiguous (also "throw"), but with mail context it means send
+    re.compile(r"\b(?:mail|e-?posta|mesaj)\b.*\b(?:at|atıver)\b", re.IGNORECASE),
+    re.compile(r"\b(?:at|atıver)\b.*\b(?:mail|e-?posta|mesaj)\b", re.IGNORECASE),
+    # "X'e yaz" (write to X) — when in gmail context
+    re.compile(r"\b(?:mail|e-?posta)\b.*\byaz\b", re.IGNORECASE),
+    re.compile(r"\byaz\b.*\b(?:mail|e-?posta)\b", re.IGNORECASE),
+    # "reply" / "cevap ver" / "cevapla"
+    re.compile(r"\bcevap(?:la|lar|layın|lasın)?\b", re.IGNORECASE),
+    re.compile(r"\bcevap\s+ver\b", re.IGNORECASE),
+    re.compile(r"\byanıtla\b", re.IGNORECASE),
+]
+
+# Read indicators
+_READ_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b(?:mail|e-?posta|mesaj)\w*\s+oku\b", re.IGNORECASE),
+    re.compile(r"\boku\w*\s+(?:mail|e-?posta|mesaj)\b", re.IGNORECASE),
+    re.compile(r"\b(?:mail|e-?posta|mesaj)\w*\s+aç\b", re.IGNORECASE),
+    re.compile(r"\baç\w*\s+(?:mail|e-?posta|mesaj)\b", re.IGNORECASE),
+    # "maili göster" / "maile bak"
+    re.compile(r"\b(?:mail|e-?posta|mesaj)\w*\s+(?:göster|bak)\b", re.IGNORECASE),
+    # "son maili oku" / "gelen maili aç"
+    re.compile(r"\b(?:son|gelen|yeni)\s+(?:mail|e-?posta)\w*\b.*\b(?:oku|aç|göster|bak)\b", re.IGNORECASE),
+]
+
+# Search indicators
+_SEARCH_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b(?:mail|e-?posta|mesaj)\w*\s+(?:ara|bul)\b", re.IGNORECASE),
+    re.compile(r"\b(?:ara|bul)\w*\s+(?:mail|e-?posta|mesaj)\b", re.IGNORECASE),
+    re.compile(r"\b(?:mail|e-?posta)\w*\s+filtrele\b", re.IGNORECASE),
+    # Implicit search: "linkedin maili", "amazon siparişi maili"
+    re.compile(r"\b\w+\s+(?:maili|mailini|maillerini)\b", re.IGNORECASE),
+    # "X'den gelen mail"
+    re.compile(r"\b\w+['\u2019]?(?:den|dan|ten|tan)\s+(?:gelen|gönderilen)\s+(?:mail|e-?posta)\b", re.IGNORECASE),
+]
+
+# List indicators
+_LIST_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b(?:mail|e-?posta|mesaj)\w*\s+(?:listele|sırala)\b", re.IGNORECASE),
+    re.compile(r"\b(?:listele|sırala)\w*\s+(?:mail|e-?posta|mesaj)\b", re.IGNORECASE),
+    # "kaç mail var" / "maillerim" / "gelen kutusu"
+    re.compile(r"\b(?:kaç|ne\s+kadar)\s+(?:mail|e-?posta|mesaj)\b", re.IGNORECASE),
+    re.compile(r"\bgelen\s+kutu(?:su|m)\b", re.IGNORECASE),
+    re.compile(r"\bmaillerim\b", re.IGNORECASE),
+    # "son mailleri göster" (plural → list, not read single)
+    re.compile(r"\b(?:son|tüm|bütün|yeni)\s+(?:mailler|e-?postalar|mesajlar)\w*\b", re.IGNORECASE),
+]
+
+# Gmail context detector — does the text mention mail at all?
+# Allow Turkish suffixes: maili, maile, mailim, mailini, mailleri, etc.
+_GMAIL_CONTEXT_RE = re.compile(
+    r"\b(?:mail\w*|e-?posta\w*|gmail|inbox|gelen\s+kutu\w*|mesaj\w*)\b",
+    re.IGNORECASE,
+)
+
+
+def detect_gmail_intent(text: str) -> Optional[str]:
+    """Detect Gmail intent from Turkish user text using keyword patterns.
+
+    Returns one of: 'send', 'read', 'search', 'list', or None if no
+    Gmail intent could be determined.
+
+    Priority order (most specific first):
+    1. send — explicit send verbs
+    2. read — explicit read/open verbs for a single email
+    3. search — explicit search/find verbs
+    4. list — plural listing verbs or inbox queries
+    """
+    if not text:
+        return None
+
+    text = text.strip()
+
+    # Must have some gmail context
+    if not _GMAIL_CONTEXT_RE.search(text):
+        return None
+
+    # ── Check for plural indicators first (list takes priority over read
+    #    when the noun is plural: mailleri, mailler, e-postaları, mesajları)
+    _plural_re = re.compile(r"\b(?:mailler\w*|e-?postalar\w*|mesajlar\w*)\b", re.IGNORECASE)
+    is_plural = bool(_plural_re.search(text))
+
+    # Check in priority order
+    for pattern in _SEND_PATTERNS:
+        if pattern.search(text):
+            logger.debug("[gmail_intent] detected 'send' from: %s", text[:60])
+            return "send"
+
+    # If plural noun → list before read
+    if is_plural:
+        for pattern in _LIST_PATTERNS:
+            if pattern.search(text):
+                logger.debug("[gmail_intent] detected 'list' (plural) from: %s", text[:60])
+                return "list"
+
+    for pattern in _READ_PATTERNS:
+        if pattern.search(text):
+            logger.debug("[gmail_intent] detected 'read' from: %s", text[:60])
+            return "read"
+
+    for pattern in _SEARCH_PATTERNS:
+        if pattern.search(text):
+            logger.debug("[gmail_intent] detected 'search' from: %s", text[:60])
+            return "search"
+
+    for pattern in _LIST_PATTERNS:
+        if pattern.search(text):
+            logger.debug("[gmail_intent] detected 'list' from: %s", text[:60])
+            return "list"
+
+    return None
+
+
+def resolve_gmail_intent(
+    *,
+    llm_intent: str,
+    user_text: str,
+    route: str = "",
+) -> str:
+    """Resolve final Gmail intent, combining LLM output with rule-based fallback.
+
+    Logic:
+    1. If LLM returned a valid intent (!= 'none'), trust it.
+    2. If LLM returned 'none' or route is 'gmail', use keyword detection.
+    3. Return 'none' as last resort.
+
+    Args:
+        llm_intent: Intent from LLM output (list|search|read|send|none)
+        user_text: Original user text for keyword fallback
+        route: LLM route (used to decide if gmail context is implied)
+
+    Returns:
+        Resolved intent string.
+    """
+    # Valid LLM intent → trust it
+    if llm_intent in {"list", "search", "read", "send"}:
+        return llm_intent
+
+    # Keyword-based fallback
+    detected = detect_gmail_intent(user_text)
+    if detected:
+        logger.info(
+            "[gmail_intent] keyword fallback: LLM='%s' → detected='%s'",
+            llm_intent,
+            detected,
+        )
+        return detected
+
+    # If route is gmail but no intent could be determined, default to list
+    if route == "gmail":
+        logger.info("[gmail_intent] route=gmail but no intent detected, defaulting to 'list'")
+        return "list"
+
+    return "none"

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1171,11 +1171,23 @@ USER: sabah beşte koşu
             if not question:
                 question = assistant_reply
         
-        # Gmail extensions (Issue #317)
+        # Gmail extensions (Issue #317 + #422: rule-based fallback)
         gmail_intent = str(parsed.get("gmail_intent") or "none").strip().lower()
         gmail_obj = parsed.get("gmail") or {}
         if not isinstance(gmail_obj, dict):
             gmail_obj = {}
+
+        # ── Issue #422: Rule-based Gmail intent resolution ───────────────
+        if user_input:
+            try:
+                from bantz.brain.gmail_intent import resolve_gmail_intent
+                gmail_intent = resolve_gmail_intent(
+                    llm_intent=gmail_intent,
+                    user_text=user_input,
+                    route=route,
+                )
+            except ImportError:
+                pass  # graceful degradation
 
         return OrchestratorOutput(
             route=route,

--- a/tests/test_issue_422_gmail_intent_detection.py
+++ b/tests/test_issue_422_gmail_intent_detection.py
@@ -1,0 +1,317 @@
+"""Tests for Issue #422: Gmail intent detection — rule-based Turkish keyword fallback.
+
+Covers:
+- detect_gmail_intent: keyword pattern matching for send/read/search/list
+- resolve_gmail_intent: combining LLM output with keyword fallback
+- Integration: _extract_output applies gmail intent resolution
+- 20+ Turkish gmail sentences for accuracy measurement
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from bantz.brain.gmail_intent import detect_gmail_intent, resolve_gmail_intent
+
+
+# ============================================================================
+# Helper
+# ============================================================================
+
+class MockLLM:
+    def __init__(self, response=""):
+        self.response = response
+    def complete_text(self, *, prompt, temperature=0.0, max_tokens=200):
+        return self.response
+
+
+def _make_router(response=""):
+    from bantz.brain.llm_router import JarvisLLMOrchestrator
+    return JarvisLLMOrchestrator(llm=MockLLM(response))
+
+
+# ============================================================================
+# detect_gmail_intent: Send patterns
+# ============================================================================
+
+class TestDetectSend:
+    """Test send intent detection."""
+
+    @pytest.mark.parametrize("text", [
+        "Ali'ye mail gönder",
+        "ali'ye e-posta gönder",
+        "ahmet'e mesaj gönder",
+        "mail at ali'ye",
+        "ali'ye mail at",
+        "mail yolla",
+        "e-posta ilet",
+        "mail yaz ahmet'e",
+        "e-posta yaz",
+        "maili cevapla",
+        "cevap ver maile",
+        "maili yanıtla",
+    ])
+    def test_send_detected(self, text):
+        assert detect_gmail_intent(text) == "send"
+
+    def test_at_without_mail_context_not_detected(self):
+        """'at' alone without mail context should not trigger send."""
+        assert detect_gmail_intent("topu at") is None
+
+    def test_yaz_without_mail_context_not_detected(self):
+        """'yaz' alone without mail context should not trigger send."""
+        assert detect_gmail_intent("bir şey yaz") is None
+
+
+# ============================================================================
+# detect_gmail_intent: Read patterns
+# ============================================================================
+
+class TestDetectRead:
+    """Test read intent detection."""
+
+    @pytest.mark.parametrize("text", [
+        "maili oku",
+        "e-postayı oku",
+        "mesajı oku",
+        "maili aç",
+        "e-postayı aç",
+        "maile bak",
+        "maili göster",
+        "son maili oku",
+        "gelen maili aç",
+        "yeni maili göster",
+    ])
+    def test_read_detected(self, text):
+        assert detect_gmail_intent(text) == "read"
+
+
+# ============================================================================
+# detect_gmail_intent: Search patterns
+# ============================================================================
+
+class TestDetectSearch:
+    """Test search intent detection."""
+
+    @pytest.mark.parametrize("text", [
+        "mail ara",
+        "e-posta bul",
+        "mail filtrele",
+        "linkedin maili",
+        "amazon mailini",
+        "ali'den gelen mail",
+    ])
+    def test_search_detected(self, text):
+        assert detect_gmail_intent(text) == "search"
+
+
+# ============================================================================
+# detect_gmail_intent: List patterns
+# ============================================================================
+
+class TestDetectList:
+    """Test list intent detection."""
+
+    @pytest.mark.parametrize("text", [
+        "mailleri listele",
+        "e-postaları sırala",
+        "kaç mail var",
+        "gelen kutum",
+        "gelen kutusu",
+        "maillerim",
+        "son mailler",
+        "tüm mailleri göster",
+        "yeni mesajları göster",
+    ])
+    def test_list_detected(self, text):
+        assert detect_gmail_intent(text) == "list"
+
+
+# ============================================================================
+# detect_gmail_intent: No detection
+# ============================================================================
+
+class TestDetectNone:
+    """Test cases where no gmail intent should be detected."""
+
+    @pytest.mark.parametrize("text", [
+        "",
+        "bugün hava nasıl",
+        "saat beşte toplantı yap",
+        "youtube aç",
+        "müzik çal",
+        "merhaba",
+    ])
+    def test_no_gmail_context(self, text):
+        assert detect_gmail_intent(text) is None
+
+
+# ============================================================================
+# resolve_gmail_intent: LLM trust vs fallback
+# ============================================================================
+
+class TestResolveGmailIntent:
+    """Test the resolution logic combining LLM and keyword detection."""
+
+    def test_valid_llm_intent_trusted(self):
+        """LLM returns valid intent → trust it."""
+        assert resolve_gmail_intent(llm_intent="send", user_text="mail gönder", route="gmail") == "send"
+        assert resolve_gmail_intent(llm_intent="read", user_text="mail oku", route="gmail") == "read"
+        assert resolve_gmail_intent(llm_intent="search", user_text="mail ara", route="gmail") == "search"
+        assert resolve_gmail_intent(llm_intent="list", user_text="maillerim", route="gmail") == "list"
+
+    def test_none_llm_falls_back_to_keyword(self):
+        """LLM returns 'none' → use keyword detection."""
+        assert resolve_gmail_intent(llm_intent="none", user_text="ali'ye mail gönder", route="gmail") == "send"
+        assert resolve_gmail_intent(llm_intent="none", user_text="maili oku", route="gmail") == "read"
+        assert resolve_gmail_intent(llm_intent="none", user_text="mail ara", route="gmail") == "search"
+
+    def test_llm_wrong_intent_overridden(self):
+        """LLM returns valid but wrong intent → we trust LLM (conservative)."""
+        # LLM said 'send' but user said 'oku' — we trust LLM when it's not 'none'
+        result = resolve_gmail_intent(llm_intent="send", user_text="maili oku", route="gmail")
+        assert result == "send"  # Trust LLM
+
+    def test_route_gmail_no_keyword_defaults_to_list(self):
+        """Route is gmail but no keyword match → default to 'list'."""
+        assert resolve_gmail_intent(llm_intent="none", user_text="gmail", route="gmail") == "list"
+
+    def test_no_gmail_context_returns_none(self):
+        """No gmail context in text and LLM says none → return 'none'."""
+        assert resolve_gmail_intent(llm_intent="none", user_text="hava nasıl", route="smalltalk") == "none"
+
+
+# ============================================================================
+# Integration: _extract_output uses resolve_gmail_intent
+# ============================================================================
+
+class TestExtractOutputGmailIntegration:
+    """Test that _extract_output applies gmail intent resolution."""
+
+    def test_llm_none_keyword_send(self):
+        """LLM gmail_intent=none + user says 'mail gönder' → send."""
+        router = _make_router()
+        parsed = {
+            "route": "gmail",
+            "calendar_intent": "none",
+            "gmail_intent": "none",
+            "confidence": 0.8,
+            "tool_plan": [],
+            "assistant_reply": "test",
+            "slots": {},
+        }
+        result = router._extract_output(parsed, raw_text="", user_input="ali'ye mail gönder", repaired=False)
+        assert result.gmail_intent == "send"
+
+    def test_llm_none_keyword_read(self):
+        """LLM gmail_intent=none + user says 'maili oku' → read."""
+        router = _make_router()
+        parsed = {
+            "route": "gmail",
+            "calendar_intent": "none",
+            "gmail_intent": "none",
+            "confidence": 0.9,
+            "tool_plan": [],
+            "assistant_reply": "test",
+            "slots": {},
+        }
+        result = router._extract_output(parsed, raw_text="", user_input="maili oku", repaired=False)
+        assert result.gmail_intent == "read"
+
+    def test_llm_valid_intent_preserved(self):
+        """LLM gmail_intent=send → preserved even with different keywords."""
+        router = _make_router()
+        parsed = {
+            "route": "gmail",
+            "calendar_intent": "none",
+            "gmail_intent": "send",
+            "confidence": 0.9,
+            "tool_plan": ["gmail.send"],
+            "assistant_reply": "test",
+            "slots": {},
+        }
+        result = router._extract_output(parsed, raw_text="", user_input="mail gönder", repaired=False)
+        assert result.gmail_intent == "send"
+
+    def test_no_user_input_no_change(self):
+        """Without user_input, gmail_intent from LLM is used as-is."""
+        router = _make_router()
+        parsed = {
+            "route": "gmail",
+            "calendar_intent": "none",
+            "gmail_intent": "none",
+            "confidence": 0.9,
+            "tool_plan": [],
+            "assistant_reply": "test",
+            "slots": {},
+        }
+        result = router._extract_output(parsed, raw_text="", user_input="", repaired=False)
+        assert result.gmail_intent == "none"
+
+
+# ============================================================================
+# Accuracy: 20+ Turkish Gmail sentences
+# ============================================================================
+
+class TestTurkishGmailAccuracy:
+    """Accuracy test with 20+ real-world Turkish Gmail sentences."""
+
+    @pytest.mark.parametrize("text,expected", [
+        # SEND (7)
+        ("Ali'ye mail gönder", "send"),
+        ("ahmet'e e-posta at", "send"),
+        ("Mehmet'e mesaj yolla", "send"),
+        ("mail yaz direktöre", "send"),
+        ("e-posta gönder patrona", "send"),
+        ("maili yanıtla", "send"),
+        ("cevap ver maile", "send"),
+        # READ (5)
+        ("son maili oku", "read"),
+        ("gelen maili aç", "read"),
+        ("maili göster", "read"),
+        ("e-postayı oku", "read"),
+        ("yeni maile bak", "read"),
+        # SEARCH (4)
+        ("linkedin maili", "search"),
+        ("amazon mailini bul", "search"),
+        ("mail ara promotions", "search"),
+        ("ali'den gelen mail", "search"),
+        # LIST (4)
+        ("mailleri listele", "list"),
+        ("kaç mail var", "list"),
+        ("gelen kutum", "list"),
+        ("son mailler", "list"),
+    ])
+    def test_accuracy_corpus(self, text, expected):
+        result = detect_gmail_intent(text)
+        assert result == expected, f"Text: '{text}' → expected '{expected}', got '{result}'"
+
+    def test_accuracy_rate(self):
+        """Overall accuracy should be 100% on this corpus."""
+        corpus = [
+            ("Ali'ye mail gönder", "send"),
+            ("ahmet'e e-posta at", "send"),
+            ("Mehmet'e mesaj yolla", "send"),
+            ("mail yaz direktöre", "send"),
+            ("e-posta gönder patrona", "send"),
+            ("maili yanıtla", "send"),
+            ("cevap ver maile", "send"),
+            ("son maili oku", "read"),
+            ("gelen maili aç", "read"),
+            ("maili göster", "read"),
+            ("e-postayı oku", "read"),
+            ("yeni maile bak", "read"),
+            ("linkedin maili", "search"),
+            ("amazon mailini bul", "search"),
+            ("mail ara promotions", "search"),
+            ("ali'den gelen mail", "search"),
+            ("mailleri listele", "list"),
+            ("kaç mail var", "list"),
+            ("gelen kutum", "list"),
+            ("son mailler", "list"),
+        ]
+        correct = sum(1 for text, exp in corpus if detect_gmail_intent(text) == exp)
+        accuracy = correct / len(corpus) * 100
+        assert accuracy == 100.0, f"Accuracy: {accuracy}% ({correct}/{len(corpus)})"


### PR DESCRIPTION
## Summary
Adds keyword-based Turkish Gmail intent detection as fallback when 3B model returns gmail_intent='none' or misroutes.

## Problem
3B model frequently confuses 'mail at' (send) with 'mail oku' (read), and often returns gmail_intent='none' when Gmail context is clear.

## Solution
- **gmail_intent.py**: Pattern-based intent detector with 4 intent categories and Turkish conjugation awareness
- **detect_gmail_intent()**: Keyword patterns for send (gönder/at/yolla), read (oku/aç/göster), search (ara/bul), list (listele/sırala)
- **resolve_gmail_intent()**: Trusts valid LLM intent, falls back to keywords when 'none'
- **Plural priority**: 'mailleri göster' → list (not read) via plural noun detection
- **Integration**: Hooked into _extract_output for automatic resolution

## Tests
- 75 tests: send (14), read (10), search (6), list (9), no-detection (6), resolution logic (5), integration (4), 20-sentence accuracy corpus (100%)

Closes #422