### PR TITLE
feat(#424): Policy Gmail/Calendar tool definitions

### DIFF
--- a/config/policy.json
+++ b/config/policy.json
@@ -78,5 +78,107 @@
     "clipboard_set": "confirm",
     "clipboard_get": "allow",
     "unknown": "deny"
-  }
+  },
+
+  "tool_levels": {
+    "__comment": "Single source of truth for tool risk levels (Issue #424). Values: safe | moderate | destructive",
+
+    "web.search":               "safe",
+    "web.open":                 "safe",
+
+    "calendar.list_events":     "safe",
+    "calendar.find_event":      "safe",
+    "calendar.get_event":       "safe",
+    "calendar.create_event":    "moderate",
+    "calendar.update_event":    "moderate",
+    "calendar.delete_event":    "destructive",
+
+    "gmail.list_messages":      "safe",
+    "gmail.unread_count":       "safe",
+    "gmail.get_message":        "safe",
+    "gmail.download_attachment":"moderate",
+    "gmail.query_from_nl":      "safe",
+    "gmail.smart_search":       "safe",
+    "gmail.search_template_upsert": "safe",
+    "gmail.search_template_get":"safe",
+    "gmail.search_template_list":"safe",
+    "gmail.search_template_delete":"safe",
+    "gmail.list_labels":        "safe",
+    "gmail.add_label":          "safe",
+    "gmail.remove_label":       "safe",
+    "gmail.mark_read":          "safe",
+    "gmail.mark_unread":        "safe",
+    "gmail.archive":            "moderate",
+    "gmail.batch_modify":       "moderate",
+    "gmail.send":               "moderate",
+    "gmail.send_to_contact":    "moderate",
+    "gmail.create_draft":       "safe",
+    "gmail.list_drafts":        "safe",
+    "gmail.update_draft":       "safe",
+    "gmail.delete_draft":       "safe",
+    "gmail.send_draft":         "moderate",
+    "gmail.generate_reply":     "moderate",
+
+    "contacts.upsert":          "safe",
+    "contacts.resolve":         "safe",
+    "contacts.list":            "safe",
+    "contacts.delete":          "safe",
+
+    "time.now":                 "safe",
+    "time.date":                "safe",
+    "weather.current":          "safe",
+    "weather.forecast":         "safe",
+    "system.status":            "safe",
+
+    "file.read":                "safe",
+    "file.list":                "safe",
+    "file.write":               "moderate",
+    "file.delete":              "destructive",
+    "file.move":                "destructive",
+
+    "vision.analyze":           "safe",
+    "vision.ocr":               "safe",
+    "vision.screenshot":        "safe",
+
+    "notification.send":        "moderate",
+    "clipboard.set":            "moderate",
+    "clipboard.get":            "moderate",
+
+    "browser.open":             "moderate",
+    "browser.navigate":         "moderate",
+    "browser.submit_form":      "destructive",
+    "browser.click_button":     "destructive",
+
+    "app.open":                 "moderate",
+    "app.focus":                "moderate",
+    "app.close":                "destructive",
+    "app.kill":                 "destructive",
+
+    "email.send":               "moderate",
+    "email.delete":             "destructive",
+    "notes.create":             "moderate",
+
+    "payment.submit":           "destructive",
+    "payment.confirm":          "destructive",
+
+    "system.shutdown":          "destructive",
+    "system.restart":           "destructive",
+    "system.execute_command":   "destructive",
+    "system.sudo":              "destructive",
+
+    "database.delete":          "destructive",
+    "database.update":          "destructive"
+  },
+
+  "always_confirm_tools": [
+    "calendar.create_event",
+    "calendar.update_event",
+    "gmail.send",
+    "gmail.send_draft",
+    "gmail.send_to_contact",
+    "gmail.download_attachment",
+    "gmail.generate_reply"
+  ],
+
+  "undefined_tool_policy": "deny"
 }

