### PR TITLE
feat(conversation): formal FSM v0 — 8 states + strict transitions (#455)

### DIFF
--- a/src/bantz/conversation/fsm_v0.py
+++ b/src/bantz/conversation/fsm_v0.py
@@ -1,0 +1,291 @@
+"""Formal Conversation FSM v0 (Issue #455).
+
+Extends the original FSM (Issue #38) with additional states required for
+the full agent lifecycle:
+
+States
+------
+IDLE → LISTENING → PLANNING → EXECUTING → CONFIRMING → RESPONDING → IDLE
+                                   ↓              ↓
+                                 ERROR ←──── CANCELLED
+
+Events (triggers)
+-----------------
+user_input, input_complete, plan_ready, no_tools, confirmation_required,
+tools_complete, user_confirmed, user_denied, response_delivered,
+error, user_cancel, error_handled, reset
+
+Features:
+
+- Strict transition table — invalid transitions are logged and ignored
+- ``can_transition`` / ``get_allowed_events`` for UI state exposure
+- Transition history with timestamps
+- Configurable timeout on EXECUTING state (default 60 s)
+- Callback hooks for state entry/exit
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "FSMState",
+    "FSMEvent",
+    "TransitionRecord",
+    "ConversationFSMv0",
+]
+
+
+# ── States ────────────────────────────────────────────────────────────
+
+class FSMState(Enum):
+    """Conversation lifecycle states."""
+
+    IDLE = "idle"
+    LISTENING = "listening"
+    PLANNING = "planning"
+    EXECUTING = "executing"
+    CONFIRMING = "confirming"
+    RESPONDING = "responding"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+# ── Events ────────────────────────────────────────────────────────────
+
+class FSMEvent(Enum):
+    """Events that trigger state transitions."""
+
+    USER_INPUT = "user_input"
+    INPUT_COMPLETE = "input_complete"
+    PLAN_READY = "plan_ready"
+    NO_TOOLS = "no_tools"
+    CONFIRMATION_REQUIRED = "confirmation_required"
+    TOOLS_COMPLETE = "tools_complete"
+    USER_CONFIRMED = "user_confirmed"
+    USER_DENIED = "user_denied"
+    RESPONSE_DELIVERED = "response_delivered"
+    ERROR = "error"
+    USER_CANCEL = "user_cancel"
+    ERROR_HANDLED = "error_handled"
+    RESET = "reset"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+# ── Transition table ──────────────────────────────────────────────────
+
+# (current_state, event) → next_state
+_TRANSITIONS: Dict[tuple[FSMState, FSMEvent], FSMState] = {
+    # Happy path
+    (FSMState.IDLE, FSMEvent.USER_INPUT): FSMState.LISTENING,
+    (FSMState.LISTENING, FSMEvent.INPUT_COMPLETE): FSMState.PLANNING,
+    (FSMState.PLANNING, FSMEvent.PLAN_READY): FSMState.EXECUTING,
+    (FSMState.PLANNING, FSMEvent.NO_TOOLS): FSMState.RESPONDING,
+    (FSMState.EXECUTING, FSMEvent.CONFIRMATION_REQUIRED): FSMState.CONFIRMING,
+    (FSMState.EXECUTING, FSMEvent.TOOLS_COMPLETE): FSMState.RESPONDING,
+    (FSMState.CONFIRMING, FSMEvent.USER_CONFIRMED): FSMState.EXECUTING,
+    (FSMState.CONFIRMING, FSMEvent.USER_DENIED): FSMState.CANCELLED,
+    (FSMState.RESPONDING, FSMEvent.RESPONSE_DELIVERED): FSMState.IDLE,
+    # Error / cancel from any state (added dynamically below)
+    (FSMState.ERROR, FSMEvent.ERROR_HANDLED): FSMState.IDLE,
+    (FSMState.CANCELLED, FSMEvent.RESET): FSMState.IDLE,
+}
+
+# ANY state → ERROR on error, ANY state → CANCELLED on user_cancel
+for _state in FSMState:
+    if _state not in (FSMState.ERROR, FSMState.CANCELLED):
+        _TRANSITIONS[(
+            _state, FSMEvent.ERROR
+        )] = FSMState.ERROR
+        _TRANSITIONS[(
+            _state, FSMEvent.USER_CANCEL
+        )] = FSMState.CANCELLED
+
+
+# ── Transition record ─────────────────────────────────────────────────
+
+@dataclass
+class TransitionRecord:
+    """Log entry for a state transition."""
+
+    from_state: FSMState
+    to_state: FSMState
+    event: FSMEvent
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+# ── FSM ───────────────────────────────────────────────────────────────
+
+StateCallback = Callable[[FSMState, FSMState, FSMEvent], None]
+
+
+class ConversationFSMv0:
+    """Formal conversation FSM with strict transition validation.
+
+    Parameters
+    ----------
+    initial_state:
+        Starting state (default ``IDLE``).
+    executing_timeout:
+        Seconds before EXECUTING auto-transitions to ERROR (default 60).
+    """
+
+    def __init__(
+        self,
+        initial_state: FSMState = FSMState.IDLE,
+        executing_timeout: float = 60.0,
+    ) -> None:
+        self._state = initial_state
+        self._executing_timeout = executing_timeout
+        self._executing_entered: Optional[float] = None
+        self._history: List[TransitionRecord] = []
+        self._on_enter: Dict[FSMState, List[StateCallback]] = {}
+        self._on_exit: Dict[FSMState, List[StateCallback]] = {}
+
+    # ── properties ────────────────────────────────────────────────────
+
+    @property
+    def state(self) -> FSMState:
+        """Current FSM state."""
+        self._check_executing_timeout()
+        return self._state
+
+    @property
+    def history(self) -> List[TransitionRecord]:
+        """Full transition history."""
+        return list(self._history)
+
+    # ── transition API ────────────────────────────────────────────────
+
+    def transition(self, event: FSMEvent | str, **metadata: Any) -> FSMState:
+        """Attempt a state transition.
+
+        If the transition is not valid, it is logged and the current
+        state is returned unchanged.
+
+        Parameters
+        ----------
+        event:
+            The event to fire.
+        **metadata:
+            Extra context stored in the :class:`TransitionRecord`.
+
+        Returns
+        -------
+        FSMState
+            The new state after the transition (or the same state if invalid).
+        """
+        if isinstance(event, str):
+            event = FSMEvent(event)
+
+        self._check_executing_timeout()
+
+        key = (self._state, event)
+        next_state = _TRANSITIONS.get(key)
+
+        if next_state is None:
+            logger.warning(
+                "Invalid transition: %s + %s (ignored)",
+                self._state, event,
+            )
+            return self._state
+
+        prev = self._state
+
+        # Fire exit callbacks
+        for cb in self._on_exit.get(prev, []):
+            try:
+                cb(prev, next_state, event)
+            except Exception:
+                logger.exception("on_exit callback error")
+
+        self._state = next_state
+
+        # Track EXECUTING entry time for timeout
+        if next_state == FSMState.EXECUTING:
+            self._executing_entered = time.monotonic()
+        else:
+            self._executing_entered = None
+
+        # Record history
+        self._history.append(TransitionRecord(
+            from_state=prev,
+            to_state=next_state,
+            event=event,
+            metadata=metadata,
+        ))
+
+        logger.info("FSM: %s → %s (event=%s)", prev, next_state, event)
+
+        # Fire enter callbacks
+        for cb in self._on_enter.get(next_state, []):
+            try:
+                cb(prev, next_state, event)
+            except Exception:
+                logger.exception("on_enter callback error")
+
+        return next_state
+
+    def can_transition(self, event: FSMEvent | str) -> bool:
+        """Check whether *event* is valid from the current state."""
+        if isinstance(event, str):
+            event = FSMEvent(event)
+        self._check_executing_timeout()
+        return (self._state, event) in _TRANSITIONS
+
+    def get_allowed_events(self) -> List[FSMEvent]:
+        """Return all events valid from the current state."""
+        self._check_executing_timeout()
+        return [
+            ev for (st, ev) in _TRANSITIONS
+            if st == self._state
+        ]
+
+    def reset(self) -> None:
+        """Force-reset to IDLE (clears history)."""
+        self._state = FSMState.IDLE
+        self._executing_entered = None
+        self._history.clear()
+
+    # ── callbacks ─────────────────────────────────────────────────────
+
+    def on_enter(self, state: FSMState, callback: StateCallback) -> None:
+        """Register a callback for entering *state*."""
+        self._on_enter.setdefault(state, []).append(callback)
+
+    def on_exit(self, state: FSMState, callback: StateCallback) -> None:
+        """Register a callback for exiting *state*."""
+        self._on_exit.setdefault(state, []).append(callback)
+
+    # ── timeout ───────────────────────────────────────────────────────
+
+    def _check_executing_timeout(self) -> None:
+        """Auto-transition EXECUTING → ERROR if timeout exceeded."""
+        if (
+            self._state == FSMState.EXECUTING
+            and self._executing_entered is not None
+            and (time.monotonic() - self._executing_entered) > self._executing_timeout
+        ):
+            logger.warning("EXECUTING timeout (%.0fs) — transitioning to ERROR", self._executing_timeout)
+            prev = self._state
+            self._state = FSMState.ERROR
+            self._executing_entered = None
+            self._history.append(TransitionRecord(
+                from_state=prev,
+                to_state=FSMState.ERROR,
+                event=FSMEvent.ERROR,
+                metadata={"reason": "executing_timeout"},
+            ))

--- a/tests/test_issue_455_conversation_fsm.py
+++ b/tests/test_issue_455_conversation_fsm.py
@@ -1,0 +1,281 @@
+"""Tests for issue #455 — Conversation FSM v0."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from bantz.conversation.fsm_v0 import (
+    ConversationFSMv0,
+    FSMEvent,
+    FSMState,
+    TransitionRecord,
+)
+
+
+# ── TestHappyPath ─────────────────────────────────────────────────────
+
+class TestHappyPath:
+    """Full IDLE → ... → IDLE cycle."""
+
+    def test_full_cycle_with_tools(self):
+        fsm = ConversationFSMv0()
+        assert fsm.state == FSMState.IDLE
+
+        fsm.transition(FSMEvent.USER_INPUT)
+        assert fsm.state == FSMState.LISTENING
+
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        assert fsm.state == FSMState.PLANNING
+
+        fsm.transition(FSMEvent.PLAN_READY)
+        assert fsm.state == FSMState.EXECUTING
+
+        fsm.transition(FSMEvent.TOOLS_COMPLETE)
+        assert fsm.state == FSMState.RESPONDING
+
+        fsm.transition(FSMEvent.RESPONSE_DELIVERED)
+        assert fsm.state == FSMState.IDLE
+
+    def test_no_tools_shortcut(self):
+        """PLANNING → RESPONDING when no tools needed (smalltalk)."""
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.NO_TOOLS)
+        assert fsm.state == FSMState.RESPONDING
+        fsm.transition(FSMEvent.RESPONSE_DELIVERED)
+        assert fsm.state == FSMState.IDLE
+
+    def test_history_recorded(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        assert len(fsm.history) == 2
+        assert fsm.history[0].from_state == FSMState.IDLE
+        assert fsm.history[0].to_state == FSMState.LISTENING
+        assert fsm.history[0].event == FSMEvent.USER_INPUT
+
+
+# ── TestConfirmationFlow ──────────────────────────────────────────────
+
+class TestConfirmationFlow:
+    """EXECUTING → CONFIRMING → EXECUTING / CANCELLED."""
+
+    def test_confirm_and_continue(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.PLAN_READY)
+        fsm.transition(FSMEvent.CONFIRMATION_REQUIRED)
+        assert fsm.state == FSMState.CONFIRMING
+
+        fsm.transition(FSMEvent.USER_CONFIRMED)
+        assert fsm.state == FSMState.EXECUTING
+
+        fsm.transition(FSMEvent.TOOLS_COMPLETE)
+        assert fsm.state == FSMState.RESPONDING
+
+    def test_deny_leads_to_cancelled(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.PLAN_READY)
+        fsm.transition(FSMEvent.CONFIRMATION_REQUIRED)
+        fsm.transition(FSMEvent.USER_DENIED)
+        assert fsm.state == FSMState.CANCELLED
+
+    def test_cancelled_to_idle(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.PLAN_READY)
+        fsm.transition(FSMEvent.CONFIRMATION_REQUIRED)
+        fsm.transition(FSMEvent.USER_DENIED)
+        fsm.transition(FSMEvent.RESET)
+        assert fsm.state == FSMState.IDLE
+
+
+# ── TestErrorRecovery ─────────────────────────────────────────────────
+
+class TestErrorRecovery:
+    def test_error_from_executing(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.PLAN_READY)
+        fsm.transition(FSMEvent.ERROR)
+        assert fsm.state == FSMState.ERROR
+
+    def test_error_handled_to_idle(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.ERROR)
+        assert fsm.state == FSMState.ERROR
+        fsm.transition(FSMEvent.ERROR_HANDLED)
+        assert fsm.state == FSMState.IDLE
+
+    def test_error_from_any_state(self):
+        for state in (FSMState.IDLE, FSMState.LISTENING, FSMState.PLANNING,
+                      FSMState.EXECUTING, FSMState.CONFIRMING, FSMState.RESPONDING):
+            fsm = ConversationFSMv0(initial_state=state)
+            fsm.transition(FSMEvent.ERROR)
+            assert fsm.state == FSMState.ERROR
+
+
+# ── TestCancel ────────────────────────────────────────────────────────
+
+class TestCancel:
+    def test_cancel_from_listening(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.USER_CANCEL)
+        assert fsm.state == FSMState.CANCELLED
+
+    def test_cancel_from_executing(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.PLAN_READY)
+        fsm.transition(FSMEvent.USER_CANCEL)
+        assert fsm.state == FSMState.CANCELLED
+
+
+# ── TestInvalidTransitions ────────────────────────────────────────────
+
+class TestInvalidTransitions:
+    def test_invalid_returns_same_state(self):
+        fsm = ConversationFSMv0()
+        result = fsm.transition(FSMEvent.TOOLS_COMPLETE)
+        assert result == FSMState.IDLE  # unchanged
+
+    def test_invalid_not_in_history(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.TOOLS_COMPLETE)
+        assert len(fsm.history) == 0
+
+    def test_responding_to_executing_invalid(self):
+        fsm = ConversationFSMv0(initial_state=FSMState.RESPONDING)
+        result = fsm.transition(FSMEvent.PLAN_READY)
+        assert result == FSMState.RESPONDING
+
+
+# ── TestCanTransition / GetAllowedEvents ──────────────────────────────
+
+class TestStateQuery:
+    def test_can_transition_true(self):
+        fsm = ConversationFSMv0()
+        assert fsm.can_transition(FSMEvent.USER_INPUT)
+
+    def test_can_transition_false(self):
+        fsm = ConversationFSMv0()
+        assert not fsm.can_transition(FSMEvent.TOOLS_COMPLETE)
+
+    def test_can_transition_string_event(self):
+        fsm = ConversationFSMv0()
+        assert fsm.can_transition("user_input")
+
+    def test_get_allowed_events(self):
+        fsm = ConversationFSMv0()
+        allowed = fsm.get_allowed_events()
+        assert FSMEvent.USER_INPUT in allowed
+        assert FSMEvent.ERROR in allowed
+        assert FSMEvent.USER_CANCEL in allowed
+        assert FSMEvent.TOOLS_COMPLETE not in allowed
+
+
+# ── TestTimeout ───────────────────────────────────────────────────────
+
+class TestTimeout:
+    def test_executing_timeout(self):
+        fsm = ConversationFSMv0(executing_timeout=0.05)
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.PLAN_READY)
+        assert fsm.state == FSMState.EXECUTING
+
+        time.sleep(0.1)
+        # Accessing .state triggers timeout check
+        assert fsm.state == FSMState.ERROR
+
+    def test_no_timeout_when_fast(self):
+        fsm = ConversationFSMv0(executing_timeout=10.0)
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        fsm.transition(FSMEvent.PLAN_READY)
+        assert fsm.state == FSMState.EXECUTING  # no timeout yet
+
+
+# ── TestCallbacks ─────────────────────────────────────────────────────
+
+class TestCallbacks:
+    def test_on_enter_callback(self):
+        fsm = ConversationFSMv0()
+        cb = MagicMock()
+        fsm.on_enter(FSMState.LISTENING, cb)
+
+        fsm.transition(FSMEvent.USER_INPUT)
+        cb.assert_called_once()
+        args = cb.call_args[0]
+        assert args[0] == FSMState.IDLE       # from_state
+        assert args[1] == FSMState.LISTENING   # to_state
+        assert args[2] == FSMEvent.USER_INPUT  # event
+
+    def test_on_exit_callback(self):
+        fsm = ConversationFSMv0()
+        cb = MagicMock()
+        fsm.on_exit(FSMState.IDLE, cb)
+
+        fsm.transition(FSMEvent.USER_INPUT)
+        cb.assert_called_once()
+
+    def test_callback_exception_does_not_break_transition(self):
+        fsm = ConversationFSMv0()
+        fsm.on_enter(FSMState.LISTENING, lambda *a: 1 / 0)
+        # Should not raise
+        fsm.transition(FSMEvent.USER_INPUT)
+        assert fsm.state == FSMState.LISTENING
+
+
+# ── TestReset ─────────────────────────────────────────────────────────
+
+class TestReset:
+    def test_reset_clears_state_and_history(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT)
+        fsm.transition(FSMEvent.INPUT_COMPLETE)
+        assert len(fsm.history) == 2
+        fsm.reset()
+        assert fsm.state == FSMState.IDLE
+        assert fsm.history == []
+
+
+# ── TestStringEvent ───────────────────────────────────────────────────
+
+class TestStringEvent:
+    def test_string_event_accepted(self):
+        fsm = ConversationFSMv0()
+        fsm.transition("user_input")
+        assert fsm.state == FSMState.LISTENING
+
+    def test_metadata_in_history(self):
+        fsm = ConversationFSMv0()
+        fsm.transition(FSMEvent.USER_INPUT, source="microphone")
+        assert fsm.history[0].metadata == {"source": "microphone"}
+
+
+# ── TestTransitionRecord ──────────────────────────────────────────────
+
+class TestTransitionRecord:
+    def test_fields(self):
+        rec = TransitionRecord(
+            from_state=FSMState.IDLE,
+            to_state=FSMState.LISTENING,
+            event=FSMEvent.USER_INPUT,
+        )
+        assert rec.from_state == FSMState.IDLE
+        assert rec.to_state == FSMState.LISTENING
+        assert rec.event == FSMEvent.USER_INPUT
+        assert isinstance(rec.timestamp, type(rec.timestamp))


