### PR TITLE
feat(planning): TaskRun persistence + pause/resume (#451)

### DIFF
--- a/src/bantz/planning/task_run.py
+++ b/src/bantz/planning/task_run.py
@@ -1,0 +1,456 @@
+"""TaskRun & TaskStep data models + SQLite persistence (Issue #451).
+
+Provides persistent lifecycle tracking for multi-step agent tasks:
+
+- :class:`TaskStep` — a single planned action in a task
+- :class:`StepResult` — the outcome of executing a step
+- :class:`TaskRun` — envelope for the full goal → plan → execute → verify cycle
+
+Data is stored in ``task_run`` and ``task_step`` tables inside the same
+memory SQLite database used by :class:`~bantz.memory.persistent.PersistentMemoryStore`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "TaskStatus",
+    "StepStatus",
+    "TaskStep",
+    "StepResult",
+    "TaskRun",
+    "TaskRunStore",
+]
+
+
+# ── Enums ─────────────────────────────────────────────────────────────
+
+class TaskStatus(Enum):
+    """Lifecycle states for a :class:`TaskRun`."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class StepStatus(Enum):
+    """Lifecycle states for a :class:`TaskStep`."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+# ── Data models ───────────────────────────────────────────────────────
+
+@dataclass
+class TaskStep:
+    """A single planned step inside a :class:`TaskRun`.
+
+    Attributes
+    ----------
+    index:
+        0-based position in the plan.
+    tool_name:
+        Name of the tool / action to execute.
+    args:
+        Keyword arguments to pass to the tool.
+    expected_output:
+        Optional human-readable description of what we expect back.
+    status:
+        Current lifecycle state.
+    """
+
+    index: int = 0
+    tool_name: str = ""
+    args: Dict[str, Any] = field(default_factory=dict)
+    expected_output: Optional[str] = None
+    status: StepStatus = StepStatus.PENDING
+
+    def __post_init__(self) -> None:
+        if isinstance(self.status, str):
+            self.status = StepStatus(self.status)
+
+
+@dataclass
+class StepResult:
+    """Outcome of executing a :class:`TaskStep`.
+
+    Attributes
+    ----------
+    step_index:
+        Which step this result belongs to.
+    output:
+        The tool's return value (JSON-serialisable).
+    error:
+        Error message if the step failed.
+    started_at:
+        When execution started.
+    finished_at:
+        When execution finished.
+    """
+
+    step_index: int = 0
+    output: Any = None
+    error: Optional[str] = None
+    started_at: datetime = field(default_factory=datetime.utcnow)
+    finished_at: Optional[datetime] = None
+
+
+@dataclass
+class TaskRun:
+    """Persistent envelope for a multi-step agent task.
+
+    Attributes
+    ----------
+    id:
+        Unique UUID.
+    goal:
+        The user's original request.
+    plan:
+        Ordered list of :class:`TaskStep` objects.
+    status:
+        Current lifecycle state.
+    steps:
+        Results of executed steps.
+    artifacts:
+        Intermediate outputs keyed by step index or name.
+    errors:
+        Accumulated error messages.
+    created_at / updated_at:
+        Timestamps.
+    resumed_from:
+        If this run was resumed from another, the original run ID.
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    goal: str = ""
+    plan: List[TaskStep] = field(default_factory=list)
+    status: TaskStatus = TaskStatus.PENDING
+    steps: List[StepResult] = field(default_factory=list)
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    updated_at: datetime = field(default_factory=datetime.utcnow)
+    resumed_from: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.status, str):
+            self.status = TaskStatus(self.status)
+
+    @property
+    def current_step_index(self) -> int:
+        """Index of the next step to execute."""
+        return len(self.steps)
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the run is in a terminal state."""
+        return self.status in (
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+            TaskStatus.CANCELLED,
+        )
+
+    def touch(self) -> None:
+        """Bump *updated_at*."""
+        self.updated_at = datetime.utcnow()
+
+
+# ── SQLite DDL ────────────────────────────────────────────────────────
+
+_CREATE_TASK_RUN = """
+CREATE TABLE IF NOT EXISTS task_run (
+    id           TEXT PRIMARY KEY,
+    goal         TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'pending',
+    artifacts    TEXT NOT NULL DEFAULT '{}',
+    errors       TEXT NOT NULL DEFAULT '[]',
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    resumed_from TEXT
+);
+"""
+
+_CREATE_TASK_STEP = """
+CREATE TABLE IF NOT EXISTS task_step (
+    run_id          TEXT NOT NULL REFERENCES task_run(id) ON DELETE CASCADE,
+    step_index      INTEGER NOT NULL,
+    tool_name       TEXT NOT NULL,
+    args            TEXT NOT NULL DEFAULT '{}',
+    expected_output TEXT,
+    status          TEXT NOT NULL DEFAULT 'pending',
+    output          TEXT,
+    error           TEXT,
+    started_at      TEXT,
+    finished_at     TEXT,
+    PRIMARY KEY (run_id, step_index)
+);
+"""
+
+
+# ── Persistence layer ─────────────────────────────────────────────────
+
+class TaskRunStore:
+    """SQLite-backed CRUD for :class:`TaskRun`.
+
+    Parameters
+    ----------
+    conn:
+        An open ``sqlite3.Connection`` (typically the same one used by
+        :class:`~bantz.memory.persistent.PersistentMemoryStore`).
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._lock = threading.Lock()
+        self._ensure_tables()
+
+    def _ensure_tables(self) -> None:
+        with self._lock:
+            self._conn.execute(_CREATE_TASK_RUN)
+            self._conn.execute(_CREATE_TASK_STEP)
+
+    # ── create ────────────────────────────────────────────────────────
+
+    def create(self, run: TaskRun) -> str:
+        """Persist a new :class:`TaskRun` (including its plan steps)."""
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO task_run
+                    (id, goal, status, artifacts, errors,
+                     created_at, updated_at, resumed_from)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run.id,
+                    run.goal,
+                    run.status.value,
+                    json.dumps(run.artifacts),
+                    json.dumps(run.errors),
+                    run.created_at.isoformat(),
+                    run.updated_at.isoformat(),
+                    run.resumed_from,
+                ),
+            )
+            for step in run.plan:
+                self._insert_step(run.id, step)
+        return run.id
+
+    def _insert_step(self, run_id: str, step: TaskStep) -> None:
+        """Insert a single plan step (must hold self._lock)."""
+        self._conn.execute(
+            """
+            INSERT INTO task_step
+                (run_id, step_index, tool_name, args,
+                 expected_output, status)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                step.index,
+                step.tool_name,
+                json.dumps(step.args),
+                step.expected_output,
+                step.status.value,
+            ),
+        )
+
+    # ── read ──────────────────────────────────────────────────────────
+
+    def get(self, run_id: str) -> Optional[TaskRun]:
+        """Load a :class:`TaskRun` by ID (with plan + step results)."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM task_run WHERE id = ?", (run_id,)
+            ).fetchone()
+            if row is None:
+                return None
+
+            step_rows = self._conn.execute(
+                "SELECT * FROM task_step WHERE run_id = ? ORDER BY step_index",
+                (run_id,),
+            ).fetchall()
+
+        return self._build_task_run(row, step_rows)
+
+    def list_runs(
+        self,
+        status: Optional[TaskStatus] = None,
+        limit: int = 20,
+    ) -> List[TaskRun]:
+        """List task runs, optionally filtered by status."""
+        params: list[Any] = []
+        where = ""
+        if status:
+            where = "WHERE status = ?"
+            params.append(status.value)
+        params.append(limit)
+
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT * FROM task_run {where} ORDER BY updated_at DESC LIMIT ?",
+                params,
+            ).fetchall()
+
+        runs: List[TaskRun] = []
+        for row in rows:
+            with self._lock:
+                step_rows = self._conn.execute(
+                    "SELECT * FROM task_step WHERE run_id = ? ORDER BY step_index",
+                    (row["id"],),
+                ).fetchall()
+            runs.append(self._build_task_run(row, step_rows))
+        return runs
+
+    # ── update ────────────────────────────────────────────────────────
+
+    def update_status(self, run_id: str, status: TaskStatus) -> bool:
+        """Change the status of a run.  Returns *True* if updated."""
+        now = datetime.utcnow().isoformat()
+        with self._lock:
+            cur = self._conn.execute(
+                "UPDATE task_run SET status = ?, updated_at = ? WHERE id = ?",
+                (status.value, now, run_id),
+            )
+        return cur.rowcount > 0
+
+    def record_step_result(self, run_id: str, result: StepResult) -> bool:
+        """Record the outcome of executing a step."""
+        now = datetime.utcnow().isoformat()
+        status = StepStatus.FAILED.value if result.error else StepStatus.DONE.value
+        finished = result.finished_at.isoformat() if result.finished_at else now
+        started = result.started_at.isoformat()
+
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                UPDATE task_step
+                SET status = ?, output = ?, error = ?,
+                    started_at = ?, finished_at = ?
+                WHERE run_id = ? AND step_index = ?
+                """,
+                (
+                    status,
+                    json.dumps(result.output),
+                    result.error,
+                    started,
+                    finished,
+                    run_id,
+                    result.step_index,
+                ),
+            )
+            # Also update the run's updated_at
+            self._conn.execute(
+                "UPDATE task_run SET updated_at = ? WHERE id = ?",
+                (now, run_id),
+            )
+
+            # If error, append to run's errors
+            if result.error:
+                row = self._conn.execute(
+                    "SELECT errors FROM task_run WHERE id = ?", (run_id,)
+                ).fetchone()
+                if row:
+                    errors = json.loads(row["errors"])
+                    errors.append(result.error)
+                    self._conn.execute(
+                        "UPDATE task_run SET errors = ? WHERE id = ?",
+                        (json.dumps(errors), run_id),
+                    )
+
+        return cur.rowcount > 0
+
+    def save_artifact(self, run_id: str, key: str, value: Any) -> bool:
+        """Store an intermediate artifact on a run."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT artifacts FROM task_run WHERE id = ?", (run_id,)
+            ).fetchone()
+            if row is None:
+                return False
+            arts = json.loads(row["artifacts"])
+            arts[key] = value
+            now = datetime.utcnow().isoformat()
+            self._conn.execute(
+                "UPDATE task_run SET artifacts = ?, updated_at = ? WHERE id = ?",
+                (json.dumps(arts), now, run_id),
+            )
+        return True
+
+    # ── delete ────────────────────────────────────────────────────────
+
+    def delete(self, run_id: str) -> bool:
+        """Delete a run and its steps.  Returns *True* if deleted."""
+        with self._lock:
+            cur = self._conn.execute(
+                "DELETE FROM task_run WHERE id = ?", (run_id,)
+            )
+        return cur.rowcount > 0
+
+    # ── internal helpers ──────────────────────────────────────────────
+
+    @staticmethod
+    def _build_task_run(row: sqlite3.Row, step_rows: list) -> TaskRun:
+        plan: List[TaskStep] = []
+        results: List[StepResult] = []
+
+        for sr in step_rows:
+            step = TaskStep(
+                index=sr["step_index"],
+                tool_name=sr["tool_name"],
+                args=json.loads(sr["args"]),
+                expected_output=sr["expected_output"],
+                status=StepStatus(sr["status"]),
+            )
+            plan.append(step)
+
+            # If the step has been executed, build a StepResult
+            if sr["status"] in (StepStatus.DONE.value, StepStatus.FAILED.value):
+                results.append(
+                    StepResult(
+                        step_index=sr["step_index"],
+                        output=json.loads(sr["output"]) if sr["output"] else None,
+                        error=sr["error"],
+                        started_at=(
+                            datetime.fromisoformat(sr["started_at"])
+                            if sr["started_at"]
+                            else datetime.utcnow()
+                        ),
+                        finished_at=(
+                            datetime.fromisoformat(sr["finished_at"])
+                            if sr["finished_at"]
+                            else None
+                        ),
+                    )
+                )
+
+        return TaskRun(
+            id=row["id"],
+            goal=row["goal"],
+            status=TaskStatus(row["status"]),
+            artifacts=json.loads(row["artifacts"]),
+            errors=json.loads(row["errors"]),
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+            resumed_from=row["resumed_from"],
+            plan=plan,
+            steps=results,
+        )

