### PR TITLE
feat(metrics): latency budgets + CI gates + turn metrics JSONL (#302)

### DIFF
--- a/scripts/latency_report.py
+++ b/scripts/latency_report.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Latency report generator — reads turn_metrics.jsonl (Issue #302).
+
+Computes per-phase p50 / p95 / p99 percentiles and outputs a Markdown
+report or JSON summary.
+
+Usage::
+
+    python scripts/latency_report.py                           # last 24h, markdown
+    python scripts/latency_report.py --hours 1                 # last 1h
+    python scripts/latency_report.py --format json             # JSON output
+    python scripts/latency_report.py --file path/to/metrics.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+# ── Defaults ──────────────────────────────────────────────────────
+
+DEFAULT_METRICS_FILE = "artifacts/logs/turn_metrics.jsonl"
+
+PHASES = ["asr_ms", "router_ms", "tool_ms", "finalize_ms", "tts_ms", "total_ms"]
+PHASE_LABELS = {
+    "asr_ms": "ASR",
+    "router_ms": "Router",
+    "tool_ms": "Tool",
+    "finalize_ms": "Finalize",
+    "tts_ms": "TTS",
+    "total_ms": "Total (E2E)",
+}
+
+BUDGETS = {
+    "asr_ms": 500,
+    "router_ms": 500,
+    "tool_ms": 2000,
+    "finalize_ms": 2000,
+    "tts_ms": 500,
+    "total_ms": 5000,
+}
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+def _percentile(values: Sequence[float], p: float) -> float:
+    """Interpolated percentile (p in 0–100)."""
+    if not values:
+        return 0.0
+    sv = sorted(values)
+    n = len(sv)
+    if n == 1:
+        return sv[0]
+    rank = (p / 100.0) * (n - 1)
+    lo = int(math.floor(rank))
+    hi = min(lo + 1, n - 1)
+    frac = rank - lo
+    return sv[lo] + frac * (sv[hi] - sv[lo])
+
+
+def _read_jsonl(path: str | Path) -> List[Dict[str, Any]]:
+    """Read JSONL, skip malformed lines."""
+    records: List[Dict[str, Any]] = []
+    p = Path(path)
+    if not p.exists():
+        print(f"Hata: {p} bulunamadı.", file=sys.stderr)
+        return records
+    with p.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def _filter_by_time(
+    records: List[Dict[str, Any]], hours: Optional[float]
+) -> List[Dict[str, Any]]:
+    """Filter records by timestamp within last *hours*."""
+    if hours is None or hours <= 0:
+        return records
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    cutoff_str = cutoff.isoformat()
+
+    filtered = []
+    for r in records:
+        ts = r.get("timestamp", "")
+        if ts >= cutoff_str:
+            filtered.append(r)
+    return filtered
+
+
+# ── Report generation ─────────────────────────────────────────────
+
+def _compute_stats(records: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Compute per-phase statistics."""
+    stats: Dict[str, Dict[str, Any]] = {}
+
+    for phase in PHASES:
+        values = [
+            float(r[phase])
+            for r in records
+            if phase in r and r[phase] is not None
+        ]
+        if not values:
+            stats[phase] = {"count": 0, "p50": 0, "p95": 0, "p99": 0, "min": 0, "max": 0, "mean": 0}
+            continue
+
+        stats[phase] = {
+            "count": len(values),
+            "p50": round(_percentile(values, 50), 1),
+            "p95": round(_percentile(values, 95), 1),
+            "p99": round(_percentile(values, 99), 1),
+            "min": round(min(values), 1),
+            "max": round(max(values), 1),
+            "mean": round(sum(values) / len(values), 1),
+        }
+
+    return stats
+
+
+def _budget_violations(records: List[Dict[str, Any]]) -> Dict[str, int]:
+    """Count records with budget violations."""
+    violations: Dict[str, int] = {}
+    for r in records:
+        bv = r.get("budget_violations", [])
+        for v in bv:
+            phase = v.split(":")[0] if ":" in v else v
+            violations[phase] = violations.get(phase, 0) + 1
+    return violations
+
+
+def _route_distribution(records: List[Dict[str, Any]]) -> Dict[str, int]:
+    """Count records per route."""
+    routes: Dict[str, int] = {}
+    for r in records:
+        route = r.get("route", "unknown")
+        routes[route] = routes.get(route, 0) + 1
+    return dict(sorted(routes.items(), key=lambda x: -x[1]))
+
+
+def generate_markdown_report(
+    records: List[Dict[str, Any]],
+    hours: Optional[float] = None,
+) -> str:
+    """Generate a Markdown latency report."""
+    stats = _compute_stats(records)
+    violations = _budget_violations(records)
+    routes = _route_distribution(records)
+
+    lines: List[str] = []
+    lines.append("# 📊 Bantz Latency Report")
+    lines.append("")
+
+    period = f"son {hours:.0f} saat" if hours else "tüm kayıtlar"
+    lines.append(f"**Dönem:** {period}  ")
+    lines.append(f"**Toplam turn:** {len(records)}  ")
+    ts_list = [r.get("timestamp", "") for r in records if r.get("timestamp")]
+    if ts_list:
+        lines.append(f"**İlk:** {min(ts_list)[:19]}  ")
+        lines.append(f"**Son:** {max(ts_list)[:19]}  ")
+    lines.append("")
+
+    # ── Per-phase table ──
+    lines.append("## Phase Latency (ms)")
+    lines.append("")
+    lines.append("| Phase | Count | p50 | p95 | p99 | Min | Max | Budget |")
+    lines.append("|-------|------:|----:|----:|----:|----:|----:|-------:|")
+
+    for phase in PHASES:
+        s = stats.get(phase, {})
+        label = PHASE_LABELS.get(phase, phase)
+        budget = BUDGETS.get(phase, "-")
+        count = s.get("count", 0)
+        if count == 0:
+            lines.append(f"| {label} | 0 | - | - | - | - | - | {budget} |")
+            continue
+
+        p95 = s["p95"]
+        p95_str = f"**{p95}** ⚠" if isinstance(budget, int) and p95 > budget else str(p95)
+        lines.append(
+            f"| {label} | {count} | {s['p50']} | {p95_str} | {s['p99']} | {s['min']} | {s['max']} | {budget} |"
+        )
+
+    lines.append("")
+
+    # ── Budget violations ──
+    if violations:
+        lines.append("## Budget Violations")
+        lines.append("")
+        for phase, cnt in sorted(violations.items(), key=lambda x: -x[1]):
+            pct = (cnt / len(records)) * 100 if records else 0
+            lines.append(f"- **{phase}**: {cnt} violations ({pct:.1f}%)")
+        lines.append("")
+
+    # ── Route distribution ──
+    if routes:
+        lines.append("## Route Distribution")
+        lines.append("")
+        lines.append("| Route | Count | % |")
+        lines.append("|-------|------:|--:|")
+        for route, cnt in routes.items():
+            pct = (cnt / len(records)) * 100 if records else 0
+            lines.append(f"| {route} | {cnt} | {pct:.1f}% |")
+        lines.append("")
+
+    # ── Gate check ──
+    lines.append("## CI Gate Status")
+    lines.append("")
+    all_pass = True
+    for phase in ["router_ms", "tool_ms", "finalize_ms", "tts_ms", "total_ms"]:
+        s = stats.get(phase, {})
+        budget = BUDGETS.get(phase, 9999)
+        p95 = s.get("p95", 0)
+        count = s.get("count", 0)
+        if count == 0:
+            lines.append(f"- ⏭ {PHASE_LABELS.get(phase, phase)}: veri yok")
+            continue
+        if p95 <= budget:
+            lines.append(f"- ✅ {PHASE_LABELS.get(phase, phase)} p95={p95}ms ≤ {budget}ms")
+        else:
+            lines.append(f"- ❌ {PHASE_LABELS.get(phase, phase)} p95={p95}ms > {budget}ms")
+            all_pass = False
+
+    lines.append("")
+    if all_pass:
+        lines.append("**Sonuç: ✅ Tüm gate'ler geçti.**")
+    else:
+        lines.append("**Sonuç: ❌ Bazı gate'ler aşıldı.**")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_json_report(
+    records: List[Dict[str, Any]],
+    hours: Optional[float] = None,
+) -> str:
+    """Generate a JSON latency report."""
+    stats = _compute_stats(records)
+    violations = _budget_violations(records)
+    routes = _route_distribution(records)
+
+    report = {
+        "period_hours": hours,
+        "total_turns": len(records),
+        "phases": {},
+        "budget_violations": violations,
+        "route_distribution": routes,
+    }
+
+    for phase in PHASES:
+        s = stats.get(phase, {})
+        report["phases"][phase] = {
+            "label": PHASE_LABELS.get(phase, phase),
+            "budget_ms": BUDGETS.get(phase),
+            **s,
+        }
+
+    return json.dumps(report, indent=2, ensure_ascii=False)
+
+
+# ── CLI ───────────────────────────────────────────────────────────
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Bantz latency report generator (Issue #302)"
+    )
+    parser.add_argument(
+        "--file", "-f",
+        default=DEFAULT_METRICS_FILE,
+        help=f"Turn metrics JSONL file (default: {DEFAULT_METRICS_FILE})",
+    )
+    parser.add_argument(
+        "--hours",
+        type=float,
+        default=None,
+        help="Filter to last N hours (default: all records)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format (default: markdown)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default=None,
+        help="Output file (default: stdout)",
+    )
+
+    args = parser.parse_args(argv)
+
+    records = _read_jsonl(args.file)
+    if not records:
+        print(f"Kayıt bulunamadı: {args.file}", file=sys.stderr)
+        return 1
+
+    records = _filter_by_time(records, args.hours)
+    if not records:
+        print("Belirtilen zaman aralığında kayıt bulunamadı.", file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        output = generate_json_report(records, args.hours)
+    else:
+        output = generate_markdown_report(records, args.hours)
+
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(output, encoding="utf-8")
+        print(f"Rapor yazıldı: {args.output}", file=sys.stderr)
+    else:
+        print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bantz/metrics/__init__.py
+++ b/src/bantz/metrics/__init__.py
@@ -1,0 +1,30 @@
+"""bantz.metrics — latency budgets, turn metrics, and CI gates (Issue #302).
+
+Exports
+-------
+- :class:`TurnMetrics` / :class:`TurnMetricsWriter` — per-turn JSONL logging
+- :class:`LatencyGate` / :class:`GateResult` / :func:`check_gates` — CI gates
+- :func:`check_gates_from_records` — gate check from pre-loaded records
+- :func:`read_turn_metrics` — JSONL reader utility
+"""
+
+from bantz.metrics.turn_metrics import TurnMetrics, TurnMetricsWriter
+from bantz.metrics.gates import (
+    LatencyGate,
+    GateResult,
+    check_gates,
+    check_gates_from_records,
+    read_turn_metrics,
+    DEFAULT_GATES,
+)
+
+__all__ = [
+    "TurnMetrics",
+    "TurnMetricsWriter",
+    "LatencyGate",
+    "GateResult",
+    "check_gates",
+    "check_gates_from_records",
+    "read_turn_metrics",
+    "DEFAULT_GATES",
+]

--- a/src/bantz/metrics/gates.py
+++ b/src/bantz/metrics/gates.py
@@ -1,0 +1,311 @@
+"""CI latency gates for pipeline quality enforcement (Issue #302).
+
+Each :class:`LatencyGate` defines a *phase* + *percentile* + *max_ms*
+threshold.  :func:`check_gates` reads a JSONL file written by
+:class:`~bantz.metrics.turn_metrics.TurnMetricsWriter` and verifies
+that every gate passes.
+
+Typical CI usage::
+
+    from bantz.metrics.gates import check_gates, DEFAULT_GATES
+    results = check_gates("artifacts/logs/turn_metrics.jsonl")
+    if not all(r.passed for r in results):
+        sys.exit(1)
+
+Command-line usage::
+
+    python -m bantz.metrics.gates artifacts/logs/turn_metrics.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "LatencyGate",
+    "GateResult",
+    "check_gates",
+    "DEFAULT_GATES",
+]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Data classes
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LatencyGate:
+    """A single latency threshold.
+
+    Attributes
+    ----------
+    phase:
+        JSONL field name (e.g. ``"router_ms"``, ``"total_ms"``).
+    percentile:
+        Percentile level to check (e.g. 95 → p95).
+    max_ms:
+        Maximum acceptable value at *percentile*.
+    label:
+        Human-readable label for CI output.
+    """
+
+    phase: str
+    percentile: float
+    max_ms: float
+    label: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.label:
+            # Construct label: "router p95 < 500ms"
+            object.__setattr__(
+                self,
+                "label",
+                f"{self.phase.replace('_ms', '')} p{int(self.percentile)} < {self.max_ms:.0f}ms",
+            )
+
+
+@dataclass
+class GateResult:
+    """Result of evaluating one :class:`LatencyGate`."""
+
+    gate: LatencyGate
+    actual_value: float
+    sample_count: int
+    passed: bool
+    detail: str = ""
+
+    def summary_line(self) -> str:
+        """Human-readable one-liner for CI output."""
+        icon = "✅" if self.passed else "❌"
+        pname = self.gate.phase.replace("_ms", "")
+        return (
+            f"{icon} {pname} p{int(self.gate.percentile)}: "
+            f"{self.actual_value:.0f}ms "
+            f"(budget: {self.gate.max_ms:.0f}ms, n={self.sample_count})"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Default gates per Issue #302 spec
+# ─────────────────────────────────────────────────────────────────
+
+DEFAULT_GATES: List[LatencyGate] = [
+    LatencyGate(phase="router_ms", percentile=95, max_ms=500.0),
+    LatencyGate(phase="tool_ms", percentile=95, max_ms=2000.0),
+    LatencyGate(phase="finalize_ms", percentile=95, max_ms=2000.0),
+    LatencyGate(phase="tts_ms", percentile=95, max_ms=500.0),
+    LatencyGate(phase="total_ms", percentile=95, max_ms=5000.0),
+]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Percentile helper (standalone — no dependency on metrics_collector)
+# ─────────────────────────────────────────────────────────────────
+
+
+def _percentile(values: Sequence[float], p: float) -> float:
+    """Interpolated percentile (p in 0–100)."""
+    if not values:
+        return 0.0
+    sv = sorted(values)
+    n = len(sv)
+    if n == 1:
+        return sv[0]
+    rank = (p / 100.0) * (n - 1)
+    lo = int(math.floor(rank))
+    hi = min(lo + 1, n - 1)
+    frac = rank - lo
+    return sv[lo] + frac * (sv[hi] - sv[lo])
+
+
+# ─────────────────────────────────────────────────────────────────
+# JSONL reader
+# ─────────────────────────────────────────────────────────────────
+
+
+def read_turn_metrics(path: str | Path) -> List[Dict[str, Any]]:
+    """Read JSONL file and return list of dicts.
+
+    Skips malformed lines with a warning.
+    """
+    records: List[Dict[str, Any]] = []
+    p = Path(path)
+    if not p.exists():
+        logger.warning("Turn metrics file not found: %s", p)
+        return records
+
+    with p.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                logger.warning("Skipping malformed line %d in %s: %s", lineno, p, exc)
+
+    return records
+
+
+# ─────────────────────────────────────────────────────────────────
+# Gate checker
+# ─────────────────────────────────────────────────────────────────
+
+
+def check_gates(
+    path: str | Path,
+    *,
+    gates: Optional[List[LatencyGate]] = None,
+    min_samples: int = 1,
+) -> List[GateResult]:
+    """Check all latency gates against a JSONL file.
+
+    Parameters
+    ----------
+    path:
+        Path to ``turn_metrics.jsonl``.
+    gates:
+        Gate definitions.  Defaults to :data:`DEFAULT_GATES`.
+    min_samples:
+        Minimum number of samples required.  If fewer, the gate
+        is marked as passed with a warning detail.
+
+    Returns
+    -------
+    list[GateResult]
+        One result per gate.
+    """
+    gates = gates or DEFAULT_GATES
+    records = read_turn_metrics(path)
+    results: List[GateResult] = []
+
+    for gate in gates:
+        # Extract values for this phase
+        values = [
+            float(r[gate.phase])
+            for r in records
+            if gate.phase in r and r[gate.phase] is not None
+        ]
+
+        if len(values) < min_samples:
+            results.append(
+                GateResult(
+                    gate=gate,
+                    actual_value=0.0,
+                    sample_count=len(values),
+                    passed=True,
+                    detail=f"Yetersiz örnek: {len(values)} < {min_samples} (atlandı)",
+                )
+            )
+            continue
+
+        actual = _percentile(values, gate.percentile)
+        passed = actual <= gate.max_ms
+
+        results.append(
+            GateResult(
+                gate=gate,
+                actual_value=actual,
+                sample_count=len(values),
+                passed=passed,
+                detail="" if passed else f"p{int(gate.percentile)} aşıldı: {actual:.0f}ms > {gate.max_ms:.0f}ms",
+            )
+        )
+
+    return results
+
+
+def check_gates_from_records(
+    records: List[Dict[str, Any]],
+    *,
+    gates: Optional[List[LatencyGate]] = None,
+    min_samples: int = 1,
+) -> List[GateResult]:
+    """Same as :func:`check_gates` but takes pre-loaded records."""
+    gates = gates or DEFAULT_GATES
+    results: List[GateResult] = []
+
+    for gate in gates:
+        values = [
+            float(r[gate.phase])
+            for r in records
+            if gate.phase in r and r[gate.phase] is not None
+        ]
+
+        if len(values) < min_samples:
+            results.append(
+                GateResult(
+                    gate=gate,
+                    actual_value=0.0,
+                    sample_count=len(values),
+                    passed=True,
+                    detail=f"Yetersiz örnek: {len(values)} < {min_samples} (atlandı)",
+                )
+            )
+            continue
+
+        actual = _percentile(values, gate.percentile)
+        passed = actual <= gate.max_ms
+
+        results.append(
+            GateResult(
+                gate=gate,
+                actual_value=actual,
+                sample_count=len(values),
+                passed=passed,
+                detail="" if passed else f"p{int(gate.percentile)} aşıldı: {actual:.0f}ms > {gate.max_ms:.0f}ms",
+            )
+        )
+
+    return results
+
+
+# ─────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point for CI gate checking.
+
+    Usage::
+
+        python -m bantz.metrics.gates artifacts/logs/turn_metrics.jsonl
+    """
+    args = argv if argv is not None else sys.argv[1:]
+
+    if not args:
+        print("Kullanım: python -m bantz.metrics.gates <turn_metrics.jsonl>", file=sys.stderr)
+        return 2
+
+    path = args[0]
+    min_samples = int(args[1]) if len(args) > 1 else 5
+
+    results = check_gates(path, min_samples=min_samples)
+
+    print("\n── Bantz Latency Gates ──────────────────────────────")
+    all_passed = True
+    for r in results:
+        print(r.summary_line())
+        if not r.passed:
+            all_passed = False
+
+    if all_passed:
+        print("\n✅ Tüm latency gate'leri geçti.\n")
+        return 0
+    else:
+        print("\n❌ Bazı gate'ler aşıldı — CI başarısız.\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bantz/metrics/turn_metrics.py
+++ b/src/bantz/metrics/turn_metrics.py
@@ -1,0 +1,202 @@
+"""Per-turn metrics collection and JSONL persistence (Issue #302).
+
+Each voice/text turn produces a :class:`TurnMetrics` record that is:
+1. Logged at DEBUG level for live observation.
+2. Written to JSONL for offline analysis / CI gating.
+3. Fed into the :class:`~bantz.core.latency_budget.LatencyTracker` for
+   rolling p50/p95 dashboards.
+
+The :class:`TurnMetricsWriter` handles thread-safe JSONL persistence
+with configurable file path.
+
+Usage::
+
+    writer = TurnMetricsWriter("artifacts/logs/turn_metrics.jsonl")
+    m = TurnMetrics(turn_id="t1", user_input="saat kaç", route="time", ...)
+    writer.write(m)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["TurnMetrics", "TurnMetricsWriter"]
+
+# Default output path
+DEFAULT_TURN_METRICS_FILE = "artifacts/logs/turn_metrics.jsonl"
+
+
+@dataclass
+class TurnMetrics:
+    """Metrics snapshot for a single voice/text turn.
+
+    Follows the schema defined in Issue #302.
+    All latency values are in **milliseconds**.
+    """
+
+    # Identity
+    turn_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+    # Input/Output
+    user_input: str = ""
+    route: str = ""
+    intent: str = ""
+    tool: Optional[str] = None
+    finalizer_tier: str = ""  # "gemini" | "3b" | "default"
+    success: bool = True
+
+    # Per-phase latency (ms)
+    asr_ms: Optional[float] = None
+    router_ms: Optional[float] = None
+    tool_ms: Optional[float] = None
+    finalize_ms: Optional[float] = None
+    tts_ms: Optional[float] = None
+    total_ms: float = 0.0
+
+    # Budget violations
+    budget_violations: List[str] = field(default_factory=list)
+
+    # Extra context
+    error: Optional[str] = None
+    tags: Dict[str, str] = field(default_factory=dict)
+
+    def check_budgets(
+        self,
+        *,
+        asr_budget: float = 500.0,
+        router_budget: float = 500.0,
+        tool_budget: float = 2000.0,
+        finalize_budget: float = 2000.0,
+        tts_budget: float = 500.0,
+        total_budget: float = 5000.0,
+    ) -> List[str]:
+        """Check each phase against its budget and return violation strings.
+
+        Each violation is formatted as ``"phase:actual>budget"``
+        (e.g. ``"router:620>500"``).
+        """
+        violations: List[str] = []
+        checks = [
+            ("asr", self.asr_ms, asr_budget),
+            ("router", self.router_ms, router_budget),
+            ("tool", self.tool_ms, tool_budget),
+            ("finalize", self.finalize_ms, finalize_budget),
+            ("tts", self.tts_ms, tts_budget),
+            ("total", self.total_ms, total_budget),
+        ]
+        for name, actual, budget in checks:
+            if actual is not None and actual > budget:
+                violations.append(f"{name}:{actual:.0f}>{budget:.0f}")
+
+        self.budget_violations = violations
+        return violations
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dict suitable for JSON serialization."""
+        d = asdict(self)
+        # Remove None latencies for cleaner output
+        for key in ("asr_ms", "router_ms", "tool_ms", "finalize_ms", "tts_ms"):
+            if d[key] is None:
+                del d[key]
+        if d.get("error") is None:
+            del d["error"]
+        if d.get("tool") is None:
+            del d["tool"]
+        if not d.get("tags"):
+            del d["tags"]
+        return d
+
+    def to_json(self) -> str:
+        """JSON string for JSONL output."""
+        return json.dumps(self.to_dict(), ensure_ascii=False)
+
+    def log_debug(self) -> None:
+        """Emit a structured debug log line."""
+        violations = self.budget_violations
+        v_str = f" ⚠ violations={violations}" if violations else ""
+        logger.debug(
+            "TurnMetrics[%s] route=%s total=%.0fms router=%.0fms tool=%s finalize=%s%s",
+            self.turn_id,
+            self.route,
+            self.total_ms,
+            self.router_ms or 0,
+            f"{self.tool_ms:.0f}ms" if self.tool_ms is not None else "-",
+            f"{self.finalize_ms:.0f}ms" if self.finalize_ms is not None else "-",
+            v_str,
+        )
+
+
+class TurnMetricsWriter:
+    """Thread-safe JSONL writer for turn metrics.
+
+    Parameters
+    ----------
+    path:
+        JSONL output file path.  Created automatically if missing.
+        Defaults to ``BANTZ_TURN_METRICS_FILE`` env var or
+        ``artifacts/logs/turn_metrics.jsonl``.
+    enabled:
+        If ``False``, :meth:`write` is a no-op.  Controlled by
+        ``BANTZ_TURN_METRICS`` env var (``1`` / ``true`` to enable).
+    """
+
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> None:
+        self._path = path or os.getenv(
+            "BANTZ_TURN_METRICS_FILE", DEFAULT_TURN_METRICS_FILE
+        )
+        if enabled is not None:
+            self._enabled = enabled
+        else:
+            raw = os.getenv("BANTZ_TURN_METRICS", "1").strip().lower()
+            self._enabled = raw in ("1", "true", "yes")
+        self._lock = threading.Lock()
+        self._count = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def count(self) -> int:
+        """Number of records written in this session."""
+        return self._count
+
+    def write(self, metrics: TurnMetrics) -> bool:
+        """Write a single turn metric record to JSONL.
+
+        Returns ``True`` if written successfully, ``False`` otherwise.
+        """
+        if not self._enabled:
+            return False
+
+        line = metrics.to_json() + "\n"
+        path = Path(self._path)
+
+        with self._lock:
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with path.open("a", encoding="utf-8") as fh:
+                    fh.write(line)
+                self._count += 1
+                return True
+            except OSError as exc:
+                logger.warning("Failed to write turn metrics: %s", exc)
+                return False

--- a/tests/test_issue_302_latency_metrics.py
+++ b/tests/test_issue_302_latency_metrics.py
@@ -1,0 +1,690 @@
+"""Tests for Issue #302 — Latency Budgets + Metrics Gates.
+
+Covers:
+  - TurnMetrics dataclass (schema, budget checking, serialization)
+  - TurnMetricsWriter (JSONL persistence, thread safety, enable/disable)
+  - LatencyGate + GateResult (CI gate definitions, evaluation)
+  - check_gates / check_gates_from_records (JSONL gate checking)
+  - read_turn_metrics (JSONL reader)
+  - latency_report.py (report generation — markdown + JSON)
+  - VoicePipeline integration (_emit_turn_metrics helper)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────
+# TurnMetrics dataclass
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestTurnMetrics:
+    """TurnMetrics schema and budget-check logic."""
+
+    def test_default_fields(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics()
+        assert len(m.turn_id) == 12
+        assert m.timestamp  # ISO string
+        assert m.total_ms == 0.0
+        assert m.success is True
+        assert m.budget_violations == []
+
+    def test_custom_fields(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(
+            turn_id="t42",
+            user_input="saat kaç",
+            route="time",
+            router_ms=120.0,
+            total_ms=450.0,
+        )
+        assert m.turn_id == "t42"
+        assert m.route == "time"
+        assert m.router_ms == 120.0
+
+    def test_check_budgets_no_violation(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(router_ms=100.0, total_ms=1000.0)
+        violations = m.check_budgets(router_budget=500.0, total_budget=5000.0)
+        assert violations == []
+        assert m.budget_violations == []
+
+    def test_check_budgets_with_violations(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(
+            router_ms=620.0,
+            finalize_ms=2500.0,
+            total_ms=4200.0,
+        )
+        violations = m.check_budgets(
+            router_budget=500.0,
+            finalize_budget=2000.0,
+            total_budget=5000.0,
+        )
+        assert len(violations) == 2
+        assert any("router:620>500" in v for v in violations)
+        assert any("finalize:2500>2000" in v for v in violations)
+
+    def test_check_budgets_skips_none_phases(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(router_ms=100.0, total_ms=500.0)
+        # asr_ms, tool_ms, finalize_ms, tts_ms are all None
+        violations = m.check_budgets()
+        assert violations == []
+
+    def test_to_dict_omits_none_latencies(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(router_ms=100.0, total_ms=500.0)
+        d = m.to_dict()
+        assert "router_ms" in d
+        assert "asr_ms" not in d
+        assert "tool_ms" not in d
+        assert "error" not in d
+
+    def test_to_json_is_valid(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(
+            turn_id="t1",
+            user_input="merhaba",
+            route="greeting",
+            router_ms=50.0,
+            total_ms=200.0,
+        )
+        j = m.to_json()
+        parsed = json.loads(j)
+        assert parsed["turn_id"] == "t1"
+        assert parsed["route"] == "greeting"
+        assert parsed["router_ms"] == 50.0
+
+    def test_to_json_handles_turkish_chars(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(user_input="bugün hava nasıl?", route="hava")
+        j = m.to_json()
+        parsed = json.loads(j)
+        assert "bugün" in parsed["user_input"]
+
+    def test_log_debug_does_not_raise(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(router_ms=100.0, total_ms=500.0)
+        m.log_debug()  # Should not raise
+
+    def test_log_debug_with_violations(self):
+        from bantz.metrics.turn_metrics import TurnMetrics
+
+        m = TurnMetrics(router_ms=800.0, total_ms=6000.0)
+        m.check_budgets(router_budget=500.0, total_budget=5000.0)
+        m.log_debug()  # Should not raise
+
+
+# ─────────────────────────────────────────────────────────────────
+# TurnMetricsWriter
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestTurnMetricsWriter:
+    """JSONL writer with enable/disable and thread safety."""
+
+    def test_write_creates_file(self, tmp_path):
+        from bantz.metrics.turn_metrics import TurnMetrics, TurnMetricsWriter
+
+        path = tmp_path / "metrics.jsonl"
+        writer = TurnMetricsWriter(path=str(path), enabled=True)
+        m = TurnMetrics(turn_id="t1", router_ms=100.0, total_ms=500.0)
+
+        assert writer.write(m) is True
+        assert path.exists()
+        lines = path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["turn_id"] == "t1"
+
+    def test_write_appends(self, tmp_path):
+        from bantz.metrics.turn_metrics import TurnMetrics, TurnMetricsWriter
+
+        path = tmp_path / "metrics.jsonl"
+        writer = TurnMetricsWriter(path=str(path), enabled=True)
+
+        writer.write(TurnMetrics(turn_id="t1", total_ms=100.0))
+        writer.write(TurnMetrics(turn_id="t2", total_ms=200.0))
+
+        lines = path.read_text().strip().split("\n")
+        assert len(lines) == 2
+        assert writer.count == 2
+
+    def test_write_disabled_returns_false(self, tmp_path):
+        from bantz.metrics.turn_metrics import TurnMetrics, TurnMetricsWriter
+
+        path = tmp_path / "metrics.jsonl"
+        writer = TurnMetricsWriter(path=str(path), enabled=False)
+
+        result = writer.write(TurnMetrics(turn_id="t1", total_ms=100.0))
+        assert result is False
+        assert not path.exists()
+        assert writer.count == 0
+
+    def test_env_var_enable(self, tmp_path):
+        from bantz.metrics.turn_metrics import TurnMetricsWriter
+
+        with mock.patch.dict(os.environ, {"BANTZ_TURN_METRICS": "1"}):
+            writer = TurnMetricsWriter(path=str(tmp_path / "m.jsonl"))
+            assert writer.enabled is True
+
+    def test_env_var_disable(self, tmp_path):
+        from bantz.metrics.turn_metrics import TurnMetricsWriter
+
+        with mock.patch.dict(os.environ, {"BANTZ_TURN_METRICS": "0"}):
+            writer = TurnMetricsWriter(path=str(tmp_path / "m.jsonl"))
+            assert writer.enabled is False
+
+    def test_creates_parent_dirs(self, tmp_path):
+        from bantz.metrics.turn_metrics import TurnMetrics, TurnMetricsWriter
+
+        path = tmp_path / "deep" / "nested" / "metrics.jsonl"
+        writer = TurnMetricsWriter(path=str(path), enabled=True)
+        writer.write(TurnMetrics(turn_id="t1", total_ms=100.0))
+        assert path.exists()
+
+    def test_thread_safety(self, tmp_path):
+        """Multiple threads can write concurrently without data corruption."""
+        import threading
+
+        from bantz.metrics.turn_metrics import TurnMetrics, TurnMetricsWriter
+
+        path = tmp_path / "mt.jsonl"
+        writer = TurnMetricsWriter(path=str(path), enabled=True)
+
+        def write_batch(start: int):
+            for i in range(10):
+                writer.write(TurnMetrics(turn_id=f"t{start + i}", total_ms=float(i * 10)))
+
+        threads = [threading.Thread(target=write_batch, args=(i * 10,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        lines = path.read_text().strip().split("\n")
+        assert len(lines) == 50
+        assert writer.count == 50
+
+
+# ─────────────────────────────────────────────────────────────────
+# LatencyGate / GateResult
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLatencyGate:
+    """CI gate definitions."""
+
+    def test_default_label_auto_generated(self):
+        from bantz.metrics.gates import LatencyGate
+
+        g = LatencyGate(phase="router_ms", percentile=95, max_ms=500.0)
+        assert "router" in g.label
+        assert "p95" in g.label
+        assert "500" in g.label
+
+    def test_custom_label(self):
+        from bantz.metrics.gates import LatencyGate
+
+        g = LatencyGate(phase="total_ms", percentile=99, max_ms=5000.0, label="custom")
+        assert g.label == "custom"
+
+    def test_default_gates_exist(self):
+        from bantz.metrics.gates import DEFAULT_GATES
+
+        assert len(DEFAULT_GATES) >= 4
+        phases = [g.phase for g in DEFAULT_GATES]
+        assert "router_ms" in phases
+        assert "total_ms" in phases
+
+
+class TestGateResult:
+    """Gate evaluation result."""
+
+    def test_summary_line_pass(self):
+        from bantz.metrics.gates import GateResult, LatencyGate
+
+        g = LatencyGate(phase="router_ms", percentile=95, max_ms=500.0)
+        r = GateResult(gate=g, actual_value=350.0, sample_count=100, passed=True)
+        line = r.summary_line()
+        assert "✅" in line
+        assert "350" in line
+
+    def test_summary_line_fail(self):
+        from bantz.metrics.gates import GateResult, LatencyGate
+
+        g = LatencyGate(phase="router_ms", percentile=95, max_ms=500.0)
+        r = GateResult(gate=g, actual_value=620.0, sample_count=100, passed=False)
+        line = r.summary_line()
+        assert "❌" in line
+        assert "620" in line
+
+
+# ─────────────────────────────────────────────────────────────────
+# read_turn_metrics
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestReadTurnMetrics:
+    """JSONL reader."""
+
+    def test_read_valid_jsonl(self, tmp_path):
+        from bantz.metrics.gates import read_turn_metrics
+
+        path = tmp_path / "m.jsonl"
+        lines = [
+            json.dumps({"turn_id": "t1", "router_ms": 100, "total_ms": 500}),
+            json.dumps({"turn_id": "t2", "router_ms": 200, "total_ms": 600}),
+        ]
+        path.write_text("\n".join(lines) + "\n")
+
+        records = read_turn_metrics(path)
+        assert len(records) == 2
+        assert records[0]["turn_id"] == "t1"
+
+    def test_skip_malformed_lines(self, tmp_path):
+        from bantz.metrics.gates import read_turn_metrics
+
+        path = tmp_path / "m.jsonl"
+        path.write_text('{"ok": true}\nNOT JSON\n{"ok": true}\n')
+
+        records = read_turn_metrics(path)
+        assert len(records) == 2
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from bantz.metrics.gates import read_turn_metrics
+
+        records = read_turn_metrics(tmp_path / "nonexistent.jsonl")
+        assert records == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        from bantz.metrics.gates import read_turn_metrics
+
+        path = tmp_path / "empty.jsonl"
+        path.write_text("")
+
+        records = read_turn_metrics(path)
+        assert records == []
+
+
+# ─────────────────────────────────────────────────────────────────
+# check_gates
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestCheckGates:
+    """End-to-end gate checking from JSONL."""
+
+    def _write_jsonl(self, path: Path, records: list[dict]) -> None:
+        with path.open("w") as fh:
+            for r in records:
+                fh.write(json.dumps(r) + "\n")
+
+    def test_all_gates_pass(self, tmp_path):
+        from bantz.metrics.gates import LatencyGate, check_gates
+
+        path = tmp_path / "m.jsonl"
+        records = [
+            {"router_ms": 100, "tool_ms": 500, "finalize_ms": 800, "tts_ms": 200, "total_ms": 1600}
+            for _ in range(20)
+        ]
+        self._write_jsonl(path, records)
+
+        gates = [
+            LatencyGate(phase="router_ms", percentile=95, max_ms=500.0),
+            LatencyGate(phase="total_ms", percentile=95, max_ms=5000.0),
+        ]
+        results = check_gates(path, gates=gates)
+        assert all(r.passed for r in results)
+
+    def test_gate_fails(self, tmp_path):
+        from bantz.metrics.gates import LatencyGate, check_gates
+
+        path = tmp_path / "m.jsonl"
+        # 10 fast + 10 slow → p95 will be slow
+        records = [{"router_ms": 100, "total_ms": 500} for _ in range(10)]
+        records += [{"router_ms": 800, "total_ms": 3000} for _ in range(10)]
+        self._write_jsonl(path, records)
+
+        gates = [LatencyGate(phase="router_ms", percentile=95, max_ms=500.0)]
+        results = check_gates(path, gates=gates)
+        assert len(results) == 1
+        assert not results[0].passed
+        assert results[0].actual_value > 500
+
+    def test_insufficient_samples_skips(self, tmp_path):
+        from bantz.metrics.gates import LatencyGate, check_gates
+
+        path = tmp_path / "m.jsonl"
+        records = [{"router_ms": 1000, "total_ms": 5000}]  # only 1
+        self._write_jsonl(path, records)
+
+        gates = [LatencyGate(phase="router_ms", percentile=95, max_ms=500.0)]
+        results = check_gates(path, gates=gates, min_samples=5)
+        assert results[0].passed  # skipped due to insufficient samples
+        assert "Yetersiz" in results[0].detail
+
+    def test_missing_phase_in_records(self, tmp_path):
+        from bantz.metrics.gates import LatencyGate, check_gates
+
+        path = tmp_path / "m.jsonl"
+        records = [{"router_ms": 100, "total_ms": 500} for _ in range(10)]
+        self._write_jsonl(path, records)
+
+        # Gate for tool_ms which is missing from records
+        gates = [LatencyGate(phase="tool_ms", percentile=95, max_ms=2000.0)]
+        results = check_gates(path, gates=gates, min_samples=5)
+        assert results[0].passed  # skipped — no tool_ms data
+
+    def test_check_gates_from_records(self):
+        from bantz.metrics.gates import LatencyGate, check_gates_from_records
+
+        records = [
+            {"router_ms": 100, "total_ms": 500},
+            {"router_ms": 200, "total_ms": 600},
+            {"router_ms": 150, "total_ms": 550},
+        ]
+        gates = [LatencyGate(phase="router_ms", percentile=95, max_ms=500.0)]
+        results = check_gates_from_records(records, gates=gates, min_samples=1)
+        assert results[0].passed
+        assert results[0].sample_count == 3
+
+
+# ─────────────────────────────────────────────────────────────────
+# Latency report
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLatencyReport:
+    """scripts/latency_report.py report generation."""
+
+    def _write_jsonl(self, path: Path, records: list[dict]) -> None:
+        with path.open("w") as fh:
+            for r in records:
+                fh.write(json.dumps(r) + "\n")
+
+    def test_markdown_report(self, tmp_path):
+        import importlib
+        import sys
+
+        # Import the script
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "latency_report.py"
+        spec = importlib.util.spec_from_file_location("latency_report", script_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        records = [
+            {
+                "turn_id": f"t{i}",
+                "timestamp": "2025-01-01T00:00:00+00:00",
+                "route": "time",
+                "router_ms": 100 + i * 5,
+                "total_ms": 1000 + i * 20,
+            }
+            for i in range(20)
+        ]
+
+        report = mod.generate_markdown_report(records)
+        assert "Bantz Latency Report" in report
+        assert "Router" in report
+        assert "p50" in report or "p95" in report
+
+    def test_json_report(self, tmp_path):
+        import importlib
+
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "latency_report.py"
+        spec = importlib.util.spec_from_file_location("latency_report", script_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        records = [
+            {"turn_id": f"t{i}", "router_ms": 100 + i, "total_ms": 500 + i * 10}
+            for i in range(10)
+        ]
+
+        output = mod.generate_json_report(records)
+        parsed = json.loads(output)
+        assert "phases" in parsed
+        assert "router_ms" in parsed["phases"]
+        assert parsed["total_turns"] == 10
+
+    def test_cli_main(self, tmp_path):
+        import importlib
+
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "latency_report.py"
+        spec = importlib.util.spec_from_file_location("latency_report", script_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        path = tmp_path / "m.jsonl"
+        records = [
+            {"turn_id": f"t{i}", "router_ms": 100, "total_ms": 500, "timestamp": "2025-01-01T00:00:00+00:00"}
+            for i in range(5)
+        ]
+        self._write_jsonl(path, records)
+
+        output_file = tmp_path / "report.md"
+        ret = mod.main(["--file", str(path), "--output", str(output_file)])
+        assert ret == 0
+        assert output_file.exists()
+        content = output_file.read_text()
+        assert "Bantz" in content
+
+
+# ─────────────────────────────────────────────────────────────────
+# Gates CLI
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestGatesCLI:
+    """CLI entry for bantz.metrics.gates."""
+
+    def _write_jsonl(self, path: Path, records: list[dict]) -> None:
+        with path.open("w") as fh:
+            for r in records:
+                fh.write(json.dumps(r) + "\n")
+
+    def test_cli_all_pass(self, tmp_path, capsys):
+        from bantz.metrics.gates import main
+
+        path = tmp_path / "m.jsonl"
+        records = [
+            {"router_ms": 100, "tool_ms": 500, "finalize_ms": 800, "tts_ms": 200, "total_ms": 1600}
+            for _ in range(20)
+        ]
+        self._write_jsonl(path, records)
+
+        ret = main([str(path), "5"])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "✅" in captured.out
+
+    def test_cli_gate_fail(self, tmp_path, capsys):
+        from bantz.metrics.gates import main
+
+        path = tmp_path / "m.jsonl"
+        records = [
+            {"router_ms": 800, "tool_ms": 500, "finalize_ms": 800, "tts_ms": 200, "total_ms": 6000}
+            for _ in range(20)
+        ]
+        self._write_jsonl(path, records)
+
+        ret = main([str(path), "5"])
+        assert ret == 1
+        captured = capsys.readouterr()
+        assert "❌" in captured.out
+
+    def test_cli_no_args(self, capsys):
+        from bantz.metrics.gates import main
+
+        ret = main([])
+        assert ret == 2
+
+
+# ─────────────────────────────────────────────────────────────────
+# VoicePipeline integration
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPipelineMetricsIntegration:
+    """VoicePipeline._emit_turn_metrics wiring."""
+
+    def test_emit_turn_metrics_writes_jsonl(self, tmp_path):
+        """_emit_turn_metrics should produce a valid JSONL record."""
+        from bantz.voice.pipeline import PipelineResult, StepTiming, VoicePipeline
+
+        # Prepare a writer pointing to tmp_path
+        jsonl = tmp_path / "turn_metrics.jsonl"
+
+        with mock.patch(
+            "bantz.voice.pipeline._get_metrics_writer"
+        ) as mock_get:
+            from bantz.metrics.turn_metrics import TurnMetricsWriter
+
+            writer = TurnMetricsWriter(path=str(jsonl), enabled=True)
+            mock_get.return_value = writer
+
+            result = PipelineResult(
+                transcription="saat kaç",
+                route="time",
+                reply="Saat 14:30 efendim.",
+                timings=[
+                    StepTiming(name="brain", elapsed_ms=450.0, budget_ms=4500.0),
+                ],
+                total_ms=500.0,
+                success=True,
+                finalizer_tier="3b",
+            )
+
+            VoicePipeline._emit_turn_metrics(result)
+
+        assert jsonl.exists()
+        data = json.loads(jsonl.read_text().strip())
+        assert data["route"] == "time"
+        assert data["total_ms"] == 500.0
+        assert data["router_ms"] == 450.0  # "brain" maps to router_ms
+
+    def test_emit_turn_metrics_disabled_no_file(self, tmp_path):
+        """When writer is disabled, no file is created."""
+        from bantz.voice.pipeline import PipelineResult, VoicePipeline
+
+        jsonl = tmp_path / "turn_metrics.jsonl"
+
+        with mock.patch("bantz.voice.pipeline._get_metrics_writer") as mock_get:
+            from bantz.metrics.turn_metrics import TurnMetricsWriter
+
+            writer = TurnMetricsWriter(path=str(jsonl), enabled=False)
+            mock_get.return_value = writer
+
+            result = PipelineResult(transcription="test", total_ms=100.0)
+            VoicePipeline._emit_turn_metrics(result)
+
+        assert not jsonl.exists()
+
+    def test_emit_turn_metrics_handles_missing_writer(self):
+        """When _get_metrics_writer returns None, nothing crashes."""
+        from bantz.voice.pipeline import PipelineResult, VoicePipeline
+
+        with mock.patch("bantz.voice.pipeline._get_metrics_writer", return_value=None):
+            result = PipelineResult(transcription="test", total_ms=100.0)
+            VoicePipeline._emit_turn_metrics(result)  # Should not raise
+
+    def test_emit_turn_metrics_with_asr_and_tts(self, tmp_path):
+        """Full pipeline with ASR + TTS timings."""
+        from bantz.voice.pipeline import PipelineResult, StepTiming, VoicePipeline
+
+        jsonl = tmp_path / "turn_metrics.jsonl"
+
+        with mock.patch("bantz.voice.pipeline._get_metrics_writer") as mock_get:
+            from bantz.metrics.turn_metrics import TurnMetricsWriter
+
+            writer = TurnMetricsWriter(path=str(jsonl), enabled=True)
+            mock_get.return_value = writer
+
+            result = PipelineResult(
+                transcription="haber ver",
+                route="news",
+                timings=[
+                    StepTiming(name="asr", elapsed_ms=300.0, budget_ms=500.0),
+                    StepTiming(name="brain", elapsed_ms=800.0, budget_ms=4500.0),
+                    StepTiming(name="tts", elapsed_ms=250.0, budget_ms=500.0),
+                ],
+                total_ms=1350.0,
+                success=True,
+            )
+
+            VoicePipeline._emit_turn_metrics(result)
+
+        data = json.loads(jsonl.read_text().strip())
+        assert data["asr_ms"] == 300.0
+        assert data["tts_ms"] == 250.0
+        assert data["total_ms"] == 1350.0
+
+    def test_emit_handles_exception_gracefully(self, tmp_path):
+        """If TurnMetrics import fails, _emit_turn_metrics doesn't crash."""
+        from bantz.voice.pipeline import PipelineResult, VoicePipeline
+
+        with mock.patch("bantz.voice.pipeline._get_metrics_writer") as mock_get:
+            # Return a writer that throws on write
+            mock_writer = mock.MagicMock()
+            mock_writer.return_value = True
+            mock_get.return_value = mock_writer
+
+            # Patch TurnMetrics to raise
+            with mock.patch(
+                "bantz.metrics.turn_metrics.TurnMetrics",
+                side_effect=RuntimeError("boom"),
+            ):
+                result = PipelineResult(transcription="test", total_ms=100.0)
+                VoicePipeline._emit_turn_metrics(result)  # Should not raise
+
+
+# ─────────────────────────────────────────────────────────────────
+# Package imports
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPackageImports:
+    """Verify bantz.metrics package exports are accessible."""
+
+    def test_import_turn_metrics(self):
+        from bantz.metrics import TurnMetrics, TurnMetricsWriter
+
+        assert TurnMetrics is not None
+        assert TurnMetricsWriter is not None
+
+    def test_import_gates(self):
+        from bantz.metrics import LatencyGate, GateResult, check_gates, DEFAULT_GATES
+
+        assert LatencyGate is not None
+        assert check_gates is not None
+        assert len(DEFAULT_GATES) >= 4
+
+    def test_import_read_turn_metrics(self):
+        from bantz.metrics import read_turn_metrics
+
+        assert callable(read_turn_metrics)
+
+    def test_import_check_gates_from_records(self):
+        from bantz.metrics import check_gates_from_records
+
+        assert callable(check_gates_from_records)


### PR DESCRIPTION
## Issue #302 — Latency Budgets + Metrics Gates

### Deliverables

#### 1. `bantz.metrics` package (new)
- **`turn_metrics.py`** — `TurnMetrics` dataclass with per-turn schema (turn_id, timestamp, route, per-phase ms, budget_violations), `TurnMetricsWriter` for thread-safe JSONL persistence
- **`gates.py`** — `LatencyGate` / `GateResult` / `check_gates()` for CI p95 enforcement, `DEFAULT_GATES` (router<500, tool<2000, finalize<2000, tts<500, total<5000), CLI via `python -m bantz.metrics.gates`

#### 2. VoicePipeline integration
- `_emit_turn_metrics()` best-effort helper on every process_text/process_utterance call
- Maps StepTiming names → per-phase ms fields
- Auto budget-check + DEBUG log line per turn

#### 3. `scripts/latency_report.py`
- Per-phase p50/p95/p99 Markdown or JSON reports
- Time-window filtering (`--hours`)
- Route distribution + budget violation summary
- CI gate status section

#### 4. Tests — 46/46 ✅
- TurnMetrics schema, serialization, Turkish chars, budget checks
- Writer enable/disable, env vars, thread safety, parent-dir creation
- Gate pass/fail/insufficient-samples/missing-phase
- Report Markdown + JSON + CLI
- Pipeline integration (mock writer)
- Package exports

### Three Rules
1. ✅ Debug trace — every turn emits `TurnMetrics.log_debug()`
2. ✅ Failure mode — Turkish messages in budget violation strings
3. ✅ `create_runtime()` — pipeline still uses it via `_get_runtime()`

Closes #302