### PR TITLE
feat(agent): startup tool validator + health check + dependency graph (#459)

### DIFF
--- a/src/bantz/agent/tool_validator.py
+++ b/src/bantz/agent/tool_validator.py
@@ -1,0 +1,226 @@
+"""Startup Tool Validator (Issue #459).
+
+Validates every registered tool at boot time:
+
+- Required secrets present (via vault or env)
+- Required packages importable
+- Optional health-check callback passes
+- Dependency graph: tool A depends on tool B
+
+Disabled tools get ``enabled=False`` and a clear report is logged.
+
+See Also
+--------
+- ``src/bantz/agent/tools.py`` — ToolRegistry / ToolSpec
+- ``src/bantz/agent/circuit_breaker.py`` — circuit breaker
+- ``src/bantz/security/secret_vault.py`` — secrets (Issue #454)
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ValidatedTool",
+    "ValidationResult",
+    "ToolValidationReport",
+    "ToolValidator",
+]
+
+
+# ── Validated tool spec ───────────────────────────────────────────────
+
+@dataclass
+class ValidatedTool:
+    """Extended tool spec with validation metadata."""
+
+    name: str
+    description: str = ""
+    handler: Optional[Callable[..., Any]] = None
+    health_check: Optional[Callable[[], bool]] = None
+    required_secrets: List[str] = field(default_factory=list)
+    required_packages: List[str] = field(default_factory=list)
+    depends_on: List[str] = field(default_factory=list)  # tool names
+    enabled: bool = True
+    disable_reason: Optional[str] = None
+
+
+# ── Validation result per tool ────────────────────────────────────────
+
+class ValidationResult(Enum):
+    OK = "ok"
+    MISSING_SECRET = "missing_secret"
+    MISSING_PACKAGE = "missing_package"
+    HEALTH_CHECK_FAILED = "health_check_failed"
+    DEPENDENCY_DISABLED = "dependency_disabled"
+
+
+@dataclass
+class ToolValidationReport:
+    """Aggregate report of tool validation."""
+
+    total: int = 0
+    enabled_count: int = 0
+    disabled: List[tuple[str, str]] = field(default_factory=list)  # (name, reason)
+
+    @property
+    def summary(self) -> str:
+        lines = [f"[TOOLS] {self.enabled_count}/{self.total} tools ready"]
+        for name, reason in self.disabled:
+            lines.append(f"[TOOLS] DISABLED: {name} ({reason})")
+        return "\n".join(lines)
+
+
+# ── Validator ─────────────────────────────────────────────────────────
+
+class ToolValidator:
+    """Validates tools at startup and produces a report.
+
+    Parameters
+    ----------
+    secret_checker:
+        ``(secret_name) → bool`` — returns True if secret is available.
+        If ``None``, secret checks are skipped.
+    package_checker:
+        ``(module_name) → bool`` — returns True if package is importable.
+        If ``None``, uses :func:`importlib.util.find_spec`.
+    """
+
+    def __init__(
+        self,
+        *,
+        secret_checker: Optional[Callable[[str], bool]] = None,
+        package_checker: Optional[Callable[[str], bool]] = None,
+    ) -> None:
+        self._check_secret = secret_checker
+        self._check_package = package_checker or self._default_package_check
+        self._tools: Dict[str, ValidatedTool] = {}
+
+    # ── register ──────────────────────────────────────────────────────
+
+    def register(self, tool: ValidatedTool) -> None:
+        """Register a tool for validation."""
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Optional[ValidatedTool]:
+        """Retrieve a registered tool."""
+        return self._tools.get(name)
+
+    def list_tools(self) -> List[ValidatedTool]:
+        """Return all tools sorted by name."""
+        return [self._tools[n] for n in sorted(self._tools)]
+
+    # ── validate ──────────────────────────────────────────────────────
+
+    def validate_all(self) -> ToolValidationReport:
+        """Validate every registered tool.
+
+        Returns
+        -------
+        ToolValidationReport
+        """
+        report = ToolValidationReport(total=len(self._tools))
+
+        # Phase 1: check secrets, packages, health
+        for tool in self._tools.values():
+            self._validate_tool(tool)
+
+        # Phase 2: dependency graph (disabled deps propagate)
+        self._propagate_dependencies()
+
+        # Build report
+        for tool in self._tools.values():
+            if tool.enabled:
+                report.enabled_count += 1
+            else:
+                report.disabled.append((tool.name, tool.disable_reason or "unknown"))
+
+        logger.info(report.summary)
+        return report
+
+    def _validate_tool(self, tool: ValidatedTool) -> None:
+        """Check a single tool's secrets, packages, health."""
+        # Secrets
+        if self._check_secret is not None:
+            for secret in tool.required_secrets:
+                if not self._check_secret(secret):
+                    tool.enabled = False
+                    tool.disable_reason = f"missing secret: {secret}"
+                    return
+
+        # Packages
+        for pkg in tool.required_packages:
+            if not self._check_package(pkg):
+                tool.enabled = False
+                tool.disable_reason = f"missing package: {pkg}"
+                return
+
+        # Health check
+        if tool.health_check is not None:
+            try:
+                result = tool.health_check()
+                if not result:
+                    tool.enabled = False
+                    tool.disable_reason = "health check returned False"
+                    return
+            except Exception as exc:
+                tool.enabled = False
+                tool.disable_reason = f"health check error: {exc}"
+                return
+
+    def _propagate_dependencies(self) -> None:
+        """Disable tools whose dependencies are disabled."""
+        changed = True
+        iterations = 0
+        max_iter = len(self._tools) + 1  # prevent infinite loop
+
+        while changed and iterations < max_iter:
+            changed = False
+            iterations += 1
+            for tool in self._tools.values():
+                if not tool.enabled:
+                    continue
+                for dep_name in tool.depends_on:
+                    dep = self._tools.get(dep_name)
+                    if dep is None or not dep.enabled:
+                        tool.enabled = False
+                        tool.disable_reason = f"dependency disabled: {dep_name}"
+                        changed = True
+                        break
+
+    # ── reload ────────────────────────────────────────────────────────
+
+    def reload(self) -> ToolValidationReport:
+        """Re-validate all tools (hot-reload)."""
+        for tool in self._tools.values():
+            tool.enabled = True
+            tool.disable_reason = None
+        return self.validate_all()
+
+    # ── call disabled tool helper ─────────────────────────────────────
+
+    def check_enabled(self, name: str) -> tuple[bool, str]:
+        """Check if tool is enabled. Returns ``(enabled, message)``."""
+        tool = self._tools.get(name)
+        if tool is None:
+            return False, f"Tool '{name}' not found"
+        if not tool.enabled:
+            return False, f"Tool '{name}' is disabled: {tool.disable_reason}"
+        return True, "ok"
+
+    # ── default package checker ───────────────────────────────────────
+
+    @staticmethod
+    def _default_package_check(module_name: str) -> bool:
+        """Check if a module is importable."""
+        try:
+            spec = importlib.util.find_spec(module_name)
+            return spec is not None
+        except (ModuleNotFoundError, ValueError):
+            return False

--- a/tests/test_issue_459_tool_validator.py
+++ b/tests/test_issue_459_tool_validator.py
@@ -1,0 +1,185 @@
+"""Tests for issue #459 — Tool registry startup validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from bantz.agent.tool_validator import (
+    ToolValidationReport,
+    ToolValidator,
+    ValidatedTool,
+    ValidationResult,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+def _make_tool(name: str, **kw) -> ValidatedTool:
+    return ValidatedTool(name=name, description=f"Tool {name}", **kw)
+
+
+# ── All valid ─────────────────────────────────────────────────────────
+
+class TestAllValid:
+    def test_all_enabled(self):
+        v = ToolValidator()
+        v.register(_make_tool("a"))
+        v.register(_make_tool("b"))
+        report = v.validate_all()
+        assert report.total == 2
+        assert report.enabled_count == 2
+        assert report.disabled == []
+
+    def test_summary_format(self):
+        v = ToolValidator()
+        v.register(_make_tool("x"))
+        report = v.validate_all()
+        assert "[TOOLS] 1/1 tools ready" in report.summary
+
+
+# ── Missing secret ────────────────────────────────────────────────────
+
+class TestMissingSecret:
+    def test_missing_secret_disables(self):
+        v = ToolValidator(secret_checker=lambda s: s != "GOOGLE_API_KEY")
+        v.register(_make_tool("gmail", required_secrets=["GOOGLE_API_KEY"]))
+        report = v.validate_all()
+        assert report.enabled_count == 0
+        assert "missing secret" in report.disabled[0][1]
+
+    def test_available_secret_ok(self):
+        v = ToolValidator(secret_checker=lambda s: True)
+        v.register(_make_tool("gmail", required_secrets=["KEY"]))
+        report = v.validate_all()
+        assert report.enabled_count == 1
+
+
+# ── Missing package ───────────────────────────────────────────────────
+
+class TestMissingPackage:
+    def test_missing_package_disables(self):
+        v = ToolValidator(package_checker=lambda p: p != "serpapi")
+        v.register(_make_tool("search", required_packages=["serpapi"]))
+        report = v.validate_all()
+        assert report.enabled_count == 0
+        assert "missing package" in report.disabled[0][1]
+
+    def test_available_package_ok(self):
+        v = ToolValidator(package_checker=lambda p: True)
+        v.register(_make_tool("search", required_packages=["json"]))
+        report = v.validate_all()
+        assert report.enabled_count == 1
+
+    def test_default_package_checker_real(self):
+        """json is always available."""
+        v = ToolValidator()
+        v.register(_make_tool("t", required_packages=["json"]))
+        report = v.validate_all()
+        assert report.enabled_count == 1
+
+    def test_default_package_checker_missing(self):
+        v = ToolValidator()
+        v.register(_make_tool("t", required_packages=["__nonexistent_pkg_xyz__"]))
+        report = v.validate_all()
+        assert report.enabled_count == 0
+
+
+# ── Health check ──────────────────────────────────────────────────────
+
+class TestHealthCheck:
+    def test_health_check_pass(self):
+        v = ToolValidator()
+        v.register(_make_tool("ok", health_check=lambda: True))
+        report = v.validate_all()
+        assert report.enabled_count == 1
+
+    def test_health_check_fail(self):
+        v = ToolValidator()
+        v.register(_make_tool("bad", health_check=lambda: False))
+        report = v.validate_all()
+        assert report.enabled_count == 0
+        assert "health check returned False" in report.disabled[0][1]
+
+    def test_health_check_exception(self):
+        v = ToolValidator()
+        v.register(_make_tool("err", health_check=lambda: 1 / 0))
+        report = v.validate_all()
+        assert report.enabled_count == 0
+        assert "health check error" in report.disabled[0][1]
+
+
+# ── Dependency graph ──────────────────────────────────────────────────
+
+class TestDependencyGraph:
+    def test_disabled_dependency_propagates(self):
+        v = ToolValidator()
+        v.register(_make_tool("auth", health_check=lambda: False))
+        v.register(_make_tool("calendar", depends_on=["auth"]))
+        report = v.validate_all()
+        assert report.enabled_count == 0
+        cal = v.get("calendar")
+        assert "dependency disabled" in cal.disable_reason
+
+    def test_valid_dependency_ok(self):
+        v = ToolValidator()
+        v.register(_make_tool("auth"))
+        v.register(_make_tool("calendar", depends_on=["auth"]))
+        report = v.validate_all()
+        assert report.enabled_count == 2
+
+    def test_missing_dependency_disables(self):
+        v = ToolValidator()
+        v.register(_make_tool("calendar", depends_on=["nonexistent"]))
+        report = v.validate_all()
+        assert report.enabled_count == 0
+
+
+# ── Disabled tool call ────────────────────────────────────────────────
+
+class TestCheckEnabled:
+    def test_enabled_tool(self):
+        v = ToolValidator()
+        v.register(_make_tool("t"))
+        v.validate_all()
+        ok, msg = v.check_enabled("t")
+        assert ok and msg == "ok"
+
+    def test_disabled_tool(self):
+        v = ToolValidator()
+        v.register(_make_tool("t", health_check=lambda: False))
+        v.validate_all()
+        ok, msg = v.check_enabled("t")
+        assert not ok
+        assert "disabled" in msg
+
+    def test_unknown_tool(self):
+        v = ToolValidator()
+        ok, msg = v.check_enabled("unknown")
+        assert not ok
+        assert "not found" in msg
+
+
+# ── Reload (hot-reload) ──────────────────────────────────────────────
+
+class TestReload:
+    def test_reload_revalidates(self):
+        state = {"healthy": False}
+        v = ToolValidator()
+        v.register(_make_tool("svc", health_check=lambda: state["healthy"]))
+        r1 = v.validate_all()
+        assert r1.enabled_count == 0
+
+        state["healthy"] = True
+        r2 = v.reload()
+        assert r2.enabled_count == 1
+
+
+# ── list_tools ────────────────────────────────────────────────────────
+
+class TestListTools:
+    def test_sorted(self):
+        v = ToolValidator()
+        v.register(_make_tool("z"))
+        v.register(_make_tool("a"))
+        names = [t.name for t in v.list_tools()]
+        assert names == ["a", "z"]


### PR DESCRIPTION
Closes #459

## Changes
- `ToolValidator` with secret/package/health validation at startup
- Dependency graph: disabled deps cascade to dependents
- Hot-reload + clear disabled-tool error messages
- 19 tests, all passing