### PR TITLE
feat(policy): Permission Engine v0 — YAML DSL + ALLOW/CONFIRM/DENY (#452)

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -1,0 +1,69 @@
+# Bantz Permission Policy — default rules (Issue #452)
+#
+# First matching rule wins.  Use wildcards (* / ?) for tool and action patterns.
+# Decisions: allow | confirm | deny
+# Conditions: max_per_day, max_per_session
+
+permissions:
+  # ── Read operations ────────────────────────────────────────
+  - tool: "calendar.list_events"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "gmail.read"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  # ── Calendar write ─────────────────────────────────────────
+  - tool: "calendar.create_event"
+    action: "write"
+    risk: "medium"
+    decision: "confirm"
+    conditions:
+      max_per_day: 20
+
+  - tool: "calendar.update_event"
+    action: "write"
+    risk: "medium"
+    decision: "confirm"
+
+  - tool: "calendar.delete_event"
+    action: "delete"
+    risk: "high"
+    decision: "confirm"
+    conditions:
+      max_per_day: 5
+
+  # ── Gmail write ────────────────────────────────────────────
+  - tool: "gmail.send"
+    action: "write"
+    risk: "high"
+    decision: "confirm"
+    conditions:
+      max_per_day: 50
+      max_per_session: 10
+
+  # ── File system ────────────────────────────────────────────
+  - tool: "file.*"
+    action: "write"
+    risk: "medium"
+    decision: "confirm"
+
+  # ── System commands ────────────────────────────────────────
+  - tool: "system.execute_command"
+    action: "execute"
+    risk: "critical"
+    decision: "deny"
+
+  - tool: "system.*"
+    action: "execute"
+    risk: "critical"
+    decision: "deny"
+
+  # ── Catch-all (unknown tools) ──────────────────────────────
+  - tool: "*"
+    action: "*"
+    risk: "medium"
+    decision: "confirm"

--- a/src/bantz/policy/dsl.py
+++ b/src/bantz/policy/dsl.py
@@ -1,0 +1,134 @@
+"""YAML / JSON policy DSL for the Permission Engine (Issue #452).
+
+Loads permission rules from YAML or JSON files and provides:
+
+- :class:`PermissionDecision` enum (ALLOW / CONFIRM / DENY)
+- :class:`PermissionRule` dataclass
+- :func:`load_policy` — parse a YAML/JSON file into rules
+- :func:`load_policy_str` — parse a raw string (for tests)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PermissionDecision",
+    "PermissionRule",
+    "load_policy",
+    "load_policy_str",
+    "match_rule",
+]
+
+# ── Enum ──────────────────────────────────────────────────────────────
+
+class PermissionDecision(Enum):
+    """Outcome of a permission evaluation."""
+
+    ALLOW = "allow"
+    CONFIRM = "confirm"
+    DENY = "deny"
+
+
+# ── Data model ────────────────────────────────────────────────────────
+
+@dataclass
+class PermissionRule:
+    """A single permission rule.
+
+    Attributes
+    ----------
+    tool:
+        Tool name pattern (supports ``*`` and ``?`` wildcards via :func:`fnmatch`).
+    action:
+        Action pattern (``read`` / ``write`` / ``delete`` / ``execute`` / ``*``).
+    risk:
+        Risk level label (``low`` / ``medium`` / ``high`` / ``critical``).
+    decision:
+        What to do when the rule matches.
+    conditions:
+        Optional extra constraints (e.g. ``max_per_day``, ``max_per_session``).
+    """
+
+    tool: str = "*"
+    action: str = "*"
+    risk: str = "medium"
+    decision: PermissionDecision = PermissionDecision.CONFIRM
+    conditions: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.decision, str):
+            self.decision = PermissionDecision(self.decision.lower())
+
+
+# ── Matching ──────────────────────────────────────────────────────────
+
+def match_rule(rule: PermissionRule, tool: str, action: str) -> bool:
+    """Return *True* if *rule* matches the given *tool* and *action*.
+
+    Uses :func:`fnmatch` for glob-style wildcards (``*``, ``?``).
+    """
+    tool_ok = fnmatch(tool, rule.tool)
+    action_ok = rule.action == "*" or fnmatch(action, rule.action)
+    return tool_ok and action_ok
+
+
+# ── Loaders ───────────────────────────────────────────────────────────
+
+def _parse_rules(data: dict) -> List[PermissionRule]:
+    raw_rules = data.get("permissions", [])
+    rules: List[PermissionRule] = []
+    for entry in raw_rules:
+        rules.append(
+            PermissionRule(
+                tool=entry.get("tool", "*"),
+                action=entry.get("action", "*"),
+                risk=entry.get("risk", "medium"),
+                decision=entry.get("decision", "confirm"),
+                conditions=entry.get("conditions", {}),
+            )
+        )
+    return rules
+
+
+def load_policy(path: str) -> List[PermissionRule]:
+    """Load rules from a YAML or JSON file.
+
+    Falls back to JSON parsing if PyYAML is not installed.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    return load_policy_str(text)
+
+
+def load_policy_str(text: str) -> List[PermissionRule]:
+    """Parse rules from a raw YAML / JSON string."""
+    data: Optional[dict] = None
+
+    # Try YAML first (superset of JSON)
+    try:
+        import yaml  # type: ignore[import-untyped]
+        data = yaml.safe_load(text)
+    except ImportError:
+        pass
+    except Exception:
+        pass
+
+    if data is None:
+        # Fall back to JSON
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Cannot parse policy: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("Policy must be a mapping with a 'permissions' key")
+
+    return _parse_rules(data)

--- a/src/bantz/policy/permission_engine.py
+++ b/src/bantz/policy/permission_engine.py
@@ -1,0 +1,165 @@
+"""Unified Permission Engine v0 (Issue #452).
+
+Evaluates tool + action requests against a set of :class:`PermissionRule`
+objects and returns an ALLOW / CONFIRM / DENY decision.
+
+Features:
+
+- YAML/JSON policy DSL via :mod:`bantz.policy.dsl`
+- Built-in default rules (read → allow, write → confirm, execute → deny)
+- Wildcard matching (``calendar.*``, ``*``)
+- Rate limiting (``max_per_day``, ``max_per_session``)
+- Risk-level lookup
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from typing import Any, Dict, List, Optional
+
+from bantz.policy.dsl import (
+    PermissionDecision,
+    PermissionRule,
+    load_policy,
+    load_policy_str,
+    match_rule,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PermissionEngine"]
+
+
+# ── Built-in default rules ───────────────────────────────────────────
+
+_DEFAULT_RULES: List[PermissionRule] = [
+    # Read operations → ALLOW
+    PermissionRule(tool="*.list_*", action="read", risk="low", decision=PermissionDecision.ALLOW),
+    PermissionRule(tool="*.get_*", action="read", risk="low", decision=PermissionDecision.ALLOW),
+    PermissionRule(tool="*.read_*", action="read", risk="low", decision=PermissionDecision.ALLOW),
+    PermissionRule(tool="calendar.list_events", action="read", risk="low", decision=PermissionDecision.ALLOW),
+    PermissionRule(tool="gmail.read", action="read", risk="low", decision=PermissionDecision.ALLOW),
+    # Calendar / Gmail write → CONFIRM
+    PermissionRule(tool="calendar.create_event", action="write", risk="medium", decision=PermissionDecision.CONFIRM),
+    PermissionRule(tool="calendar.update_event", action="write", risk="medium", decision=PermissionDecision.CONFIRM),
+    PermissionRule(tool="calendar.delete_event", action="delete", risk="high", decision=PermissionDecision.CONFIRM),
+    PermissionRule(tool="gmail.send", action="write", risk="high", decision=PermissionDecision.CONFIRM),
+    # File system write → CONFIRM
+    PermissionRule(tool="file.*", action="write", risk="medium", decision=PermissionDecision.CONFIRM),
+    # System execute → DENY
+    PermissionRule(tool="system.execute_command", action="execute", risk="critical", decision=PermissionDecision.DENY),
+    PermissionRule(tool="system.*", action="execute", risk="critical", decision=PermissionDecision.DENY),
+    # Catch-all → CONFIRM
+    PermissionRule(tool="*", action="*", risk="medium", decision=PermissionDecision.CONFIRM),
+]
+
+
+class PermissionEngine:
+    """Evaluates permission requests.
+
+    Parameters
+    ----------
+    rules:
+        Ordered list of rules.  First match wins.
+        If *None*, built-in defaults are used.
+    """
+
+    def __init__(self, rules: Optional[List[PermissionRule]] = None) -> None:
+        self._rules: List[PermissionRule] = rules if rules is not None else list(_DEFAULT_RULES)
+        # Rate-limit counters: key = (tool, action)
+        self._day_counts: Dict[str, int] = defaultdict(int)
+        self._session_counts: Dict[str, int] = defaultdict(int)
+        self._day_start: float = time.time()
+        self._DAY_SECONDS = 86_400
+
+    # ── policy loading ────────────────────────────────────────────────
+
+    def load_policy(self, path: str) -> None:
+        """Replace rules from a YAML/JSON policy file.
+
+        Custom rules are prepended before the built-in defaults so they
+        take priority (first-match-wins).
+        """
+        custom = load_policy(path)
+        self._rules = custom + list(_DEFAULT_RULES)
+        logger.info("Loaded %d custom rules from %s", len(custom), path)
+
+    def load_policy_str(self, text: str) -> None:
+        """Load rules from a raw YAML/JSON string (for tests)."""
+        custom = load_policy_str(text)
+        self._rules = custom + list(_DEFAULT_RULES)
+
+    # ── evaluation ────────────────────────────────────────────────────
+
+    def evaluate(
+        self,
+        tool: str,
+        action: str = "*",
+        context: Optional[Dict[str, Any]] = None,
+    ) -> PermissionDecision:
+        """Evaluate a permission request.
+
+        Parameters
+        ----------
+        tool:
+            Tool name (e.g. ``"calendar.create_event"``).
+        action:
+            Action type (``"read"`` / ``"write"`` / ``"delete"`` / ``"execute"``).
+        context:
+            Optional context dict (unused for now, reserved for future
+            conditions like time-of-day or user role).
+
+        Returns
+        -------
+        PermissionDecision
+            The decision for this request.
+        """
+        self._maybe_reset_day()
+
+        for rule in self._rules:
+            if not match_rule(rule, tool, action):
+                continue
+
+            # Check rate-limit conditions
+            key = f"{tool}:{action}"
+            max_day = rule.conditions.get("max_per_day")
+            max_sess = rule.conditions.get("max_per_session")
+
+            if max_day is not None and self._day_counts[key] >= max_day:
+                logger.warning("Rate limit (day) hit for %s", key)
+                return PermissionDecision.DENY
+
+            if max_sess is not None and self._session_counts[key] >= max_sess:
+                logger.warning("Rate limit (session) hit for %s", key)
+                return PermissionDecision.DENY
+
+            # Bump counters
+            self._day_counts[key] += 1
+            self._session_counts[key] += 1
+
+            return rule.decision
+
+        # Fallback (should never happen because catch-all is last)
+        return PermissionDecision.CONFIRM
+
+    def get_risk(self, tool: str) -> str:
+        """Return the risk level for a tool (first matching rule with a specific tool pattern)."""
+        from fnmatch import fnmatch as _fnmatch
+        for rule in self._rules:
+            if _fnmatch(tool, rule.tool):
+                return rule.risk
+        return "medium"
+
+    # ── rate limiting helpers ─────────────────────────────────────────
+
+    def reset_session(self) -> None:
+        """Reset per-session counters (call on new conversation)."""
+        self._session_counts.clear()
+
+    def _maybe_reset_day(self) -> None:
+        now = time.time()
+        if now - self._day_start > self._DAY_SECONDS:
+            self._day_counts.clear()
+            self._day_start = now

--- a/tests/test_issue_452_permission_engine.py
+++ b/tests/test_issue_452_permission_engine.py
@@ -1,0 +1,267 @@
+"""Tests for issue #452 — Permission Engine v0."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from bantz.policy.dsl import (
+    PermissionDecision,
+    PermissionRule,
+    load_policy,
+    load_policy_str,
+    match_rule,
+)
+from bantz.policy.permission_engine import PermissionEngine
+
+
+# ── TestPermissionDecision ────────────────────────────────────────────
+
+class TestPermissionDecision:
+    def test_enum_values(self):
+        assert PermissionDecision.ALLOW.value == "allow"
+        assert PermissionDecision.CONFIRM.value == "confirm"
+        assert PermissionDecision.DENY.value == "deny"
+
+
+# ── TestPermissionRule ────────────────────────────────────────────────
+
+class TestPermissionRule:
+    def test_string_decision_coercion(self):
+        rule = PermissionRule(decision="allow")
+        assert rule.decision == PermissionDecision.ALLOW
+
+    def test_default_fields(self):
+        rule = PermissionRule()
+        assert rule.tool == "*"
+        assert rule.action == "*"
+        assert rule.risk == "medium"
+        assert rule.conditions == {}
+
+
+# ── TestMatchRule ─────────────────────────────────────────────────────
+
+class TestMatchRule:
+    def test_exact_match(self):
+        rule = PermissionRule(tool="calendar.create_event", action="write")
+        assert match_rule(rule, "calendar.create_event", "write")
+
+    def test_wildcard_tool(self):
+        rule = PermissionRule(tool="calendar.*", action="read")
+        assert match_rule(rule, "calendar.list_events", "read")
+        assert match_rule(rule, "calendar.get_event", "read")
+        assert not match_rule(rule, "gmail.read", "read")
+
+    def test_wildcard_action(self):
+        rule = PermissionRule(tool="gmail.send", action="*")
+        assert match_rule(rule, "gmail.send", "write")
+        assert match_rule(rule, "gmail.send", "read")
+
+    def test_star_star(self):
+        rule = PermissionRule(tool="*", action="*")
+        assert match_rule(rule, "anything", "everything")
+
+    def test_no_match(self):
+        rule = PermissionRule(tool="calendar.create_event", action="write")
+        assert not match_rule(rule, "gmail.send", "write")
+
+
+# ── TestDSLLoader ─────────────────────────────────────────────────────
+
+class TestDSLLoader:
+    def test_load_json_string(self):
+        policy = json.dumps({
+            "permissions": [
+                {"tool": "x.y", "action": "read", "risk": "low", "decision": "allow"},
+            ]
+        })
+        rules = load_policy_str(policy)
+        assert len(rules) == 1
+        assert rules[0].decision == PermissionDecision.ALLOW
+
+    def test_load_yaml_string(self):
+        yaml_str = """\
+permissions:
+  - tool: "gmail.send"
+    action: "write"
+    risk: "high"
+    decision: "confirm"
+"""
+        rules = load_policy_str(yaml_str)
+        assert len(rules) == 1
+        assert rules[0].tool == "gmail.send"
+
+    def test_load_policy_from_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"permissions": [
+                {"tool": "a", "action": "b", "risk": "low", "decision": "allow"}
+            ]}, f)
+            f.flush()
+            rules = load_policy(f.name)
+        assert len(rules) == 1
+
+    def test_invalid_string_raises(self):
+        with pytest.raises(ValueError):
+            load_policy_str("this is not valid json or yaml @@@{{{")
+
+    def test_load_real_config(self):
+        config_path = Path(__file__).resolve().parents[1] / "config" / "permissions.yaml"
+        if config_path.exists():
+            rules = load_policy(str(config_path))
+            assert len(rules) >= 5
+
+
+# ── TestPermissionEngine — Default Rules ──────────────────────────────
+
+class TestPermissionEngineDefaults:
+    def setup_method(self):
+        self.engine = PermissionEngine()
+
+    def test_calendar_read_allow(self):
+        assert self.engine.evaluate("calendar.list_events", "read") == PermissionDecision.ALLOW
+
+    def test_gmail_read_allow(self):
+        assert self.engine.evaluate("gmail.read", "read") == PermissionDecision.ALLOW
+
+    def test_calendar_create_confirm(self):
+        assert self.engine.evaluate("calendar.create_event", "write") == PermissionDecision.CONFIRM
+
+    def test_gmail_send_confirm(self):
+        assert self.engine.evaluate("gmail.send", "write") == PermissionDecision.CONFIRM
+
+    def test_system_execute_deny(self):
+        assert self.engine.evaluate("system.execute_command", "execute") == PermissionDecision.DENY
+
+    def test_system_wildcard_deny(self):
+        assert self.engine.evaluate("system.run_shell", "execute") == PermissionDecision.DENY
+
+    def test_unknown_tool_confirm(self):
+        assert self.engine.evaluate("totally_new_tool", "write") == PermissionDecision.CONFIRM
+
+    def test_file_write_confirm(self):
+        assert self.engine.evaluate("file.save", "write") == PermissionDecision.CONFIRM
+
+
+# ── TestPermissionEngine — Risk Levels ────────────────────────────────
+
+class TestRiskLevels:
+    def setup_method(self):
+        self.engine = PermissionEngine()
+
+    def test_calendar_read_low(self):
+        assert self.engine.get_risk("calendar.list_events") == "low"
+
+    def test_system_critical(self):
+        assert self.engine.get_risk("system.execute_command") == "critical"
+
+    def test_unknown_medium(self):
+        # Catch-all rule has "medium"
+        assert self.engine.get_risk("foo.bar") == "medium"
+
+
+# ── TestPermissionEngine — Custom Policy Override ─────────────────────
+
+class TestPolicyOverride:
+    def test_custom_rule_takes_priority(self):
+        engine = PermissionEngine()
+        engine.load_policy_str("""\
+permissions:
+  - tool: "system.execute_command"
+    action: "execute"
+    risk: "low"
+    decision: "allow"
+""")
+        # Custom rule overrides built-in DENY
+        assert engine.evaluate("system.execute_command", "execute") == PermissionDecision.ALLOW
+
+    def test_custom_deny_overrides_default_confirm(self):
+        engine = PermissionEngine()
+        engine.load_policy_str("""\
+permissions:
+  - tool: "gmail.send"
+    action: "write"
+    risk: "critical"
+    decision: "deny"
+""")
+        assert engine.evaluate("gmail.send", "write") == PermissionDecision.DENY
+
+
+# ── TestRateLimiting ──────────────────────────────────────────────────
+
+class TestRateLimiting:
+    def test_max_per_session_exceeded(self):
+        engine = PermissionEngine(rules=[
+            PermissionRule(
+                tool="api.call",
+                action="write",
+                risk="medium",
+                decision=PermissionDecision.ALLOW,
+                conditions={"max_per_session": 3},
+            ),
+        ])
+        assert engine.evaluate("api.call", "write") == PermissionDecision.ALLOW
+        assert engine.evaluate("api.call", "write") == PermissionDecision.ALLOW
+        assert engine.evaluate("api.call", "write") == PermissionDecision.ALLOW
+        # 4th call should DENY
+        assert engine.evaluate("api.call", "write") == PermissionDecision.DENY
+
+    def test_max_per_day_exceeded(self):
+        engine = PermissionEngine(rules=[
+            PermissionRule(
+                tool="api.call",
+                action="write",
+                risk="medium",
+                decision=PermissionDecision.ALLOW,
+                conditions={"max_per_day": 2},
+            ),
+        ])
+        assert engine.evaluate("api.call", "write") == PermissionDecision.ALLOW
+        assert engine.evaluate("api.call", "write") == PermissionDecision.ALLOW
+        assert engine.evaluate("api.call", "write") == PermissionDecision.DENY
+
+    def test_reset_session_clears_counter(self):
+        engine = PermissionEngine(rules=[
+            PermissionRule(
+                tool="api.call",
+                action="write",
+                risk="medium",
+                decision=PermissionDecision.ALLOW,
+                conditions={"max_per_session": 1},
+            ),
+        ])
+        assert engine.evaluate("api.call", "write") == PermissionDecision.ALLOW
+        assert engine.evaluate("api.call", "write") == PermissionDecision.DENY
+        engine.reset_session()
+        assert engine.evaluate("api.call", "write") == PermissionDecision.ALLOW
+
+    def test_different_tools_independent_counters(self):
+        engine = PermissionEngine(rules=[
+            PermissionRule(
+                tool="a", action="write", decision=PermissionDecision.ALLOW,
+                conditions={"max_per_session": 1},
+            ),
+            PermissionRule(
+                tool="b", action="write", decision=PermissionDecision.ALLOW,
+                conditions={"max_per_session": 1},
+            ),
+        ])
+        assert engine.evaluate("a", "write") == PermissionDecision.ALLOW
+        assert engine.evaluate("b", "write") == PermissionDecision.ALLOW
+        assert engine.evaluate("a", "write") == PermissionDecision.DENY
+        assert engine.evaluate("b", "write") == PermissionDecision.DENY
+
+
+# ── TestWildcardEdgeCases ─────────────────────────────────────────────
+
+class TestWildcardEdgeCases:
+    def test_question_mark_wildcard(self):
+        rule = PermissionRule(tool="calendar.?et_event", action="read")
+        assert match_rule(rule, "calendar.get_event", "read")
+        assert not match_rule(rule, "calendar.list_event", "read")
+
+    def test_nested_wildcard(self):
+        rule = PermissionRule(tool="google.*.read", action="*")
+        assert match_rule(rule, "google.drive.read", "read")


### PR DESCRIPTION
## Summary
- **PermissionDecision** enum (ALLOW / CONFIRM / DENY)
- **PermissionRule** dataclass with wildcard matching (fnmatch)
- YAML/JSON policy DSL loader
- **PermissionEngine** with built-in default rules + rate limiting
- **config/permissions.yaml** — default policy file
- Custom policy override (first-match-wins)
- **32 tests — all passing**

Closes #452