### PR TITLE
feat(e2e): E2E test suite — golden tasks, mock LLM, regression detection (#463)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,5 @@ markers =
     integration: marks integration tests that may require external services (run with --run-integration)
     benchmark: marks performance benchmark tests (run with --run-benchmark)
     regression: marks regression tests for CI (run with --run-regression)
+    e2e: marks end-to-end tests with mock LLM (run with pytest tests/e2e/)
 asyncio_mode = auto

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,43 @@
+"""E2E test suite — conftest (fixtures only).
+
+Imports from e2e_framework.py and provides pytest fixtures.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure e2e dir is importable
+_e2e_dir = Path(__file__).resolve().parent
+if str(_e2e_dir) not in sys.path:
+    sys.path.insert(0, str(_e2e_dir))
+
+from e2e_framework import (  # noqa: E402
+    E2ETestRunner,
+    MockLLMProvider,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+MOCK_RESPONSES_PATH = str(FIXTURES_DIR / "mock_llm_responses.json")
+
+
+@pytest.fixture
+def mock_llm():
+    """MockLLMProvider loaded with golden responses."""
+    return MockLLMProvider(MOCK_RESPONSES_PATH)
+
+
+@pytest.fixture
+def e2e_runner(tmp_path):
+    """E2ETestRunner with mock LLM and tmp report path."""
+    report_path = str(tmp_path / "e2e_report.json")
+    runner = E2ETestRunner(
+        mock_responses_path=MOCK_RESPONSES_PATH,
+        report_path=report_path,
+    )
+    runner.setup()
+    yield runner
+    runner.teardown()

--- a/tests/e2e/e2e_framework.py
+++ b/tests/e2e/e2e_framework.py
@@ -1,0 +1,202 @@
+"""E2E test framework — runner, mock LLM, report generation.
+
+This module contains the E2ETestRunner framework, MockLLMProvider,
+TurnResult, TaskReport, and E2EReport classes.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+__all__ = [
+    "TurnResult",
+    "TaskReport",
+    "E2EReport",
+    "MockLLMProvider",
+    "E2ETestRunner",
+]
+
+
+# ── Data classes ──────────────────────────────────────────────────────
+
+@dataclass
+class TurnResult:
+    """Result of a single conversational turn."""
+
+    response: str = ""
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+    latency_ms: float = 0.0
+    tier: str = ""
+    error: Optional[str] = None
+
+    @property
+    def tool_names(self) -> List[str]:
+        return [tc.get("tool", "") for tc in self.tool_calls]
+
+
+@dataclass
+class TaskReport:
+    """Report for a single golden task."""
+
+    name: str
+    status: str = "pending"      # pass / fail / error
+    latency_ms: float = 0.0
+    tool_called: Optional[str] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class E2EReport:
+    """Full E2E test report."""
+
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    tests_run: int = 0
+    tests_passed: int = 0
+    tests_failed: int = 0
+    duration_ms: float = 0.0
+    tasks: List[TaskReport] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def save(self, path: str) -> None:
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps(self.to_dict(), indent=2, ensure_ascii=False))
+
+
+# ── Mock LLM provider ────────────────────────────────────────────────
+
+class MockLLMProvider:
+    """Deterministic LLM mock that returns pre-defined responses."""
+
+    def __init__(self, responses_path: Optional[str] = None) -> None:
+        self._scenarios: Dict[str, Dict[str, Any]] = {}
+        self._input_map: Dict[str, str] = {}
+
+        if responses_path:
+            self.load(responses_path)
+
+    def load(self, path: str) -> None:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        for name, scenario in data.items():
+            self._scenarios[name] = scenario
+            inp = scenario.get("input", "")
+            if inp:
+                self._input_map[inp.lower().strip()] = name
+
+    def get_scenario(self, name: str) -> Optional[Dict[str, Any]]:
+        return self._scenarios.get(name)
+
+    def generate(self, user_input: str) -> TurnResult:
+        key = user_input.lower().strip()
+        scenario_name = self._input_map.get(key)
+
+        if scenario_name is None:
+            return TurnResult(
+                response="Anlayamadım efendim.",
+                error=f"No mock scenario for: {user_input}",
+            )
+
+        scenario = self._scenarios[scenario_name]
+        return TurnResult(
+            response=scenario.get("response", ""),
+            tool_calls=scenario.get("tool_calls", []),
+            tier=scenario.get("tier", ""),
+        )
+
+
+# ── E2E Test Runner ──────────────────────────────────────────────────
+
+class E2ETestRunner:
+    """End-to-end test runner with mock LLM mode."""
+
+    def __init__(
+        self,
+        mock_responses_path: Optional[str] = None,
+        report_path: str = "artifacts/results/e2e_report.json",
+    ) -> None:
+        self._mock = MockLLMProvider(mock_responses_path)
+        self._report_path = report_path
+        self._report = E2EReport()
+        self._history: List[TurnResult] = []
+        self._started = False
+        self._start_time = 0.0
+
+    def setup(self) -> None:
+        self._started = True
+        self._start_time = time.monotonic()
+        self._history.clear()
+        self._report = E2EReport()
+
+    def teardown(self) -> None:
+        elapsed = (time.monotonic() - self._start_time) * 1000
+        self._report.duration_ms = elapsed
+        self._report.save(self._report_path)
+        self._started = False
+
+    def send(self, text: str) -> TurnResult:
+        if not self._started:
+            raise RuntimeError("E2ETestRunner not started — call setup() first")
+
+        t0 = time.monotonic()
+        result = self._mock.generate(text)
+        result.latency_ms = (time.monotonic() - t0) * 1000
+
+        self._history.append(result)
+        return result
+
+    @property
+    def last_result(self) -> Optional[TurnResult]:
+        return self._history[-1] if self._history else None
+
+    def assert_tool_called(self, tool_name: str, result: Optional[TurnResult] = None) -> None:
+        r = result or self.last_result
+        assert r is not None, "No result to check"
+        names = r.tool_names
+        assert tool_name in names, (
+            f"Expected tool '{tool_name}' to be called, got: {names}"
+        )
+
+    def assert_no_tools_called(self, result: Optional[TurnResult] = None) -> None:
+        r = result or self.last_result
+        assert r is not None, "No result to check"
+        assert len(r.tool_calls) == 0, (
+            f"Expected no tool calls, got: {r.tool_names}"
+        )
+
+    def assert_response_contains(self, substring: str, result: Optional[TurnResult] = None) -> None:
+        r = result or self.last_result
+        assert r is not None, "No result to check"
+        assert substring.lower() in r.response.lower(), (
+            f"Expected '{substring}' in response: {r.response!r}"
+        )
+
+    def assert_response_language(self, lang: str, result: Optional[TurnResult] = None) -> None:
+        r = result or self.last_result
+        assert r is not None, "No result to check"
+
+        if lang == "tr":
+            turkish_chars = set("çğıöşüÇĞİÖŞÜ")
+            has_turkish = any(c in turkish_chars for c in r.response)
+            assert has_turkish, (
+                f"Expected Turkish response, got: {r.response!r}"
+            )
+
+    def record_task(self, report: TaskReport) -> None:
+        self._report.tasks.append(report)
+        self._report.tests_run += 1
+        if report.status == "pass":
+            self._report.tests_passed += 1
+        elif report.status == "fail":
+            self._report.tests_failed += 1
+
+    def get_report(self) -> E2EReport:
+        return self._report

