### PR TITLE
#427 Voice Pipeline Latency Budget

### DIFF
--- a/config/model-settings.yaml
+++ b/config/model-settings.yaml
@@ -187,6 +187,25 @@ hardware:
     chat_p95_ms: 300
 
 # =============================================================================
+# Voice Pipeline Latency Budget (Issue #427)
+# =============================================================================
+# Per-phase budget for ASR → Router → Tool → Finalizer → TTS pipeline.
+# Used by src/bantz/core/latency_budget.py
+voice_pipeline:
+  latency_budget:
+    asr_max_ms: 500        # Whisper ASR timeout; fallback → partial result
+    router_max_ms: 100     # 3B router; fallback → pre-route cache
+    tool_max_ms: 1000      # Calendar/Gmail API; fallback → async + feedback phrase
+    finalizer_max_ms: 500  # Gemini quality pass; fallback → skip, use 3B
+    tts_max_ms: 300        # Piper TTS; fallback → pre-cached common phrases
+    end_to_end_max_ms: 2000  # Total pipeline target
+
+  # Feedback phrases injected when a phase blocks
+  feedback_phrases:
+    tool: "Bir bakayım efendim..."
+    finalizer: "Hemen söylüyorum..."
+
+# =============================================================================
 # Benchmarking Configuration
 # =============================================================================
 benchmark:

--- a/src/bantz/core/latency_budget.py
+++ b/src/bantz/core/latency_budget.py
@@ -1,0 +1,416 @@
+"""
+Voice Pipeline Latency Budget — Issue #427.
+
+Per-phase latency budgets for the ASR → Router → Tool → Finalizer → TTS pipeline.
+Provides:
+- Budget configuration (from model-settings.yaml or defaults)
+- Per-phase timing tracking with p50/p95 percentile calculation
+- Budget violation detection with degradation recommendations
+- Feedback phrase trigger points
+- Dashboard-ready metric export
+
+Typical budget (end-to-end ≤2000ms):
+  ASR:        max 500ms  → timeout + partial result
+  Router:     max 100ms  → pre-route cache hit
+  Tool:       max 1000ms → async + feedback phrase
+  Finalizer:  max 500ms  → streaming + 3B fallback
+  TTS:        max 300ms  → pre-cache common phrases
+
+Reference: Issue #302, Issue #427
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Any, Deque, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────
+# Constants / Defaults
+# ─────────────────────────────────────────────────────────────────
+
+_DEFAULT_YAML_PATH = Path(__file__).resolve().parents[3] / "config" / "model-settings.yaml"
+
+# Maximum number of samples retained per phase for percentile calculation
+_MAX_SAMPLES = 500
+
+
+class Phase(str, Enum):
+    """Pipeline phases in execution order."""
+    ASR = "asr"
+    ROUTER = "router"
+    TOOL = "tool"
+    FINALIZER = "finalizer"
+    TTS = "tts"
+
+
+class DegradationAction(str, Enum):
+    """Recommended degradation when a phase exceeds its budget."""
+    NONE = "none"
+    USE_PARTIAL_ASR = "use_partial_asr"
+    USE_PREROUTE_CACHE = "use_preroute_cache"
+    ASYNC_TOOL_WITH_FEEDBACK = "async_tool_with_feedback"
+    SKIP_FINALIZER_USE_3B = "skip_finalizer_use_3b"
+    USE_CACHED_TTS = "use_cached_tts"
+    STREAM_FINALIZER = "stream_finalizer"
+
+
+# Mapping: phase → default degradation action
+_PHASE_DEGRADATION: Dict[Phase, DegradationAction] = {
+    Phase.ASR: DegradationAction.USE_PARTIAL_ASR,
+    Phase.ROUTER: DegradationAction.USE_PREROUTE_CACHE,
+    Phase.TOOL: DegradationAction.ASYNC_TOOL_WITH_FEEDBACK,
+    Phase.FINALIZER: DegradationAction.SKIP_FINALIZER_USE_3B,
+    Phase.TTS: DegradationAction.USE_CACHED_TTS,
+}
+
+# Turkish feedback phrases injected when a phase blocks
+_FEEDBACK_PHRASES: Dict[Phase, str] = {
+    Phase.ASR: "",  # ASR phase — no feedback while listening
+    Phase.ROUTER: "",  # Router too fast for feedback
+    Phase.TOOL: "Bir bakayım efendim...",
+    Phase.FINALIZER: "Hemen söylüyorum...",
+    Phase.TTS: "",
+}
+
+
+# ─────────────────────────────────────────────────────────────────
+# Budget Configuration
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PhaseBudget:
+    """Budget for a single pipeline phase."""
+    phase: Phase
+    max_ms: float
+    degradation: DegradationAction
+    feedback_phrase: str = ""
+
+    def is_exceeded(self, elapsed_ms: float) -> bool:
+        return elapsed_ms > self.max_ms
+
+
+@dataclass(frozen=True)
+class LatencyBudgetConfig:
+    """
+    Full pipeline latency budget.
+
+    Can be loaded from model-settings.yaml ``voice_pipeline.latency_budget``
+    section or constructed with defaults.
+    """
+    asr_max_ms: float = 500.0
+    router_max_ms: float = 100.0
+    tool_max_ms: float = 1000.0
+    finalizer_max_ms: float = 500.0
+    tts_max_ms: float = 300.0
+    end_to_end_max_ms: float = 2000.0
+
+    # ── helpers ──────────────────────────────────────────────
+
+    @property
+    def total_phase_budget_ms(self) -> float:
+        """Sum of individual phase budgets."""
+        return (
+            self.asr_max_ms
+            + self.router_max_ms
+            + self.tool_max_ms
+            + self.finalizer_max_ms
+            + self.tts_max_ms
+        )
+
+    def phase_budget(self, phase: Phase) -> PhaseBudget:
+        """Get *PhaseBudget* for a single phase."""
+        max_map = {
+            Phase.ASR: self.asr_max_ms,
+            Phase.ROUTER: self.router_max_ms,
+            Phase.TOOL: self.tool_max_ms,
+            Phase.FINALIZER: self.finalizer_max_ms,
+            Phase.TTS: self.tts_max_ms,
+        }
+        return PhaseBudget(
+            phase=phase,
+            max_ms=max_map[phase],
+            degradation=_PHASE_DEGRADATION[phase],
+            feedback_phrase=_FEEDBACK_PHRASES.get(phase, ""),
+        )
+
+    def all_phase_budgets(self) -> List[PhaseBudget]:
+        return [self.phase_budget(p) for p in Phase]
+
+
+def load_budget_from_yaml(path: Optional[Path] = None) -> LatencyBudgetConfig:
+    """
+    Load latency budget from model-settings.yaml.
+
+    Looks for ``voice_pipeline.latency_budget`` section.
+    Falls back to defaults if missing or yaml not loadable.
+    """
+    yaml_path = path or _DEFAULT_YAML_PATH
+    try:
+        import yaml  # type: ignore[import-untyped]
+
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f) or {}
+        budget = (data.get("voice_pipeline") or {}).get("latency_budget") or {}
+        if not budget:
+            return LatencyBudgetConfig()
+        return LatencyBudgetConfig(
+            asr_max_ms=float(budget.get("asr_max_ms", 500)),
+            router_max_ms=float(budget.get("router_max_ms", 100)),
+            tool_max_ms=float(budget.get("tool_max_ms", 1000)),
+            finalizer_max_ms=float(budget.get("finalizer_max_ms", 500)),
+            tts_max_ms=float(budget.get("tts_max_ms", 300)),
+            end_to_end_max_ms=float(budget.get("end_to_end_max_ms", 2000)),
+        )
+    except Exception as exc:
+        logger.warning("Failed to load latency budget from %s: %s — using defaults", yaml_path, exc)
+        return LatencyBudgetConfig()
+
+
+# ─────────────────────────────────────────────────────────────────
+# Phase Timing Record
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class PhaseRecord:
+    """Timing record for one pipeline phase execution."""
+    phase: Phase
+    elapsed_ms: float
+    budget_ms: float
+    exceeded: bool
+    degradation: DegradationAction = DegradationAction.NONE
+    feedback_phrase: str = ""
+
+    @property
+    def headroom_ms(self) -> float:
+        """Positive = under budget, negative = over budget."""
+        return self.budget_ms - self.elapsed_ms
+
+
+@dataclass
+class PipelineRun:
+    """Full end-to-end pipeline timing for one utterance."""
+    records: List[PhaseRecord] = field(default_factory=list)
+    start_epoch: float = 0.0
+    end_epoch: float = 0.0
+
+    @property
+    def total_ms(self) -> float:
+        if self.end_epoch and self.start_epoch:
+            return (self.end_epoch - self.start_epoch) * 1000
+        return sum(r.elapsed_ms for r in self.records)
+
+    @property
+    def exceeded_phases(self) -> List[PhaseRecord]:
+        return [r for r in self.records if r.exceeded]
+
+    @property
+    def degradation_actions(self) -> List[DegradationAction]:
+        """Recommended degradation actions for exceeded phases."""
+        return [r.degradation for r in self.records if r.exceeded and r.degradation != DegradationAction.NONE]
+
+    @property
+    def feedback_phrases(self) -> List[str]:
+        """Feedback phrases to inject for slow phases."""
+        return [r.feedback_phrase for r in self.records if r.exceeded and r.feedback_phrase]
+
+    def summary(self) -> Dict[str, Any]:
+        return {
+            "total_ms": round(self.total_ms, 1),
+            "phases": {
+                r.phase.value: {
+                    "elapsed_ms": round(r.elapsed_ms, 1),
+                    "budget_ms": r.budget_ms,
+                    "exceeded": r.exceeded,
+                }
+                for r in self.records
+            },
+            "exceeded_count": len(self.exceeded_phases),
+            "degradation_actions": [a.value for a in self.degradation_actions],
+        }
+
+
+# ─────────────────────────────────────────────────────────────────
+# Latency Tracker  (p50 / p95 dashboard)
+# ─────────────────────────────────────────────────────────────────
+
+
+def _percentile(samples: List[float], pct: float) -> float:
+    """Calculate percentile from sorted sample list."""
+    if not samples:
+        return 0.0
+    sorted_s = sorted(samples)
+    k = (len(sorted_s) - 1) * (pct / 100.0)
+    f = int(k)
+    c = f + 1
+    if c >= len(sorted_s):
+        return sorted_s[-1]
+    return sorted_s[f] + (sorted_s[c] - sorted_s[f]) * (k - f)
+
+
+class LatencyTracker:
+    """
+    Per-phase latency tracker with rolling window percentiles.
+
+    Usage::
+
+        tracker = LatencyTracker(budget_config)
+        run = tracker.start_pipeline()
+        tracker.record_phase(run, Phase.ASR, elapsed_ms=320)
+        tracker.record_phase(run, Phase.ROUTER, elapsed_ms=45)
+        ...
+        tracker.finish_pipeline(run)
+        dashboard = tracker.dashboard()
+    """
+
+    def __init__(self, config: Optional[LatencyBudgetConfig] = None, max_samples: int = _MAX_SAMPLES):
+        self._config = config or LatencyBudgetConfig()
+        self._max_samples = max_samples
+        # phase → deque of elapsed_ms values
+        self._samples: Dict[Phase, Deque[float]] = {p: deque(maxlen=max_samples) for p in Phase}
+        # end-to-end totals
+        self._e2e_samples: Deque[float] = deque(maxlen=max_samples)
+        self._total_runs = 0
+        self._exceeded_runs = 0
+
+    @property
+    def config(self) -> LatencyBudgetConfig:
+        return self._config
+
+    # ── pipeline lifecycle ────────────────────────────────────
+
+    def start_pipeline(self) -> PipelineRun:
+        """Begin a new pipeline run."""
+        return PipelineRun(start_epoch=time.monotonic())
+
+    def record_phase(self, run: PipelineRun, phase: Phase, elapsed_ms: float) -> PhaseRecord:
+        """Record one phase's latency into *run* and the rolling window."""
+        budget = self._config.phase_budget(phase)
+        exceeded = budget.is_exceeded(elapsed_ms)
+        record = PhaseRecord(
+            phase=phase,
+            elapsed_ms=elapsed_ms,
+            budget_ms=budget.max_ms,
+            exceeded=exceeded,
+            degradation=budget.degradation if exceeded else DegradationAction.NONE,
+            feedback_phrase=budget.feedback_phrase if exceeded else "",
+        )
+        run.records.append(record)
+        self._samples[phase].append(elapsed_ms)
+
+        if exceeded:
+            logger.warning(
+                "Phase %s exceeded budget: %.1fms > %.1fms — recommend %s",
+                phase.value, elapsed_ms, budget.max_ms, record.degradation.value,
+            )
+        return record
+
+    def finish_pipeline(self, run: PipelineRun) -> PipelineRun:
+        """Finalise a pipeline run and record e2e latency."""
+        run.end_epoch = time.monotonic()
+        self._e2e_samples.append(run.total_ms)
+        self._total_runs += 1
+        if run.exceeded_phases:
+            self._exceeded_runs += 1
+        return run
+
+    # ── dashboard / metrics ──────────────────────────────────
+
+    def phase_stats(self, phase: Phase) -> Dict[str, float]:
+        """p50 / p95 / min / max for a single phase."""
+        samples = list(self._samples[phase])
+        if not samples:
+            return {"p50": 0.0, "p95": 0.0, "min": 0.0, "max": 0.0, "count": 0}
+        return {
+            "p50": round(_percentile(samples, 50), 1),
+            "p95": round(_percentile(samples, 95), 1),
+            "min": round(min(samples), 1),
+            "max": round(max(samples), 1),
+            "count": len(samples),
+        }
+
+    def e2e_stats(self) -> Dict[str, float]:
+        """End-to-end pipeline percentiles."""
+        samples = list(self._e2e_samples)
+        if not samples:
+            return {"p50": 0.0, "p95": 0.0, "min": 0.0, "max": 0.0, "count": 0}
+        return {
+            "p50": round(_percentile(samples, 50), 1),
+            "p95": round(_percentile(samples, 95), 1),
+            "min": round(min(samples), 1),
+            "max": round(max(samples), 1),
+            "count": len(samples),
+        }
+
+    def dashboard(self) -> Dict[str, Any]:
+        """Full dashboard export suitable for logging / UI."""
+        return {
+            "total_runs": self._total_runs,
+            "exceeded_runs": self._exceeded_runs,
+            "budget_violation_rate": (
+                round(self._exceeded_runs / self._total_runs, 3) if self._total_runs else 0.0
+            ),
+            "end_to_end": self.e2e_stats(),
+            "phases": {p.value: self.phase_stats(p) for p in Phase},
+            "budget_config": {
+                "asr_max_ms": self._config.asr_max_ms,
+                "router_max_ms": self._config.router_max_ms,
+                "tool_max_ms": self._config.tool_max_ms,
+                "finalizer_max_ms": self._config.finalizer_max_ms,
+                "tts_max_ms": self._config.tts_max_ms,
+                "end_to_end_max_ms": self._config.end_to_end_max_ms,
+            },
+        }
+
+    def reset(self) -> None:
+        """Clear all samples."""
+        for d in self._samples.values():
+            d.clear()
+        self._e2e_samples.clear()
+        self._total_runs = 0
+        self._exceeded_runs = 0
+
+
+# ─────────────────────────────────────────────────────────────────
+# Budget Check Helper (for orchestrator integration)
+# ─────────────────────────────────────────────────────────────────
+
+
+def check_budget(
+    config: LatencyBudgetConfig,
+    phase: Phase,
+    elapsed_ms: float,
+) -> Tuple[bool, DegradationAction, str]:
+    """
+    Quick one-shot budget check.
+
+    Returns:
+        (exceeded, degradation_action, feedback_phrase)
+    """
+    budget = config.phase_budget(phase)
+    exceeded = budget.is_exceeded(elapsed_ms)
+    action = budget.degradation if exceeded else DegradationAction.NONE
+    phrase = budget.feedback_phrase if exceeded else ""
+    return exceeded, action, phrase
+
+
+def should_skip_finalizer(
+    config: LatencyBudgetConfig,
+    elapsed_so_far_ms: float,
+) -> bool:
+    """
+    Determine if the Gemini finalizer should be skipped in favor of 3B fallback.
+
+    Called after ASR+Router+Tool phases. If the remaining budget is less than
+    the finalizer's max, skip it.
+    """
+    remaining = config.end_to_end_max_ms - elapsed_so_far_ms
+    return remaining < config.finalizer_max_ms