--- a/src/bantz/planning/task_runner.py
+++ b/src/bantz/planning/task_runner.py
@@ -1,0 +1,216 @@
+"""TaskRunner — orchestrates multi-step task execution (Issue #451).
+
+Provides the high-level lifecycle API on top of :class:`TaskRunStore`:
+
+- :meth:`start` — create a new run from a goal + plan
+- :meth:`execute_step` — execute the next (or specific) step
+- :meth:`pause` / :meth:`resume` / :meth:`cancel`
+- :meth:`get_status` — retrieve current state
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+from bantz.planning.task_run import (
+    StepResult,
+    StepStatus,
+    TaskRun,
+    TaskRunStore,
+    TaskStatus,
+    TaskStep,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["TaskRunner"]
+
+# Type alias for tool executors: (tool_name, args) → output
+ToolExecutor = Callable[[str, Dict[str, Any]], Any]
+
+
+class TaskRunner:
+    """Orchestrates multi-step task execution with persistence.
+
+    Parameters
+    ----------
+    conn:
+        SQLite connection (shared with PersistentMemoryStore).
+    tool_executor:
+        Optional callback ``(tool_name, args) → output``.
+        If *None*, steps must be executed externally and results recorded
+        via :meth:`record_result`.
+    """
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        tool_executor: Optional[ToolExecutor] = None,
+    ) -> None:
+        self._store = TaskRunStore(conn)
+        self._executor = tool_executor
+
+    # ── lifecycle ─────────────────────────────────────────────────────
+
+    def start(self, goal: str, plan: List[TaskStep]) -> TaskRun:
+        """Create and persist a new task run.
+
+        Parameters
+        ----------
+        goal:
+            The user's request / objective.
+        plan:
+            Ordered list of steps to execute.
+
+        Returns
+        -------
+        TaskRun
+            The newly created run in ``PENDING`` state.
+        """
+        run = TaskRun(goal=goal, plan=plan, status=TaskStatus.PENDING)
+        self._store.create(run)
+        logger.info("TaskRun %s created: %s (%d steps)", run.id, goal, len(plan))
+        return run
+
+    def execute_step(self, run_id: str, step_index: Optional[int] = None) -> StepResult:
+        """Execute a step of the run.
+
+        If *step_index* is ``None``, the next pending step is used.
+
+        Returns
+        -------
+        StepResult
+            The result of the executed step.
+
+        Raises
+        ------
+        ValueError
+            If the run doesn't exist, is in a terminal state, or no
+            pending steps remain.
+        RuntimeError
+            If no tool_executor is configured.
+        """
+        run = self._store.get(run_id)
+        if run is None:
+            raise ValueError(f"TaskRun {run_id} not found")
+        if run.is_terminal:
+            raise ValueError(f"TaskRun {run_id} is in terminal state: {run.status.value}")
+
+        # Move to RUNNING if still PENDING
+        if run.status == TaskStatus.PENDING:
+            self._store.update_status(run_id, TaskStatus.RUNNING)
+
+        idx = step_index if step_index is not None else run.current_step_index
+        if idx >= len(run.plan):
+            raise ValueError(f"No pending step at index {idx}")
+
+        step = run.plan[idx]
+
+        if self._executor is None:
+            raise RuntimeError("No tool_executor configured")
+
+        started = datetime.utcnow()
+        try:
+            output = self._executor(step.tool_name, step.args)
+            result = StepResult(
+                step_index=idx,
+                output=output,
+                started_at=started,
+                finished_at=datetime.utcnow(),
+            )
+        except Exception as exc:
+            result = StepResult(
+                step_index=idx,
+                error=str(exc),
+                started_at=started,
+                finished_at=datetime.utcnow(),
+            )
+
+        self._store.record_step_result(run_id, result)
+        logger.info("Step %d of run %s: %s", idx, run_id, "OK" if not result.error else result.error)
+
+        # Check if all steps done → mark completed / failed
+        updated_run = self._store.get(run_id)
+        if updated_run and updated_run.current_step_index >= len(updated_run.plan):
+            if updated_run.errors:
+                self._store.update_status(run_id, TaskStatus.FAILED)
+            else:
+                self._store.update_status(run_id, TaskStatus.COMPLETED)
+
+        return result
+
+    def record_result(self, run_id: str, result: StepResult) -> bool:
+        """Manually record a step result (for external execution)."""
+        return self._store.record_step_result(run_id, result)
+
+    def pause(self, run_id: str) -> bool:
+        """Pause a running task.  Returns *True* if status changed."""
+        run = self._store.get(run_id)
+        if run is None:
+            raise ValueError(f"TaskRun {run_id} not found")
+        if run.status not in (TaskStatus.PENDING, TaskStatus.RUNNING):
+            raise ValueError(f"Cannot pause run in state {run.status.value}")
+        return self._store.update_status(run_id, TaskStatus.PAUSED)
+
+    def resume(self, run_id: str) -> TaskRun:
+        """Resume a paused task — returns the run so caller can continue.
+
+        Raises
+        ------
+        ValueError
+            If the run is not paused.
+        """
+        run = self._store.get(run_id)
+        if run is None:
+            raise ValueError(f"TaskRun {run_id} not found")
+        if run.status != TaskStatus.PAUSED:
+            raise ValueError(f"Cannot resume run in state {run.status.value}")
+        self._store.update_status(run_id, TaskStatus.RUNNING)
+        run.status = TaskStatus.RUNNING
+        logger.info("TaskRun %s resumed from step %d", run_id, run.current_step_index)
+        return run
+
+    def cancel(self, run_id: str) -> bool:
+        """Cancel a task.  Returns *True* if status changed."""
+        run = self._store.get(run_id)
+        if run is None:
+            raise ValueError(f"TaskRun {run_id} not found")
+        if run.is_terminal:
+            raise ValueError(f"Cannot cancel run in terminal state {run.status.value}")
+        # Mark remaining pending steps as SKIPPED
+        for step in run.plan:
+            if step.status == StepStatus.PENDING:
+                self._store.record_step_result(
+                    run_id,
+                    StepResult(
+                        step_index=step.index,
+                        error="cancelled",
+                        finished_at=datetime.utcnow(),
+                    ),
+                )
+        return self._store.update_status(run_id, TaskStatus.CANCELLED)
+
+    def get_status(self, run_id: str) -> TaskRun:
+        """Get the current state of a task run.
+
+        Raises
+        ------
+        ValueError
+            If the run doesn't exist.
+        """
+        run = self._store.get(run_id)
+        if run is None:
+            raise ValueError(f"TaskRun {run_id} not found")
+        return run
+
+    def get_last_run(self) -> Optional[TaskRun]:
+        """Return the most recently updated run, or *None*."""
+        runs = self._store.list_runs(limit=1)
+        return runs[0] if runs else None
+
+    def save_artifact(self, run_id: str, key: str, value: Any) -> bool:
+        """Store an intermediate artifact on a run."""
+        return self._store.save_artifact(run_id, key, value)

--- a/tests/test_issue_451_task_run.py
+++ b/tests/test_issue_451_task_run.py
@@ -1,0 +1,257 @@
+"""Tests for issue #451 — TaskRun persistence + pause/resume."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+import pytest
+
+from bantz.planning.task_run import (
+    StepResult,
+    StepStatus,
+    TaskRun,
+    TaskRunStore,
+    TaskStatus,
+    TaskStep,
+)
+from bantz.planning.task_runner import TaskRunner
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def conn():
+    """In-memory SQLite connection with WAL + FK."""
+    c = sqlite3.connect(":memory:")
+    c.execute("PRAGMA journal_mode=WAL")
+    c.execute("PRAGMA foreign_keys=ON")
+    c.row_factory = sqlite3.Row
+    yield c
+    c.close()
+
+
+@pytest.fixture()
+def store(conn):
+    return TaskRunStore(conn)
+
+
+@pytest.fixture()
+def runner(conn):
+    """TaskRunner with a dummy executor that echoes args."""
+    def echo_executor(tool_name: str, args: dict):
+        return {"tool": tool_name, **args}
+    return TaskRunner(conn, tool_executor=echo_executor)
+
+
+def _plan() -> list[TaskStep]:
+    return [
+        TaskStep(index=0, tool_name="search", args={"q": "Ankara"}, expected_output="results"),
+        TaskStep(index=1, tool_name="summarise", args={"text": "..."}),
+        TaskStep(index=2, tool_name="respond", args={"msg": "done"}),
+    ]
+
+
+# ── TestTaskRunStore ──────────────────────────────────────────────────
+
+class TestTaskRunStore:
+    """Persistence round-trip tests."""
+
+    def test_create_and_read(self, store):
+        run = TaskRun(goal="test görev", plan=_plan())
+        store.create(run)
+        loaded = store.get(run.id)
+        assert loaded is not None
+        assert loaded.goal == "test görev"
+        assert loaded.status == TaskStatus.PENDING
+        assert len(loaded.plan) == 3
+
+    def test_step_fields_persisted(self, store):
+        run = TaskRun(goal="g", plan=_plan())
+        store.create(run)
+        loaded = store.get(run.id)
+        assert loaded.plan[0].tool_name == "search"
+        assert loaded.plan[0].args == {"q": "Ankara"}
+        assert loaded.plan[0].expected_output == "results"
+        assert loaded.plan[0].status == StepStatus.PENDING
+
+    def test_update_status(self, store):
+        run = TaskRun(goal="g", plan=_plan())
+        store.create(run)
+        store.update_status(run.id, TaskStatus.RUNNING)
+        loaded = store.get(run.id)
+        assert loaded.status == TaskStatus.RUNNING
+
+    def test_record_step_result(self, store):
+        run = TaskRun(goal="g", plan=_plan())
+        store.create(run)
+        result = StepResult(step_index=0, output={"key": "val"})
+        store.record_step_result(run.id, result)
+        loaded = store.get(run.id)
+        assert loaded.plan[0].status == StepStatus.DONE
+        assert len(loaded.steps) == 1
+        assert loaded.steps[0].output == {"key": "val"}
+
+    def test_record_failed_step(self, store):
+        run = TaskRun(goal="g", plan=_plan())
+        store.create(run)
+        result = StepResult(step_index=0, error="boom")
+        store.record_step_result(run.id, result)
+        loaded = store.get(run.id)
+        assert loaded.plan[0].status == StepStatus.FAILED
+        assert "boom" in loaded.errors
+
+    def test_save_artifact(self, store):
+        run = TaskRun(goal="g", plan=_plan())
+        store.create(run)
+        store.save_artifact(run.id, "url", "https://example.com")
+        loaded = store.get(run.id)
+        assert loaded.artifacts["url"] == "https://example.com"
+
+    def test_delete(self, store):
+        run = TaskRun(goal="g", plan=_plan())
+        store.create(run)
+        assert store.delete(run.id)
+        assert store.get(run.id) is None
+
+    def test_list_runs(self, store):
+        for i in range(5):
+            store.create(TaskRun(goal=f"goal-{i}", plan=[]))
+        runs = store.list_runs(limit=3)
+        assert len(runs) == 3
+
+    def test_list_runs_by_status(self, store):
+        r1 = TaskRun(goal="a", plan=[], status=TaskStatus.RUNNING)
+        r2 = TaskRun(goal="b", plan=[], status=TaskStatus.PENDING)
+        store.create(r1)
+        store.create(r2)
+        runs = store.list_runs(status=TaskStatus.RUNNING)
+        assert len(runs) == 1
+        assert runs[0].status == TaskStatus.RUNNING
+
+
+# ── TestTaskRunner ────────────────────────────────────────────────────
+
+class TestTaskRunner:
+    """High-level lifecycle tests."""
+
+    def test_start_creates_run(self, runner):
+        run = runner.start("do things", _plan())
+        assert run.status == TaskStatus.PENDING
+        assert len(run.plan) == 3
+
+    def test_execute_step(self, runner):
+        run = runner.start("go", _plan())
+        result = runner.execute_step(run.id)
+        assert result.error is None
+        assert result.output["tool"] == "search"
+
+    def test_execute_all_steps_completes(self, runner):
+        run = runner.start("go", _plan())
+        for _ in range(3):
+            runner.execute_step(run.id)
+        status = runner.get_status(run.id)
+        assert status.status == TaskStatus.COMPLETED
+
+    def test_pause_and_resume(self, runner):
+        run = runner.start("go", _plan())
+        runner.execute_step(run.id)  # step 0
+
+        runner.pause(run.id)
+        status = runner.get_status(run.id)
+        assert status.status == TaskStatus.PAUSED
+
+        resumed = runner.resume(run.id)
+        assert resumed.status == TaskStatus.RUNNING
+        assert resumed.current_step_index == 1  # resumes from step 1
+
+    def test_cancel(self, runner):
+        run = runner.start("go", _plan())
+        runner.execute_step(run.id)
+        runner.cancel(run.id)
+        status = runner.get_status(run.id)
+        assert status.status == TaskStatus.CANCELLED
+
+    def test_execute_on_terminal_raises(self, runner):
+        run = runner.start("go", _plan())
+        for _ in range(3):
+            runner.execute_step(run.id)
+        with pytest.raises(ValueError, match="terminal"):
+            runner.execute_step(run.id)
+
+    def test_pause_completed_raises(self, runner):
+        run = runner.start("go", _plan())
+        for _ in range(3):
+            runner.execute_step(run.id)
+        with pytest.raises(ValueError, match="Cannot pause"):
+            runner.pause(run.id)
+
+    def test_resume_non_paused_raises(self, runner):
+        run = runner.start("go", _plan())
+        with pytest.raises(ValueError, match="Cannot resume"):
+            runner.resume(run.id)
+
+    def test_failed_step_tracks_error(self, conn):
+        def bad_executor(tool: str, args: dict):
+            raise RuntimeError("tool exploded")
+        runner = TaskRunner(conn, tool_executor=bad_executor)
+        run = runner.start("go", [TaskStep(index=0, tool_name="boom", args={})])
+        result = runner.execute_step(run.id)
+        assert result.error == "tool exploded"
+        status = runner.get_status(run.id)
+        assert status.status == TaskStatus.FAILED
+        assert "tool exploded" in status.errors
+
+    def test_get_last_run(self, runner):
+        runner.start("first", [])
+        runner.start("second", [])
+        last = runner.get_last_run()
+        assert last is not None
+        assert last.goal == "second"
+
+    def test_save_artifact(self, runner):
+        run = runner.start("go", _plan())
+        runner.save_artifact(run.id, "data", [1, 2, 3])
+        status = runner.get_status(run.id)
+        assert status.artifacts["data"] == [1, 2, 3]
+
+    def test_no_executor_raises(self, conn):
+        runner = TaskRunner(conn, tool_executor=None)
+        run = runner.start("go", [TaskStep(index=0, tool_name="x", args={})])
+        with pytest.raises(RuntimeError, match="No tool_executor"):
+            runner.execute_step(run.id)
+
+
+# ── TestTaskRunDataModel ──────────────────────────────────────────────
+
+class TestTaskRunDataModel:
+    """Unit tests for data model properties."""
+
+    def test_current_step_index_zero_initially(self):
+        run = TaskRun()
+        assert run.current_step_index == 0
+
+    def test_is_terminal(self):
+        for status in (TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED):
+            run = TaskRun(status=status)
+            assert run.is_terminal
+
+    def test_is_not_terminal(self):
+        for status in (TaskStatus.PENDING, TaskStatus.RUNNING, TaskStatus.PAUSED):
+            run = TaskRun(status=status)
+            assert not run.is_terminal
+
+    def test_touch_updates_timestamp(self):
+        run = TaskRun()
+        old = run.updated_at
+        import time; time.sleep(0.01)
+        run.touch()
+        assert run.updated_at >= old
+
+    def test_string_status_coercion(self):
+        run = TaskRun(status="running")  # type: ignore[arg-type]
+        assert run.status == TaskStatus.RUNNING
+
+    def test_step_string_status_coercion(self):
+        step = TaskStep(status="done")  # type: ignore[arg-type]
+        assert step.status == StepStatus.DONE


### PR DESCRIPTION
## Summary
- **TaskRun / TaskStep / StepResult** dataclasses with status enums
- **TaskRunStore**: SQLite CRUD (task_run + task_step tables)
- **TaskRunner**: start → execute_step → pause → resume → cancel
- Artifact storage per-run
- Error tracking (per-step + run-level)
- Auto-complete/fail detection after last step
- **27 tests — all passing**

Closes #451