--- a/src/bantz/tools/metadata.py
+++ b/src/bantz/tools/metadata.py
@@ -1,18 +1,28 @@
-"""Tool Risk Classification & Metadata (Issue #160).
+"""Tool Risk Classification & Metadata (Issue #160, #424).
 
-This module defines risk levels for all tools and enforces the confirmation
-firewall for destructive operations.
+Single source of truth: ``config/policy.json`` → ``tool_levels`` section.
+This module loads risk levels from the JSON file at import time and falls
+back to hardcoded defaults if the file is missing or malformed.
 
 Risk Levels:
 - SAFE: Read-only operations, harmless queries (web.search, calendar.list_events)
 - MODERATE: State changes with low impact (calendar.create_event, notifications)
 - DESTRUCTIVE: Dangerous operations requiring confirmation (delete, file operations, payments)
+
+Issue #424 additions:
+- ``load_policy_json()`` reads tool_levels / always_confirm_tools / undefined_tool_policy
+- ``UNDEFINED_TOOL_POLICY`` controls behaviour for tools not listed in policy.json
 """
 
 from __future__ import annotations
 
+import json
+import logging
 from enum import Enum
+from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class ToolRisk(str, Enum):
@@ -23,12 +33,12 @@ class ToolRisk(str, Enum):
     DESTRUCTIVE = "destructive"  # Dangerous, requires confirmation
 
 
-# Tool Risk Registry
-# Maps tool names to their risk levels
-TOOL_REGISTRY: dict[str, ToolRisk] = {
-    # ═══════════════════════════════════════════════════════════
-    # SAFE Tools (Read-only, no side effects)
-    # ═══════════════════════════════════════════════════════════
+# ---------------------------------------------------------------------------
+# Hardcoded fallback registry (used when policy.json is absent)
+# ---------------------------------------------------------------------------
+
+_FALLBACK_TOOL_REGISTRY: dict[str, ToolRisk] = {
+    # SAFE
     "web.search": ToolRisk.SAFE,
     "web.open": ToolRisk.SAFE,
     "calendar.list_events": ToolRisk.SAFE,
@@ -37,7 +47,6 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "gmail.list_messages": ToolRisk.SAFE,
     "gmail.unread_count": ToolRisk.SAFE,
     "gmail.get_message": ToolRisk.SAFE,
-    "gmail.download_attachment": ToolRisk.MODERATE,
     "gmail.query_from_nl": ToolRisk.SAFE,
     "gmail.smart_search": ToolRisk.SAFE,
     "gmail.search_template_upsert": ToolRisk.SAFE,
@@ -49,20 +58,14 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "gmail.remove_label": ToolRisk.SAFE,
     "gmail.mark_read": ToolRisk.SAFE,
     "gmail.mark_unread": ToolRisk.SAFE,
-    "gmail.archive": ToolRisk.MODERATE,
-    "gmail.batch_modify": ToolRisk.MODERATE,
-    "gmail.send": ToolRisk.MODERATE,
-    "gmail.send_to_contact": ToolRisk.MODERATE,
-    "contacts.upsert": ToolRisk.SAFE,
-    "contacts.resolve": ToolRisk.SAFE,
-    "contacts.list": ToolRisk.SAFE,
-    "contacts.delete": ToolRisk.SAFE,
     "gmail.create_draft": ToolRisk.SAFE,
     "gmail.list_drafts": ToolRisk.SAFE,
     "gmail.update_draft": ToolRisk.SAFE,
     "gmail.delete_draft": ToolRisk.SAFE,
-    "gmail.send_draft": ToolRisk.MODERATE,
-    "gmail.generate_reply": ToolRisk.MODERATE,
+    "contacts.upsert": ToolRisk.SAFE,
+    "contacts.resolve": ToolRisk.SAFE,
+    "contacts.list": ToolRisk.SAFE,
+    "contacts.delete": ToolRisk.SAFE,
     "time.now": ToolRisk.SAFE,
     "time.date": ToolRisk.SAFE,
     "weather.current": ToolRisk.SAFE,
@@ -73,10 +76,14 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "vision.analyze": ToolRisk.SAFE,
     "vision.ocr": ToolRisk.SAFE,
     "vision.screenshot": ToolRisk.SAFE,
-    
-    # ═══════════════════════════════════════════════════════════
-    # MODERATE Tools (State changes, reversible)
-    # ═══════════════════════════════════════════════════════════
+    # MODERATE
+    "gmail.download_attachment": ToolRisk.MODERATE,
+    "gmail.archive": ToolRisk.MODERATE,
+    "gmail.batch_modify": ToolRisk.MODERATE,
+    "gmail.send": ToolRisk.MODERATE,
+    "gmail.send_to_contact": ToolRisk.MODERATE,
+    "gmail.send_draft": ToolRisk.MODERATE,
+    "gmail.generate_reply": ToolRisk.MODERATE,
     "calendar.create_event": ToolRisk.MODERATE,
     "calendar.update_event": ToolRisk.MODERATE,
     "notification.send": ToolRisk.MODERATE,
@@ -89,10 +96,7 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "app.focus": ToolRisk.MODERATE,
     "email.send": ToolRisk.MODERATE,
     "notes.create": ToolRisk.MODERATE,
-    
-    # ═══════════════════════════════════════════════════════════
-    # DESTRUCTIVE Tools (Dangerous, requires confirmation)
-    # ═══════════════════════════════════════════════════════════
+    # DESTRUCTIVE
     "calendar.delete_event": ToolRisk.DESTRUCTIVE,
     "file.delete": ToolRisk.DESTRUCTIVE,
     "file.move": ToolRisk.DESTRUCTIVE,
@@ -111,9 +115,7 @@ TOOL_REGISTRY: dict[str, ToolRisk] = {
     "database.update": ToolRisk.DESTRUCTIVE,
 }
 
-
-# Moderate tools that must always require confirmation.
-ALWAYS_CONFIRM_TOOLS: set[str] = {
+_FALLBACK_ALWAYS_CONFIRM: set[str] = {
     "calendar.create_event",
     "calendar.update_event",
     "gmail.send",
@@ -124,25 +126,121 @@ ALWAYS_CONFIRM_TOOLS: set[str] = {
 }
 
 
-def get_tool_risk(tool_name: str, default: ToolRisk = ToolRisk.MODERATE) -> ToolRisk:
+# ---------------------------------------------------------------------------
+# Policy JSON loader (Issue #424)
+# ---------------------------------------------------------------------------
+
+_RISK_NAME_MAP = {"safe": ToolRisk.SAFE, "moderate": ToolRisk.MODERATE, "destructive": ToolRisk.DESTRUCTIVE}
+
+# Default policy.json path (relative to project root)
+_DEFAULT_POLICY_PATH = Path(__file__).resolve().parents[3] / "config" / "policy.json"
+
+
+def load_policy_json(
+    path: Optional[Path] = None,
+) -> tuple[dict[str, ToolRisk], set[str], str]:
+    """Load tool_levels, always_confirm_tools, and undefined_tool_policy from policy.json.
+
+    Returns:
+        (tool_registry, always_confirm_set, undefined_policy)
+        - tool_registry: mapping of tool name → ToolRisk
+        - always_confirm_set: set of tool names that always need confirmation
+        - undefined_policy: "deny" | "moderate" — behaviour for tools not in tool_levels
+
+    Falls back to hardcoded defaults on any error.
+    """
+    policy_path = path or _DEFAULT_POLICY_PATH
+
+    try:
+        raw = json.loads(policy_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        logger.warning("policy.json load failed (%s), using hardcoded fallback", exc)
+        return dict(_FALLBACK_TOOL_REGISTRY), set(_FALLBACK_ALWAYS_CONFIRM), "deny"
+
+    # tool_levels → TOOL_REGISTRY
+    tool_levels = raw.get("tool_levels")
+    if not isinstance(tool_levels, dict):
+        logger.warning("policy.json missing tool_levels, using hardcoded fallback")
+        return dict(_FALLBACK_TOOL_REGISTRY), set(_FALLBACK_ALWAYS_CONFIRM), "deny"
+
+    registry: dict[str, ToolRisk] = {}
+    for tool_name, risk_str in tool_levels.items():
+        if tool_name == "__comment":
+            continue
+        risk_enum = _RISK_NAME_MAP.get(str(risk_str).lower())
+        if risk_enum is None:
+            logger.warning("policy.json: unknown risk '%s' for tool '%s', skipping", risk_str, tool_name)
+            continue
+        registry[tool_name] = risk_enum
+
+    # always_confirm_tools
+    raw_confirm = raw.get("always_confirm_tools")
+    if isinstance(raw_confirm, list):
+        confirm_set = {str(t) for t in raw_confirm}
+    else:
+        confirm_set = set(_FALLBACK_ALWAYS_CONFIRM)
+
+    # undefined_tool_policy
+    undef = str(raw.get("undefined_tool_policy", "deny")).lower()
+    if undef not in ("deny", "moderate"):
+        undef = "deny"
+
+    logger.info(
+        "policy.json loaded: %d tool_levels, %d always_confirm, undefined=%s",
+        len(registry), len(confirm_set), undef,
+    )
+    return registry, confirm_set, undef
+
+
+# ---------------------------------------------------------------------------
+# Module-level globals (populated from policy.json at import time)
+# ---------------------------------------------------------------------------
+
+TOOL_REGISTRY: dict[str, ToolRisk]
+ALWAYS_CONFIRM_TOOLS: set[str]
+UNDEFINED_TOOL_POLICY: str  # "deny" or "moderate"
+
+TOOL_REGISTRY, ALWAYS_CONFIRM_TOOLS, UNDEFINED_TOOL_POLICY = load_policy_json()
+
+
+def reload_policy(path: Optional[Path] = None) -> None:
+    """Re-read policy.json and refresh the module-level globals.
+
+    Useful after config changes or in tests.
+    """
+    global TOOL_REGISTRY, ALWAYS_CONFIRM_TOOLS, UNDEFINED_TOOL_POLICY  # noqa: PLW0603
+    TOOL_REGISTRY, ALWAYS_CONFIRM_TOOLS, UNDEFINED_TOOL_POLICY = load_policy_json(path)
+
+
+def get_tool_risk(tool_name: str, default: Optional[ToolRisk] = None) -> ToolRisk:
     """Get risk level for a tool.
+
+    If the tool is not in the registry the ``UNDEFINED_TOOL_POLICY`` from
+    policy.json decides:
+    - ``"deny"``     → treat as DESTRUCTIVE (requires confirmation, Issue #424)
+    - ``"moderate"`` → treat as MODERATE (legacy behaviour)
+
+    A caller-supplied *default* overrides the policy when given explicitly.
     
     Args:
         tool_name: Name of the tool (e.g., "calendar.delete_event")
-        default: Default risk level if tool not in registry (default: MODERATE)
+        default: Explicit default risk level (overrides undefined_tool_policy)
     
     Returns:
         ToolRisk enum value
-    
-    Examples:
-        >>> get_tool_risk("web.search")
-        ToolRisk.SAFE
-        >>> get_tool_risk("calendar.delete_event")
-        ToolRisk.DESTRUCTIVE
-        >>> get_tool_risk("unknown.tool")
-        ToolRisk.MODERATE
     """
-    return TOOL_REGISTRY.get(tool_name, default)
+    risk = TOOL_REGISTRY.get(tool_name)
+    if risk is not None:
+        return risk
+
+    # Caller override
+    if default is not None:
+        return default
+
+    # Policy-driven default for undefined tools (Issue #424)
+    if UNDEFINED_TOOL_POLICY == "deny":
+        return ToolRisk.DESTRUCTIVE
+    return ToolRisk.MODERATE
 
 
 def is_destructive(tool_name: str) -> bool:

--- a/tests/test_issue_424_policy_tool_levels.py
+++ b/tests/test_issue_424_policy_tool_levels.py
@@ -1,0 +1,469 @@
+"""Tests for Issue #424 – Policy Gmail/Calendar tool definitions.
+
+Validates that:
+1. policy.json is the single source of truth for tool risk levels
+2. All gmail/calendar tools are defined in policy.json
+3. metadata.py loads tool_levels from policy.json
+4. Undefined tools get explicit deny (DESTRUCTIVE) by default
+5. ALWAYS_CONFIRM_TOOLS is loaded from policy.json
+6. reload_policy() refreshes module globals
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+POLICY_PATH = Path(__file__).resolve().parents[1] / "config" / "policy.json"
+
+
+def _load_policy() -> dict[str, Any]:
+    """Load the real policy.json."""
+    return json.loads(POLICY_PATH.read_text(encoding="utf-8"))
+
+
+# ===================================================================
+# 1. policy.json structure tests
+# ===================================================================
+
+
+class TestPolicyJsonStructure:
+    """Verify the policy.json file has all required sections."""
+
+    def test_tool_levels_section_exists(self):
+        policy = _load_policy()
+        assert "tool_levels" in policy
+        assert isinstance(policy["tool_levels"], dict)
+
+    def test_always_confirm_tools_section_exists(self):
+        policy = _load_policy()
+        assert "always_confirm_tools" in policy
+        assert isinstance(policy["always_confirm_tools"], list)
+
+    def test_undefined_tool_policy_exists(self):
+        policy = _load_policy()
+        assert "undefined_tool_policy" in policy
+        assert policy["undefined_tool_policy"] in ("deny", "moderate")
+
+    def test_tool_levels_has_valid_risk_values(self):
+        policy = _load_policy()
+        valid_risks = {"safe", "moderate", "destructive"}
+        for tool_name, risk in policy["tool_levels"].items():
+            if tool_name == "__comment":
+                continue
+            assert risk in valid_risks, f"{tool_name} has invalid risk '{risk}'"
+
+
+# ===================================================================
+# 2. Gmail tools in policy.json
+# ===================================================================
+
+
+class TestGmailToolsInPolicy:
+    """Issue #424: All gmail tools must be defined in policy.json."""
+
+    REQUIRED_GMAIL_TOOLS = [
+        "gmail.send",
+        "gmail.create_draft",
+        "gmail.send_draft",
+        "gmail.list_messages",
+        "gmail.get_message",
+        "gmail.unread_count",
+        "gmail.smart_search",
+        "gmail.send_to_contact",
+        "gmail.download_attachment",
+        "gmail.generate_reply",
+        "gmail.archive",
+        "gmail.batch_modify",
+        "gmail.list_labels",
+        "gmail.add_label",
+        "gmail.remove_label",
+        "gmail.mark_read",
+        "gmail.mark_unread",
+        "gmail.list_drafts",
+        "gmail.update_draft",
+        "gmail.delete_draft",
+    ]
+
+    def test_all_gmail_tools_present(self):
+        policy = _load_policy()
+        tool_levels = policy["tool_levels"]
+        for tool in self.REQUIRED_GMAIL_TOOLS:
+            assert tool in tool_levels, f"Missing gmail tool in policy.json: {tool}"
+
+    def test_gmail_send_is_moderate(self):
+        policy = _load_policy()
+        assert policy["tool_levels"]["gmail.send"] == "moderate"
+
+    def test_gmail_create_draft_is_safe(self):
+        policy = _load_policy()
+        assert policy["tool_levels"]["gmail.create_draft"] == "safe"
+
+    def test_gmail_send_draft_is_moderate(self):
+        policy = _load_policy()
+        assert policy["tool_levels"]["gmail.send_draft"] == "moderate"
+
+    def test_gmail_list_messages_is_safe(self):
+        policy = _load_policy()
+        assert policy["tool_levels"]["gmail.list_messages"] == "safe"
+
+
+# ===================================================================
+# 3. Calendar tools in policy.json
+# ===================================================================
+
+
+class TestCalendarToolsInPolicy:
+    """Issue #424: All calendar tools must be defined in policy.json."""
+
+    REQUIRED_CALENDAR_TOOLS = [
+        "calendar.list_events",
+        "calendar.find_event",
+        "calendar.get_event",
+        "calendar.create_event",
+        "calendar.update_event",
+        "calendar.delete_event",
+    ]
+
+    def test_all_calendar_tools_present(self):
+        policy = _load_policy()
+        tool_levels = policy["tool_levels"]
+        for tool in self.REQUIRED_CALENDAR_TOOLS:
+            assert tool in tool_levels, f"Missing calendar tool in policy.json: {tool}"
+
+    def test_calendar_create_event_is_moderate(self):
+        policy = _load_policy()
+        assert policy["tool_levels"]["calendar.create_event"] == "moderate"
+
+    def test_calendar_delete_event_is_destructive(self):
+        policy = _load_policy()
+        assert policy["tool_levels"]["calendar.delete_event"] == "destructive"
+
+
+# ===================================================================
+# 4. always_confirm_tools in policy.json
+# ===================================================================
+
+
+class TestAlwaysConfirmInPolicy:
+    """Verify always_confirm_tools includes critical send/create operations."""
+
+    REQUIRED_ALWAYS_CONFIRM = [
+        "calendar.create_event",
+        "calendar.update_event",
+        "gmail.send",
+        "gmail.send_draft",
+        "gmail.send_to_contact",
+        "gmail.download_attachment",
+        "gmail.generate_reply",
+    ]
+
+    def test_all_required_always_confirm(self):
+        policy = _load_policy()
+        confirm_list = policy["always_confirm_tools"]
+        for tool in self.REQUIRED_ALWAYS_CONFIRM:
+            assert tool in confirm_list, f"Missing in always_confirm_tools: {tool}"
+
+
+# ===================================================================
+# 5. metadata.py loads from policy.json (single source of truth)
+# ===================================================================
+
+
+class TestMetadataLoadsFromPolicy:
+    """metadata.py TOOL_REGISTRY should match policy.json tool_levels."""
+
+    def test_registry_loaded_from_policy(self):
+        from bantz.tools.metadata import TOOL_REGISTRY, ToolRisk
+
+        policy = _load_policy()
+        tool_levels = policy["tool_levels"]
+        risk_map = {"safe": ToolRisk.SAFE, "moderate": ToolRisk.MODERATE, "destructive": ToolRisk.DESTRUCTIVE}
+
+        for tool_name, risk_str in tool_levels.items():
+            if tool_name == "__comment":
+                continue
+            expected = risk_map[risk_str]
+            assert tool_name in TOOL_REGISTRY, f"{tool_name} from policy.json not in TOOL_REGISTRY"
+            assert TOOL_REGISTRY[tool_name] == expected, (
+                f"{tool_name}: expected {expected}, got {TOOL_REGISTRY[tool_name]}"
+            )
+
+    def test_always_confirm_loaded(self):
+        from bantz.tools.metadata import ALWAYS_CONFIRM_TOOLS
+
+        policy = _load_policy()
+        expected = set(policy["always_confirm_tools"])
+        assert ALWAYS_CONFIRM_TOOLS == expected
+
+    def test_undefined_tool_policy_loaded(self):
+        from bantz.tools.metadata import UNDEFINED_TOOL_POLICY
+
+        policy = _load_policy()
+        assert UNDEFINED_TOOL_POLICY == policy["undefined_tool_policy"]
+
+
+# ===================================================================
+# 6. Undefined tool → explicit deny
+# ===================================================================
+
+
+class TestUndefinedToolDeny:
+    """Issue #424: tools not in policy.json must be denied (DESTRUCTIVE)."""
+
+    def test_unknown_tool_returns_destructive(self):
+        from bantz.tools.metadata import get_tool_risk, ToolRisk
+
+        risk = get_tool_risk("totally.unknown.tool")
+        assert risk == ToolRisk.DESTRUCTIVE
+
+    def test_unknown_tool_requires_confirmation(self):
+        from bantz.tools.metadata import requires_confirmation
+
+        assert requires_confirmation("totally.unknown.tool", llm_requested=False) is True
+
+    def test_unknown_tool_is_destructive_flag(self):
+        from bantz.tools.metadata import is_destructive
+
+        assert is_destructive("totally.unknown.tool") is True
+
+    def test_explicit_default_overrides_policy(self):
+        from bantz.tools.metadata import get_tool_risk, ToolRisk
+
+        # Caller can override with explicit default
+        risk = get_tool_risk("totally.unknown.tool", default=ToolRisk.SAFE)
+        assert risk == ToolRisk.SAFE
+
+
+# ===================================================================
+# 7. load_policy_json with custom file
+# ===================================================================
+
+
+class TestLoadPolicyJson:
+    """Test loading from custom / missing / malformed policy files."""
+
+    def test_load_from_custom_path(self, tmp_path):
+        from bantz.tools.metadata import load_policy_json, ToolRisk
+
+        custom = tmp_path / "custom_policy.json"
+        custom.write_text(json.dumps({
+            "tool_levels": {
+                "my.tool": "safe",
+                "my.danger": "destructive",
+            },
+            "always_confirm_tools": ["my.danger"],
+            "undefined_tool_policy": "moderate",
+        }), encoding="utf-8")
+
+        registry, confirm_set, undef_policy = load_policy_json(custom)
+
+        assert registry["my.tool"] == ToolRisk.SAFE
+        assert registry["my.danger"] == ToolRisk.DESTRUCTIVE
+        assert confirm_set == {"my.danger"}
+        assert undef_policy == "moderate"
+
+    def test_missing_file_returns_fallback(self, tmp_path):
+        from bantz.tools.metadata import load_policy_json, ToolRisk
+
+        missing = tmp_path / "does_not_exist.json"
+        registry, confirm_set, undef_policy = load_policy_json(missing)
+
+        # Should fall back to hardcoded registry
+        assert "gmail.send" in registry
+        assert registry["gmail.send"] == ToolRisk.MODERATE
+        assert "gmail.send" in confirm_set
+        assert undef_policy == "deny"
+
+    def test_malformed_json_returns_fallback(self, tmp_path):
+        from bantz.tools.metadata import load_policy_json
+
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("{invalid json!!!", encoding="utf-8")
+
+        registry, confirm_set, undef_policy = load_policy_json(bad_file)
+
+        assert "gmail.send" in registry
+        assert undef_policy == "deny"
+
+    def test_missing_tool_levels_key_returns_fallback(self, tmp_path):
+        from bantz.tools.metadata import load_policy_json
+
+        no_levels = tmp_path / "no_levels.json"
+        no_levels.write_text(json.dumps({"intent_levels": {}}), encoding="utf-8")
+
+        registry, confirm_set, undef_policy = load_policy_json(no_levels)
+
+        assert "gmail.send" in registry  # fallback
+
+    def test_invalid_risk_value_skipped(self, tmp_path):
+        from bantz.tools.metadata import load_policy_json
+
+        invalid = tmp_path / "invalid_risk.json"
+        invalid.write_text(json.dumps({
+            "tool_levels": {
+                "good.tool": "safe",
+                "bad.tool": "banana",  # invalid
+            },
+            "always_confirm_tools": [],
+            "undefined_tool_policy": "deny",
+        }), encoding="utf-8")
+
+        registry, _, _ = load_policy_json(invalid)
+
+        assert "good.tool" in registry
+        assert "bad.tool" not in registry  # skipped
+
+    def test_comment_key_ignored(self, tmp_path):
+        from bantz.tools.metadata import load_policy_json
+
+        with_comment = tmp_path / "comment.json"
+        with_comment.write_text(json.dumps({
+            "tool_levels": {
+                "__comment": "This is a comment",
+                "real.tool": "safe",
+            },
+            "always_confirm_tools": [],
+            "undefined_tool_policy": "deny",
+        }), encoding="utf-8")
+
+        registry, _, _ = load_policy_json(with_comment)
+
+        assert "__comment" not in registry
+        assert "real.tool" in registry
+
+
+# ===================================================================
+# 8. reload_policy refreshes globals
+# ===================================================================
+
+
+class TestReloadPolicy:
+    """reload_policy() should refresh TOOL_REGISTRY and related globals."""
+
+    def test_reload_updates_registry(self, tmp_path):
+        import bantz.tools.metadata as mod
+
+        custom = tmp_path / "reload_test.json"
+        custom.write_text(json.dumps({
+            "tool_levels": {
+                "new.tool": "destructive",
+            },
+            "always_confirm_tools": ["new.tool"],
+            "undefined_tool_policy": "moderate",
+        }), encoding="utf-8")
+
+        # Save originals
+        orig_registry = dict(mod.TOOL_REGISTRY)
+        orig_confirm = set(mod.ALWAYS_CONFIRM_TOOLS)
+        orig_policy = mod.UNDEFINED_TOOL_POLICY
+
+        try:
+            mod.reload_policy(custom)
+
+            assert "new.tool" in mod.TOOL_REGISTRY
+            assert mod.TOOL_REGISTRY["new.tool"] == mod.ToolRisk.DESTRUCTIVE
+            assert "new.tool" in mod.ALWAYS_CONFIRM_TOOLS
+            assert mod.UNDEFINED_TOOL_POLICY == "moderate"
+        finally:
+            # Restore originals
+            mod.TOOL_REGISTRY = orig_registry
+            mod.ALWAYS_CONFIRM_TOOLS = orig_confirm
+            mod.UNDEFINED_TOOL_POLICY = orig_policy
+
+
+# ===================================================================
+# 9. Sync: metadata.py ↔ policy.json parity
+# ===================================================================
+
+
+class TestRegistryPolicySync:
+    """All tools in policy.json tool_levels should be in TOOL_REGISTRY and vice versa."""
+
+    def test_policy_tools_in_registry(self):
+        from bantz.tools.metadata import TOOL_REGISTRY
+
+        policy = _load_policy()
+        for tool in policy["tool_levels"]:
+            if tool == "__comment":
+                continue
+            assert tool in TOOL_REGISTRY, f"policy.json tool '{tool}' not in TOOL_REGISTRY"
+
+    def test_registry_tools_in_policy(self):
+        from bantz.tools.metadata import TOOL_REGISTRY
+
+        policy = _load_policy()
+        policy_tools = {k for k in policy["tool_levels"] if k != "__comment"}
+        for tool in TOOL_REGISTRY:
+            assert tool in policy_tools, f"TOOL_REGISTRY tool '{tool}' not in policy.json"
+
+
+# ===================================================================
+# 10. Existing API backward compatibility
+# ===================================================================
+
+
+class TestBackwardCompat:
+    """Ensure all existing public API still works after #424 refactor."""
+
+    def test_get_tool_risk(self):
+        from bantz.tools.metadata import get_tool_risk, ToolRisk
+
+        assert get_tool_risk("web.search") == ToolRisk.SAFE
+        assert get_tool_risk("calendar.delete_event") == ToolRisk.DESTRUCTIVE
+        assert get_tool_risk("gmail.send") == ToolRisk.MODERATE
+
+    def test_is_destructive(self):
+        from bantz.tools.metadata import is_destructive
+
+        assert is_destructive("calendar.delete_event") is True
+        assert is_destructive("web.search") is False
+
+    def test_requires_confirmation(self):
+        from bantz.tools.metadata import requires_confirmation
+
+        # Destructive always True
+        assert requires_confirmation("calendar.delete_event", llm_requested=False) is True
+        # Safe + no LLM request → False
+        assert requires_confirmation("web.search", llm_requested=False) is False
+        # Safe + LLM request → True
+        assert requires_confirmation("web.search", llm_requested=True) is True
+        # Always-confirm tools
+        assert requires_confirmation("gmail.send", llm_requested=False) is True
+
+    def test_get_confirmation_prompt(self):
+        from bantz.tools.metadata import get_confirmation_prompt
+
+        prompt = get_confirmation_prompt("gmail.send", {"to": "user@test.com", "subject": "Test"})
+        assert "user@test.com" in prompt
+
+    def test_register_tool_risk(self):
+        from bantz.tools.metadata import register_tool_risk, ToolRisk, TOOL_REGISTRY
+
+        register_tool_risk("test.dynamic_tool", ToolRisk.SAFE)
+        assert TOOL_REGISTRY["test.dynamic_tool"] == ToolRisk.SAFE
+        # Cleanup
+        del TOOL_REGISTRY["test.dynamic_tool"]
+
+    def test_get_all_tools_by_risk(self):
+        from bantz.tools.metadata import get_all_tools_by_risk, ToolRisk
+
+        destructive = get_all_tools_by_risk(ToolRisk.DESTRUCTIVE)
+        assert "calendar.delete_event" in destructive
+
+    def test_get_registry_stats(self):
+        from bantz.tools.metadata import get_registry_stats
+
+        stats = get_registry_stats()
+        assert stats["safe"] > 0
+        assert stats["moderate"] > 0
+        assert stats["destructive"] > 0
+        assert stats["total"] == stats["safe"] + stats["moderate"] + stats["destructive"]


### PR DESCRIPTION
## Issue #424 – Policy: Gmail send ve agent operation'lar için policy tanımı yok

### Problem
- `config/policy.json` had no gmail/calendar tool risk levels
- `tools/metadata.py` hardcoded all tool risks, not in sync with policy
- No explicit deny for undefined tools

### Solution
1. **policy.json**: Added `tool_levels` (65 tools), `always_confirm_tools` (7 tools), `undefined_tool_policy: deny`
2. **metadata.py**: `load_policy_json()` reads from policy.json at import time; hardcoded fallback
3. **Undefined tools → DESTRUCTIVE** (explicit deny, requires confirmation)
4. **`reload_policy()`** for runtime refresh

### Testing
```
36 passed in 0.08s
```

Closes #424