--- a/tests/test_issue_427_latency_budget.py
+++ b/tests/test_issue_427_latency_budget.py
@@ -1,0 +1,437 @@
+"""
+Tests for Issue #427 — Voice Pipeline Latency Budget.
+
+Covers:
+- LatencyBudgetConfig defaults and construction
+- PhaseBudget exceeded checks
+- LatencyTracker per-phase recording + e2e finalization
+- Percentile calculation (p50 / p95)
+- Dashboard export
+- Degradation action mapping
+- Feedback phrases
+- should_skip_finalizer decision
+- check_budget helper
+- load_budget_from_yaml (with mock and real file)
+- Conversation orchestrator integration (latency in get_stats)
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bantz.core.latency_budget import (
+    DegradationAction,
+    LatencyBudgetConfig,
+    LatencyTracker,
+    Phase,
+    PhaseBudget,
+    PhaseRecord,
+    PipelineRun,
+    _percentile,
+    check_budget,
+    load_budget_from_yaml,
+    should_skip_finalizer,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Config defaults
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLatencyBudgetConfig:
+    """Test configuration dataclass."""
+
+    def test_defaults(self):
+        cfg = LatencyBudgetConfig()
+        assert cfg.asr_max_ms == 500.0
+        assert cfg.router_max_ms == 100.0
+        assert cfg.tool_max_ms == 1000.0
+        assert cfg.finalizer_max_ms == 500.0
+        assert cfg.tts_max_ms == 300.0
+        assert cfg.end_to_end_max_ms == 2000.0
+
+    def test_total_phase_budget(self):
+        cfg = LatencyBudgetConfig()
+        assert cfg.total_phase_budget_ms == 2400.0  # 500+100+1000+500+300
+
+    def test_custom_values(self):
+        cfg = LatencyBudgetConfig(asr_max_ms=300, router_max_ms=50)
+        assert cfg.asr_max_ms == 300
+        assert cfg.router_max_ms == 50
+
+    def test_phase_budget_returns_correct_type(self):
+        cfg = LatencyBudgetConfig()
+        pb = cfg.phase_budget(Phase.ASR)
+        assert isinstance(pb, PhaseBudget)
+        assert pb.phase == Phase.ASR
+        assert pb.max_ms == 500.0
+
+    def test_all_phase_budgets_has_five(self):
+        cfg = LatencyBudgetConfig()
+        budgets = cfg.all_phase_budgets()
+        assert len(budgets) == 5
+        phases = [b.phase for b in budgets]
+        assert Phase.ASR in phases
+        assert Phase.TTS in phases
+
+
+# ─────────────────────────────────────────────────────────────────
+# Phase budget checks
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPhaseBudget:
+    """Test single-phase budget behaviour."""
+
+    def test_within_budget(self):
+        pb = PhaseBudget(phase=Phase.ROUTER, max_ms=100, degradation=DegradationAction.NONE)
+        assert not pb.is_exceeded(99)
+
+    def test_exactly_at_budget(self):
+        pb = PhaseBudget(phase=Phase.ROUTER, max_ms=100, degradation=DegradationAction.NONE)
+        assert not pb.is_exceeded(100)
+
+    def test_exceeds_budget(self):
+        pb = PhaseBudget(phase=Phase.ROUTER, max_ms=100, degradation=DegradationAction.NONE)
+        assert pb.is_exceeded(101)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Percentile helper
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPercentile:
+    """Test _percentile()."""
+
+    def test_empty(self):
+        assert _percentile([], 50) == 0.0
+
+    def test_single_value(self):
+        assert _percentile([42.0], 50) == 42.0
+        assert _percentile([42.0], 95) == 42.0
+
+    def test_known_p50(self):
+        samples = [10, 20, 30, 40, 50]
+        assert _percentile(samples, 50) == 30.0
+
+    def test_p95_high(self):
+        samples = list(range(1, 101))  # 1..100
+        p95 = _percentile(samples, 95)
+        assert 95 <= p95 <= 96  # close to 95.05
+
+
+# ─────────────────────────────────────────────────────────────────
+# Pipeline Run
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPipelineRun:
+    """Test PipelineRun aggregate methods."""
+
+    def test_total_from_records(self):
+        run = PipelineRun()
+        run.records = [
+            PhaseRecord(Phase.ASR, 200, 500, False),
+            PhaseRecord(Phase.ROUTER, 50, 100, False),
+        ]
+        assert run.total_ms == 250
+
+    def test_total_from_epoch(self):
+        run = PipelineRun(start_epoch=1000.0, end_epoch=1001.5)
+        assert run.total_ms == 1500.0
+
+    def test_exceeded_phases(self):
+        run = PipelineRun()
+        run.records = [
+            PhaseRecord(Phase.ASR, 200, 500, False),
+            PhaseRecord(Phase.TOOL, 1500, 1000, True, DegradationAction.ASYNC_TOOL_WITH_FEEDBACK),
+        ]
+        assert len(run.exceeded_phases) == 1
+        assert run.exceeded_phases[0].phase == Phase.TOOL
+
+    def test_degradation_actions(self):
+        run = PipelineRun()
+        run.records = [
+            PhaseRecord(Phase.TOOL, 1500, 1000, True, DegradationAction.ASYNC_TOOL_WITH_FEEDBACK),
+            PhaseRecord(Phase.FINALIZER, 600, 500, True, DegradationAction.SKIP_FINALIZER_USE_3B),
+        ]
+        actions = run.degradation_actions
+        assert DegradationAction.ASYNC_TOOL_WITH_FEEDBACK in actions
+        assert DegradationAction.SKIP_FINALIZER_USE_3B in actions
+
+    def test_feedback_phrases(self):
+        run = PipelineRun()
+        run.records = [
+            PhaseRecord(Phase.TOOL, 1500, 1000, True, feedback_phrase="Bir bakayım efendim..."),
+        ]
+        assert run.feedback_phrases == ["Bir bakayım efendim..."]
+
+    def test_summary_keys(self):
+        run = PipelineRun()
+        run.records = [PhaseRecord(Phase.ASR, 200, 500, False)]
+        s = run.summary()
+        assert "total_ms" in s
+        assert "phases" in s
+        assert "exceeded_count" in s
+        assert "degradation_actions" in s
+
+    def test_headroom(self):
+        rec = PhaseRecord(Phase.ASR, 300, 500, False)
+        assert rec.headroom_ms == 200
+
+
+# ─────────────────────────────────────────────────────────────────
+# Latency Tracker
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLatencyTracker:
+    """Test the main tracker with rolling window."""
+
+    def test_basic_pipeline(self):
+        tracker = LatencyTracker()
+        run = tracker.start_pipeline()
+        tracker.record_phase(run, Phase.ASR, 300)
+        tracker.record_phase(run, Phase.ROUTER, 50)
+        tracker.record_phase(run, Phase.TOOL, 400)
+        tracker.record_phase(run, Phase.FINALIZER, 200)
+        tracker.record_phase(run, Phase.TTS, 150)
+        tracker.finish_pipeline(run)
+
+        assert tracker._total_runs == 1
+        assert tracker._exceeded_runs == 0
+
+    def test_exceeded_pipeline(self):
+        tracker = LatencyTracker()
+        run = tracker.start_pipeline()
+        tracker.record_phase(run, Phase.ASR, 600)  # over 500
+        tracker.record_phase(run, Phase.ROUTER, 50)
+        tracker.record_phase(run, Phase.TOOL, 400)
+        tracker.record_phase(run, Phase.FINALIZER, 200)
+        tracker.record_phase(run, Phase.TTS, 150)
+        tracker.finish_pipeline(run)
+
+        assert tracker._exceeded_runs == 1
+        assert run.exceeded_phases[0].phase == Phase.ASR
+
+    def test_phase_stats(self):
+        tracker = LatencyTracker()
+        for val in [100, 200, 300, 400, 500]:
+            run = tracker.start_pipeline()
+            tracker.record_phase(run, Phase.ASR, val)
+            tracker.finish_pipeline(run)
+
+        stats = tracker.phase_stats(Phase.ASR)
+        assert stats["count"] == 5
+        assert stats["min"] == 100
+        assert stats["max"] == 500
+        assert stats["p50"] == 300.0
+
+    def test_e2e_stats(self):
+        tracker = LatencyTracker()
+        run = tracker.start_pipeline()
+        tracker.record_phase(run, Phase.ASR, 200)
+        tracker.record_phase(run, Phase.ROUTER, 50)
+        tracker.finish_pipeline(run)
+
+        stats = tracker.e2e_stats()
+        assert stats["count"] == 1
+        # p50 may be very small (near zero) because start/finish are close
+        assert stats["p50"] >= 0
+
+    def test_dashboard_structure(self):
+        tracker = LatencyTracker()
+        run = tracker.start_pipeline()
+        tracker.record_phase(run, Phase.ASR, 200)
+        tracker.finish_pipeline(run)
+
+        dash = tracker.dashboard()
+        assert "total_runs" in dash
+        assert "exceeded_runs" in dash
+        assert "budget_violation_rate" in dash
+        assert "end_to_end" in dash
+        assert "phases" in dash
+        assert "budget_config" in dash
+        assert "asr" in dash["phases"]
+
+    def test_reset(self):
+        tracker = LatencyTracker()
+        run = tracker.start_pipeline()
+        tracker.record_phase(run, Phase.ASR, 200)
+        tracker.finish_pipeline(run)
+        tracker.reset()
+
+        assert tracker._total_runs == 0
+        assert tracker.phase_stats(Phase.ASR)["count"] == 0
+
+    def test_degradation_logged_on_exceed(self):
+        tracker = LatencyTracker()
+        run = tracker.start_pipeline()
+        rec = tracker.record_phase(run, Phase.TOOL, 1500)
+        assert rec.exceeded
+        assert rec.degradation == DegradationAction.ASYNC_TOOL_WITH_FEEDBACK
+
+    def test_no_degradation_within_budget(self):
+        tracker = LatencyTracker()
+        run = tracker.start_pipeline()
+        rec = tracker.record_phase(run, Phase.ROUTER, 50)
+        assert not rec.exceeded
+        assert rec.degradation == DegradationAction.NONE
+
+    def test_max_samples_cap(self):
+        tracker = LatencyTracker(max_samples=10)
+        for i in range(20):
+            run = tracker.start_pipeline()
+            tracker.record_phase(run, Phase.ASR, float(i * 10))
+            tracker.finish_pipeline(run)
+        assert tracker.phase_stats(Phase.ASR)["count"] == 10
+
+
+# ─────────────────────────────────────────────────────────────────
+# Helper functions
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCheckBudget:
+    """Test check_budget() one-shot helper."""
+
+    def test_within_budget(self):
+        cfg = LatencyBudgetConfig()
+        exceeded, action, phrase = check_budget(cfg, Phase.ROUTER, 50)
+        assert not exceeded
+        assert action == DegradationAction.NONE
+        assert phrase == ""
+
+    def test_over_budget(self):
+        cfg = LatencyBudgetConfig()
+        exceeded, action, phrase = check_budget(cfg, Phase.TOOL, 1500)
+        assert exceeded
+        assert action == DegradationAction.ASYNC_TOOL_WITH_FEEDBACK
+        assert phrase == "Bir bakayım efendim..."
+
+    def test_finalizer_over_budget(self):
+        cfg = LatencyBudgetConfig()
+        exceeded, action, phrase = check_budget(cfg, Phase.FINALIZER, 600)
+        assert exceeded
+        assert action == DegradationAction.SKIP_FINALIZER_USE_3B
+        assert phrase == "Hemen söylüyorum..."
+
+
+class TestShouldSkipFinalizer:
+    """Test should_skip_finalizer decision."""
+
+    def test_plenty_of_time(self):
+        cfg = LatencyBudgetConfig()
+        # elapsed 800ms, remaining 1200ms > 500ms finalizer budget
+        assert not should_skip_finalizer(cfg, 800)
+
+    def test_no_time_left(self):
+        cfg = LatencyBudgetConfig()
+        # elapsed 1700ms, remaining 300ms < 500ms finalizer budget
+        assert should_skip_finalizer(cfg, 1700)
+
+    def test_exact_boundary(self):
+        cfg = LatencyBudgetConfig()
+        # remaining == finalizer budget → should NOT skip (not less than)
+        assert not should_skip_finalizer(cfg, 1500)
+
+
+# ─────────────────────────────────────────────────────────────────
+# YAML loading
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLoadBudgetFromYaml:
+    """Test load_budget_from_yaml."""
+
+    def test_load_real_config(self):
+        """Load actual model-settings.yaml from project."""
+        cfg = load_budget_from_yaml()
+        assert cfg.asr_max_ms == 500
+        assert cfg.router_max_ms == 100
+        assert cfg.end_to_end_max_ms == 2000
+
+    def test_missing_file_returns_defaults(self):
+        cfg = load_budget_from_yaml(Path("/nonexistent/path.yaml"))
+        assert cfg.asr_max_ms == 500  # default
+        assert cfg.end_to_end_max_ms == 2000
+
+    def test_yaml_without_section_returns_defaults(self, tmp_path):
+        """YAML file that has no voice_pipeline section."""
+        p = tmp_path / "empty.yaml"
+        p.write_text("models:\n  router:\n    name: test\n")
+        cfg = load_budget_from_yaml(p)
+        assert cfg.asr_max_ms == 500
+
+
+# ─────────────────────────────────────────────────────────────────
+# Degradation mapping
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestDegradationMapping:
+    """Verify every phase has a sensible degradation action."""
+
+    def test_all_phases_have_degradation(self):
+        cfg = LatencyBudgetConfig()
+        for phase in Phase:
+            pb = cfg.phase_budget(phase)
+            # every phase has a degradation defined (even if no feedback)
+            assert pb.degradation is not None
+
+    def test_asr_degradation(self):
+        cfg = LatencyBudgetConfig()
+        pb = cfg.phase_budget(Phase.ASR)
+        assert pb.degradation == DegradationAction.USE_PARTIAL_ASR
+
+    def test_tts_degradation(self):
+        cfg = LatencyBudgetConfig()
+        pb = cfg.phase_budget(Phase.TTS)
+        assert pb.degradation == DegradationAction.USE_CACHED_TTS
+
+
+# ─────────────────────────────────────────────────────────────────
+# Feedback phrases
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestFeedbackPhrases:
+    """Verify Turkish feedback phrases are set for slow phases."""
+
+    def test_tool_has_phrase(self):
+        cfg = LatencyBudgetConfig()
+        pb = cfg.phase_budget(Phase.TOOL)
+        assert "bakayım" in pb.feedback_phrase
+
+    def test_finalizer_has_phrase(self):
+        cfg = LatencyBudgetConfig()
+        pb = cfg.phase_budget(Phase.FINALIZER)
+        assert "söylüyorum" in pb.feedback_phrase
+
+    def test_asr_no_phrase(self):
+        cfg = LatencyBudgetConfig()
+        pb = cfg.phase_budget(Phase.ASR)
+        assert pb.feedback_phrase == ""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Orchestrator integration (latency in stats)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestOrchestratorIntegration:
+    """Verify conversation orchestrator exposes latency dashboard."""
+
+    def test_get_stats_has_latency(self):
+        from bantz.conversation.orchestrator import ConversationOrchestrator
+        orch = ConversationOrchestrator()
+        stats = orch.get_stats()
+        assert "latency" in stats
+        assert "total_runs" in stats["latency"]
+        assert "phases" in stats["latency"]


### PR DESCRIPTION
## Summary
Per-phase latency budget for the ASR → Router → Tool → Finalizer → TTS voice pipeline.

## Changes
- **New `src/bantz/core/latency_budget.py`**:
  - `LatencyBudgetConfig`: Per-phase budgets (ASR 500ms, Router 100ms, Tool 1000ms, Finalizer 500ms, TTS 300ms, E2E 2000ms)
  - `Phase` enum (5 pipeline stages), `DegradationAction` enum (6 fallback strategies)
  - `LatencyTracker`: Rolling-window p50/p95 percentile tracking, `dashboard()` export
  - `PipelineRun`/`PhaseRecord`: Per-utterance timing with headroom, exceeded detection, feedback phrases
  - `check_budget()`: One-shot helper, `should_skip_finalizer()`: Gemini skip decision
  - `load_budget_from_yaml()`: Reads from `config/model-settings.yaml`
- **`config/model-settings.yaml`**: Added `voice_pipeline.latency_budget` section
- **`src/bantz/conversation/orchestrator.py`**: Integrated `LatencyTracker`, per-phase router timing, latency dashboard in `get_stats()`

## Testing
```
pytest tests/test_issue_427_latency_budget.py -v
44 passed in 0.12s
```

Closes #427