### PR TITLE
feat(memory): hybrid retrieval scoring — BM25-lite + recency + importance (#450)

### DIFF
--- a/src/bantz/memory/ranking.py
+++ b/src/bantz/memory/ranking.py
@@ -1,0 +1,270 @@
+"""Hybrid memory-ranking engine (Issue #450).
+
+Scores :class:`~bantz.memory.models.MemoryItem` objects against a text
+query using a weighted combination of:
+
+* **keyword score** — BM25-lite (TF-IDF-ish) with Turkish stop-word removal
+* **semantic score** — cosine similarity when embeddings are available
+* **recency boost** — decays over time (last 24 h → +0.20, 7 d → +0.10)
+* **importance** — the ``importance`` field on each item
+
+Default weights (configurable):
+
+    α=0.30  keyword
+    β=0.40  semantic
+    γ=0.15  recency
+    δ=0.15  importance
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Sequence
+
+from bantz.memory.models import MemoryItem, MemoryItemType
+
+__all__ = [
+    "RankedMemory",
+    "RankingWeights",
+    "HybridRanker",
+    "TURKISH_STOPWORDS",
+]
+
+# ── Turkish stop-words ────────────────────────────────────────────────
+TURKISH_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "bir", "ve", "bu", "da", "de", "ile", "için", "ama",
+        "ya", "ki", "ne", "mı", "mi", "mu", "mü", "var",
+        "yok", "ben", "sen", "biz", "siz", "o", "şu",
+        "çok", "daha", "en", "her", "gibi", "kadar",
+        "ise", "olan", "olarak", "onu", "bunu", "şey",
+        "hem", "veya", "ya da", "evet", "hayır", "tamam",
+        "acaba", "ancak", "belki", "bile", "böyle", "çünkü",
+        "diğer", "dolayı", "fakat", "hep", "henüz", "hiç",
+        "nasıl", "neden", "nerede", "niye", "sadece", "sonra",
+        "şimdi", "tüm", "üzere", "yani", "zaten",
+    }
+)
+
+
+# ── Data structures ───────────────────────────────────────────────────
+
+@dataclass
+class RankingWeights:
+    """Configurable weights for the hybrid scoring formula."""
+
+    keyword: float = 0.30    # α
+    semantic: float = 0.40   # β
+    recency: float = 0.15    # γ
+    importance: float = 0.15  # δ
+
+    def __post_init__(self) -> None:
+        total = self.keyword + self.semantic + self.recency + self.importance
+        if total <= 0:
+            raise ValueError("Weights must sum to a positive value")
+
+
+@dataclass
+class RankedMemory:
+    """A memory item together with its computed score breakdown."""
+
+    item: MemoryItem
+    total_score: float = 0.0
+    keyword_score: float = 0.0
+    semantic_score: float = 0.0
+    recency_boost: float = 0.0
+    importance_score: float = 0.0
+
+    def __lt__(self, other: "RankedMemory") -> bool:  # for heapq / sorted
+        return self.total_score < other.total_score
+
+
+# ── Ranker ────────────────────────────────────────────────────────────
+
+class HybridRanker:
+    """Hybrid keyword + semantic + recency + importance ranker.
+
+    Parameters
+    ----------
+    weights:
+        Scoring weights (defaults to ``α=0.30, β=0.40, γ=0.15, δ=0.15``).
+    stopwords:
+        Stop-word set.  Defaults to :data:`TURKISH_STOPWORDS`.
+    """
+
+    def __init__(
+        self,
+        weights: Optional[RankingWeights] = None,
+        stopwords: Optional[frozenset[str]] = None,
+    ) -> None:
+        self.weights = weights or RankingWeights()
+        self._stopwords = stopwords if stopwords is not None else TURKISH_STOPWORDS
+
+    # ── public API ────────────────────────────────────────────────────
+
+    def rank(
+        self,
+        query: str,
+        items: Sequence[MemoryItem],
+        top_k: int = 5,
+        type_filter: Optional[MemoryItemType] = None,
+        time_window: Optional[timedelta] = None,
+        now: Optional[datetime] = None,
+    ) -> List[RankedMemory]:
+        """Score and rank *items* against *query*.
+
+        Parameters
+        ----------
+        query:
+            Natural-language query.
+        items:
+            Candidate memory items.
+        top_k:
+            Maximum number of results.
+        type_filter:
+            If set, only items of this type are considered.
+        time_window:
+            If set, items older than ``now - time_window`` are excluded.
+        now:
+            Reference time (defaults to ``datetime.utcnow()``).
+        """
+        now = now or datetime.utcnow()
+        query_tokens = self._tokenise(query)
+
+        # Build IDF over the item corpus
+        idf = self._build_idf(items)
+
+        candidates: List[RankedMemory] = []
+        for item in items:
+            # Apply filters
+            if type_filter and item.type != type_filter:
+                continue
+            if time_window and (now - item.created_at) > time_window:
+                continue
+
+            kw_score = self._keyword_score(query_tokens, item.content, idf)
+            sem_score = self._semantic_score(query, item)
+            rec_boost = self._recency_boost(item, now)
+            imp_score = item.importance
+
+            w = self.weights
+            # If no embeddings available anywhere, redistribute β to keyword
+            if sem_score == 0.0 and item.embedding_vector is None:
+                effective_kw = w.keyword + w.semantic
+                effective_sem = 0.0
+            else:
+                effective_kw = w.keyword
+                effective_sem = w.semantic
+
+            total = (
+                effective_kw * kw_score
+                + effective_sem * sem_score
+                + w.recency * rec_boost
+                + w.importance * imp_score
+            )
+
+            candidates.append(
+                RankedMemory(
+                    item=item,
+                    total_score=total,
+                    keyword_score=kw_score,
+                    semantic_score=sem_score,
+                    recency_boost=rec_boost,
+                    importance_score=imp_score,
+                )
+            )
+
+        candidates.sort(key=lambda r: r.total_score, reverse=True)
+        return candidates[:top_k]
+
+    # ── keyword scoring (BM25-lite) ──────────────────────────────────
+
+    def _tokenise(self, text: str) -> List[str]:
+        """Lower-case, split, strip punctuation, remove stop-words."""
+        tokens: List[str] = []
+        for raw in text.lower().split():
+            tok = raw.strip(".,;:!?\"'()-–—…")
+            if tok and tok not in self._stopwords:
+                tokens.append(tok)
+        return tokens
+
+    def _build_idf(self, items: Sequence[MemoryItem]) -> Dict[str, float]:
+        """Inverse Document Frequency across the item corpus."""
+        n = len(items)
+        if n == 0:
+            return {}
+        doc_freq: Dict[str, int] = {}
+        for item in items:
+            unique_tokens = set(self._tokenise(item.content))
+            for tok in unique_tokens:
+                doc_freq[tok] = doc_freq.get(tok, 0) + 1
+
+        idf: Dict[str, float] = {}
+        for tok, df in doc_freq.items():
+            idf[tok] = math.log((n - df + 0.5) / (df + 0.5) + 1.0)
+        return idf
+
+    def _keyword_score(
+        self,
+        query_tokens: List[str],
+        content: str,
+        idf: Dict[str, float],
+    ) -> float:
+        """BM25-lite score: TF × IDF with saturation.
+
+        Uses *k1 = 1.5* and *b = 0.0* (no length normalisation) so the
+        formula simplifies to::
+
+            score = Σ idf(q) × (tf(q, doc) × (k1 + 1)) / (tf(q, doc) + k1)
+        """
+        if not query_tokens:
+            return 0.0
+
+        k1 = 1.5
+        doc_tokens = self._tokenise(content)
+        if not doc_tokens:
+            return 0.0
+
+        # term frequency in document
+        tf: Dict[str, int] = {}
+        for t in doc_tokens:
+            tf[t] = tf.get(t, 0) + 1
+
+        score = 0.0
+        for qt in query_tokens:
+            f = tf.get(qt, 0)
+            if f == 0:
+                continue
+            idf_val = idf.get(qt, 1.0)
+            score += idf_val * (f * (k1 + 1)) / (f + k1)
+
+        # Normalise to 0–1 range (cap at reasonable ceiling)
+        max_possible = len(query_tokens) * 3.0  # generous upper bound
+        return min(score / max_possible, 1.0) if max_possible > 0 else 0.0
+
+    # ── semantic scoring ─────────────────────────────────────────────
+
+    @staticmethod
+    def _semantic_score(query: str, item: MemoryItem) -> float:  # noqa: ARG004
+        """Cosine similarity between query embedding and item embedding.
+
+        Phase-1: always returns 0.0 (embedding support is optional).
+        When an embedding provider is wired in, this will compute the
+        actual cosine similarity.
+        """
+        # TODO(#450): integrate embedding provider (sentence-transformers / Gemini)
+        return 0.0
+
+    # ── recency boost ────────────────────────────────────────────────
+
+    @staticmethod
+    def _recency_boost(item: MemoryItem, now: datetime) -> float:
+        """Recency bonus: last 24 h → 1.0, last 7 d → 0.5, older → 0.0."""
+        age = now - item.created_at
+        if age <= timedelta(hours=24):
+            return 1.0
+        if age <= timedelta(days=7):
+            return 0.5
+        return 0.0

--- a/tests/test_issue_450_retrieval.py
+++ b/tests/test_issue_450_retrieval.py
@@ -1,0 +1,305 @@
+"""Tests for issue #450 — Memory retrieval v0: hybrid scoring."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from bantz.memory.models import MemoryItem, MemoryItemType
+from bantz.memory.ranking import (
+    TURKISH_STOPWORDS,
+    HybridRanker,
+    RankedMemory,
+    RankingWeights,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+NOW = datetime(2025, 6, 1, 12, 0, 0)
+
+
+def _item(
+    content: str,
+    importance: float = 0.5,
+    created_at: datetime | None = None,
+    item_type: MemoryItemType = MemoryItemType.EPISODIC,
+    session_id: str | None = None,
+) -> MemoryItem:
+    return MemoryItem(
+        content=content,
+        importance=importance,
+        created_at=created_at or NOW,
+        accessed_at=created_at or NOW,
+        type=item_type,
+        session_id=session_id,
+    )
+
+
+# ── TestKeywordScoring ────────────────────────────────────────────────
+
+class TestKeywordScoring:
+    """BM25-lite keyword matching."""
+
+    def test_exact_word_match(self):
+        ranker = HybridRanker()
+        items = [
+            _item("Ankara'ya yarın uçak bileti al"),
+            _item("Bugün hava çok güzel"),
+        ]
+        results = ranker.rank("Ankara uçak", items, now=NOW)
+        assert results[0].item.content.startswith("Ankara")
+        assert results[0].keyword_score > 0
+
+    def test_no_match_returns_zero_keyword(self):
+        ranker = HybridRanker()
+        items = [_item("Bugün hava güzel")]
+        results = ranker.rank("programlama python", items, now=NOW)
+        assert results[0].keyword_score == 0.0
+
+    def test_stopwords_ignored(self):
+        ranker = HybridRanker()
+        tokens = ranker._tokenise("bu bir çok güzel ev")
+        assert "bu" not in tokens
+        assert "bir" not in tokens
+        assert "çok" not in tokens
+        assert "güzel" in tokens
+        assert "ev" in tokens
+
+    def test_turkish_stopwords_present(self):
+        assert "ve" in TURKISH_STOPWORDS
+        assert "için" in TURKISH_STOPWORDS
+        assert "şimdi" in TURKISH_STOPWORDS
+
+    def test_multiple_keyword_match_beats_single(self):
+        ranker = HybridRanker()
+        items = [
+            _item("Ankara uçak bileti"),
+            _item("Ankara şehir merkezi"),
+        ]
+        results = ranker.rank("Ankara uçak", items, now=NOW)
+        # first result should have both keywords
+        assert results[0].keyword_score >= results[1].keyword_score
+
+    def test_case_insensitive_matching(self):
+        ranker = HybridRanker()
+        items = [_item("ANKARA uçak BİLETİ")]
+        results = ranker.rank("ankara bileti", items, now=NOW)
+        assert results[0].keyword_score > 0
+
+
+# ── TestRecencyBoost ──────────────────────────────────────────────────
+
+class TestRecencyBoost:
+    """Recency scoring: newer items score higher."""
+
+    def test_recent_item_high_boost(self):
+        ranker = HybridRanker()
+        item = _item("test", created_at=NOW - timedelta(hours=2))
+        results = ranker.rank("test", [item], now=NOW)
+        assert results[0].recency_boost == 1.0
+
+    def test_week_old_item_medium_boost(self):
+        ranker = HybridRanker()
+        item = _item("test", created_at=NOW - timedelta(days=3))
+        results = ranker.rank("test", [item], now=NOW)
+        assert results[0].recency_boost == 0.5
+
+    def test_old_item_no_boost(self):
+        ranker = HybridRanker()
+        item = _item("test", created_at=NOW - timedelta(days=30))
+        results = ranker.rank("test", [item], now=NOW)
+        assert results[0].recency_boost == 0.0
+
+    def test_newer_beats_older(self):
+        ranker = HybridRanker()
+        items = [
+            _item("toplantı notu", created_at=NOW - timedelta(days=30), importance=0.5),
+            _item("toplantı notu", created_at=NOW - timedelta(hours=1), importance=0.5),
+        ]
+        results = ranker.rank("toplantı", items, now=NOW)
+        assert results[0].recency_boost > results[1].recency_boost
+
+
+# ── TestImportanceBoost ───────────────────────────────────────────────
+
+class TestImportanceBoost:
+    """Importance field boosts ranking."""
+
+    def test_high_importance_beats_low(self):
+        ranker = HybridRanker()
+        items = [
+            _item("Python kursu", importance=0.2, created_at=NOW),
+            _item("Python sertifika", importance=0.9, created_at=NOW),
+        ]
+        results = ranker.rank("Python", items, now=NOW)
+        # Higher importance should win (both have same recency/keyword match)
+        assert results[0].importance_score >= results[1].importance_score
+
+    def test_importance_in_score(self):
+        ranker = HybridRanker()
+        item = _item("veri", importance=0.8, created_at=NOW)
+        results = ranker.rank("veri", [item], now=NOW)
+        assert results[0].importance_score == 0.8
+
+
+# ── TestTopK ──────────────────────────────────────────────────────────
+
+class TestTopK:
+    """top_k parameter limits results."""
+
+    def test_top_k_limits_output(self):
+        ranker = HybridRanker()
+        items = [_item(f"belge {i}") for i in range(20)]
+        results = ranker.rank("belge", items, top_k=3, now=NOW)
+        assert len(results) == 3
+
+    def test_top_k_larger_than_items(self):
+        ranker = HybridRanker()
+        items = [_item("tek belge")]
+        results = ranker.rank("belge", items, top_k=10, now=NOW)
+        assert len(results) == 1
+
+
+# ── TestEmptyMemory ───────────────────────────────────────────────────
+
+class TestEmptyMemory:
+    """Edge case: no items in memory."""
+
+    def test_empty_items_returns_empty(self):
+        ranker = HybridRanker()
+        results = ranker.rank("herhangi sorgu", [], now=NOW)
+        assert results == []
+
+    def test_empty_query(self):
+        ranker = HybridRanker()
+        items = [_item("veri")]
+        results = ranker.rank("", items, now=NOW)
+        # Still returns items (recency + importance contribute)
+        assert len(results) == 1
+        assert results[0].keyword_score == 0.0
+
+
+# ── TestTypeFilter ────────────────────────────────────────────────────
+
+class TestTypeFilter:
+    """type_filter parameter restricts item types."""
+
+    def test_filter_episodic_only(self):
+        ranker = HybridRanker()
+        items = [
+            _item("fakt", item_type=MemoryItemType.FACT),
+            _item("anı", item_type=MemoryItemType.EPISODIC),
+            _item("bilgi", item_type=MemoryItemType.SEMANTIC),
+        ]
+        results = ranker.rank(
+            "test", items, type_filter=MemoryItemType.EPISODIC, now=NOW
+        )
+        assert all(r.item.type == MemoryItemType.EPISODIC for r in results)
+
+    def test_filter_fact_only(self):
+        ranker = HybridRanker()
+        items = [
+            _item("fakt bilgi", item_type=MemoryItemType.FACT),
+            _item("anı bilgi", item_type=MemoryItemType.EPISODIC),
+        ]
+        results = ranker.rank(
+            "bilgi", items, type_filter=MemoryItemType.FACT, now=NOW
+        )
+        assert len(results) == 1
+        assert results[0].item.type == MemoryItemType.FACT
+
+
+# ── TestTimeWindow ────────────────────────────────────────────────────
+
+class TestTimeWindow:
+    """time_window parameter filters old items."""
+
+    def test_time_window_excludes_old(self):
+        ranker = HybridRanker()
+        items = [
+            _item("yeni not", created_at=NOW - timedelta(hours=5)),
+            _item("eski not", created_at=NOW - timedelta(days=10)),
+        ]
+        results = ranker.rank(
+            "not", items, time_window=timedelta(days=7), now=NOW
+        )
+        assert len(results) == 1
+        assert "yeni" in results[0].item.content
+
+
+# ── TestWeights ───────────────────────────────────────────────────────
+
+class TestWeights:
+    """Custom weight configuration."""
+
+    def test_custom_weights(self):
+        w = RankingWeights(keyword=0.5, semantic=0.0, recency=0.25, importance=0.25)
+        ranker = HybridRanker(weights=w)
+        items = [_item("test veri")]
+        results = ranker.rank("test", items, now=NOW)
+        assert len(results) == 1
+
+    def test_zero_weights_raises(self):
+        with pytest.raises(ValueError):
+            RankingWeights(keyword=0, semantic=0, recency=0, importance=0)
+
+
+# ── TestRankedMemoryOrdering ──────────────────────────────────────────
+
+class TestRankedMemoryOrdering:
+    """RankedMemory comparison support."""
+
+    def test_lt_comparison(self):
+        a = RankedMemory(item=_item("a"), total_score=0.3)
+        b = RankedMemory(item=_item("b"), total_score=0.7)
+        assert a < b
+
+    def test_sorted_descending(self):
+        ranker = HybridRanker()
+        items = [
+            _item("belge A", importance=0.1),
+            _item("belge B", importance=0.9),
+        ]
+        results = ranker.rank("belge", items, now=NOW)
+        scores = [r.total_score for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+
+# ── TestIntegrationWithPersistentStore ────────────────────────────────
+
+class TestIntegrationWithPersistentStore:
+    """Round-trip: write to PersistentMemoryStore → rank results."""
+
+    def test_store_search_then_rank(self):
+        from bantz.memory.persistent import PersistentMemoryStore
+
+        store = PersistentMemoryStore(":memory:")
+        sess = store.create_session()
+
+        store.write(_item("Ankara'ya bilet al", session_id=sess.id))
+        store.write(_item("Python öğren", session_id=sess.id))
+        store.write(_item("Ankara toplantısı", session_id=sess.id))
+
+        found = store.search("Ankara", limit=10)
+        ranker = HybridRanker()
+        ranked = ranker.rank("Ankara", found, now=NOW)
+        assert len(ranked) == 2
+        assert all("Ankara" in r.item.content for r in ranked)
+
+    def test_access_count_updated(self):
+        from bantz.memory.persistent import PersistentMemoryStore
+
+        store = PersistentMemoryStore(":memory:")
+        sess = store.create_session()
+        item = _item("hatırla bunu", session_id=sess.id)
+        store.write(item)
+
+        # Simulate retrieval → update access
+        found = store.search("hatırla")
+        for f in found:
+            store.update_access(f.id)
+
+        updated = store.read(item.id)
+        assert updated is not None
+        assert updated.access_count == 1


### PR DESCRIPTION
## Summary
- **HybridRanker** with configurable weights (α=0.30 keyword, β=0.40 semantic, γ=0.15 recency, δ=0.15 importance)
- BM25-lite keyword scoring with TF-IDF saturation
- **Turkish stopword list** (50+ words)
- Recency boost: 24h → 1.0, 7d → 0.5, older → 0.0
- Semantic scoring stub (Phase-1: keyword-only, graceful degradation)
- **RankedMemory** dataclass with score breakdown
- type_filter and time_window support
- Integration with PersistentMemoryStore
- **25 tests — all passing**

Closes #450