### PR TITLE
feat(core): unified metrics collector — JSONL, percentiles, time windows (#462)

### DIFF
--- a/src/bantz/core/metrics_collector.py
+++ b/src/bantz/core/metrics_collector.py
@@ -1,0 +1,363 @@
+"""Unified Metrics Collector (Issue #462).
+
+Central metrics aggregation with JSONL persistence, in-memory
+percentile computation, and time-window filtering.
+
+This module complements the existing ``bantz.llm.metrics`` (LLM-specific
+JSONL logger) and ``bantz.core.timing`` (timing constants) by providing
+a **general-purpose** metric collection / query layer that any subsystem
+can use.
+
+Key features
+------------
+- ``MetricsCollector.record()`` — fire-and-forget metric recording
+- JSONL persistence (``flush()``) with configurable path
+- In-memory ring buffer with configurable max size
+- Percentile computation (p50 / p90 / p99)
+- Time-window filtering (last N seconds)
+- ``MetricsSummary`` — aggregated snapshot per metric name
+
+See Also
+--------
+- ``src/bantz/core/timing.py`` — timing constants / thresholds
+- ``src/bantz/llm/metrics.py`` — LLM-specific JSONL logging
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import threading
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MetricRecord",
+    "MetricsSummary",
+    "MetricsConfig",
+    "MetricsCollector",
+    "percentile",
+]
+
+
+# ── Data classes ──────────────────────────────────────────────────────
+
+@dataclass
+class MetricRecord:
+    """A single metric data point."""
+
+    name: str
+    value: float
+    unit: str = ""
+    tags: Dict[str, str] = field(default_factory=dict)
+    ts: float = field(default_factory=time.monotonic)
+    wall_ts: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False)
+
+
+@dataclass
+class MetricsSummary:
+    """Aggregated statistics for one metric name."""
+
+    name: str
+    count: int
+    total: float
+    mean: float
+    min: float
+    max: float
+    p50: float
+    p90: float
+    p99: float
+    unit: str = ""
+
+    def __str__(self) -> str:
+        return (
+            f"[{self.name}] count={self.count}  mean={self.mean:.2f}  "
+            f"p50={self.p50:.2f}  p90={self.p90:.2f}  p99={self.p99:.2f}  "
+            f"min={self.min:.2f}  max={self.max:.2f}  ({self.unit})"
+        )
+
+
+# ── Config ────────────────────────────────────────────────────────────
+
+@dataclass
+class MetricsConfig:
+    """Configuration for the metrics collector."""
+
+    jsonl_path: Optional[str] = None
+    max_records: int = 10_000  # ring buffer size
+    auto_flush_every: int = 0  # 0 = manual flush only
+
+
+# ── Percentile helper ─────────────────────────────────────────────────
+
+def percentile(values: Sequence[float], p: float) -> float:
+    """Compute the *p*-th percentile (0–100) using nearest-rank.
+
+    Parameters
+    ----------
+    values:
+        Sorted (or unsorted) numeric sequence.  Must be non-empty.
+    p:
+        Percentile in [0, 100].
+
+    Returns
+    -------
+    float
+        The percentile value.
+
+    Raises
+    ------
+    ValueError
+        If *values* is empty or *p* is out of range.
+    """
+    if not values:
+        raise ValueError("Cannot compute percentile of empty sequence")
+    if not (0 <= p <= 100):
+        raise ValueError(f"p must be between 0 and 100, got {p}")
+
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+
+    if n == 1:
+        return sorted_vals[0]
+
+    # nearest-rank index
+    rank = (p / 100) * (n - 1)
+    lo = int(math.floor(rank))
+    hi = min(lo + 1, n - 1)
+    frac = rank - lo
+    return sorted_vals[lo] + frac * (sorted_vals[hi] - sorted_vals[lo])
+
+
+# ── Collector ─────────────────────────────────────────────────────────
+
+class MetricsCollector:
+    """General-purpose metric collector with JSONL persistence.
+
+    Thread-safe — safe to call ``record()`` from any thread.
+
+    Parameters
+    ----------
+    config:
+        Optional ``MetricsConfig``.  Defaults are sensible for dev use.
+
+    Examples
+    --------
+    >>> mc = MetricsCollector()
+    >>> mc.record("llm_latency", 245.0, unit="ms", tags={"backend": "vllm"})
+    >>> mc.record("llm_latency", 310.0, unit="ms", tags={"backend": "vllm"})
+    >>> s = mc.summarize("llm_latency")
+    >>> s.count
+    2
+    """
+
+    def __init__(self, config: Optional[MetricsConfig] = None) -> None:
+        self._config = config or MetricsConfig()
+        self._lock = threading.Lock()
+        self._records: List[MetricRecord] = []
+        self._flush_counter = 0
+
+    # ── recording ─────────────────────────────────────────────────────
+
+    def record(
+        self,
+        name: str,
+        value: float,
+        *,
+        unit: str = "",
+        tags: Optional[Dict[str, str]] = None,
+    ) -> MetricRecord:
+        """Record a metric data point.
+
+        Parameters
+        ----------
+        name:
+            Metric name (e.g. ``"llm_latency"``, ``"tool_exec_time"``).
+        value:
+            Numeric value.
+        unit:
+            Unit label (e.g. ``"ms"``, ``"bytes"``).
+        tags:
+            Optional key-value tags for filtering.
+
+        Returns
+        -------
+        MetricRecord
+            The recorded data point.
+        """
+        rec = MetricRecord(name=name, value=value, unit=unit, tags=tags or {})
+
+        with self._lock:
+            self._records.append(rec)
+            # Ring buffer — drop oldest when over limit
+            if len(self._records) > self._config.max_records:
+                self._records = self._records[-self._config.max_records :]
+
+            self._flush_counter += 1
+            need_flush = (
+                self._config.auto_flush_every > 0
+                and self._flush_counter >= self._config.auto_flush_every
+            )
+
+        if need_flush:
+            self.flush()
+
+        return rec
+
+    # ── query ─────────────────────────────────────────────────────────
+
+    def get_records(
+        self,
+        name: Optional[str] = None,
+        *,
+        last_seconds: Optional[float] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> List[MetricRecord]:
+        """Return matching records.
+
+        Parameters
+        ----------
+        name:
+            Filter by metric name.  ``None`` returns all names.
+        last_seconds:
+            Only records from the last N seconds (monotonic clock).
+        tags:
+            Require records whose tags are a superset of these.
+        """
+        with self._lock:
+            snapshot = list(self._records)
+
+        if name is not None:
+            snapshot = [r for r in snapshot if r.name == name]
+
+        if last_seconds is not None:
+            cutoff = time.monotonic() - last_seconds
+            snapshot = [r for r in snapshot if r.ts >= cutoff]
+
+        if tags:
+            snapshot = [
+                r for r in snapshot
+                if all(r.tags.get(k) == v for k, v in tags.items())
+            ]
+
+        return snapshot
+
+    def summarize(
+        self,
+        name: str,
+        *,
+        last_seconds: Optional[float] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> Optional[MetricsSummary]:
+        """Aggregate stats for a single metric name.
+
+        Returns ``None`` if no matching records exist.
+        """
+        records = self.get_records(name, last_seconds=last_seconds, tags=tags)
+        if not records:
+            return None
+
+        values = [r.value for r in records]
+        total = sum(values)
+        count = len(values)
+
+        return MetricsSummary(
+            name=name,
+            count=count,
+            total=total,
+            mean=total / count,
+            min=min(values),
+            max=max(values),
+            p50=percentile(values, 50),
+            p90=percentile(values, 90),
+            p99=percentile(values, 99),
+            unit=records[0].unit,
+        )
+
+    def summarize_all(
+        self,
+        *,
+        last_seconds: Optional[float] = None,
+    ) -> Dict[str, MetricsSummary]:
+        """Summarize all metric names.
+
+        Returns
+        -------
+        Dict[str, MetricsSummary]
+            Keys are metric names.
+        """
+        with self._lock:
+            names = {r.name for r in self._records}
+
+        result: Dict[str, MetricsSummary] = {}
+        for n in sorted(names):
+            s = self.summarize(n, last_seconds=last_seconds)
+            if s is not None:
+                result[n] = s
+        return result
+
+    # ── persistence ───────────────────────────────────────────────────
+
+    def flush(self) -> int:
+        """Write all un-flushed records to JSONL file.
+
+        Returns
+        -------
+        int
+            Number of records written.
+        """
+        if not self._config.jsonl_path:
+            return 0
+
+        with self._lock:
+            to_write = list(self._records)
+            self._flush_counter = 0
+
+        if not to_write:
+            return 0
+
+        path = Path(self._config.jsonl_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            with path.open("a", encoding="utf-8") as fh:
+                for rec in to_write:
+                    fh.write(rec.to_json() + "\n")
+        except OSError:
+            logger.exception("Failed to flush metrics to %s", self._config.jsonl_path)
+            return 0
+
+        logger.debug("Flushed %d metric records to %s", len(to_write), self._config.jsonl_path)
+        return len(to_write)
+
+    # ── housekeeping ──────────────────────────────────────────────────
+
+    def clear(self) -> None:
+        """Drop all in-memory records."""
+        with self._lock:
+            self._records.clear()
+            self._flush_counter = 0
+
+    @property
+    def count(self) -> int:
+        """Total records currently in memory."""
+        with self._lock:
+            return len(self._records)
+
+    def metric_names(self) -> List[str]:
+        """Return sorted list of distinct metric names."""
+        with self._lock:
+            return sorted({r.name for r in self._records})

--- a/tests/test_issue_462_unified_metrics.py
+++ b/tests/test_issue_462_unified_metrics.py
@@ -1,0 +1,229 @@
+"""Tests for issue #462 — Unified Metrics Collector."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+
+import pytest
+
+from bantz.core.metrics_collector import (
+    MetricRecord,
+    MetricsCollector,
+    MetricsConfig,
+    MetricsSummary,
+    percentile,
+)
+
+
+# ── TestPercentile ────────────────────────────────────────────────────
+
+class TestPercentile:
+    def test_single_value(self):
+        assert percentile([42.0], 50) == 42.0
+
+    def test_even_count(self):
+        assert percentile([10, 20, 30, 40], 50) == 25.0
+
+    def test_p99_large_list(self):
+        vals = list(range(1, 101))  # 1..100
+        p = percentile(vals, 99)
+        assert p >= 99.0
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            percentile([], 50)
+
+    def test_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="0 and 100"):
+            percentile([1, 2, 3], 101)
+
+
+# ── TestMetricRecord ──────────────────────────────────────────────────
+
+class TestMetricRecord:
+    def test_to_dict(self):
+        r = MetricRecord(name="latency", value=100.0, unit="ms")
+        d = r.to_dict()
+        assert d["name"] == "latency"
+        assert d["value"] == 100.0
+        assert d["unit"] == "ms"
+
+    def test_to_json_roundtrip(self):
+        r = MetricRecord(name="x", value=1.5, tags={"k": "v"})
+        parsed = json.loads(r.to_json())
+        assert parsed["name"] == "x"
+        assert parsed["tags"] == {"k": "v"}
+
+
+# ── TestRecording ─────────────────────────────────────────────────────
+
+class TestRecording:
+    def test_record_returns_metric(self):
+        mc = MetricsCollector()
+        rec = mc.record("test", 42.0)
+        assert isinstance(rec, MetricRecord)
+        assert rec.name == "test"
+        assert rec.value == 42.0
+
+    def test_count_increases(self):
+        mc = MetricsCollector()
+        assert mc.count == 0
+        mc.record("a", 1.0)
+        mc.record("b", 2.0)
+        assert mc.count == 2
+
+    def test_metric_names(self):
+        mc = MetricsCollector()
+        mc.record("beta", 1.0)
+        mc.record("alpha", 2.0)
+        mc.record("alpha", 3.0)
+        assert mc.metric_names() == ["alpha", "beta"]
+
+
+# ── TestRingBuffer ────────────────────────────────────────────────────
+
+class TestRingBuffer:
+    def test_max_records_enforced(self):
+        mc = MetricsCollector(MetricsConfig(max_records=5))
+        for i in range(10):
+            mc.record("x", float(i))
+        assert mc.count == 5
+        records = mc.get_records()
+        values = [r.value for r in records]
+        assert values == [5.0, 6.0, 7.0, 8.0, 9.0]
+
+
+# ── TestGetRecords ────────────────────────────────────────────────────
+
+class TestGetRecords:
+    def test_filter_by_name(self):
+        mc = MetricsCollector()
+        mc.record("a", 1.0)
+        mc.record("b", 2.0)
+        mc.record("a", 3.0)
+        recs = mc.get_records("a")
+        assert len(recs) == 2
+        assert all(r.name == "a" for r in recs)
+
+    def test_filter_by_tags(self):
+        mc = MetricsCollector()
+        mc.record("lat", 100.0, tags={"backend": "vllm"})
+        mc.record("lat", 200.0, tags={"backend": "gemini"})
+        recs = mc.get_records("lat", tags={"backend": "vllm"})
+        assert len(recs) == 1
+        assert recs[0].value == 100.0
+
+    def test_filter_by_time_window(self):
+        mc = MetricsCollector()
+        # Insert an old record by manually setting ts
+        old = MetricRecord(name="x", value=1.0, ts=time.monotonic() - 9999)
+        mc._records.append(old)
+        mc.record("x", 2.0)
+        recs = mc.get_records("x", last_seconds=10)
+        assert len(recs) == 1
+        assert recs[0].value == 2.0
+
+
+# ── TestSummarize ─────────────────────────────────────────────────────
+
+class TestSummarize:
+    def test_basic_summary(self):
+        mc = MetricsCollector()
+        for v in [10, 20, 30, 40, 50]:
+            mc.record("lat", float(v), unit="ms")
+        s = mc.summarize("lat")
+        assert s is not None
+        assert s.name == "lat"
+        assert s.count == 5
+        assert s.total == 150.0
+        assert s.mean == 30.0
+        assert s.min == 10.0
+        assert s.max == 50.0
+        assert s.unit == "ms"
+
+    def test_summarize_none_if_empty(self):
+        mc = MetricsCollector()
+        assert mc.summarize("nonexistent") is None
+
+    def test_summarize_all(self):
+        mc = MetricsCollector()
+        mc.record("a", 1.0)
+        mc.record("b", 2.0)
+        mc.record("a", 3.0)
+        summaries = mc.summarize_all()
+        assert set(summaries.keys()) == {"a", "b"}
+        assert summaries["a"].count == 2
+        assert summaries["b"].count == 1
+
+    def test_percentiles_in_summary(self):
+        mc = MetricsCollector()
+        for v in range(1, 101):
+            mc.record("lat", float(v))
+        s = mc.summarize("lat")
+        assert s is not None
+        assert s.p50 == pytest.approx(50.5, abs=1.0)
+        assert s.p90 >= 89.0
+        assert s.p99 >= 98.0
+
+
+# ── TestJSONLPersistence ──────────────────────────────────────────────
+
+class TestJSONLPersistence:
+    def test_flush_writes_jsonl(self, tmp_path):
+        path = str(tmp_path / "metrics.jsonl")
+        mc = MetricsCollector(MetricsConfig(jsonl_path=path))
+        mc.record("lat", 100.0, unit="ms")
+        mc.record("lat", 200.0, unit="ms")
+        written = mc.flush()
+        assert written == 2
+
+        lines = open(path).readlines()
+        assert len(lines) == 2
+        parsed = json.loads(lines[0])
+        assert parsed["name"] == "lat"
+
+    def test_flush_no_path_returns_zero(self):
+        mc = MetricsCollector()
+        assert mc.flush() == 0
+
+    def test_auto_flush(self, tmp_path):
+        path = str(tmp_path / "auto.jsonl")
+        mc = MetricsCollector(MetricsConfig(jsonl_path=path, auto_flush_every=3))
+        mc.record("a", 1.0)
+        mc.record("a", 2.0)
+        # After 2 records, no auto-flush yet
+        assert not os.path.exists(path)
+        mc.record("a", 3.0)
+        # 3rd record triggers auto flush
+        assert os.path.exists(path)
+        lines = open(path).readlines()
+        assert len(lines) == 3
+
+
+# ── TestClear ─────────────────────────────────────────────────────────
+
+class TestClear:
+    def test_clear_removes_all(self):
+        mc = MetricsCollector()
+        mc.record("a", 1.0)
+        mc.record("b", 2.0)
+        mc.clear()
+        assert mc.count == 0
+        assert mc.metric_names() == []
+
+
+# ── TestSummaryStr ────────────────────────────────────────────────────
+
+class TestSummaryStr:
+    def test_str_format(self):
+        s = MetricsSummary(
+            name="lat", count=10, total=100.0, mean=10.0,
+            min=5.0, max=15.0, p50=10.0, p90=14.0, p99=15.0, unit="ms"
+        )
+        text = str(s)
+        assert "[lat]" in text
+        assert "count=10" in text
+        assert "(ms)" in text


### PR DESCRIPTION
## Summary
General-purpose metrics collector with JSONL persistence, in-memory percentile computation, and time-window filtering.

## Changes
- `src/bantz/core/metrics_collector.py` — MetricsCollector, MetricRecord, MetricsSummary
- `tests/test_issue_462_unified_metrics.py` — 23 tests

## Key Features
- Thread-safe `record()`, `get_records()`, `summarize()`
- Ring buffer with configurable max_records
- Percentile computation (p50/p90/p99)
- Time-window and tag filtering
- JSONL persistence with flush() and auto_flush_every
- summarize_all() for full dashboard snapshot

## Tests
23 tests — all passing

Closes #462