### PR TITLE
feat(#434): Tool Result Formatting — Human-Readable Turkish

### DIFF
--- a/src/bantz/tools/result_formatter.py
+++ b/src/bantz/tools/result_formatter.py
@@ -1,0 +1,309 @@
+"""
+Tool Result Formatting — Issue #434.
+
+Human-readable Turkish formatting for tool results so the finalizer
+doesn't have to interpret raw JSON (reducing hallucination risk).
+
+Supports:
+- calendar.list_events → "14:00 Toplantı (1 saat) | 16:00 Doktor (30 dk)"
+- calendar.create_event → "Toplantı oluşturuldu: 15 Ocak 14:00"
+- gmail.list_messages → "Ali Yılmaz: Proje hakkında (2 dk önce)"
+- gmail.send → "E-posta gönderildi: ali@test.com"
+- Configurable: human_readable | raw_json
+
+Usage::
+
+    from bantz.tools.result_formatter import format_tool_result, OutputFormat
+    formatted = format_tool_result("calendar.list_events", raw_result)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Config
+# ─────────────────────────────────────────────────────────────────
+
+
+class OutputFormat(str, Enum):
+    HUMAN_READABLE = "human_readable"
+    RAW_JSON = "raw_json"
+
+
+_MONTH_NAMES_TR = {
+    1: "Ocak", 2: "Şubat", 3: "Mart", 4: "Nisan",
+    5: "Mayıs", 6: "Haziran", 7: "Temmuz", 8: "Ağustos",
+    9: "Eylül", 10: "Ekim", 11: "Kasım", 12: "Aralık",
+}
+
+_DAY_NAMES_TR = {
+    0: "Pazartesi", 1: "Salı", 2: "Çarşamba", 3: "Perşembe",
+    4: "Cuma", 5: "Cumartesi", 6: "Pazar",
+}
+
+
+# ─────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────
+
+
+def _parse_iso(dt_str: str) -> Optional[datetime]:
+    """Best-effort ISO datetime parse."""
+    if not dt_str:
+        return None
+    try:
+        # Handle "2025-01-15T14:00:00+03:00" and "2025-01-15T14:00:00"
+        clean = dt_str.replace("Z", "+00:00")
+        return datetime.fromisoformat(clean)
+    except (ValueError, TypeError):
+        return None
+
+
+def _format_date_tr(dt: datetime) -> str:
+    """Format as '15 Ocak Çarşamba'."""
+    month = _MONTH_NAMES_TR.get(dt.month, str(dt.month))
+    day_name = _DAY_NAMES_TR.get(dt.weekday(), "")
+    return f"{dt.day} {month} {day_name}".strip()
+
+
+def _format_time_tr(dt: datetime) -> str:
+    """Format as 'HH:MM'."""
+    return dt.strftime("%H:%M")
+
+
+def _format_duration(minutes: int) -> str:
+    """Format duration in Turkish: '1 saat', '30 dk', '1 saat 30 dk'."""
+    if minutes <= 0:
+        return ""
+    hours = minutes // 60
+    mins = minutes % 60
+    parts = []
+    if hours:
+        parts.append(f"{hours} saat")
+    if mins:
+        parts.append(f"{mins} dk")
+    return " ".join(parts)
+
+
+def _calc_duration_minutes(start: datetime, end: datetime) -> int:
+    delta = end - start
+    return max(int(delta.total_seconds() / 60), 0)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Calendar formatters
+# ─────────────────────────────────────────────────────────────────
+
+
+def format_calendar_list_events(result: Dict[str, Any]) -> str:
+    """Format calendar.list_events result as Turkish summary.
+
+    Input: {"events": [{"summary": ..., "start": ..., "end": ...}, ...]}
+    Output: "14:00 Toplantı (1 saat) | 16:00 Doktor (30 dk)"
+    """
+    events = result.get("events") or []
+    if not events:
+        return "Takvimde etkinlik bulunamadı efendim."
+
+    lines: List[str] = []
+    for ev in events:
+        summary = ev.get("summary") or ev.get("title") or "İsimsiz Etkinlik"
+        start_str = ev.get("start") or ev.get("start_time") or ""
+        end_str = ev.get("end") or ev.get("end_time") or ""
+
+        # Handle Google Calendar's dateTime / date nested format
+        if isinstance(start_str, dict):
+            start_str = start_str.get("dateTime") or start_str.get("date") or ""
+        if isinstance(end_str, dict):
+            end_str = end_str.get("dateTime") or end_str.get("date") or ""
+
+        start_dt = _parse_iso(start_str)
+        end_dt = _parse_iso(end_str)
+
+        if start_dt:
+            time_str = _format_time_tr(start_dt)
+            dur_str = ""
+            if end_dt:
+                mins = _calc_duration_minutes(start_dt, end_dt)
+                if mins > 0:
+                    dur_str = f" ({_format_duration(mins)})"
+            lines.append(f"{time_str} {summary}{dur_str}")
+        else:
+            lines.append(summary)
+
+    count = len(lines)
+    header = f"{count} etkinlik bulundu efendim:"
+    body = " | ".join(lines)
+    return f"{header} {body}"
+
+
+def format_calendar_create_event(result: Dict[str, Any]) -> str:
+    """Format calendar.create_event result."""
+    if not result.get("ok", True):
+        error = result.get("error", "Bilinmeyen hata")
+        return f"Etkinlik oluşturulamadı efendim: {error}"
+
+    summary = result.get("summary") or result.get("title") or "Etkinlik"
+    start_str = result.get("start") or ""
+    if isinstance(start_str, dict):
+        start_str = start_str.get("dateTime") or start_str.get("date") or ""
+
+    start_dt = _parse_iso(start_str)
+    if start_dt:
+        date_str = _format_date_tr(start_dt)
+        time_str = _format_time_tr(start_dt)
+        return f"'{summary}' oluşturuldu efendim: {date_str} {time_str}"
+
+    return f"'{summary}' oluşturuldu efendim."
+
+
+def format_calendar_delete_event(result: Dict[str, Any]) -> str:
+    """Format calendar.delete_event result."""
+    if not result.get("ok", True):
+        return f"Etkinlik silinemedi efendim: {result.get('error', 'Bilinmeyen hata')}"
+    summary = result.get("summary") or result.get("title") or "Etkinlik"
+    return f"'{summary}' silindi efendim."
+
+
+def format_calendar_update_event(result: Dict[str, Any]) -> str:
+    """Format calendar.update_event result."""
+    if not result.get("ok", True):
+        return f"Etkinlik güncellenemedi efendim: {result.get('error', 'Bilinmeyen hata')}"
+    summary = result.get("summary") or result.get("title") or "Etkinlik"
+    return f"'{summary}' güncellendi efendim."
+
+
+# ─────────────────────────────────────────────────────────────────
+# Gmail formatters
+# ─────────────────────────────────────────────────────────────────
+
+
+def format_gmail_list_messages(result: Dict[str, Any]) -> str:
+    """Format gmail.list_messages as Turkish summary.
+
+    Input: {"messages": [{"from": ..., "subject": ..., "snippet": ...}, ...]}
+    Output: "Ali Yılmaz: Proje hakkında | Mehmet: Toplantı notu"
+    """
+    messages = result.get("messages") or []
+    if not messages:
+        return "Gelen kutusunda mesaj bulunamadı efendim."
+
+    lines: List[str] = []
+    for msg in messages:
+        sender = msg.get("from") or msg.get("sender") or "Bilinmeyen"
+        # Extract just the name part from "Ali Yılmaz <ali@test.com>"
+        if "<" in sender:
+            sender = sender.split("<")[0].strip()
+        subject = msg.get("subject") or "Konu yok"
+        # Truncate long subjects
+        if len(subject) > 40:
+            subject = subject[:37] + "..."
+        lines.append(f"{sender}: {subject}")
+
+    count = len(lines)
+    header = f"{count} mesaj bulundu efendim:"
+    body = " | ".join(lines)
+    return f"{header} {body}"
+
+
+def format_gmail_send(result: Dict[str, Any]) -> str:
+    """Format gmail.send result."""
+    if not result.get("ok", True):
+        return f"E-posta gönderilemedi efendim: {result.get('error', 'Bilinmeyen hata')}"
+    to = result.get("to") or result.get("recipient") or ""
+    return f"E-posta gönderildi efendim{': ' + to if to else ''}."
+
+
+def format_gmail_get_message(result: Dict[str, Any]) -> str:
+    """Format gmail.get_message result."""
+    sender = result.get("from") or result.get("sender") or "Bilinmeyen"
+    if "<" in sender:
+        sender = sender.split("<")[0].strip()
+    subject = result.get("subject") or "Konu yok"
+    snippet = result.get("snippet") or result.get("body") or ""
+    if len(snippet) > 100:
+        snippet = snippet[:97] + "..."
+    return f"Gönderen: {sender} | Konu: {subject} | {snippet}"
+
+
+# ─────────────────────────────────────────────────────────────────
+# System / time formatters
+# ─────────────────────────────────────────────────────────────────
+
+
+def format_time_now(result: Dict[str, Any]) -> str:
+    """Format time.now result."""
+    time_val = result.get("time") or result.get("now") or result.get("current_time") or ""
+    date_val = result.get("date") or result.get("current_date") or ""
+    if time_val and date_val:
+        return f"Şu an {date_val} {time_val} efendim."
+    if time_val:
+        return f"Saat {time_val} efendim."
+    return str(result)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Formatter registry
+# ─────────────────────────────────────────────────────────────────
+
+_FORMATTERS: Dict[str, Callable[[Dict[str, Any]], str]] = {
+    "calendar.list_events": format_calendar_list_events,
+    "calendar.create_event": format_calendar_create_event,
+    "calendar.delete_event": format_calendar_delete_event,
+    "calendar.update_event": format_calendar_update_event,
+    "gmail.list_messages": format_gmail_list_messages,
+    "gmail.send": format_gmail_send,
+    "gmail.get_message": format_gmail_get_message,
+    "time.now": format_time_now,
+}
+
+
+def format_tool_result(
+    tool_name: str,
+    result: Any,
+    *,
+    output_format: OutputFormat = OutputFormat.HUMAN_READABLE,
+) -> Any:
+    """
+    Format a tool result for user consumption.
+
+    Args:
+        tool_name: The tool that produced the result.
+        result: Raw tool result (usually dict).
+        output_format: HUMAN_READABLE (Turkish text) or RAW_JSON (passthrough).
+
+    Returns:
+        Formatted string (human_readable) or original dict (raw_json).
+    """
+    if output_format == OutputFormat.RAW_JSON:
+        return result
+
+    if not isinstance(result, dict):
+        return result
+
+    # Check for error
+    if result.get("ok") is False and "error" in result:
+        error = result["error"]
+        return f"İşlem başarısız oldu efendim: {error}"
+
+    formatter = _FORMATTERS.get(tool_name)
+    if formatter:
+        try:
+            return formatter(result)
+        except Exception as exc:
+            logger.warning("Formatter failed for %s: %s", tool_name, exc)
+            return result
+
+    return result
+
+
+def get_supported_tools() -> List[str]:
+    """Return tool names that have human-readable formatters."""
+    return sorted(_FORMATTERS.keys())

--- a/tests/test_issue_434_tool_result_formatting.py
+++ b/tests/test_issue_434_tool_result_formatting.py
@@ -1,0 +1,259 @@
+"""
+Tests for Issue #434 — Tool Result Formatting.
+
+Covers:
+- Calendar list_events formatting (Turkish summary)
+- Calendar create/delete/update event formatting
+- Gmail list_messages / send / get_message formatting
+- time.now formatting
+- OutputFormat.RAW_JSON passthrough
+- Error result handling
+- Unknown tool passthrough
+- Edge cases: empty events, nested dateTime, long subjects
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bantz.tools.result_formatter import (
+    OutputFormat,
+    format_calendar_create_event,
+    format_calendar_delete_event,
+    format_calendar_list_events,
+    format_calendar_update_event,
+    format_gmail_get_message,
+    format_gmail_list_messages,
+    format_gmail_send,
+    format_time_now,
+    format_tool_result,
+    get_supported_tools,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Calendar list_events
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCalendarListEvents:
+
+    def test_empty_events(self):
+        r = format_calendar_list_events({"events": []})
+        assert "bulunamadı" in r
+
+    def test_single_event(self):
+        r = format_calendar_list_events({
+            "events": [
+                {"summary": "Toplantı", "start": "2025-01-15T14:00:00+03:00", "end": "2025-01-15T15:00:00+03:00"}
+            ]
+        })
+        assert "14:00" in r
+        assert "Toplantı" in r
+        assert "1 saat" in r
+
+    def test_multiple_events(self):
+        r = format_calendar_list_events({
+            "events": [
+                {"summary": "Toplantı", "start": "2025-01-15T14:00:00+03:00", "end": "2025-01-15T15:00:00+03:00"},
+                {"summary": "Doktor", "start": "2025-01-15T16:00:00+03:00", "end": "2025-01-15T16:30:00+03:00"},
+            ]
+        })
+        assert "2 etkinlik" in r
+        assert "14:00 Toplantı" in r
+        assert "16:00 Doktor" in r
+        assert "30 dk" in r
+        assert "|" in r
+
+    def test_nested_datetime_format(self):
+        """Google Calendar sometimes nests dateTime in a dict."""
+        r = format_calendar_list_events({
+            "events": [
+                {"summary": "Test", "start": {"dateTime": "2025-01-15T10:00:00+03:00"}, "end": {"dateTime": "2025-01-15T11:00:00+03:00"}}
+            ]
+        })
+        assert "10:00" in r
+        assert "Test" in r
+
+    def test_no_events_key(self):
+        r = format_calendar_list_events({})
+        assert "bulunamadı" in r
+
+    def test_missing_summary(self):
+        r = format_calendar_list_events({
+            "events": [{"start": "2025-01-15T14:00:00+03:00"}]
+        })
+        assert "İsimsiz Etkinlik" in r
+
+    def test_header_count(self):
+        events = [
+            {"summary": f"Etkinlik {i}", "start": f"2025-01-15T{10+i}:00:00+03:00"}
+            for i in range(5)
+        ]
+        r = format_calendar_list_events({"events": events})
+        assert "5 etkinlik" in r
+
+
+# ─────────────────────────────────────────────────────────────────
+# Calendar create/delete/update
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCalendarMutations:
+
+    def test_create_success(self):
+        r = format_calendar_create_event({
+            "ok": True, "summary": "Toplantı", "start": "2025-01-15T14:00:00+03:00"
+        })
+        assert "oluşturuldu" in r
+        assert "Toplantı" in r
+        assert "14:00" in r
+        assert "Ocak" in r
+
+    def test_create_failure(self):
+        r = format_calendar_create_event({"ok": False, "error": "API error"})
+        assert "oluşturulamadı" in r
+        assert "API error" in r
+
+    def test_create_no_start(self):
+        r = format_calendar_create_event({"ok": True, "summary": "Test"})
+        assert "oluşturuldu" in r
+
+    def test_delete_success(self):
+        r = format_calendar_delete_event({"ok": True, "summary": "Toplantı"})
+        assert "silindi" in r
+
+    def test_delete_failure(self):
+        r = format_calendar_delete_event({"ok": False, "error": "not found"})
+        assert "silinemedi" in r
+
+    def test_update_success(self):
+        r = format_calendar_update_event({"ok": True, "summary": "Toplantı"})
+        assert "güncellendi" in r
+
+    def test_update_failure(self):
+        r = format_calendar_update_event({"ok": False, "error": "conflict"})
+        assert "güncellenemedi" in r
+
+
+# ─────────────────────────────────────────────────────────────────
+# Gmail
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestGmailFormatting:
+
+    def test_list_empty(self):
+        r = format_gmail_list_messages({"messages": []})
+        assert "bulunamadı" in r
+
+    def test_list_messages(self):
+        r = format_gmail_list_messages({
+            "messages": [
+                {"from": "Ali Yılmaz <ali@test.com>", "subject": "Proje hakkında"},
+                {"from": "Mehmet <m@test.com>", "subject": "Toplantı notu"},
+            ]
+        })
+        assert "2 mesaj" in r
+        assert "Ali Yılmaz" in r
+        assert "Proje hakkında" in r
+        assert "|" in r
+
+    def test_list_long_subject_truncated(self):
+        long_subject = "Bu çok uzun bir konu başlığıdır ve kırpılması gerekir çünkü çok fazla karakter var"
+        r = format_gmail_list_messages({
+            "messages": [{"from": "Test", "subject": long_subject}]
+        })
+        assert "..." in r
+
+    def test_send_success(self):
+        r = format_gmail_send({"ok": True, "to": "ali@test.com"})
+        assert "gönderildi" in r
+        assert "ali@test.com" in r
+
+    def test_send_failure(self):
+        r = format_gmail_send({"ok": False, "error": "rate limit"})
+        assert "gönderilemedi" in r
+
+    def test_get_message(self):
+        r = format_gmail_get_message({
+            "from": "Ali <ali@test.com>",
+            "subject": "Test konu",
+            "snippet": "Merhaba, toplantı hakkında...",
+        })
+        assert "Ali" in r
+        assert "Test konu" in r
+        assert "Merhaba" in r
+
+
+# ─────────────────────────────────────────────────────────────────
+# time.now
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestTimeNow:
+
+    def test_time_and_date(self):
+        r = format_time_now({"time": "14:30", "date": "2025-01-15"})
+        assert "14:30" in r
+        assert "2025-01-15" in r
+
+    def test_time_only(self):
+        r = format_time_now({"time": "14:30"})
+        assert "Saat 14:30" in r
+
+
+# ─────────────────────────────────────────────────────────────────
+# format_tool_result dispatcher
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestFormatToolResult:
+
+    def test_human_readable(self):
+        r = format_tool_result("calendar.list_events", {"events": []})
+        assert isinstance(r, str)
+        assert "bulunamadı" in r
+
+    def test_raw_json_passthrough(self):
+        data = {"events": [{"x": 1}]}
+        r = format_tool_result("calendar.list_events", data, output_format=OutputFormat.RAW_JSON)
+        assert r == data
+
+    def test_unknown_tool_passthrough(self):
+        data = {"some": "data"}
+        r = format_tool_result("unknown.tool", data)
+        assert r == data
+
+    def test_error_result(self):
+        r = format_tool_result("calendar.list_events", {"ok": False, "error": "timeout"})
+        assert "başarısız" in r
+
+    def test_non_dict_passthrough(self):
+        r = format_tool_result("calendar.list_events", "plain string")
+        assert r == "plain string"
+
+    def test_none_result(self):
+        r = format_tool_result("calendar.list_events", None)
+        assert r is None
+
+
+# ─────────────────────────────────────────────────────────────────
+# Utilities
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestUtilities:
+
+    def test_get_supported_tools(self):
+        tools = get_supported_tools()
+        assert "calendar.list_events" in tools
+        assert "gmail.send" in tools
+        assert "time.now" in tools
+
+    def test_efendim_in_outputs(self):
+        """All formatter outputs should include efendim for Jarvis persona."""
+        assert "efendim" in format_calendar_list_events({"events": []})
+        assert "efendim" in format_gmail_list_messages({"messages": []})
+        assert "efendim" in format_gmail_send({"ok": True})
+        assert "efendim" in format_time_now({"time": "14:00"})


### PR DESCRIPTION
Closes #434

- `src/bantz/tools/result_formatter.py`: Human-readable Turkish formatters for calendar/gmail/time tools
- `format_tool_result()` dispatcher with OutputFormat.HUMAN_READABLE | RAW_JSON
- 30 tests passing