### PR TITLE
feat(brain): single runtime entry via create_runtime() factory (#516)

### DIFF
--- a/src/bantz/brain/runtime_factory.py
+++ b/src/bantz/brain/runtime_factory.py
@@ -1,0 +1,215 @@
+"""Runtime Factory — canonical brain wiring for all entry points (Issue #516).
+
+This is the SINGLE source of truth for how a BANTZ brain is created.
+Both ``terminal_jarvis.py`` and ``server.py`` MUST use this factory
+instead of directly instantiating ``OrchestratorLoop`` or ``Router``.
+
+Usage::
+
+    from bantz.brain.runtime_factory import create_runtime, BantzRuntime
+
+    runtime = create_runtime()  # reads from env vars
+    output, state = runtime.process_turn("bugün plan var mı", state)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["BantzRuntime", "create_runtime"]
+
+
+def _env_get_any(*keys: str) -> Optional[str]:
+    """Return the first non-empty env var from the given keys."""
+    for k in keys:
+        v = os.getenv(k, "").strip()
+        if v:
+            return v
+    return None
+
+
+@dataclass
+class BantzRuntime:
+    """Holds all runtime components created by :func:`create_runtime`.
+
+    This is the canonical brain wiring.  All entry points (terminal, server,
+    tests) should use this instead of manually assembling the pipeline.
+
+    Attributes:
+        router_client: vLLM-backed LLM client for routing.
+        gemini_client: Gemini client for finalization (may be None).
+        tools: Registered tool registry.
+        event_bus: Shared event bus.
+        loop: The OrchestratorLoop instance.
+        router_model: Model name used for routing.
+        gemini_model: Model name used for finalization.
+        finalizer_is_gemini: True if Gemini is the finalizer.
+    """
+
+    router_client: Any
+    gemini_client: Any  # Optional[GeminiClient]
+    tools: Any  # ToolRegistry
+    event_bus: Any  # EventBus
+    loop: Any  # OrchestratorLoop
+    router_model: str = ""
+    gemini_model: str = ""
+    finalizer_is_gemini: bool = False
+
+    def process_turn(
+        self, user_input: str, state: Any
+    ) -> tuple[Any, Any]:
+        """Process a single turn through the brain.
+
+        Returns:
+            (OrchestratorOutput, OrchestratorState) tuple.
+        """
+        return self.loop.process_turn(user_input, state)
+
+    def run_full_cycle(
+        self, user_input: str, *, confirmation_token: str = "", state: Any = None
+    ) -> dict:
+        """Run a full orchestration cycle (for confirmation flows)."""
+        return self.loop.run_full_cycle(
+            user_input, confirmation_token=confirmation_token, state=state
+        )
+
+
+def create_runtime(
+    *,
+    vllm_url: Optional[str] = None,
+    router_model: Optional[str] = None,
+    gemini_key: Optional[str] = None,
+    gemini_model: Optional[str] = None,
+    event_bus: Any = None,
+    tools: Any = None,
+    debug: bool = False,
+) -> BantzRuntime:
+    """Create a fully wired BANTZ runtime.
+
+    This is the **single canonical factory** for creating the brain.
+    All parameters default to environment variables.
+
+    Parameters
+    ----------
+    vllm_url:
+        vLLM server URL (default: ``BANTZ_VLLM_URL`` or ``http://localhost:8001``).
+    router_model:
+        Router model name (default: ``BANTZ_VLLM_MODEL``).
+    gemini_key:
+        Gemini API key (default: ``GEMINI_API_KEY`` / ``GOOGLE_API_KEY``).
+    gemini_model:
+        Gemini model name (default: ``BANTZ_GEMINI_MODEL``).
+    event_bus:
+        Shared EventBus (created if not provided).
+    tools:
+        ToolRegistry (created with default tools if not provided).
+    debug:
+        Enable debug logging.
+
+    Returns
+    -------
+    BantzRuntime
+        Ready-to-use runtime with all components wired.
+    """
+    from bantz.core.events import EventBus
+    from bantz.brain.llm_router import JarvisLLMOrchestrator
+    from bantz.brain.orchestrator_loop import OrchestratorConfig, OrchestratorLoop
+    from bantz.llm.vllm_openai_client import VLLMOpenAIClient
+
+    # ── Resolve parameters from env ─────────────────────────────────
+    _vllm_url = vllm_url or os.getenv("BANTZ_VLLM_URL", "http://localhost:8001")
+    _router_model = router_model or os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct")
+    _gemini_model = gemini_model or os.getenv("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
+    _gemini_key = gemini_key or _env_get_any(
+        "GEMINI_API_KEY", "GOOGLE_API_KEY", "BANTZ_GEMINI_API_KEY"
+    )
+
+    # ── Router LLM client ───────────────────────────────────────────
+    router_client = VLLMOpenAIClient(
+        base_url=_vllm_url, model=_router_model, timeout_seconds=30.0
+    )
+
+    # ── Gemini finalizer client ─────────────────────────────────────
+    gemini_client = None
+    finalizer_is_gemini = False
+    if _gemini_key:
+        try:
+            from bantz.llm.gemini_client import GeminiClient
+
+            gemini_client = GeminiClient(
+                api_key=_gemini_key, model=_gemini_model, timeout_seconds=30.0
+            )
+            finalizer_is_gemini = True
+            logger.info("Finalizer: %s ✓ (Gemini)", _gemini_model)
+        except Exception as e:
+            logger.warning("Gemini client init failed: %s — using 3B fallback", e)
+    else:
+        logger.warning(
+            "⚠ GEMINI_API_KEY not set — finalization will use 3B router (%s). "
+            "Quality may be degraded.",
+            _router_model,
+        )
+
+    # ── Event bus ───────────────────────────────────────────────────
+    _event_bus = event_bus
+    if _event_bus is None:
+        _event_bus = EventBus(history_size=200)
+
+    # ── Tool registry ───────────────────────────────────────────────
+    _tools = tools
+    if _tools is None:
+        try:
+            # Import the canonical tool builder from terminal_jarvis
+            # (will be moved to a shared module in future PRs)
+            import importlib
+            mod = importlib.import_module("terminal_jarvis")
+            if hasattr(mod, "_build_registry"):
+                _tools = mod._build_registry()
+        except Exception:
+            pass
+
+    if _tools is None:
+        from bantz.agent.tools import ToolRegistry
+        _tools = ToolRegistry()
+        logger.warning("No tools registered — using empty ToolRegistry")
+
+    # ── Orchestrator ────────────────────────────────────────────────
+    orchestrator = JarvisLLMOrchestrator(llm_client=router_client)
+
+    # ── Finalizer wiring (#517 invariant) ───────────────────────────
+    effective_finalizer = gemini_client or router_client
+
+    # ── OrchestratorLoop ────────────────────────────────────────────
+    loop = OrchestratorLoop(
+        orchestrator=orchestrator,
+        tools=_tools,
+        event_bus=_event_bus,
+        config=OrchestratorConfig(debug=debug),
+        finalizer_llm=effective_finalizer,
+    )
+
+    # ── Boot log ────────────────────────────────────────────────────
+    finalizer_name = _gemini_model if finalizer_is_gemini else _router_model
+    finalizer_type = "Gemini" if finalizer_is_gemini else "3B (local)"
+    logger.info(
+        "🧠 BANTZ Runtime initialized: router=%s, finalizer=%s (%s)",
+        _router_model,
+        finalizer_name,
+        finalizer_type,
+    )
+
+    return BantzRuntime(
+        router_client=router_client,
+        gemini_client=gemini_client,
+        tools=_tools,
+        event_bus=_event_bus,
+        loop=loop,
+        router_model=_router_model,
+        gemini_model=_gemini_model,
+        finalizer_is_gemini=finalizer_is_gemini,
+    )

--- a/tests/test_issue_516_single_runtime.py
+++ b/tests/test_issue_516_single_runtime.py
@@ -1,0 +1,147 @@
+"""Tests for Issue #516: Single Runtime Entry — runtime_factory.
+
+Ensures:
+1. create_runtime() creates all components correctly
+2. BantzRuntime has the expected interface
+3. Both terminal_jarvis and server can use the same factory
+4. Boot log shows which brain is active
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestRuntimeFactoryImport:
+    """Verify the factory module is importable and has expected exports."""
+
+    def test_import_create_runtime(self):
+        from bantz.brain.runtime_factory import create_runtime
+        assert callable(create_runtime)
+
+    def test_import_bantz_runtime(self):
+        from bantz.brain.runtime_factory import BantzRuntime
+        assert BantzRuntime is not None
+
+    def test_bantz_runtime_has_process_turn(self):
+        from bantz.brain.runtime_factory import BantzRuntime
+        assert hasattr(BantzRuntime, "process_turn")
+
+    def test_bantz_runtime_has_run_full_cycle(self):
+        from bantz.brain.runtime_factory import BantzRuntime
+        assert hasattr(BantzRuntime, "run_full_cycle")
+
+
+class TestCreateRuntime:
+    """Test create_runtime() with mocked LLM clients."""
+
+    @patch.dict(os.environ, {
+        "BANTZ_VLLM_URL": "http://localhost:8001",
+        "BANTZ_VLLM_MODEL": "test-model",
+    }, clear=False)
+    @patch("bantz.llm.vllm_openai_client.VLLMOpenAIClient")
+    @patch("bantz.brain.orchestrator_loop.OrchestratorLoop")
+    @patch("bantz.brain.llm_router.JarvisLLMOrchestrator")
+    def test_creates_runtime_without_gemini(self, mock_orch, mock_loop, mock_vllm):
+        """Runtime should be created even without Gemini key."""
+        from bantz.brain.runtime_factory import create_runtime
+
+        # Remove Gemini keys to test 3B fallback
+        env_override = {
+            "GEMINI_API_KEY": "",
+            "GOOGLE_API_KEY": "",
+            "BANTZ_GEMINI_API_KEY": "",
+        }
+        with patch.dict(os.environ, env_override, clear=False):
+            runtime = create_runtime()
+
+        assert runtime is not None
+        assert runtime.gemini_client is None
+        assert runtime.finalizer_is_gemini is False
+        assert runtime.router_model == "test-model"
+
+    @patch.dict(os.environ, {
+        "BANTZ_VLLM_URL": "http://localhost:8001",
+        "BANTZ_VLLM_MODEL": "test-model",
+        "GEMINI_API_KEY": "test-key",
+        "BANTZ_GEMINI_MODEL": "gemini-1.5-flash",
+    }, clear=False)
+    @patch("bantz.llm.vllm_openai_client.VLLMOpenAIClient")
+    @patch("bantz.brain.orchestrator_loop.OrchestratorLoop")
+    @patch("bantz.brain.llm_router.JarvisLLMOrchestrator")
+    @patch("bantz.llm.gemini_client.GeminiClient")
+    def test_creates_runtime_with_gemini(self, mock_gemini_cls, mock_orch, mock_loop, mock_vllm):
+        """Runtime should wire Gemini when key is available."""
+        from bantz.brain.runtime_factory import create_runtime
+
+        mock_gemini_cls.return_value = MagicMock()
+
+        runtime = create_runtime(gemini_key="test-key")
+
+        assert runtime is not None
+        assert runtime.gemini_client is not None
+        assert runtime.finalizer_is_gemini is True
+        assert runtime.gemini_model == "gemini-1.5-flash"
+
+    @patch("bantz.llm.vllm_openai_client.VLLMOpenAIClient")
+    @patch("bantz.brain.orchestrator_loop.OrchestratorLoop")
+    @patch("bantz.brain.llm_router.JarvisLLMOrchestrator")
+    def test_explicit_params_override_env(self, mock_orch, mock_loop, mock_vllm):
+        """Explicit parameters should override env vars."""
+        from bantz.brain.runtime_factory import create_runtime
+
+        runtime = create_runtime(
+            vllm_url="http://custom:9999",
+            router_model="custom-model",
+        )
+
+        mock_vllm.assert_called_once_with(
+            base_url="http://custom:9999",
+            model="custom-model",
+            timeout_seconds=30.0,
+        )
+        assert runtime.router_model == "custom-model"
+
+
+class TestTerminalJarvisDoesNotDirectlyImportLoop:
+    """Verify terminal_jarvis.py no longer directly imports OrchestratorLoop."""
+
+    def test_no_direct_orchestrator_loop_import(self):
+        """terminal_jarvis should NOT have 'from bantz.brain.orchestrator_loop import OrchestratorLoop'."""
+        import inspect
+        from pathlib import Path
+
+        terminal_path = Path(__file__).parent.parent / "scripts" / "terminal_jarvis.py"
+        if not terminal_path.exists():
+            pytest.skip("terminal_jarvis.py not found")
+
+        source = terminal_path.read_text()
+        # Should NOT directly import OrchestratorLoop or OrchestratorConfig
+        assert "from bantz.brain.orchestrator_loop import OrchestratorLoop" not in source
+        assert "from bantz.brain.orchestrator_loop import" not in source
+
+    def test_no_direct_llm_router_import_for_instantiation(self):
+        """terminal_jarvis should NOT directly import JarvisLLMOrchestrator."""
+        from pathlib import Path
+
+        terminal_path = Path(__file__).parent.parent / "scripts" / "terminal_jarvis.py"
+        if not terminal_path.exists():
+            pytest.skip("terminal_jarvis.py not found")
+
+        source = terminal_path.read_text()
+        assert "from bantz.brain.llm_router import JarvisLLMOrchestrator" not in source
+
+    def test_uses_runtime_factory(self):
+        """terminal_jarvis should use create_runtime from runtime_factory."""
+        from pathlib import Path
+
+        terminal_path = Path(__file__).parent.parent / "scripts" / "terminal_jarvis.py"
+        if not terminal_path.exists():
+            pytest.skip("terminal_jarvis.py not found")
+
+        source = terminal_path.read_text()
+        assert "from bantz.brain.runtime_factory import create_runtime" in source


### PR DESCRIPTION
## Issue #516 — Single Runtime Entry

### Problem
`terminal_jarvis.py` and `server.py` independently wire the brain pipeline (VLLMOpenAIClient → JarvisLLMOrchestrator → OrchestratorLoop).
This means every config change needs to be replicated in both places — a recipe for drift and bugs.

### Solution
**New canonical factory: `src/bantz/brain/runtime_factory.py`**

- `create_runtime()` — single source of truth for all brain wiring
- `BantzRuntime` dataclass with `process_turn()` and `run_full_cycle()` methods
- Reads env vars: `BANTZ_VLLM_URL`, `BANTZ_VLLM_MODEL`, `GEMINI_API_KEY`, etc.
- Boot-time log shows router model, finalizer model & type
- All explicit parameters override env vars

### Changes

| File | Change |
|------|--------|
| `src/bantz/brain/runtime_factory.py` | **NEW** — canonical brain factory |
| `scripts/terminal_jarvis.py` | Migrated to `create_runtime()`, removed 6 unused imports |
| `src/bantz/server.py` | Optional brain handler behind `BANTZ_USE_BRAIN=1` env flag |
| `tests/test_issue_516_single_runtime.py` | **NEW** — 10 tests |

### Testing
- 10/10 new tests pass
- 82/84 existing tests pass (2 pre-existing timing failures in TestIssue431ToolTimeout)
- No regressions

### Migration Path
- Terminal: Automatic — `terminal_jarvis.py` already uses the factory
- Server: Set `BANTZ_USE_BRAIN=1` to enable brain-first routing (legacy Router preserved as fallback)

Closes #516