### PR TITLE
feat(#448): Memory v0 — SQLite persistent storage backend

### DIFF
--- a/src/bantz/memory/migrations.py
+++ b/src/bantz/memory/migrations.py
@@ -1,0 +1,128 @@
+"""Schema migrations for persistent memory database (Issue #448).
+
+Simple version-based migration system.  Each migration is a plain SQL
+string keyed by its target version number.  :func:`migrate` applies any
+outstanding migrations in order.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------
+# Migration registry — version → SQL
+# -----------------------------------------------------------------------
+
+MIGRATIONS: Dict[int, str] = {
+    1: """
+    -- v1: initial schema (Issue #448)
+    CREATE TABLE IF NOT EXISTS schema_version (
+        version   INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS user_profile (
+        id         TEXT PRIMARY KEY,
+        key        TEXT NOT NULL UNIQUE,
+        value      TEXT NOT NULL DEFAULT '',
+        updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS session (
+        id          TEXT PRIMARY KEY,
+        start_time  TEXT NOT NULL,
+        end_time    TEXT,
+        summary     TEXT NOT NULL DEFAULT '',
+        turn_count  INTEGER NOT NULL DEFAULT 0,
+        metadata    TEXT NOT NULL DEFAULT '{}'
+    );
+
+    CREATE TABLE IF NOT EXISTS memory_item (
+        id               TEXT PRIMARY KEY,
+        session_id       TEXT,
+        type             TEXT NOT NULL DEFAULT 'episodic',
+        content          TEXT NOT NULL DEFAULT '',
+        embedding_vector TEXT,
+        importance       REAL NOT NULL DEFAULT 0.5,
+        created_at       TEXT NOT NULL,
+        accessed_at      TEXT NOT NULL,
+        access_count     INTEGER NOT NULL DEFAULT 0,
+        tags             TEXT NOT NULL DEFAULT '[]',
+        metadata         TEXT NOT NULL DEFAULT '{}',
+        FOREIGN KEY (session_id) REFERENCES session(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS tool_trace (
+        id              TEXT PRIMARY KEY,
+        session_id      TEXT,
+        tool_name       TEXT NOT NULL DEFAULT '',
+        args_hash       TEXT NOT NULL DEFAULT '',
+        result_summary  TEXT NOT NULL DEFAULT '',
+        success         INTEGER NOT NULL DEFAULT 1,
+        latency_ms      REAL NOT NULL DEFAULT 0.0,
+        created_at      TEXT NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES session(id)
+    );
+
+    -- Indexes for common queries
+    CREATE INDEX IF NOT EXISTS idx_memory_item_session ON memory_item(session_id);
+    CREATE INDEX IF NOT EXISTS idx_memory_item_type    ON memory_item(type);
+    CREATE INDEX IF NOT EXISTS idx_memory_item_importance ON memory_item(importance);
+    CREATE INDEX IF NOT EXISTS idx_tool_trace_session  ON tool_trace(session_id);
+    CREATE INDEX IF NOT EXISTS idx_tool_trace_tool     ON tool_trace(tool_name);
+    CREATE INDEX IF NOT EXISTS idx_user_profile_key    ON user_profile(key);
+    """,
+}
+
+LATEST_VERSION = max(MIGRATIONS.keys())
+
+
+def _current_version(conn: sqlite3.Connection) -> int:
+    """Return the current schema version (0 if fresh database)."""
+    try:
+        row = conn.execute(
+            "SELECT MAX(version) FROM schema_version"
+        ).fetchone()
+        return row[0] if row and row[0] is not None else 0
+    except sqlite3.OperationalError:
+        # schema_version table doesn't exist yet → version 0
+        return 0
+
+
+def migrate(conn: sqlite3.Connection) -> int:
+    """Apply all outstanding migrations and return the new version.
+
+    Parameters
+    ----------
+    conn:
+        An open SQLite connection (WAL mode recommended).
+
+    Returns
+    -------
+    int
+        The schema version after migration.
+    """
+    current = _current_version(conn)
+    if current >= LATEST_VERSION:
+        logger.debug("[migrate] Schema already at v%d — nothing to do.", current)
+        return current
+
+    for version in sorted(MIGRATIONS.keys()):
+        if version <= current:
+            continue
+        logger.info("[migrate] Applying migration v%d …", version)
+        conn.executescript(MIGRATIONS[version])
+        conn.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+            (version, datetime.utcnow().isoformat()),
+        )
+        conn.commit()
+        logger.info("[migrate] Migration v%d applied.", version)
+
+    new_version = _current_version(conn)
+    return new_version

--- a/src/bantz/memory/models.py
+++ b/src/bantz/memory/models.py
@@ -1,0 +1,166 @@
+"""Memory data models for persistent SQLite storage (Issue #448).
+
+Defines the core data structures used by :class:`PersistentMemoryStore`:
+
+- :class:`MemoryItem` — episodic / semantic / fact memory entries
+- :class:`Session` — conversation session envelope
+- :class:`ToolTrace` — individual tool execution record
+- :class:`UserProfile` — key-value user preference pair
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class MemoryItemType(Enum):
+    """Kinds of persistent memory items."""
+
+    EPISODIC = "episodic"
+    SEMANTIC = "semantic"
+    FACT = "fact"
+
+
+@dataclass
+class MemoryItem:
+    """A single persistent memory entry.
+
+    Attributes
+    ----------
+    id:
+        Unique identifier (UUID).
+    session_id:
+        Owning session, if any.
+    type:
+        ``episodic``, ``semantic``, or ``fact``.
+    content:
+        Plain-text content of the memory.
+    embedding_vector:
+        Optional embedding for semantic retrieval (JSON-serialised list).
+    importance:
+        Importance score 0.0–1.0.
+    created_at:
+        When the memory was created.
+    accessed_at:
+        Last access timestamp.
+    access_count:
+        Number of times this memory was retrieved.
+    tags:
+        Free-form tags for quick filtering.
+    metadata:
+        Arbitrary JSON-serialisable metadata.
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    session_id: Optional[str] = None
+    type: MemoryItemType = MemoryItemType.EPISODIC
+    content: str = ""
+    embedding_vector: Optional[List[float]] = None
+    importance: float = 0.5
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    accessed_at: datetime = field(default_factory=datetime.utcnow)
+    access_count: int = 0
+    tags: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.importance = max(0.0, min(1.0, self.importance))
+        if isinstance(self.type, str):
+            self.type = MemoryItemType(self.type)
+
+    def touch(self) -> None:
+        """Record an access (bump count + timestamp)."""
+        self.access_count += 1
+        self.accessed_at = datetime.utcnow()
+
+
+@dataclass
+class Session:
+    """A conversation session envelope.
+
+    Attributes
+    ----------
+    id:
+        Unique session identifier (UUID).
+    start_time:
+        When the session started.
+    end_time:
+        When the session ended (*None* while active).
+    summary:
+        LLM-generated session summary (filled on close).
+    turn_count:
+        Number of user turns in this session.
+    metadata:
+        Arbitrary metadata (locale, timezone, …).
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    start_time: datetime = field(default_factory=datetime.utcnow)
+    end_time: Optional[datetime] = None
+    summary: str = ""
+    turn_count: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_active(self) -> bool:
+        return self.end_time is None
+
+
+@dataclass
+class ToolTrace:
+    """Record of a single tool execution.
+
+    Attributes
+    ----------
+    id:
+        Unique trace identifier (UUID).
+    session_id:
+        Session that triggered this tool call.
+    tool_name:
+        Canonical tool name (``calendar.create_event``).
+    args_hash:
+        SHA-256 of the serialised arguments.
+    result_summary:
+        Human-readable one-liner of the tool result.
+    success:
+        Whether the tool call succeeded.
+    latency_ms:
+        Execution time in milliseconds.
+    created_at:
+        When the tool was invoked.
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    session_id: Optional[str] = None
+    tool_name: str = ""
+    args_hash: str = ""
+    result_summary: str = ""
+    success: bool = True
+    latency_ms: float = 0.0
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class UserProfile:
+    """A key-value pair in the user profile store.
+
+    Attributes
+    ----------
+    id:
+        Auto-generated UUID.
+    key:
+        Profile key (``preferred_language``, ``timezone``, …).
+    value:
+        Arbitrary string value (caller may JSON-encode complex data).
+    updated_at:
+        Last update timestamp.
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    key: str = ""
+    value: str = ""
+    updated_at: datetime = field(default_factory=datetime.utcnow)

--- a/src/bantz/memory/persistent.py
+++ b/src/bantz/memory/persistent.py
@@ -1,0 +1,475 @@
+"""Persistent SQLite-backed memory store (Issue #448).
+
+Provides :class:`PersistentMemoryStore` — the CRUD + search layer over
+``~/.bantz/memory.db`` (or ``$XDG_DATA_HOME/bantz/memory.db``).
+
+Thread-safe via ``threading.Lock`` around every database operation.
+
+Usage::
+
+    store = PersistentMemoryStore()          # uses default path
+    store = PersistentMemoryStore(":memory:") # in-memory for tests
+
+    item_id = store.write(MemoryItem(content="merhaba"))
+    item = store.read(item_id)
+    results = store.search("merhaba", limit=5)
+    store.delete(item_id)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import threading
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from bantz.memory.migrations import migrate
+from bantz.memory.models import (
+    MemoryItem,
+    MemoryItemType,
+    Session,
+    ToolTrace,
+    UserProfile,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PersistentMemoryStore"]
+
+
+def _default_db_path() -> str:
+    """Return the default database file path.
+
+    Follows XDG_DATA_HOME → ``~/.local/share/bantz/memory.db``
+    Falls back to ``~/.bantz/memory.db``.
+    """
+    xdg = os.environ.get("XDG_DATA_HOME")
+    if xdg:
+        base = Path(xdg) / "bantz"
+    else:
+        base = Path.home() / ".bantz"
+    base.mkdir(parents=True, exist_ok=True)
+    return str(base / "memory.db")
+
+
+class PersistentMemoryStore:
+    """SQLite-backed persistent memory store.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database file.  Use ``":memory:"`` for tests.
+    """
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self._db_path = db_path or _default_db_path()
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        self._connect()
+
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+
+    def _connect(self) -> None:
+        self._conn = sqlite3.connect(
+            self._db_path,
+            check_same_thread=False,
+            isolation_level=None,  # autocommit
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.row_factory = sqlite3.Row
+        migrate(self._conn)
+
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        with self._lock:
+            if self._conn:
+                self._conn.close()
+                self._conn = None
+
+    # ------------------------------------------------------------------
+    # MemoryItem CRUD
+    # ------------------------------------------------------------------
+
+    def write(self, item: MemoryItem) -> str:
+        """Persist a :class:`MemoryItem` and return its id."""
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO memory_item
+                    (id, session_id, type, content, embedding_vector,
+                     importance, created_at, accessed_at, access_count,
+                     tags, metadata)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    item.id,
+                    item.session_id,
+                    item.type.value if isinstance(item.type, MemoryItemType) else item.type,
+                    item.content,
+                    json.dumps(item.embedding_vector) if item.embedding_vector else None,
+                    item.importance,
+                    item.created_at.isoformat(),
+                    item.accessed_at.isoformat(),
+                    item.access_count,
+                    json.dumps(item.tags),
+                    json.dumps(item.metadata),
+                ),
+            )
+        return item.id
+
+    def read(self, item_id: str) -> Optional[MemoryItem]:
+        """Read a :class:`MemoryItem` by id."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM memory_item WHERE id = ?", (item_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_memory_item(row)
+
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        type_filter: Optional[str] = None,
+    ) -> List[MemoryItem]:
+        """Search memory items by keyword matching.
+
+        Parameters
+        ----------
+        query:
+            Space-separated keywords (matched against ``content``).
+        limit:
+            Maximum number of results.
+        type_filter:
+            Optional memory type filter (``"episodic"`` / ``"semantic"`` / ``"fact"``).
+
+        Returns
+        -------
+        list[MemoryItem]
+            Matching items sorted by importance descending.
+        """
+        keywords = [kw.strip().lower() for kw in query.split() if kw.strip()]
+        if not keywords:
+            return []
+
+        conditions = []
+        params: list[Any] = []
+
+        # Keyword matching — each keyword must appear in content
+        for kw in keywords:
+            conditions.append("LOWER(content) LIKE ?")
+            params.append(f"%{kw}%")
+
+        if type_filter:
+            conditions.append("type = ?")
+            params.append(type_filter)
+
+        where = " AND ".join(conditions)
+        params.append(limit)
+
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM memory_item WHERE {where} "
+                f"ORDER BY importance DESC, accessed_at DESC LIMIT ?",
+                params,
+            ).fetchall()
+
+        return [self._row_to_memory_item(r) for r in rows]
+
+    def delete(self, item_id: str) -> bool:
+        """Delete a :class:`MemoryItem` by id.  Returns *True* if deleted."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM memory_item WHERE id = ?", (item_id,)
+            )
+        return cur.rowcount > 0
+
+    def list_items(
+        self,
+        type_filter: Optional[str] = None,
+        session_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[MemoryItem]:
+        """List memory items with optional filters."""
+        conditions = []
+        params: list[Any] = []
+
+        if type_filter:
+            conditions.append("type = ?")
+            params.append(type_filter)
+        if session_id:
+            conditions.append("session_id = ?")
+            params.append(session_id)
+
+        where = "WHERE " + " AND ".join(conditions) if conditions else ""
+        params.append(limit)
+
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM memory_item {where} "
+                f"ORDER BY created_at DESC LIMIT ?",
+                params,
+            ).fetchall()
+
+        return [self._row_to_memory_item(r) for r in rows]
+
+    def update_access(self, item_id: str) -> bool:
+        """Bump access count and timestamp for a memory item."""
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE memory_item SET access_count = access_count + 1, "
+                "accessed_at = ? WHERE id = ?",
+                (now, item_id),
+            )
+        return cur.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Session CRUD
+    # ------------------------------------------------------------------
+
+    def create_session(self, metadata: Optional[Dict[str, Any]] = None) -> Session:
+        """Create and persist a new session."""
+        sess = Session(metadata=metadata or {})
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO session (id, start_time, end_time, summary,
+                                     turn_count, metadata)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    sess.id,
+                    sess.start_time.isoformat(),
+                    None,
+                    sess.summary,
+                    sess.turn_count,
+                    json.dumps(sess.metadata),
+                ),
+            )
+        return sess
+
+    def get_session(self, session_id: str) -> Optional[Session]:
+        """Read a :class:`Session` by id."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM session WHERE id = ?", (session_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_session(row)
+
+    def close_session(self, session_id: str, summary: str = "") -> bool:
+        """Close a session (set end_time and summary)."""
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE session SET end_time = ?, summary = ? WHERE id = ?",
+                (now, summary, session_id),
+            )
+        return cur.rowcount > 0
+
+    def increment_turn_count(self, session_id: str) -> bool:
+        """Increment the turn counter for a session."""
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE session SET turn_count = turn_count + 1 WHERE id = ?",
+                (session_id,),
+            )
+        return cur.rowcount > 0
+
+    def list_sessions(self, limit: int = 20) -> List[Session]:
+        """List recent sessions ordered by start_time descending."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM session ORDER BY start_time DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [self._row_to_session(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # ToolTrace CRUD
+    # ------------------------------------------------------------------
+
+    def write_tool_trace(self, trace: ToolTrace) -> str:
+        """Persist a tool trace and return its id."""
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO tool_trace
+                    (id, session_id, tool_name, args_hash,
+                     result_summary, success, latency_ms, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    trace.id,
+                    trace.session_id,
+                    trace.tool_name,
+                    trace.args_hash,
+                    trace.result_summary,
+                    1 if trace.success else 0,
+                    trace.latency_ms,
+                    trace.created_at.isoformat(),
+                ),
+            )
+        return trace.id
+
+    def get_tool_traces(
+        self,
+        session_id: Optional[str] = None,
+        tool_name: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[ToolTrace]:
+        """Query tool traces with optional filters."""
+        conditions = []
+        params: list[Any] = []
+
+        if session_id:
+            conditions.append("session_id = ?")
+            params.append(session_id)
+        if tool_name:
+            conditions.append("tool_name = ?")
+            params.append(tool_name)
+
+        where = "WHERE " + " AND ".join(conditions) if conditions else ""
+        params.append(limit)
+
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM tool_trace {where} "
+                f"ORDER BY created_at DESC LIMIT ?",
+                params,
+            ).fetchall()
+
+        return [self._row_to_tool_trace(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # UserProfile CRUD
+    # ------------------------------------------------------------------
+
+    def set_profile(self, key: str, value: str) -> str:
+        """Set (upsert) a user-profile entry.  Returns the profile row id."""
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT id FROM user_profile WHERE key = ?", (key,)
+            ).fetchone()
+            if row:
+                self._conn.execute(
+                    "UPDATE user_profile SET value = ?, updated_at = ? WHERE key = ?",
+                    (value, now, key),
+                )
+                return row["id"]
+            else:
+                profile = UserProfile(key=key, value=value)
+                self._conn.execute(
+                    "INSERT INTO user_profile (id, key, value, updated_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (profile.id, profile.key, profile.value, now),
+                )
+                return profile.id
+
+    def get_profile(self, key: str) -> Optional[str]:
+        """Get a profile value by key."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT value FROM user_profile WHERE key = ?", (key,)
+            ).fetchone()
+        return row["value"] if row else None
+
+    def delete_profile(self, key: str) -> bool:
+        """Delete a profile entry by key."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM user_profile WHERE key = ?", (key,)
+            )
+        return cur.rowcount > 0
+
+    def list_profile_keys(self) -> List[str]:
+        """Return all profile keys."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT key FROM user_profile ORDER BY key"
+            ).fetchall()
+        return [r["key"] for r in rows]
+
+    # ------------------------------------------------------------------
+    # Stats / introspection
+    # ------------------------------------------------------------------
+
+    def stats(self) -> Dict[str, Any]:
+        """Return a summary of the store contents."""
+        with self._lock:
+            items = self._conn.execute(
+                "SELECT COUNT(*) AS cnt FROM memory_item"
+            ).fetchone()["cnt"]
+            sessions = self._conn.execute(
+                "SELECT COUNT(*) AS cnt FROM session"
+            ).fetchone()["cnt"]
+            traces = self._conn.execute(
+                "SELECT COUNT(*) AS cnt FROM tool_trace"
+            ).fetchone()["cnt"]
+            profiles = self._conn.execute(
+                "SELECT COUNT(*) AS cnt FROM user_profile"
+            ).fetchone()["cnt"]
+        return {
+            "memory_items": items,
+            "sessions": sessions,
+            "tool_traces": traces,
+            "user_profiles": profiles,
+        }
+
+    # ------------------------------------------------------------------
+    # Row → model helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_to_memory_item(row: sqlite3.Row) -> MemoryItem:
+        emb_raw = row["embedding_vector"]
+        embedding = json.loads(emb_raw) if emb_raw else None
+        return MemoryItem(
+            id=row["id"],
+            session_id=row["session_id"],
+            type=MemoryItemType(row["type"]),
+            content=row["content"],
+            embedding_vector=embedding,
+            importance=row["importance"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            accessed_at=datetime.fromisoformat(row["accessed_at"]),
+            access_count=row["access_count"],
+            tags=json.loads(row["tags"]),
+            metadata=json.loads(row["metadata"]),
+        )
+
+    @staticmethod
+    def _row_to_session(row: sqlite3.Row) -> Session:
+        end = row["end_time"]
+        return Session(
+            id=row["id"],
+            start_time=datetime.fromisoformat(row["start_time"]),
+            end_time=datetime.fromisoformat(end) if end else None,
+            summary=row["summary"],
+            turn_count=row["turn_count"],
+            metadata=json.loads(row["metadata"]),
+        )
+
+    @staticmethod
+    def _row_to_tool_trace(row: sqlite3.Row) -> ToolTrace:
+        return ToolTrace(
+            id=row["id"],
+            session_id=row["session_id"],
+            tool_name=row["tool_name"],
+            args_hash=row["args_hash"],
+            result_summary=row["result_summary"],
+            success=bool(row["success"]),
+            latency_ms=row["latency_ms"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )

--- a/tests/test_issue_448_memory_persistent.py
+++ b/tests/test_issue_448_memory_persistent.py
@@ -1,0 +1,424 @@
+"""Tests for Issue #448 — Memory v0: SQLite persistent storage.
+
+Covers:
+- MemoryItem CRUD (write, read, search, delete, list, update_access)
+- Session lifecycle (create, get, close, increment_turn, list)
+- ToolTrace CRUD (write, get with filters)
+- UserProfile CRUD (set, get, delete, list_keys, upsert)
+- Migration system (fresh DB, idempotent re-run)
+- Thread safety (concurrent writes)
+- Stats / introspection
+- Edge cases (empty search, missing IDs, type filters)
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta
+
+import pytest
+
+from bantz.memory.models import (
+    MemoryItem,
+    MemoryItemType,
+    Session,
+    ToolTrace,
+    UserProfile,
+)
+from bantz.memory.migrations import LATEST_VERSION, migrate, _current_version
+from bantz.memory.persistent import PersistentMemoryStore
+
+
+@pytest.fixture()
+def store():
+    """In-memory store for each test."""
+    s = PersistentMemoryStore(":memory:")
+    yield s
+    s.close()
+
+
+# ===================================================================
+# 1. MemoryItem CRUD
+# ===================================================================
+
+class TestMemoryItemCRUD:
+    def test_write_and_read_roundtrip(self, store):
+        item = MemoryItem(content="Merhaba dünya", importance=0.8)
+        item_id = store.write(item)
+        got = store.read(item_id)
+        assert got is not None
+        assert got.content == "Merhaba dünya"
+        assert got.importance == 0.8
+        assert got.type == MemoryItemType.EPISODIC
+
+    def test_read_nonexistent_returns_none(self, store):
+        assert store.read("nonexistent-id") is None
+
+    def test_write_with_all_fields(self, store):
+        sess = store.create_session()
+        item = MemoryItem(
+            content="test content",
+            session_id=sess.id,
+            type=MemoryItemType.FACT,
+            embedding_vector=[0.1, 0.2, 0.3],
+            importance=0.9,
+            tags=["tag1", "tag2"],
+            metadata={"source": "calendar"},
+        )
+        item_id = store.write(item)
+        got = store.read(item_id)
+        assert got.session_id == sess.id
+        assert got.type == MemoryItemType.FACT
+        assert got.embedding_vector == [0.1, 0.2, 0.3]
+        assert got.tags == ["tag1", "tag2"]
+        assert got.metadata == {"source": "calendar"}
+
+    def test_delete_existing(self, store):
+        item = MemoryItem(content="to delete")
+        item_id = store.write(item)
+        assert store.delete(item_id) is True
+        assert store.read(item_id) is None
+
+    def test_delete_nonexistent(self, store):
+        assert store.delete("nope") is False
+
+    def test_update_access(self, store):
+        item = MemoryItem(content="access me")
+        item_id = store.write(item)
+        assert store.update_access(item_id) is True
+        got = store.read(item_id)
+        assert got.access_count == 1
+
+    def test_update_access_twice(self, store):
+        item = MemoryItem(content="access me twice")
+        item_id = store.write(item)
+        store.update_access(item_id)
+        store.update_access(item_id)
+        got = store.read(item_id)
+        assert got.access_count == 2
+
+    def test_write_replaces_on_same_id(self, store):
+        item = MemoryItem(id="fixed-id", content="original")
+        store.write(item)
+        item2 = MemoryItem(id="fixed-id", content="updated")
+        store.write(item2)
+        got = store.read("fixed-id")
+        assert got.content == "updated"
+
+    def test_list_items_all(self, store):
+        for i in range(5):
+            store.write(MemoryItem(content=f"item {i}"))
+        items = store.list_items(limit=10)
+        assert len(items) == 5
+
+    def test_list_items_type_filter(self, store):
+        store.write(MemoryItem(content="ep", type=MemoryItemType.EPISODIC))
+        store.write(MemoryItem(content="fact", type=MemoryItemType.FACT))
+        items = store.list_items(type_filter="fact")
+        assert len(items) == 1
+        assert items[0].content == "fact"
+
+    def test_list_items_session_filter(self, store):
+        s1 = store.create_session()
+        s2 = store.create_session()
+        store.write(MemoryItem(content="a", session_id=s1.id))
+        store.write(MemoryItem(content="b", session_id=s2.id))
+        items = store.list_items(session_id=s1.id)
+        assert len(items) == 1
+
+
+# ===================================================================
+# 2. Search
+# ===================================================================
+
+class TestSearch:
+    def test_keyword_search(self, store):
+        store.write(MemoryItem(content="yarın toplantı var saat 3'te"))
+        store.write(MemoryItem(content="hava durumu güzel"))
+        results = store.search("toplantı")
+        assert len(results) == 1
+        assert "toplantı" in results[0].content
+
+    def test_multiple_keywords(self, store):
+        store.write(MemoryItem(content="yarın toplantı saat 3"))
+        store.write(MemoryItem(content="toplantı iptal"))
+        results = store.search("toplantı saat")
+        assert len(results) == 1
+        assert "saat" in results[0].content
+
+    def test_search_with_type_filter(self, store):
+        store.write(MemoryItem(content="takvim etkinliği", type=MemoryItemType.EPISODIC))
+        store.write(MemoryItem(content="takvim bilgisi", type=MemoryItemType.FACT))
+        results = store.search("takvim", type_filter="fact")
+        assert len(results) == 1
+        assert results[0].type == MemoryItemType.FACT
+
+    def test_search_empty_query(self, store):
+        store.write(MemoryItem(content="something"))
+        assert store.search("") == []
+        assert store.search("   ") == []
+
+    def test_search_no_match(self, store):
+        store.write(MemoryItem(content="hello world"))
+        assert store.search("xyznomatch") == []
+
+    def test_search_limit(self, store):
+        for i in range(10):
+            store.write(MemoryItem(content=f"test item {i}"))
+        results = store.search("test", limit=3)
+        assert len(results) == 3
+
+    def test_search_ordered_by_importance(self, store):
+        store.write(MemoryItem(content="low test", importance=0.1))
+        store.write(MemoryItem(content="high test", importance=0.9))
+        results = store.search("test", limit=10)
+        assert results[0].importance >= results[1].importance
+
+
+# ===================================================================
+# 3. Session lifecycle
+# ===================================================================
+
+class TestSession:
+    def test_create_session(self, store):
+        sess = store.create_session()
+        assert sess.id
+        assert sess.is_active is True
+        assert sess.turn_count == 0
+
+    def test_get_session(self, store):
+        sess = store.create_session(metadata={"lang": "tr"})
+        got = store.get_session(sess.id)
+        assert got is not None
+        assert got.metadata == {"lang": "tr"}
+
+    def test_get_nonexistent_session(self, store):
+        assert store.get_session("nope") is None
+
+    def test_close_session(self, store):
+        sess = store.create_session()
+        assert store.close_session(sess.id, summary="güzel sohbet") is True
+        got = store.get_session(sess.id)
+        assert got.end_time is not None
+        assert got.summary == "güzel sohbet"
+
+    def test_increment_turn_count(self, store):
+        sess = store.create_session()
+        store.increment_turn_count(sess.id)
+        store.increment_turn_count(sess.id)
+        got = store.get_session(sess.id)
+        assert got.turn_count == 2
+
+    def test_list_sessions(self, store):
+        for _ in range(3):
+            store.create_session()
+        sessions = store.list_sessions(limit=10)
+        assert len(sessions) == 3
+
+    def test_session_with_memory_items(self, store):
+        sess = store.create_session()
+        store.write(MemoryItem(content="turn 1", session_id=sess.id))
+        store.write(MemoryItem(content="turn 2", session_id=sess.id))
+        items = store.list_items(session_id=sess.id)
+        assert len(items) == 2
+
+
+# ===================================================================
+# 4. ToolTrace
+# ===================================================================
+
+class TestToolTrace:
+    def test_write_and_get(self, store):
+        trace = ToolTrace(
+            tool_name="calendar.create_event",
+            args_hash="abc123",
+            result_summary="Event created",
+            success=True,
+            latency_ms=150.5,
+        )
+        trace_id = store.write_tool_trace(trace)
+        traces = store.get_tool_traces()
+        assert len(traces) == 1
+        assert traces[0].tool_name == "calendar.create_event"
+        assert traces[0].latency_ms == 150.5
+
+    def test_filter_by_session(self, store):
+        s1 = store.create_session()
+        s2 = store.create_session()
+        store.write_tool_trace(ToolTrace(tool_name="t1", session_id=s1.id))
+        store.write_tool_trace(ToolTrace(tool_name="t2", session_id=s2.id))
+        traces = store.get_tool_traces(session_id=s1.id)
+        assert len(traces) == 1
+        assert traces[0].tool_name == "t1"
+
+    def test_filter_by_tool_name(self, store):
+        store.write_tool_trace(ToolTrace(tool_name="calendar.list"))
+        store.write_tool_trace(ToolTrace(tool_name="gmail.send"))
+        traces = store.get_tool_traces(tool_name="gmail.send")
+        assert len(traces) == 1
+
+    def test_failed_trace(self, store):
+        store.write_tool_trace(ToolTrace(tool_name="x", success=False))
+        traces = store.get_tool_traces()
+        assert traces[0].success is False
+
+
+# ===================================================================
+# 5. UserProfile
+# ===================================================================
+
+class TestUserProfile:
+    def test_set_and_get(self, store):
+        store.set_profile("language", "tr")
+        assert store.get_profile("language") == "tr"
+
+    def test_upsert(self, store):
+        store.set_profile("theme", "dark")
+        store.set_profile("theme", "light")
+        assert store.get_profile("theme") == "light"
+
+    def test_get_nonexistent(self, store):
+        assert store.get_profile("nope") is None
+
+    def test_delete_profile(self, store):
+        store.set_profile("key", "val")
+        assert store.delete_profile("key") is True
+        assert store.get_profile("key") is None
+
+    def test_delete_nonexistent(self, store):
+        assert store.delete_profile("nope") is False
+
+    def test_list_keys(self, store):
+        store.set_profile("a", "1")
+        store.set_profile("b", "2")
+        keys = store.list_profile_keys()
+        assert sorted(keys) == ["a", "b"]
+
+
+# ===================================================================
+# 6. Migration
+# ===================================================================
+
+class TestMigration:
+    def test_fresh_db_migration(self, store):
+        # Store fixture already migrated — just check version
+        with store._lock:
+            ver = _current_version(store._conn)
+        assert ver == LATEST_VERSION
+
+    def test_idempotent_migration(self, store):
+        # Running migrate again should be a no-op
+        with store._lock:
+            ver = migrate(store._conn)
+        assert ver == LATEST_VERSION
+
+
+# ===================================================================
+# 7. Thread safety
+# ===================================================================
+
+class TestThreadSafety:
+    def test_concurrent_writes(self, store):
+        errors = []
+
+        def writer(idx):
+            try:
+                for i in range(20):
+                    store.write(MemoryItem(content=f"thread-{idx}-item-{i}"))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(t,)) for t in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert errors == []
+        items = store.list_items(limit=200)
+        assert len(items) == 80  # 4 threads × 20 items
+
+    def test_concurrent_sessions(self, store):
+        errors = []
+        session_ids = []
+
+        def session_worker(idx):
+            try:
+                sess = store.create_session()
+                session_ids.append(sess.id)
+                for _ in range(5):
+                    store.increment_turn_count(sess.id)
+                store.close_session(sess.id, summary=f"session {idx}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=session_worker, args=(t,)) for t in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert errors == []
+        sessions = store.list_sessions(limit=10)
+        assert len(sessions) == 4
+        for sess in sessions:
+            assert sess.turn_count == 5
+
+
+# ===================================================================
+# 8. Stats
+# ===================================================================
+
+class TestStats:
+    def test_empty_stats(self, store):
+        s = store.stats()
+        assert s["memory_items"] == 0
+        assert s["sessions"] == 0
+        assert s["tool_traces"] == 0
+        assert s["user_profiles"] == 0
+
+    def test_stats_after_writes(self, store):
+        store.write(MemoryItem(content="a"))
+        store.write(MemoryItem(content="b"))
+        store.create_session()
+        store.write_tool_trace(ToolTrace(tool_name="x"))
+        store.set_profile("k", "v")
+        s = store.stats()
+        assert s["memory_items"] == 2
+        assert s["sessions"] == 1
+        assert s["tool_traces"] == 1
+        assert s["user_profiles"] == 1
+
+
+# ===================================================================
+# 9. Models
+# ===================================================================
+
+class TestModels:
+    def test_memory_item_defaults(self):
+        item = MemoryItem()
+        assert item.id
+        assert item.type == MemoryItemType.EPISODIC
+        assert 0.0 <= item.importance <= 1.0
+
+    def test_memory_item_clamps_importance(self):
+        item = MemoryItem(importance=2.0)
+        assert item.importance == 1.0
+        item2 = MemoryItem(importance=-0.5)
+        assert item2.importance == 0.0
+
+    def test_memory_item_touch(self):
+        item = MemoryItem()
+        assert item.access_count == 0
+        item.touch()
+        assert item.access_count == 1
+
+    def test_session_is_active(self):
+        sess = Session()
+        assert sess.is_active is True
+        sess.end_time = datetime.utcnow()
+        assert sess.is_active is False
+
+    def test_memory_item_type_from_string(self):
+        item = MemoryItem(type="fact")
+        assert item.type == MemoryItemType.FACT


### PR DESCRIPTION
Closes #448

## Changes
- **models.py**: MemoryItem, Session, ToolTrace, UserProfile dataclasses
- **migrations.py**: Version-based schema migration (v1 = initial schema)
- **persistent.py**: PersistentMemoryStore — full CRUD, keyword search, session lifecycle, thread safety, WAL mode

## Tests
46 passed in 0.17s