--- a/tests/e2e/test_golden_tasks.py
+++ b/tests/e2e/test_golden_tasks.py
@@ -1,0 +1,180 @@
+"""E2E golden-task tests (Issue #463).
+
+Three golden tasks verified against mock LLM responses:
+1. Smalltalk — Turkish greeting with "efendim"
+2. Calendar — create_event tool called
+3. System info — system.info tool called, Turkish response
+
+Plus meta-tests for the E2E framework itself.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the e2e dir is importable
+_e2e_dir = Path(__file__).resolve().parent
+if str(_e2e_dir) not in sys.path:
+    sys.path.insert(0, str(_e2e_dir))
+
+from e2e_framework import (  # noqa: E402
+    E2EReport,
+    E2ETestRunner,
+    MockLLMProvider,
+    TaskReport,
+    TurnResult,
+)
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+MOCK_RESPONSES_PATH = str(FIXTURES_DIR / "mock_llm_responses.json")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Golden Task Tests
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestGoldenSmallTalk:
+    """Golden task 1: Smalltalk — 'Nasılsın?' → Turkish + efendim."""
+
+    def test_smalltalk_response(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Nasılsın?")
+        e2e_runner.assert_response_contains("efendim", result)
+
+    def test_smalltalk_turkish(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Nasılsın?")
+        e2e_runner.assert_response_language("tr", result)
+
+    def test_smalltalk_no_tools(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Nasılsın?")
+        e2e_runner.assert_no_tools_called(result)
+
+
+class TestGoldenCalendar:
+    """Golden task 2: Calendar — create_event tool called."""
+
+    def test_calendar_tool_called(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Yarın saat 3'te toplantı kur")
+        e2e_runner.assert_tool_called("calendar.create_event", result)
+
+    def test_calendar_response_turkish(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Yarın saat 3'te toplantı kur")
+        e2e_runner.assert_response_language("tr", result)
+
+    def test_calendar_response_contains_keyword(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Yarın saat 3'te toplantı kur")
+        e2e_runner.assert_response_contains("toplantı", result)
+
+
+class TestGoldenSystemInfo:
+    """Golden task 3: System info — system.info tool called."""
+
+    def test_sysinfo_tool_called(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Sistem durumu nedir?")
+        e2e_runner.assert_tool_called("system.info", result)
+
+    def test_sysinfo_response_turkish(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Sistem durumu nedir?")
+        e2e_runner.assert_response_language("tr", result)
+
+    def test_sysinfo_response_contains_status(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Sistem durumu nedir?")
+        e2e_runner.assert_response_contains("sistem", result)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Meta-tests: E2E Framework
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestMockLLMProvider:
+    """Tests for MockLLMProvider itself."""
+
+    def test_load_scenarios(self):
+        provider = MockLLMProvider(MOCK_RESPONSES_PATH)
+        assert provider.get_scenario("smalltalk") is not None
+        assert provider.get_scenario("calendar_create") is not None
+        assert provider.get_scenario("system_info") is not None
+
+    def test_generate_known_input(self):
+        provider = MockLLMProvider(MOCK_RESPONSES_PATH)
+        result = provider.generate("Nasılsın?")
+        assert "efendim" in result.response.lower()
+        assert result.error is None
+
+    def test_generate_unknown_input(self):
+        provider = MockLLMProvider(MOCK_RESPONSES_PATH)
+        result = provider.generate("Bu bilinmeyen bir komut")
+        assert result.error is not None
+        assert "No mock scenario" in result.error
+
+
+class TestTurnResult:
+    def test_tool_names_property(self):
+        tr = TurnResult(
+            tool_calls=[{"tool": "a"}, {"tool": "b"}]
+        )
+        assert tr.tool_names == ["a", "b"]
+
+    def test_empty_tool_calls(self):
+        tr = TurnResult(response="hello")
+        assert tr.tool_names == []
+
+
+class TestE2ERunnerAssertions:
+    def test_assert_tool_called_passes(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Yarın saat 3'te toplantı kur")
+        e2e_runner.assert_tool_called("calendar.create_event", result)
+
+    def test_assert_tool_called_fails(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Nasılsın?")
+        with pytest.raises(AssertionError, match="Expected tool"):
+            e2e_runner.assert_tool_called("calendar.create_event", result)
+
+    def test_assert_response_contains_fails(self, e2e_runner: E2ETestRunner):
+        result = e2e_runner.send("Nasılsın?")
+        with pytest.raises(AssertionError, match="Expected"):
+            e2e_runner.assert_response_contains("impossible_string_xyz", result)
+
+    def test_runner_not_started_raises(self):
+        runner = E2ETestRunner()
+        with pytest.raises(RuntimeError, match="not started"):
+            runner.send("hello")
+
+
+class TestE2EReport:
+    def test_report_saved(self, e2e_runner: E2ETestRunner, tmp_path):
+        e2e_runner.send("Nasılsın?")
+        e2e_runner.record_task(TaskReport(
+            name="smalltalk", status="pass", latency_ms=10.0,
+        ))
+        report = e2e_runner.get_report()
+        assert report.tests_run == 1
+        assert report.tests_passed == 1
+
+    def test_report_json_structure(self, tmp_path):
+        report = E2EReport(
+            tests_run=3, tests_passed=2, tests_failed=1,
+            duration_ms=5000.0,
+            tasks=[
+                TaskReport(name="smalltalk", status="pass", latency_ms=1000),
+                TaskReport(name="calendar", status="pass", latency_ms=2000, tool_called="calendar.create_event"),
+                TaskReport(name="sysinfo", status="fail", latency_ms=2000, error="timeout"),
+            ],
+        )
+        path = str(tmp_path / "report.json")
+        report.save(path)
+        loaded = json.loads(Path(path).read_text())
+        assert loaded["tests_run"] == 3
+        assert loaded["tests_passed"] == 2
+        assert loaded["tests_failed"] == 1
+        assert len(loaded["tasks"]) == 3
+        assert loaded["tasks"][0]["name"] == "smalltalk"
+
+    def test_report_to_dict(self):
+        report = E2EReport(tests_run=1, tests_passed=1)
+        d = report.to_dict()
+        assert isinstance(d, dict)
+        assert d["tests_run"] == 1

--- a/tests/fixtures/mock_llm_responses.json
+++ b/tests/fixtures/mock_llm_responses.json
@@ -1,0 +1,46 @@
+{
+  "smalltalk": {
+    "input": "Nasılsın?",
+    "response": "İyiyim efendim, teşekkür ederim! Size nasıl yardımcı olabilirim?",
+    "tool_calls": [],
+    "tier": "fast"
+  },
+  "calendar_create": {
+    "input": "Yarın saat 3'te toplantı kur",
+    "response": "Toplantınızı yarın saat 15:00'e oluşturdum efendim.",
+    "tool_calls": [
+      {
+        "tool": "calendar.create_event",
+        "args": {
+          "summary": "Toplantı",
+          "start_time": "tomorrow 15:00",
+          "duration_minutes": 60
+        },
+        "result": {
+          "event_id": "mock-evt-001",
+          "status": "confirmed",
+          "summary": "Toplantı",
+          "start": "2025-01-02T15:00:00+03:00"
+        }
+      }
+    ],
+    "tier": "quality"
+  },
+  "system_info": {
+    "input": "Sistem durumu nedir?",
+    "response": "Sistem durumu: CPU %12, RAM %45, disk %60. Her şey normal efendim.",
+    "tool_calls": [
+      {
+        "tool": "system.info",
+        "args": {},
+        "result": {
+          "cpu_percent": 12,
+          "memory_percent": 45,
+          "disk_percent": 60,
+          "status": "healthy"
+        }
+      }
+    ],
+    "tier": "fast"
+  }
+}


### PR DESCRIPTION
## Summary
End-to-end test suite with 3 golden tasks and mock LLM mode for CI.

## Changes
- `tests/e2e/e2e_framework.py` — E2ETestRunner, MockLLMProvider, TurnResult, TaskReport, E2EReport
- `tests/e2e/conftest.py` — pytest fixtures (mock_llm, e2e_runner)
- `tests/e2e/test_golden_tasks.py` — 21 tests (9 golden + 12 meta)
- `tests/fixtures/mock_llm_responses.json` — 3 golden scenarios
- `pytest.ini` — added e2e marker

## Golden Tasks
1. **Smalltalk**: 'Nasılsın?' → Turkish response + 'efendim' + no tools
2. **Calendar**: 'Yarın saat 3'te toplantı kur' → calendar.create_event tool called
3. **System info**: 'Sistem durumu nedir?' → system.info tool called

## Framework Features
- MockLLMProvider: deterministic JSON-based responses
- E2ETestRunner: setup/teardown, send(), assertion helpers
- E2EReport: JSON report to artifacts/results/e2e_report.json
- Language detection (Turkish character heuristic)

## Tests
21 tests — all passing

Closes #463