### PR TITLE
fix(brain): Gemini finalizer wiring invariant + finalizer_model trace (#517)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -250,6 +250,7 @@ class OrchestratorOutput:
     
     # Debug/trace
     raw_output: dict[str, Any] = field(default_factory=dict)  # Full LLM response for debugging
+    finalizer_model: str = ""  # Issue #517: which model generated assistant_reply
 
 
 # Legacy alias for backward compatibility

--- a/tests/test_issue_517_finalizer_invariant.py
+++ b/tests/test_issue_517_finalizer_invariant.py
@@ -1,0 +1,191 @@
+"""Tests for Issue #517: Gemini Finalizer Wiring Invariant.
+
+Ensures:
+1. OrchestratorOutput has finalizer_model field
+2. FinalizationPipeline stamps finalizer_model on every output
+3. OrchestratorLoop warns when finalizer_llm is None
+4. Quality finalizer path stamps the correct model name
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import replace
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.brain.llm_router import OrchestratorOutput
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_output(**overrides) -> OrchestratorOutput:
+    """Create a minimal OrchestratorOutput for testing."""
+    defaults = dict(
+        route="calendar",
+        calendar_intent="query",
+        slots={"window_hint": "today"},
+        confidence=0.9,
+        tool_plan=["calendar.list_events"],
+        assistant_reply="",
+    )
+    defaults.update(overrides)
+    return OrchestratorOutput(**defaults)
+
+
+class _FakeLLM:
+    """Minimal LLM mock with model_name and complete_text."""
+
+    def __init__(self, model_name: str = "gemini-1.5-flash", reply: str = "Test reply"):
+        self.model_name = model_name
+        self._reply = reply
+
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 256) -> str:
+        return self._reply
+
+
+# ---------------------------------------------------------------------------
+# Test: OrchestratorOutput has finalizer_model field
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorOutputFinalizerModel:
+
+    def test_default_finalizer_model_empty(self):
+        """finalizer_model should default to empty string."""
+        output = _make_output()
+        assert output.finalizer_model == ""
+
+    def test_finalizer_model_can_be_set(self):
+        """finalizer_model should be settable via replace."""
+        output = _make_output()
+        updated = replace(output, finalizer_model="gemini-1.5-flash")
+        assert updated.finalizer_model == "gemini-1.5-flash"
+
+    def test_finalizer_model_in_dataclass_fields(self):
+        """finalizer_model should be a proper dataclass field."""
+        from dataclasses import fields
+        field_names = {f.name for f in fields(OrchestratorOutput)}
+        assert "finalizer_model" in field_names
+
+
+# ---------------------------------------------------------------------------
+# Test: FinalizationPipeline stamps finalizer_model
+# ---------------------------------------------------------------------------
+
+class TestPipelineFinalizerModel:
+
+    def test_ask_user_stamps_model(self):
+        """ask_user early exit should stamp finalizer_model."""
+        from bantz.brain.finalization_pipeline import FinalizationPipeline, FinalizationContext
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        output = _make_output(ask_user=True, question="Saat kaçta?", assistant_reply="")
+        ctx = FinalizationContext(
+            user_input="toplantı ekle",
+            orchestrator_output=output,
+            tool_results=[],
+            state=OrchestratorState(),
+            planner_decision={},
+        )
+
+        pipeline = FinalizationPipeline()
+        result = pipeline.run(ctx)
+        assert result.finalizer_model == "none(ask_user)"
+        assert result.assistant_reply == "Saat kaçta?"
+
+    def test_quality_path_stamps_gemini_model(self):
+        """Quality finalizer path should stamp the model name."""
+        from bantz.brain.finalization_pipeline import (
+            FinalizationPipeline,
+            FinalizationContext,
+            QualityFinalizer,
+            NoNewFactsGuard,
+        )
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        gemini = _FakeLLM(model_name="gemini-1.5-flash", reply="İşte takvim sonuçları efendim")
+        guard = NoNewFactsGuard(finalizer_llm=gemini)
+        quality = QualityFinalizer(finalizer_llm=gemini, guard=guard)
+
+        output = _make_output()
+        ctx = FinalizationContext(
+            user_input="bugün planım ne",
+            orchestrator_output=output,
+            tool_results=[{"tool": "calendar.list_events", "success": True, "result": "Toplantı"}],
+            state=OrchestratorState(),
+            planner_decision={},
+            use_quality=True,
+        )
+
+        pipeline = FinalizationPipeline(quality=quality)
+        result = pipeline.run(ctx)
+        assert result.finalizer_model == "gemini-1.5-flash"
+
+    def test_no_tools_stamps_model(self):
+        """No tool results should stamp finalizer_model."""
+        from bantz.brain.finalization_pipeline import FinalizationPipeline, FinalizationContext
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        output = _make_output(tool_plan=[], assistant_reply="İyiyim efendim")
+        ctx = FinalizationContext(
+            user_input="nasılsın",
+            orchestrator_output=output,
+            tool_results=[],
+            state=OrchestratorState(),
+            planner_decision={},
+        )
+
+        pipeline = FinalizationPipeline()
+        result = pipeline.run(ctx)
+        assert result.finalizer_model == "none(no_tools)"
+
+
+# ---------------------------------------------------------------------------
+# Test: OrchestratorLoop warns when finalizer_llm is None
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorLoopFinalizerWarning:
+
+    def test_warns_when_no_finalizer(self):
+        """OrchestratorLoop should warn when created without finalizer_llm."""
+        from bantz.brain.orchestrator_loop import OrchestratorLoop
+
+        mock_orchestrator = MagicMock()
+        mock_tools = MagicMock()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            loop = OrchestratorLoop(
+                orchestrator=mock_orchestrator,
+                tools=mock_tools,
+                finalizer_llm=None,
+            )
+            # Should have at least the finalizer warning (and deprecation warning)
+            finalizer_warnings = [
+                x for x in w if "finalizer_llm" in str(x.message)
+            ]
+            assert len(finalizer_warnings) >= 1
+
+    def test_no_warning_with_finalizer(self):
+        """OrchestratorLoop should NOT warn when finalizer_llm is provided."""
+        from bantz.brain.orchestrator_loop import OrchestratorLoop
+
+        mock_orchestrator = MagicMock()
+        mock_tools = MagicMock()
+        mock_finalizer = _FakeLLM()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            loop = OrchestratorLoop(
+                orchestrator=mock_orchestrator,
+                tools=mock_tools,
+                finalizer_llm=mock_finalizer,
+            )
+            finalizer_warnings = [
+                x for x in w if "finalizer_llm" in str(x.message)
+            ]
+            assert len(finalizer_warnings) == 0


### PR DESCRIPTION
## Problem
`finalizer_llm` could be `None` without any warning. No visibility into which model generated the `assistant_reply`. If `GEMINI_API_KEY` was missing, the system silently fell back to 3B for finalization — making responses feel 'stupid' with no debug trace.

## Solution

### 1. `OrchestratorOutput.finalizer_model` field
Every finalization path now stamps which model/strategy generated the reply:
- `gemini-1.5-flash` — quality path (cloud)
- `fast` / `fast(fallback)` — fast path (local 3B)
- `none(ask_user)` / `none(error)` / `none(no_tools)` — early exits

### 2. Boot-time logging (`terminal_jarvis.py`)
- Gemini configured: `Finalizer: gemini-1.5-flash ✓ (Gemini)`
- Gemini missing: `⚠ GEMINI_API_KEY not set — finalization will use 3B`

### 3. `OrchestratorLoop.__init__` warning
`UserWarning` when `finalizer_llm=None` with guidance to pass a GeminiClient.

### 4. `FinalizationPipeline.run()` stamps model on ALL paths
Quality, fast, fallback, ask_user, error — every exit stamps `finalizer_model`.

### 5. Trace captures `finalizer_strategy`
`_update_state_phase` now records `finalizer_strategy` in trace metadata.

## Tests
8 new tests in `test_issue_517_finalizer_invariant.py`:
- `finalizer_model` field exists, defaults empty, settable
- Pipeline stamps correct model on ask_user/quality/no_tools paths
- OrchestratorLoop warns when no finalizer, silent with finalizer

Closes #517