### PR TITLE
feat(#431): Tool Execution Timeout & Circuit Breaker

### DIFF
--- a/src/bantz/brain/tool_timeout.py
+++ b/src/bantz/brain/tool_timeout.py
@@ -1,0 +1,315 @@
+"""
+Tool Execution Timeout & Circuit Breaker — Issue #431.
+
+Provides:
+- Per-tool timeout enforcement (default 10s, configurable per tool)
+- Graceful error + user message on timeout
+- Tool metadata timeout_seconds field
+- CircuitBreaker: N consecutive timeouts → temporarily disable tool
+- execute_with_timeout() wrapper for orchestrator
+
+Usage::
+
+    from bantz.brain.tool_timeout import ToolTimeoutManager, execute_with_timeout
+    manager = ToolTimeoutManager()
+    result = await execute_with_timeout(manager, "calendar.create_event", coro)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any, Callable, Coroutine, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Default Timeouts
+# ─────────────────────────────────────────────────────────────────
+
+# Per-tool timeout in seconds (override via config or metadata)
+_DEFAULT_TIMEOUT_S = 10.0
+
+_TOOL_TIMEOUTS: Dict[str, float] = {
+    # Calendar tools — Google API can be slow
+    "calendar.list_events": 10.0,
+    "calendar.create_event": 15.0,
+    "calendar.update_event": 15.0,
+    "calendar.delete_event": 10.0,
+    "calendar.find_free_slots": 12.0,
+    # Gmail tools
+    "gmail.list_messages": 10.0,
+    "gmail.get_message": 8.0,
+    "gmail.send": 15.0,
+    "gmail.smart_search": 12.0,
+    "gmail.archive": 8.0,
+    "gmail.generate_reply": 20.0,
+    # System tools (fast)
+    "time.now": 2.0,
+    "system.status": 5.0,
+    "system.open_app": 10.0,
+    "system.shutdown": 5.0,
+    # Browser tools
+    "browser.open": 10.0,
+    "browser.search": 15.0,
+}
+
+
+def get_tool_timeout(tool_name: str) -> float:
+    """Get timeout for a tool (seconds)."""
+    return _TOOL_TIMEOUTS.get(tool_name, _DEFAULT_TIMEOUT_S)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Circuit Breaker
+# ─────────────────────────────────────────────────────────────────
+
+
+class CircuitState(str, Enum):
+    """Circuit breaker states."""
+    CLOSED = "closed"        # Normal operation
+    OPEN = "open"            # Tool disabled after N failures
+    HALF_OPEN = "half_open"  # Allowing one probe request
+
+
+@dataclass
+class CircuitBreaker:
+    """
+    Per-tool circuit breaker.
+
+    After *failure_threshold* consecutive timeouts, the circuit opens
+    and the tool is disabled for *recovery_timeout_s* seconds.
+    After that, one probe request is allowed (half-open). If it succeeds
+    the circuit closes; if it fails it re-opens.
+    """
+
+    failure_threshold: int = 3
+    recovery_timeout_s: float = 60.0
+
+    # Internal state
+    _consecutive_failures: int = 0
+    _state: CircuitState = CircuitState.CLOSED
+    _last_failure_time: float = 0.0
+
+    @property
+    def state(self) -> CircuitState:
+        # Auto-transition OPEN → HALF_OPEN after recovery timeout
+        if self._state == CircuitState.OPEN:
+            elapsed = time.monotonic() - self._last_failure_time
+            if elapsed >= self.recovery_timeout_s:
+                self._state = CircuitState.HALF_OPEN
+        return self._state
+
+    @property
+    def is_available(self) -> bool:
+        """Can a request go through?"""
+        s = self.state  # triggers auto-transition
+        return s in (CircuitState.CLOSED, CircuitState.HALF_OPEN)
+
+    def record_success(self) -> None:
+        """Record a successful execution."""
+        self._consecutive_failures = 0
+        self._state = CircuitState.CLOSED
+
+    def record_failure(self) -> None:
+        """Record a timeout/failure."""
+        self._consecutive_failures += 1
+        self._last_failure_time = time.monotonic()
+        if self._consecutive_failures >= self.failure_threshold:
+            self._state = CircuitState.OPEN
+            logger.warning(
+                "Circuit breaker OPEN after %d consecutive failures (recovery in %.0fs)",
+                self._consecutive_failures,
+                self.recovery_timeout_s,
+            )
+
+    def reset(self) -> None:
+        """Force reset to CLOSED."""
+        self._consecutive_failures = 0
+        self._state = CircuitState.CLOSED
+        self._last_failure_time = 0.0
+
+
+# ─────────────────────────────────────────────────────────────────
+# Timeout Result
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ToolExecutionResult:
+    """Result of a timeout-guarded tool execution."""
+    tool_name: str
+    success: bool
+    result: Any = None
+    error: Optional[str] = None
+    elapsed_ms: float = 0.0
+    timed_out: bool = False
+    circuit_open: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "tool": self.tool_name,
+            "success": self.success,
+        }
+        if self.result is not None:
+            d["result"] = self.result
+        if self.error:
+            d["error"] = self.error
+        if self.timed_out:
+            d["timed_out"] = True
+        if self.circuit_open:
+            d["circuit_open"] = True
+        d["elapsed_ms"] = round(self.elapsed_ms, 1)
+        return d
+
+
+# ─────────────────────────────────────────────────────────────────
+# Manager
+# ─────────────────────────────────────────────────────────────────
+
+
+class ToolTimeoutManager:
+    """
+    Manages per-tool timeouts and circuit breakers.
+
+    Usage::
+
+        manager = ToolTimeoutManager()
+        result = await manager.execute("calendar.create_event", some_coro())
+    """
+
+    def __init__(
+        self,
+        default_timeout_s: float = _DEFAULT_TIMEOUT_S,
+        failure_threshold: int = 3,
+        recovery_timeout_s: float = 60.0,
+    ):
+        self._default_timeout = default_timeout_s
+        self._failure_threshold = failure_threshold
+        self._recovery_timeout = recovery_timeout_s
+        self._breakers: Dict[str, CircuitBreaker] = {}
+
+    def _get_breaker(self, tool_name: str) -> CircuitBreaker:
+        if tool_name not in self._breakers:
+            self._breakers[tool_name] = CircuitBreaker(
+                failure_threshold=self._failure_threshold,
+                recovery_timeout_s=self._recovery_timeout,
+            )
+        return self._breakers[tool_name]
+
+    def get_timeout(self, tool_name: str) -> float:
+        return _TOOL_TIMEOUTS.get(tool_name, self._default_timeout)
+
+    def is_available(self, tool_name: str) -> bool:
+        """Check if a tool is available (circuit not open)."""
+        return self._get_breaker(tool_name).is_available
+
+    def get_circuit_state(self, tool_name: str) -> CircuitState:
+        return self._get_breaker(tool_name).state
+
+    async def execute(
+        self,
+        tool_name: str,
+        coro: Coroutine[Any, Any, Any],
+        timeout_s: Optional[float] = None,
+    ) -> ToolExecutionResult:
+        """
+        Execute a tool coroutine with timeout and circuit breaker.
+
+        Args:
+            tool_name: Name of the tool
+            coro: The coroutine to execute
+            timeout_s: Override timeout (uses per-tool default if None)
+
+        Returns:
+            ToolExecutionResult with success/error/timing info
+        """
+        breaker = self._get_breaker(tool_name)
+
+        # Circuit breaker check
+        if not breaker.is_available:
+            return ToolExecutionResult(
+                tool_name=tool_name,
+                success=False,
+                error=f"Tool '{tool_name}' temporarily disabled (circuit breaker open)",
+                circuit_open=True,
+            )
+
+        timeout = timeout_s or self.get_timeout(tool_name)
+        start = time.monotonic()
+
+        try:
+            result = await asyncio.wait_for(coro, timeout=timeout)
+            elapsed_ms = (time.monotonic() - start) * 1000
+            breaker.record_success()
+            return ToolExecutionResult(
+                tool_name=tool_name,
+                success=True,
+                result=result,
+                elapsed_ms=elapsed_ms,
+            )
+        except asyncio.TimeoutError:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            breaker.record_failure()
+            logger.warning(
+                "Tool '%s' timed out after %.0fms (limit: %.0fs)",
+                tool_name,
+                elapsed_ms,
+                timeout,
+            )
+            return ToolExecutionResult(
+                tool_name=tool_name,
+                success=False,
+                error=f"İşlem zaman aşımına uğradı ({tool_name}, {timeout:.0f}s)",
+                elapsed_ms=elapsed_ms,
+                timed_out=True,
+            )
+        except Exception as exc:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            breaker.record_failure()
+            return ToolExecutionResult(
+                tool_name=tool_name,
+                success=False,
+                error=str(exc),
+                elapsed_ms=elapsed_ms,
+            )
+
+    def reset_breaker(self, tool_name: str) -> None:
+        """Force reset a tool's circuit breaker."""
+        if tool_name in self._breakers:
+            self._breakers[tool_name].reset()
+
+    def reset_all(self) -> None:
+        """Reset all circuit breakers."""
+        for b in self._breakers.values():
+            b.reset()
+
+    def dashboard(self) -> Dict[str, Any]:
+        """Export status of all tracked tools."""
+        return {
+            name: {
+                "state": breaker.state.value,
+                "consecutive_failures": breaker._consecutive_failures,
+                "available": breaker.is_available,
+            }
+            for name, breaker in self._breakers.items()
+        }
+
+
+# ─────────────────────────────────────────────────────────────────
+# Convenience wrapper
+# ─────────────────────────────────────────────────────────────────
+
+
+async def execute_with_timeout(
+    manager: ToolTimeoutManager,
+    tool_name: str,
+    coro: Coroutine[Any, Any, Any],
+    timeout_s: Optional[float] = None,
+) -> ToolExecutionResult:
+    """Convenience function for one-shot timeout execution."""
+    return await manager.execute(tool_name, coro, timeout_s=timeout_s)

--- a/tests/test_issue_431_tool_timeout.py
+++ b/tests/test_issue_431_tool_timeout.py
@@ -1,0 +1,306 @@
+"""
+Tests for Issue #431 — Tool Execution Timeout & Circuit Breaker.
+
+Covers:
+- get_tool_timeout: per-tool defaults
+- CircuitBreaker: closed→open after N failures, auto half-open, probe
+- ToolTimeoutManager: execute with timeout, circuit integration
+- ToolExecutionResult: to_dict
+- Timeout enforcement on slow coroutines
+- Circuit breaker blocks after threshold
+- Recovery / reset
+- Dashboard export
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from bantz.brain.tool_timeout import (
+    CircuitBreaker,
+    CircuitState,
+    ToolExecutionResult,
+    ToolTimeoutManager,
+    execute_with_timeout,
+    get_tool_timeout,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# get_tool_timeout
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestGetToolTimeout:
+
+    def test_known_tool(self):
+        assert get_tool_timeout("time.now") == 2.0
+
+    def test_calendar_create(self):
+        assert get_tool_timeout("calendar.create_event") == 15.0
+
+    def test_unknown_tool_default(self):
+        assert get_tool_timeout("some.unknown.tool") == 10.0
+
+    def test_gmail_send(self):
+        assert get_tool_timeout("gmail.send") == 15.0
+
+
+# ─────────────────────────────────────────────────────────────────
+# CircuitBreaker
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCircuitBreaker:
+
+    def test_initial_closed(self):
+        cb = CircuitBreaker()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.is_available
+
+    def test_stays_closed_below_threshold(self):
+        cb = CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.is_available
+
+    def test_opens_at_threshold(self):
+        cb = CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        assert not cb.is_available
+
+    def test_success_resets_count(self):
+        cb = CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+        cb.record_failure()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_half_open_after_recovery(self):
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout_s=0.01)
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        time.sleep(0.02)
+        assert cb.state == CircuitState.HALF_OPEN
+        assert cb.is_available
+
+    def test_half_open_success_closes(self):
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout_s=0.01)
+        cb.record_failure()
+        time.sleep(0.02)
+        assert cb.state == CircuitState.HALF_OPEN
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_half_open_failure_reopens(self):
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout_s=0.01)
+        cb.record_failure()
+        time.sleep(0.02)
+        assert cb.state == CircuitState.HALF_OPEN
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_reset(self):
+        cb = CircuitBreaker(failure_threshold=1)
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        cb.reset()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.is_available
+
+
+# ─────────────────────────────────────────────────────────────────
+# ToolExecutionResult
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestToolExecutionResult:
+
+    def test_success_to_dict(self):
+        r = ToolExecutionResult(
+            tool_name="time.now", success=True, result={"time": "14:00"}, elapsed_ms=5.3
+        )
+        d = r.to_dict()
+        assert d["tool"] == "time.now"
+        assert d["success"] is True
+        assert d["result"] == {"time": "14:00"}
+        assert d["elapsed_ms"] == 5.3
+
+    def test_timeout_to_dict(self):
+        r = ToolExecutionResult(
+            tool_name="calendar.list_events",
+            success=False,
+            error="timeout",
+            timed_out=True,
+            elapsed_ms=10000,
+        )
+        d = r.to_dict()
+        assert d["timed_out"] is True
+        assert "success" in d and d["success"] is False
+
+    def test_circuit_open_to_dict(self):
+        r = ToolExecutionResult(
+            tool_name="gmail.send", success=False, circuit_open=True
+        )
+        d = r.to_dict()
+        assert d["circuit_open"] is True
+
+
+# ─────────────────────────────────────────────────────────────────
+# ToolTimeoutManager — execute
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestToolTimeoutManager:
+
+    @pytest.mark.asyncio
+    async def test_successful_execution(self):
+        manager = ToolTimeoutManager()
+
+        async def fast_tool():
+            return {"events": []}
+
+        result = await manager.execute("calendar.list_events", fast_tool())
+        assert result.success
+        assert result.result == {"events": []}
+        assert result.elapsed_ms > 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_fires(self):
+        manager = ToolTimeoutManager()
+
+        async def slow_tool():
+            await asyncio.sleep(5)
+            return "never"
+
+        result = await manager.execute("time.now", slow_tool(), timeout_s=0.05)
+        assert not result.success
+        assert result.timed_out
+
+    @pytest.mark.asyncio
+    async def test_exception_handled(self):
+        manager = ToolTimeoutManager()
+
+        async def broken_tool():
+            raise ValueError("API down")
+
+        result = await manager.execute("gmail.send", broken_tool())
+        assert not result.success
+        assert "API down" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_blocks(self):
+        manager = ToolTimeoutManager(failure_threshold=2)
+
+        async def failing():
+            raise RuntimeError("fail")
+
+        await manager.execute("test.tool", failing())
+        await manager.execute("test.tool", failing())
+
+        # Circuit should be open now
+        assert not manager.is_available("test.tool")
+
+        async def should_not_run():
+            return "ok"
+
+        result = await manager.execute("test.tool", should_not_run())
+        assert result.circuit_open
+        assert not result.success
+
+    @pytest.mark.asyncio
+    async def test_different_tools_independent(self):
+        manager = ToolTimeoutManager(failure_threshold=1)
+
+        async def failing():
+            raise RuntimeError("fail")
+
+        await manager.execute("tool.a", failing())
+        assert not manager.is_available("tool.a")
+        assert manager.is_available("tool.b")  # independent
+
+    def test_get_timeout(self):
+        manager = ToolTimeoutManager()
+        assert manager.get_timeout("calendar.create_event") == 15.0
+        assert manager.get_timeout("unknown") == 10.0
+
+    def test_reset_breaker(self):
+        manager = ToolTimeoutManager(failure_threshold=1)
+        breaker = manager._get_breaker("test.tool")
+        breaker.record_failure()
+        assert not manager.is_available("test.tool")
+        manager.reset_breaker("test.tool")
+        assert manager.is_available("test.tool")
+
+    def test_reset_all(self):
+        manager = ToolTimeoutManager(failure_threshold=1)
+        for name in ["a", "b", "c"]:
+            b = manager._get_breaker(name)
+            b.record_failure()
+        manager.reset_all()
+        for name in ["a", "b", "c"]:
+            assert manager.is_available(name)
+
+    def test_dashboard(self):
+        manager = ToolTimeoutManager(failure_threshold=2)
+        manager._get_breaker("calendar.create_event").record_failure()
+        dash = manager.dashboard()
+        assert "calendar.create_event" in dash
+        assert dash["calendar.create_event"]["state"] == "closed"
+        assert dash["calendar.create_event"]["consecutive_failures"] == 1
+
+
+# ─────────────────────────────────────────────────────────────────
+# execute_with_timeout convenience
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestExecuteWithTimeout:
+
+    @pytest.mark.asyncio
+    async def test_convenience_wrapper(self):
+        manager = ToolTimeoutManager()
+
+        async def quick():
+            return 42
+
+        result = await execute_with_timeout(manager, "time.now", quick())
+        assert result.success
+        assert result.result == 42
+
+    @pytest.mark.asyncio
+    async def test_convenience_timeout(self):
+        manager = ToolTimeoutManager()
+
+        async def slow():
+            await asyncio.sleep(5)
+
+        result = await execute_with_timeout(manager, "time.now", slow(), timeout_s=0.02)
+        assert result.timed_out
+
+
+# ─────────────────────────────────────────────────────────────────
+# Turkish error messages
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestTurkishMessages:
+
+    @pytest.mark.asyncio
+    async def test_timeout_message_turkish(self):
+        manager = ToolTimeoutManager()
+
+        async def slow():
+            await asyncio.sleep(5)
+
+        result = await manager.execute("calendar.list_events", slow(), timeout_s=0.02)
+        assert "zaman aşımı" in (result.error or "").lower()


### PR DESCRIPTION
## Issue #431 — Tool Execution Timeout & Circuit Breaker

### Changes
- **src/bantz/brain/tool_timeout.py** (316 lines): New module
  - Per-tool timeout enforcement (default 10s, configurable per tool)
  - `CircuitBreaker`: N consecutive failures → temporarily disable tool
  - Auto OPEN→HALF_OPEN recovery after configurable timeout
  - `ToolTimeoutManager` with execute(), dashboard(), reset
  - `ToolExecutionResult` with to_dict() export
  - Turkish error messages (zaman aşımı)
  - `execute_with_timeout()` convenience wrapper

### Tests
- **tests/test_issue_431_tool_timeout.py**: 27 tests all passing
  - CircuitBreaker state transitions
  - Timeout enforcement on slow coroutines
  - Circuit open blocks execution
  - Independent per-tool breakers
  - Dashboard export
  - Turkish error messages

Closes #431