### PR TITLE
feat(#433): Calendar Slot Pre-Validation

### DIFF
--- a/src/bantz/tools/slot_validation.py
+++ b/src/bantz/tools/slot_validation.py
@@ -1,0 +1,225 @@
+"""
+Calendar Slot Validation — Issue #433.
+
+Pre-validation for tool calls before execution:
+- required_slots metadata per tool
+- Validate slots BEFORE calling the tool
+- On failure: skip tool, return clarification question in Turkish
+- Prevents Google API errors from missing slots
+
+Usage::
+
+    from bantz.tools.slot_validation import (
+        validate_tool_slots,
+        SlotValidationResult,
+        TOOL_REQUIRED_SLOTS,
+    )
+    result = validate_tool_slots("calendar.create_event", {"title": "Toplantı"})
+    if not result.valid:
+        # result.question → "Etkinlik saatini söyler misiniz efendim?"
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Slot definitions
+# ─────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class SlotRequirement:
+    """A required slot or group of alternative slots for a tool."""
+    name: str
+    alternatives: Tuple[str, ...] = ()  # Any one of these can satisfy
+    question_tr: str = ""  # Turkish clarification question
+
+    @property
+    def all_names(self) -> Tuple[str, ...]:
+        """All slot names that can satisfy this requirement."""
+        return (self.name,) + self.alternatives
+
+
+# ─────────────────────────────────────────────────────────────────
+# Per-tool required slots
+# ─────────────────────────────────────────────────────────────────
+
+# calendar.create_event: title required, time OR window_hint OR date required
+_CREATE_EVENT_SLOTS = [
+    SlotRequirement(
+        name="title",
+        question_tr="Etkinlik adı ne olsun efendim?",
+    ),
+    SlotRequirement(
+        name="time",
+        alternatives=("date", "window_hint"),
+        question_tr="Etkinlik ne zaman olsun efendim? Tarih veya saat belirtir misiniz?",
+    ),
+]
+
+# calendar.update_event: at least an event identifier + something to update
+_UPDATE_EVENT_SLOTS = [
+    SlotRequirement(
+        name="title",
+        alternatives=("event_id", "query"),
+        question_tr="Hangi etkinliği güncellemek istiyorsunuz efendim?",
+    ),
+]
+
+# calendar.delete_event: need to know which event
+_DELETE_EVENT_SLOTS = [
+    SlotRequirement(
+        name="title",
+        alternatives=("event_id", "query"),
+        question_tr="Hangi etkinliği silmek istiyorsunuz efendim?",
+    ),
+]
+
+# gmail.send: need recipient + body
+_GMAIL_SEND_SLOTS = [
+    SlotRequirement(
+        name="to",
+        alternatives=("recipient",),
+        question_tr="E-postayı kime göndermemi istiyorsunuz efendim?",
+    ),
+    SlotRequirement(
+        name="body",
+        alternatives=("message", "content"),
+        question_tr="E-posta içeriği ne olsun efendim?",
+    ),
+]
+
+# gmail.generate_reply: need message to reply to
+_GMAIL_REPLY_SLOTS = [
+    SlotRequirement(
+        name="message_id",
+        alternatives=("thread_id", "query"),
+        question_tr="Hangi e-postaya yanıt vermemi istiyorsunuz efendim?",
+    ),
+]
+
+
+# Master registry: tool_name → list of SlotRequirements
+TOOL_REQUIRED_SLOTS: Dict[str, List[SlotRequirement]] = {
+    "calendar.create_event": _CREATE_EVENT_SLOTS,
+    "calendar.update_event": _UPDATE_EVENT_SLOTS,
+    "calendar.delete_event": _DELETE_EVENT_SLOTS,
+    "gmail.send": _GMAIL_SEND_SLOTS,
+    "gmail.generate_reply": _GMAIL_REPLY_SLOTS,
+}
+
+
+# ─────────────────────────────────────────────────────────────────
+# Validation Result
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SlotValidationResult:
+    """Result of pre-validation for a tool call."""
+
+    tool_name: str
+    valid: bool
+    missing_slots: List[str] = field(default_factory=list)
+    question: Optional[str] = None  # Turkish clarification question
+    ask_user: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "tool": self.tool_name,
+            "valid": self.valid,
+        }
+        if self.missing_slots:
+            d["missing_slots"] = self.missing_slots
+        if self.question:
+            d["question"] = self.question
+        if self.ask_user:
+            d["ask_user"] = True
+        return d
+
+
+# ─────────────────────────────────────────────────────────────────
+# Validation logic
+# ─────────────────────────────────────────────────────────────────
+
+
+def _slot_present(slots: Dict[str, Any], name: str) -> bool:
+    """Check if a slot is present and non-empty."""
+    val = slots.get(name)
+    if val is None:
+        return False
+    if isinstance(val, str) and not val.strip():
+        return False
+    return True
+
+
+def validate_tool_slots(
+    tool_name: str,
+    slots: Dict[str, Any],
+    *,
+    required_slots: Optional[List[SlotRequirement]] = None,
+) -> SlotValidationResult:
+    """
+    Validate that all required slots are present before calling a tool.
+
+    Args:
+        tool_name: The tool to validate for.
+        slots: The slots/parameters extracted by the router/LLM.
+        required_slots: Override the default required slots (for testing).
+
+    Returns:
+        SlotValidationResult — if .valid is False, .question has the
+        Turkish clarification to ask the user.
+    """
+    reqs = required_slots or TOOL_REQUIRED_SLOTS.get(tool_name)
+
+    # No requirements defined → always valid
+    if not reqs:
+        return SlotValidationResult(tool_name=tool_name, valid=True)
+
+    missing: List[str] = []
+    first_question: Optional[str] = None
+
+    for req in reqs:
+        # Check if the primary slot or any alternative is present
+        satisfied = any(_slot_present(slots, n) for n in req.all_names)
+        if not satisfied:
+            missing.append(req.name)
+            if first_question is None and req.question_tr:
+                first_question = req.question_tr
+
+    if missing:
+        logger.info(
+            "[SLOT_VALIDATION] Tool '%s' missing slots: %s",
+            tool_name,
+            ", ".join(missing),
+        )
+        return SlotValidationResult(
+            tool_name=tool_name,
+            valid=False,
+            missing_slots=missing,
+            question=first_question,
+            ask_user=True,
+        )
+
+    return SlotValidationResult(tool_name=tool_name, valid=True)
+
+
+def get_clarification_question(tool_name: str, slots: Dict[str, Any]) -> Optional[str]:
+    """
+    Convenience: returns the Turkish clarification question if slots are
+    incomplete, or None if everything is fine.
+    """
+    result = validate_tool_slots(tool_name, slots)
+    return result.question if not result.valid else None
+
+
+def get_required_slot_names(tool_name: str) -> List[str]:
+    """Return the list of primary required slot names for a tool."""
+    reqs = TOOL_REQUIRED_SLOTS.get(tool_name, [])
+    return [r.name for r in reqs]

--- a/tests/test_issue_433_calendar_slot_validation.py
+++ b/tests/test_issue_433_calendar_slot_validation.py
@@ -1,0 +1,313 @@
+"""
+Tests for Issue #433 — Calendar Slot Validation.
+
+Covers:
+- SlotRequirement: alternatives, all_names
+- TOOL_REQUIRED_SLOTS registry
+- validate_tool_slots: valid/invalid/partial/alternatives
+- SlotValidationResult: to_dict, ask_user
+- calendar.create_event: title + (time|date|window_hint) combinations
+- gmail.send: to + body required
+- Unknown tools pass through (no requirements)
+- Turkish clarification questions
+- get_clarification_question convenience
+- get_required_slot_names
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bantz.tools.slot_validation import (
+    TOOL_REQUIRED_SLOTS,
+    SlotRequirement,
+    SlotValidationResult,
+    get_clarification_question,
+    get_required_slot_names,
+    validate_tool_slots,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# SlotRequirement
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestSlotRequirement:
+
+    def test_basic(self):
+        r = SlotRequirement(name="title", question_tr="Nedir?")
+        assert r.all_names == ("title",)
+
+    def test_with_alternatives(self):
+        r = SlotRequirement(name="time", alternatives=("date", "window_hint"))
+        assert r.all_names == ("time", "date", "window_hint")
+
+    def test_frozen(self):
+        r = SlotRequirement(name="x")
+        with pytest.raises(AttributeError):
+            r.name = "y"
+
+
+# ─────────────────────────────────────────────────────────────────
+# TOOL_REQUIRED_SLOTS constants
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestToolRequiredSlots:
+
+    def test_create_event_has_title(self):
+        reqs = TOOL_REQUIRED_SLOTS["calendar.create_event"]
+        names = [r.name for r in reqs]
+        assert "title" in names
+
+    def test_create_event_has_time(self):
+        reqs = TOOL_REQUIRED_SLOTS["calendar.create_event"]
+        names = [r.name for r in reqs]
+        assert "time" in names
+
+    def test_gmail_send_has_to(self):
+        reqs = TOOL_REQUIRED_SLOTS["gmail.send"]
+        names = [r.name for r in reqs]
+        assert "to" in names
+
+    def test_gmail_send_has_body(self):
+        reqs = TOOL_REQUIRED_SLOTS["gmail.send"]
+        names = [r.name for r in reqs]
+        assert "body" in names
+
+    def test_all_have_questions(self):
+        for tool, reqs in TOOL_REQUIRED_SLOTS.items():
+            for r in reqs:
+                assert r.question_tr, f"{tool}.{r.name} has no question_tr"
+
+
+# ─────────────────────────────────────────────────────────────────
+# SlotValidationResult
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestSlotValidationResult:
+
+    def test_valid_to_dict(self):
+        r = SlotValidationResult(tool_name="calendar.create_event", valid=True)
+        d = r.to_dict()
+        assert d["valid"] is True
+        assert "missing_slots" not in d
+
+    def test_invalid_to_dict(self):
+        r = SlotValidationResult(
+            tool_name="calendar.create_event",
+            valid=False,
+            missing_slots=["title"],
+            question="Etkinlik adı ne olsun efendim?",
+            ask_user=True,
+        )
+        d = r.to_dict()
+        assert d["valid"] is False
+        assert "title" in d["missing_slots"]
+        assert d["ask_user"] is True
+        assert "question" in d
+
+
+# ─────────────────────────────────────────────────────────────────
+# calendar.create_event validation
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCalendarCreateEvent:
+
+    def test_valid_with_title_and_time(self):
+        r = validate_tool_slots("calendar.create_event", {"title": "Toplantı", "time": "14:00"})
+        assert r.valid
+        assert not r.ask_user
+
+    def test_valid_with_title_and_date(self):
+        r = validate_tool_slots("calendar.create_event", {"title": "Toplantı", "date": "2025-01-15"})
+        assert r.valid
+
+    def test_valid_with_title_and_window_hint(self):
+        r = validate_tool_slots("calendar.create_event", {"title": "Toplantı", "window_hint": "tomorrow"})
+        assert r.valid
+
+    def test_missing_title(self):
+        r = validate_tool_slots("calendar.create_event", {"time": "14:00"})
+        assert not r.valid
+        assert "title" in r.missing_slots
+        assert r.ask_user
+
+    def test_missing_time_and_alternatives(self):
+        r = validate_tool_slots("calendar.create_event", {"title": "Toplantı"})
+        assert not r.valid
+        assert "time" in r.missing_slots
+
+    def test_missing_both(self):
+        r = validate_tool_slots("calendar.create_event", {})
+        assert not r.valid
+        assert "title" in r.missing_slots
+        assert "time" in r.missing_slots
+
+    def test_empty_title_string(self):
+        r = validate_tool_slots("calendar.create_event", {"title": "", "time": "14:00"})
+        assert not r.valid
+        assert "title" in r.missing_slots
+
+    def test_whitespace_title(self):
+        r = validate_tool_slots("calendar.create_event", {"title": "  ", "time": "14:00"})
+        assert not r.valid
+        assert "title" in r.missing_slots
+
+    def test_none_title(self):
+        r = validate_tool_slots("calendar.create_event", {"title": None, "time": "14:00"})
+        assert not r.valid
+
+    def test_question_is_turkish(self):
+        r = validate_tool_slots("calendar.create_event", {})
+        assert r.question is not None
+        assert "efendim" in r.question.lower()
+
+    def test_first_question_is_title(self):
+        """When both title and time missing, first question should be about title."""
+        r = validate_tool_slots("calendar.create_event", {})
+        assert "adı" in (r.question or "").lower() or "etkinlik" in (r.question or "").lower()
+
+
+# ─────────────────────────────────────────────────────────────────
+# gmail.send validation
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestGmailSend:
+
+    def test_valid(self):
+        r = validate_tool_slots("gmail.send", {"to": "ali@test.com", "body": "Merhaba"})
+        assert r.valid
+
+    def test_valid_with_recipient_alt(self):
+        r = validate_tool_slots("gmail.send", {"recipient": "ali@test.com", "body": "Merhaba"})
+        assert r.valid
+
+    def test_valid_with_message_alt(self):
+        r = validate_tool_slots("gmail.send", {"to": "ali@test.com", "message": "Merhaba"})
+        assert r.valid
+
+    def test_valid_with_content_alt(self):
+        r = validate_tool_slots("gmail.send", {"to": "ali@test.com", "content": "Merhaba"})
+        assert r.valid
+
+    def test_missing_to(self):
+        r = validate_tool_slots("gmail.send", {"body": "Merhaba"})
+        assert not r.valid
+        assert "to" in r.missing_slots
+
+    def test_missing_body(self):
+        r = validate_tool_slots("gmail.send", {"to": "ali@test.com"})
+        assert not r.valid
+        assert "body" in r.missing_slots
+
+    def test_missing_both(self):
+        r = validate_tool_slots("gmail.send", {})
+        assert not r.valid
+        assert len(r.missing_slots) == 2
+
+
+# ─────────────────────────────────────────────────────────────────
+# Unknown / no-requirement tools
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestUnknownTools:
+
+    def test_unknown_tool_always_valid(self):
+        r = validate_tool_slots("some.unknown.tool", {})
+        assert r.valid
+
+    def test_list_events_no_requirements(self):
+        r = validate_tool_slots("calendar.list_events", {})
+        assert r.valid
+
+    def test_time_now_no_requirements(self):
+        r = validate_tool_slots("time.now", {})
+        assert r.valid
+
+
+# ─────────────────────────────────────────────────────────────────
+# Convenience functions
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestConvenience:
+
+    def test_get_clarification_question_missing(self):
+        q = get_clarification_question("calendar.create_event", {})
+        assert q is not None
+        assert "efendim" in q.lower()
+
+    def test_get_clarification_question_valid(self):
+        q = get_clarification_question("calendar.create_event", {"title": "X", "time": "14:00"})
+        assert q is None
+
+    def test_get_clarification_question_unknown_tool(self):
+        q = get_clarification_question("unknown.tool", {})
+        assert q is None
+
+    def test_get_required_slot_names(self):
+        names = get_required_slot_names("calendar.create_event")
+        assert "title" in names
+        assert "time" in names
+
+    def test_get_required_slot_names_unknown(self):
+        names = get_required_slot_names("unknown.tool")
+        assert names == []
+
+
+# ─────────────────────────────────────────────────────────────────
+# Custom required_slots override
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCustomSlots:
+
+    def test_custom_required(self):
+        custom = [SlotRequirement(name="custom_field", question_tr="Lütfen custom alanı giriniz?")]
+        r = validate_tool_slots("any.tool", {}, required_slots=custom)
+        assert not r.valid
+        assert "custom_field" in r.missing_slots
+
+    def test_custom_satisfied(self):
+        custom = [SlotRequirement(name="custom_field", question_tr="?")]
+        r = validate_tool_slots("any.tool", {"custom_field": "value"}, required_slots=custom)
+        assert r.valid
+
+
+# ─────────────────────────────────────────────────────────────────
+# calendar.delete_event / update_event
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestOtherCalendarTools:
+
+    def test_delete_event_needs_identifier(self):
+        r = validate_tool_slots("calendar.delete_event", {})
+        assert not r.valid
+        assert "title" in r.missing_slots
+
+    def test_delete_event_with_title(self):
+        r = validate_tool_slots("calendar.delete_event", {"title": "Toplantı"})
+        assert r.valid
+
+    def test_delete_event_with_event_id(self):
+        r = validate_tool_slots("calendar.delete_event", {"event_id": "abc123"})
+        assert r.valid
+
+    def test_delete_event_with_query(self):
+        r = validate_tool_slots("calendar.delete_event", {"query": "toplantı"})
+        assert r.valid
+
+    def test_update_event_needs_identifier(self):
+        r = validate_tool_slots("calendar.update_event", {})
+        assert not r.valid
+
+    def test_update_event_with_title(self):
+        r = validate_tool_slots("calendar.update_event", {"title": "Toplantı"})
+        assert r.valid


### PR DESCRIPTION
## Issue #433 — Calendar Slot Pre-Validation

### Problem
Router returns `calendar_intent='create'` with `tool_plan=['calendar.create_event']` but slots (title/time) may be missing. Currently: tool is called → Google API error → user sees error. Should: detect missing slots before tool call → ask user in Turkish.

### Changes
- **src/bantz/tools/slot_validation.py** (new module)
  - `SlotRequirement`: required slot with alternatives (`time|date|window_hint`)
  - `TOOL_REQUIRED_SLOTS`: per-tool required slot registry
    - `calendar.create_event`: title + (time|date|window_hint)
    - `calendar.update_event`: title|event_id|query
    - `calendar.delete_event`: title|event_id|query
    - `gmail.send`: to|recipient + body|message|content
    - `gmail.generate_reply`: message_id|thread_id|query
  - `validate_tool_slots()`: pre-check before tool execution
  - `SlotValidationResult`: valid, missing_slots, question (Turkish), ask_user
  - `get_clarification_question()`: convenience wrapper
  - `get_required_slot_names()`: introspection helper

### Tests
- **tests/test_issue_433_calendar_slot_validation.py**: 44 tests all passing
  - SlotRequirement basics + alternatives
  - calendar.create_event: all valid/invalid combinations
  - gmail.send: to/body with alternative slot names
  - Unknown tools pass through
  - Turkish question quality
  - Custom slot overrides
  - delete/update event validation

Closes #433