### PR DESCRIPTION
## Issue #455 — Conversation FSM v0

### New files
- `src/bantz/conversation/fsm_v0.py` — Formal conversation FSM
- `tests/test_issue_455_conversation_fsm.py` — 27 tests

### States (8)
IDLE → LISTENING → PLANNING → EXECUTING → CONFIRMING → RESPONDING → ERROR → CANCELLED

### Events (13)
user_input, input_complete, plan_ready, no_tools, confirmation_required, tools_complete, user_confirmed, user_denied, response_delivered, error, user_cancel, error_handled, reset

### Features
- Strict transition table via dict (`_TRANSITIONS`)
- ANY state → ERROR on error event
- ANY state → CANCELLED on user_cancel event
- Configurable EXECUTING timeout (default 60s)
- Callback hooks: on_enter / on_exit per state
- Transition history with `TransitionRecord` dataclass
- `can_transition()` / `get_allowed_events()` for UI state exposure
- String event coercion (`"user_input"` → `FSMEvent.USER_INPUT`)
- Invalid transitions logged and ignored

### Tests (27 / 27 ✅)
- Happy path full cycle (with tools + no-tools shortcut)
- Confirmation flow (confirm + deny)
- Error recovery from any state
- Cancel flow from multiple states
- Invalid transitions (state unchanged, no history)
- Timeout auto-transition
- Callbacks (enter/exit/exception safety)
- Reset clears state and history
- String event and metadata

Closes #455