### PR TITLE
feat(#440): Turkish error messages with i18n module

### DIFF
--- a/src/bantz/i18n/messages.py
+++ b/src/bantz/i18n/messages.py
@@ -1,0 +1,302 @@
+"""
+Turkish Error Messages — Issue #440.
+
+All user-facing error messages in Turkish. Maps internal error codes
+to human-friendly Turkish text, preventing English leakage to end users.
+
+Usage::
+
+    from bantz.i18n.messages import tr, ErrorCode
+
+    # Get Turkish error message
+    msg = tr(ErrorCode.LLM_TIMEOUT)
+    # → "Yapay zekâ yanıt vermedi. Lütfen tekrar deneyin."
+
+    # With format arguments
+    msg = tr(ErrorCode.TOOL_FAILED, tool_name="takvim")
+    # → "takvim aracı çalışırken bir hata oluştu."
+
+    # Fallback for unknown codes
+    msg = tr("unknown_code")
+    # → "Bir hata oluştu. Lütfen tekrar deneyin."
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum, unique
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Error Codes
+# ─────────────────────────────────────────────────────────────────
+
+
+@unique
+class ErrorCode(str, Enum):
+    """Internal error codes for all Bantz subsystems."""
+
+    # ── LLM / Model ────────────────────────────────────────────
+    LLM_TIMEOUT = "llm_timeout"
+    LLM_OVERLOADED = "llm_overloaded"
+    LLM_INVALID_RESPONSE = "llm_invalid_response"
+    LLM_CONNECTION_ERROR = "llm_connection_error"
+    LLM_JSON_PARSE_ERROR = "llm_json_parse_error"
+    LLM_CONTEXT_TOO_LONG = "llm_context_too_long"
+
+    # ── Gemini ─────────────────────────────────────────────────
+    GEMINI_UNAVAILABLE = "gemini_unavailable"
+    GEMINI_QUOTA_EXCEEDED = "gemini_quota_exceeded"
+    GEMINI_SAFETY_BLOCK = "gemini_safety_block"
+    GEMINI_TIMEOUT = "gemini_timeout"
+
+    # ── vLLM ───────────────────────────────────────────────────
+    VLLM_DOWN = "vllm_down"
+    VLLM_RESTART_FAILED = "vllm_restart_failed"
+    VLLM_HEALTH_CHECK_FAILED = "vllm_health_check_failed"
+
+    # ── Router ─────────────────────────────────────────────────
+    ROUTER_NO_MATCH = "router_no_match"
+    ROUTER_LOW_CONFIDENCE = "router_low_confidence"
+
+    # ── Tools ──────────────────────────────────────────────────
+    TOOL_FAILED = "tool_failed"
+    TOOL_NOT_FOUND = "tool_not_found"
+    TOOL_TIMEOUT = "tool_timeout"
+    TOOL_AUTH_ERROR = "tool_auth_error"
+
+    # ── Calendar ───────────────────────────────────────────────
+    CALENDAR_AUTH_EXPIRED = "calendar_auth_expired"
+    CALENDAR_NOT_FOUND = "calendar_not_found"
+    CALENDAR_CONFLICT = "calendar_conflict"
+    CALENDAR_API_ERROR = "calendar_api_error"
+
+    # ── Gmail ──────────────────────────────────────────────────
+    GMAIL_AUTH_EXPIRED = "gmail_auth_expired"
+    GMAIL_SEND_FAILED = "gmail_send_failed"
+    GMAIL_NOT_FOUND = "gmail_not_found"
+    GMAIL_API_ERROR = "gmail_api_error"
+
+    # ── Security ───────────────────────────────────────────────
+    SECURITY_POLICY_BLOCKED = "security_policy_blocked"
+    SECURITY_CONFIRMATION_REQUIRED = "security_confirmation_required"
+    SECURITY_INJECTION_DETECTED = "security_injection_detected"
+    SECURITY_RATE_LIMITED = "security_rate_limited"
+
+    # ── Voice ──────────────────────────────────────────────────
+    VOICE_RECOGNITION_FAILED = "voice_recognition_failed"
+    VOICE_NO_SPEECH = "voice_no_speech"
+    VOICE_TOO_NOISY = "voice_too_noisy"
+    VOICE_MIC_ERROR = "voice_mic_error"
+
+    # ── System ─────────────────────────────────────────────────
+    SYSTEM_ERROR = "system_error"
+    SYSTEM_CONFIG_ERROR = "system_config_error"
+    SYSTEM_MEMORY_LOW = "system_memory_low"
+
+    # ── Quality Gating ─────────────────────────────────────────
+    QUALITY_RATE_LIMITED = "quality_rate_limited"
+    QUALITY_FALLBACK = "quality_fallback"
+
+    # ── Generic ────────────────────────────────────────────────
+    UNKNOWN = "unknown"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Turkish Message Registry
+# ─────────────────────────────────────────────────────────────────
+
+_MESSAGES_TR: Dict[str, str] = {
+    # ── LLM / Model ──
+    ErrorCode.LLM_TIMEOUT:
+        "Yapay zekâ yanıt vermedi. Lütfen tekrar deneyin.",
+    ErrorCode.LLM_OVERLOADED:
+        "Sistem şu anda yoğun. Lütfen birkaç saniye bekleyin.",
+    ErrorCode.LLM_INVALID_RESPONSE:
+        "Yapay zekâdan geçersiz bir yanıt alındı. Tekrar deniyorum.",
+    ErrorCode.LLM_CONNECTION_ERROR:
+        "Yapay zekâ sunucusuna bağlanılamadı.",
+    ErrorCode.LLM_JSON_PARSE_ERROR:
+        "Yapay zekâ yanıtı ayrıştırılamadı. Tekrar deneniyor.",
+    ErrorCode.LLM_CONTEXT_TOO_LONG:
+        "Mesaj çok uzun. Lütfen daha kısa bir ifade deneyin.",
+
+    # ── Gemini ──
+    ErrorCode.GEMINI_UNAVAILABLE:
+        "Gemini şu anda kullanılamıyor. Hızlı model ile devam ediyorum.",
+    ErrorCode.GEMINI_QUOTA_EXCEEDED:
+        "Gemini kullanım kotası aşıldı. Hızlı model ile devam ediyorum.",
+    ErrorCode.GEMINI_SAFETY_BLOCK:
+        "İçerik güvenlik filtresi tarafından engellendi.",
+    ErrorCode.GEMINI_TIMEOUT:
+        "Gemini yanıt vermedi. Hızlı model ile devam ediyorum.",
+
+    # ── vLLM ──
+    ErrorCode.VLLM_DOWN:
+        "Yerel yapay zekâ sunucusu çalışmıyor. Yeniden başlatılıyor.",
+    ErrorCode.VLLM_RESTART_FAILED:
+        "Yapay zekâ sunucusu yeniden başlatılamadı.",
+    ErrorCode.VLLM_HEALTH_CHECK_FAILED:
+        "Yapay zekâ sunucusu sağlık kontrolünü geçemedi.",
+
+    # ── Router ──
+    ErrorCode.ROUTER_NO_MATCH:
+        "Ne demek istediğinizi anlayamadım. Lütfen başka bir şekilde ifade edin.",
+    ErrorCode.ROUTER_LOW_CONFIDENCE:
+        "Tam olarak anlayamadım. Şunu mu demek istediniz?",
+
+    # ── Tools ──
+    ErrorCode.TOOL_FAILED:
+        "{tool_name} aracı çalışırken bir hata oluştu.",
+    ErrorCode.TOOL_NOT_FOUND:
+        "İstenen araç bulunamadı: {tool_name}",
+    ErrorCode.TOOL_TIMEOUT:
+        "{tool_name} aracı zaman aşımına uğradı.",
+    ErrorCode.TOOL_AUTH_ERROR:
+        "{tool_name} için yetkilendirme hatası. Lütfen izinleri kontrol edin.",
+
+    # ── Calendar ──
+    ErrorCode.CALENDAR_AUTH_EXPIRED:
+        "Google Takvim oturumunuz sona erdi. Lütfen tekrar giriş yapın.",
+    ErrorCode.CALENDAR_NOT_FOUND:
+        "Belirtilen etkinlik bulunamadı.",
+    ErrorCode.CALENDAR_CONFLICT:
+        "Bu zaman diliminde zaten bir etkinlik var.",
+    ErrorCode.CALENDAR_API_ERROR:
+        "Google Takvim'e erişirken bir sorun oluştu.",
+
+    # ── Gmail ──
+    ErrorCode.GMAIL_AUTH_EXPIRED:
+        "Gmail oturumunuz sona erdi. Lütfen tekrar giriş yapın.",
+    ErrorCode.GMAIL_SEND_FAILED:
+        "E-posta gönderilemedi. Lütfen tekrar deneyin.",
+    ErrorCode.GMAIL_NOT_FOUND:
+        "Belirtilen e-posta bulunamadı.",
+    ErrorCode.GMAIL_API_ERROR:
+        "Gmail'e erişirken bir sorun oluştu.",
+
+    # ── Security ──
+    ErrorCode.SECURITY_POLICY_BLOCKED:
+        "Bu işlem güvenlik politikası tarafından engellendi.",
+    ErrorCode.SECURITY_CONFIRMATION_REQUIRED:
+        "Bu işlem onay gerektiriyor. Devam etmek istiyor musunuz?",
+    ErrorCode.SECURITY_INJECTION_DETECTED:
+        "Güvenlik ihlali algılandı. İşlem reddedildi.",
+    ErrorCode.SECURITY_RATE_LIMITED:
+        "Çok fazla istek gönderildi. Lütfen biraz bekleyin.",
+
+    # ── Voice ──
+    ErrorCode.VOICE_RECOGNITION_FAILED:
+        "Sesinizi anlayamadım. Lütfen tekrar söyleyin.",
+    ErrorCode.VOICE_NO_SPEECH:
+        "Herhangi bir konuşma algılanmadı.",
+    ErrorCode.VOICE_TOO_NOISY:
+        "Ortam çok gürültülü. Lütfen daha sessiz bir yerde deneyin.",
+    ErrorCode.VOICE_MIC_ERROR:
+        "Mikrofona erişilemiyor. Lütfen mikrofon ayarlarını kontrol edin.",
+
+    # ── System ──
+    ErrorCode.SYSTEM_ERROR:
+        "Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin.",
+    ErrorCode.SYSTEM_CONFIG_ERROR:
+        "Yapılandırma hatası algılandı. Lütfen ayarları kontrol edin.",
+    ErrorCode.SYSTEM_MEMORY_LOW:
+        "Sistem belleği düşük. Bazı işlemler yavaşlayabilir.",
+
+    # ── Quality Gating ──
+    ErrorCode.QUALITY_RATE_LIMITED:
+        "Kalite modeli kullanım limiti aşıldı. Hızlı model ile devam ediyorum.",
+    ErrorCode.QUALITY_FALLBACK:
+        "Kalite modeline ulaşılamadı. Hızlı model ile devam ediyorum.",
+
+    # ── Generic ──
+    ErrorCode.UNKNOWN:
+        "Bir hata oluştu. Lütfen tekrar deneyin.",
+}
+
+# Fallback message
+_FALLBACK_TR = "Bir hata oluştu. Lütfen tekrar deneyin."
+
+
+# ─────────────────────────────────────────────────────────────────
+# Public API
+# ─────────────────────────────────────────────────────────────────
+
+
+def tr(code: str | ErrorCode, **kwargs: Any) -> str:
+    """Get Turkish error message for the given code.
+
+    Args:
+        code: Error code (ErrorCode enum or string).
+        **kwargs: Format arguments (e.g. tool_name="takvim").
+
+    Returns:
+        Turkish error message string.
+    """
+    # Normalize to string key
+    key = code.value if isinstance(code, ErrorCode) else str(code)
+
+    # Lookup by enum or string
+    template: Optional[str] = None
+    if isinstance(code, ErrorCode):
+        template = _MESSAGES_TR.get(code)
+    if template is None:
+        # Try string lookup
+        for ec, msg in _MESSAGES_TR.items():
+            if ec.value == key:
+                template = msg
+                break
+
+    if template is None:
+        logger.warning("No Turkish message for error code: %s", key)
+        template = _FALLBACK_TR
+
+    try:
+        return template.format(**kwargs)
+    except (KeyError, IndexError):
+        return template
+
+
+def get_all_messages() -> Dict[str, str]:
+    """Return all Turkish error messages (for testing/export)."""
+    return {ec.value: msg for ec, msg in _MESSAGES_TR.items()}
+
+
+def get_error_code(code_str: str) -> ErrorCode:
+    """Convert a string to an ErrorCode enum, or UNKNOWN if not found."""
+    try:
+        return ErrorCode(code_str)
+    except ValueError:
+        return ErrorCode.UNKNOWN
+
+
+def is_retriable(code: str | ErrorCode) -> bool:
+    """Check if an error is retriable (user can retry the action).
+
+    Returns True for transient errors, False for permanent ones.
+    """
+    key = code.value if isinstance(code, ErrorCode) else str(code)
+    retriable_codes = {
+        ErrorCode.LLM_TIMEOUT.value,
+        ErrorCode.LLM_OVERLOADED.value,
+        ErrorCode.LLM_INVALID_RESPONSE.value,
+        ErrorCode.LLM_CONNECTION_ERROR.value,
+        ErrorCode.LLM_JSON_PARSE_ERROR.value,
+        ErrorCode.GEMINI_UNAVAILABLE.value,
+        ErrorCode.GEMINI_TIMEOUT.value,
+        ErrorCode.VLLM_DOWN.value,
+        ErrorCode.TOOL_FAILED.value,
+        ErrorCode.TOOL_TIMEOUT.value,
+        ErrorCode.VOICE_RECOGNITION_FAILED.value,
+        ErrorCode.VOICE_TOO_NOISY.value,
+        ErrorCode.GMAIL_SEND_FAILED.value,
+        ErrorCode.CALENDAR_API_ERROR.value,
+        ErrorCode.GMAIL_API_ERROR.value,
+        ErrorCode.SYSTEM_ERROR.value,
+        ErrorCode.QUALITY_RATE_LIMITED.value,
+        ErrorCode.QUALITY_FALLBACK.value,
+    }
+    return key in retriable_codes

--- a/tests/test_issue_440_turkish_error_messages.py
+++ b/tests/test_issue_440_turkish_error_messages.py
@@ -1,0 +1,174 @@
+"""Tests for Issue #440 — Turkish Error Messages.
+
+Covers:
+- All error codes have Turkish messages
+- Format arguments work
+- Fallback for unknown codes
+- ErrorCode lookup
+- Retriable error classification
+- No English leakage
+"""
+
+from __future__ import annotations
+
+import re
+import pytest
+
+from bantz.i18n.messages import (
+    ErrorCode,
+    tr,
+    get_all_messages,
+    get_error_code,
+    is_retriable,
+    _FALLBACK_TR,
+)
+
+
+# ─── Basic message lookup ───────────────────────────────────────
+
+
+class TestTrFunction:
+    def test_simple_lookup(self):
+        msg = tr(ErrorCode.LLM_TIMEOUT)
+        assert "yanıt vermedi" in msg
+
+    def test_with_format_args(self):
+        msg = tr(ErrorCode.TOOL_FAILED, tool_name="takvim")
+        assert "takvim" in msg
+
+    def test_unknown_code_returns_fallback(self):
+        msg = tr("totally_unknown_code_xyz")
+        assert msg == _FALLBACK_TR
+
+    def test_string_code_lookup(self):
+        msg = tr("llm_timeout")
+        assert "yanıt vermedi" in msg
+
+    def test_format_missing_arg_graceful(self):
+        """If format arg is missing, return template without crashing."""
+        msg = tr(ErrorCode.TOOL_FAILED)  # tool_name not provided
+        assert "{tool_name}" in msg or "hata" in msg.lower()
+
+
+# ─── All codes have messages ────────────────────────────────────
+
+
+class TestCompleteness:
+    def test_all_error_codes_have_messages(self):
+        msgs = get_all_messages()
+        for code in ErrorCode:
+            assert code.value in msgs, f"Missing Turkish message for {code.value}"
+
+    def test_no_empty_messages(self):
+        msgs = get_all_messages()
+        for code, msg in msgs.items():
+            assert len(msg.strip()) > 0, f"Empty message for {code}"
+
+
+# ─── No English leakage ─────────────────────────────────────────
+
+
+class TestNoEnglishLeakage:
+    """Verify messages are actually in Turkish, not English placeholders."""
+
+    # Common English error words that should NOT appear
+    _ENGLISH_WORDS = [
+        "error occurred",
+        "please try again",
+        "failed to",
+        "unable to",
+        "connection refused",
+        "timeout error",
+        "internal server error",
+        "something went wrong",
+    ]
+
+    def test_no_english_in_messages(self):
+        msgs = get_all_messages()
+        for code, msg in msgs.items():
+            lower = msg.lower()
+            for eng in self._ENGLISH_WORDS:
+                assert eng not in lower, (
+                    f"English text '{eng}' found in message for {code}: {msg}"
+                )
+
+    def test_messages_contain_turkish_chars(self):
+        """At least some messages should contain Turkish-specific characters."""
+        msgs = get_all_messages()
+        all_text = " ".join(msgs.values())
+        # Turkish chars: ç, ğ, ı, ö, ş, ü, İ
+        turkish_chars = set("çğıöşüİâ")
+        found = set(c for c in all_text if c in turkish_chars)
+        assert len(found) >= 3, f"Too few Turkish chars found: {found}"
+
+
+# ─── Error code lookup ──────────────────────────────────────────
+
+
+class TestErrorCodeLookup:
+    def test_valid_code(self):
+        ec = get_error_code("llm_timeout")
+        assert ec == ErrorCode.LLM_TIMEOUT
+
+    def test_invalid_code(self):
+        ec = get_error_code("not_a_real_code")
+        assert ec == ErrorCode.UNKNOWN
+
+    def test_all_codes_roundtrip(self):
+        for code in ErrorCode:
+            assert get_error_code(code.value) == code
+
+
+# ─── Retriable classification ───────────────────────────────────
+
+
+class TestRetriable:
+    def test_timeout_is_retriable(self):
+        assert is_retriable(ErrorCode.LLM_TIMEOUT)
+
+    def test_overloaded_is_retriable(self):
+        assert is_retriable(ErrorCode.LLM_OVERLOADED)
+
+    def test_policy_blocked_not_retriable(self):
+        assert not is_retriable(ErrorCode.SECURITY_POLICY_BLOCKED)
+
+    def test_injection_not_retriable(self):
+        assert not is_retriable(ErrorCode.SECURITY_INJECTION_DETECTED)
+
+    def test_string_code_retriable(self):
+        assert is_retriable("llm_timeout")
+
+    def test_unknown_not_retriable(self):
+        assert not is_retriable("totally_unknown")
+
+    def test_voice_recognition_retriable(self):
+        assert is_retriable(ErrorCode.VOICE_RECOGNITION_FAILED)
+
+
+# ─── Specific message content ───────────────────────────────────
+
+
+class TestSpecificMessages:
+    def test_gemini_fallback_mentions_fast_model(self):
+        msg = tr(ErrorCode.GEMINI_UNAVAILABLE)
+        assert "hızlı model" in msg.lower() or "devam" in msg.lower()
+
+    def test_voice_noisy_mentions_sessiz(self):
+        msg = tr(ErrorCode.VOICE_TOO_NOISY)
+        assert "sessiz" in msg.lower() or "gürültü" in msg.lower()
+
+    def test_calendar_auth_mentions_giris(self):
+        msg = tr(ErrorCode.CALENDAR_AUTH_EXPIRED)
+        assert "giriş" in msg.lower()
+
+    def test_security_confirmation_is_question(self):
+        msg = tr(ErrorCode.SECURITY_CONFIRMATION_REQUIRED)
+        assert "?" in msg
+
+    def test_router_no_match_polite(self):
+        msg = tr(ErrorCode.ROUTER_NO_MATCH)
+        assert "lütfen" in msg.lower()
+
+    def test_memory_low_warns(self):
+        msg = tr(ErrorCode.SYSTEM_MEMORY_LOW)
+        assert "bellek" in msg.lower() or "yavaş" in msg.lower()


### PR DESCRIPTION
## Issue #440 — Turkish Error Messages

### Changes
- New `src/bantz/i18n/messages.py` with complete EN→TR error mapping
- 40+ ErrorCode enum covering all subsystems (LLM, Gemini, vLLM, Router, Tools, Calendar, Gmail, Security, Voice, System)
- `tr()` function with format argument support and graceful fallback
- `is_retriable()` classification for retry logic
- No English leakage verified in tests

### Files
- `src/bantz/i18n/__init__.py` — Package init
- `src/bantz/i18n/messages.py` — Error messages module
- `tests/test_issue_440_turkish_error_messages.py` — 25 tests

### Tests
All 25 tests passing ✅