### PR TITLE
feat(voice): heartbeat + log rotation + watchdog (#301)

### DIFF
--- a/scripts/watchdog_voice.sh
+++ b/scripts/watchdog_voice.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────
+# Voice Watchdog — Issue #301
+#
+# Monitors the voice pipeline heartbeat file and restarts the
+# bantz-voice systemd service when the heartbeat goes stale.
+#
+# Features:
+#   - Heartbeat staleness detection (default 30s)
+#   - Cooldown between restarts (default 60s)
+#   - Exponential back-off on repeated restarts
+#   - Log output for troubleshooting
+#
+# Usage:
+#   ./scripts/watchdog_voice.sh                  # defaults
+#   MAX_AGE=60 COOLDOWN=120 ./scripts/watchdog_voice.sh
+#   BANTZ_VOICE_SERVICE=bantz-voice-dev ./scripts/watchdog_voice.sh
+# ─────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# ── Configuration ──────────────────────────────────────────────
+HEARTBEAT="${BANTZ_HEARTBEAT_FILE:-$HOME/.cache/bantz/voice_heartbeat}"
+MAX_AGE="${MAX_AGE:-30}"
+COOLDOWN="${COOLDOWN:-60}"
+CHECK_INTERVAL="${CHECK_INTERVAL:-10}"
+SERVICE="${BANTZ_VOICE_SERVICE:-bantz-voice}"
+MAX_BACKOFF="${MAX_BACKOFF:-600}"  # 10 min cap
+
+# ── State ──────────────────────────────────────────────────────
+LAST_RESTART=0
+CONSECUTIVE_RESTARTS=0
+CURRENT_COOLDOWN="$COOLDOWN"
+
+log() {
+    echo "[watchdog][$(date +%Y-%m-%dT%H:%M:%S)] $*"
+}
+
+restart_service() {
+    local now
+    now=$(date +%s)
+    local elapsed=$((now - LAST_RESTART))
+
+    if [ "$elapsed" -lt "$CURRENT_COOLDOWN" ]; then
+        log "Cooldown active (${elapsed}s/${CURRENT_COOLDOWN}s) — skipping restart"
+        return 1
+    fi
+
+    log "⚠ Voice service stale — restarting $SERVICE (consecutive=$CONSECUTIVE_RESTARTS)"
+    if systemctl --user restart "$SERVICE" 2>/dev/null; then
+        log "✅ Service $SERVICE restarted successfully"
+    else
+        log "❌ Service restart failed — is $SERVICE installed?"
+    fi
+
+    LAST_RESTART="$now"
+    CONSECUTIVE_RESTARTS=$((CONSECUTIVE_RESTARTS + 1))
+
+    # Exponential back-off: cooldown doubles on each consecutive restart
+    CURRENT_COOLDOWN=$((COOLDOWN * (2 ** (CONSECUTIVE_RESTARTS - 1))))
+    if [ "$CURRENT_COOLDOWN" -gt "$MAX_BACKOFF" ]; then
+        CURRENT_COOLDOWN="$MAX_BACKOFF"
+    fi
+    log "Next cooldown: ${CURRENT_COOLDOWN}s"
+    return 0
+}
+
+check_heartbeat() {
+    if [ ! -f "$HEARTBEAT" ]; then
+        log "Heartbeat file not found: $HEARTBEAT"
+        return 1  # stale
+    fi
+
+    local hb_time
+    hb_time=$(cat "$HEARTBEAT" 2>/dev/null || echo "0")
+    # Handle floating point timestamps by truncating
+    hb_time="${hb_time%%.*}"
+
+    local now
+    now=$(date +%s)
+    local age=$((now - hb_time))
+
+    if [ "$age" -gt "$MAX_AGE" ]; then
+        log "Heartbeat stale: age=${age}s > max=${MAX_AGE}s"
+        return 1  # stale
+    fi
+
+    # Heartbeat alive — reset consecutive counter
+    if [ "$CONSECUTIVE_RESTARTS" -gt 0 ]; then
+        log "Heartbeat alive — resetting back-off (was $CONSECUTIVE_RESTARTS consecutive restarts)"
+        CONSECUTIVE_RESTARTS=0
+        CURRENT_COOLDOWN="$COOLDOWN"
+    fi
+
+    return 0  # alive
+}
+
+# ── Main loop ──────────────────────────────────────────────────
+log "Voice watchdog started"
+log "  heartbeat: $HEARTBEAT"
+log "  max_age:   ${MAX_AGE}s"
+log "  cooldown:  ${COOLDOWN}s"
+log "  service:   $SERVICE"
+log "  interval:  ${CHECK_INTERVAL}s"
+
+while true; do
+    if ! check_heartbeat; then
+        restart_service || true
+    fi
+    sleep "$CHECK_INTERVAL"
+done

--- a/src/bantz/voice/heartbeat.py
+++ b/src/bantz/voice/heartbeat.py
@@ -1,0 +1,258 @@
+"""Voice pipeline heartbeat + log rotation (Issue #301).
+
+Heartbeat
+---------
+The :class:`Heartbeat` writes ``time.time()`` to
+``~/.cache/bantz/voice_heartbeat`` on every :meth:`tick`.
+:meth:`is_stale` returns ``True`` when the file is older than
+``max_age_s`` (default 30 seconds) — the watchdog script uses this
+to decide whether to restart the voice service.
+
+Log Rotation
+------------
+:class:`LogRotator` keeps voice logs tidy:
+- Max ``max_files`` rotated copies (default 7).
+- Max ``max_size_mb`` per file (default 10 MB).
+- :meth:`rotate_if_needed` is called from the voice loop.
+
+Usage::
+
+    hb = Heartbeat()
+    hb.tick()                   # called every 5-10s from voice loop
+    Heartbeat.is_stale()        # → True if no tick in 30s
+
+    rotator = LogRotator()
+    rotator.rotate_if_needed()  # called once per voice loop iteration
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["Heartbeat", "LogRotator"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Heartbeat
+# ─────────────────────────────────────────────────────────────────
+
+# Default heartbeat file path
+_DEFAULT_HB_PATH = Path.home() / ".cache" / "bantz" / "voice_heartbeat"
+
+# Default log directory
+_DEFAULT_LOG_DIR = Path.home() / ".cache" / "bantz" / "logs"
+
+
+class Heartbeat:
+    """Voice loop heartbeat — proves the loop is alive.
+
+    Parameters
+    ----------
+    path:
+        Heartbeat file path.  Defaults to ``~/.cache/bantz/voice_heartbeat``.
+    max_age_s:
+        Staleness threshold in seconds.  Default 30.
+    """
+
+    def __init__(
+        self,
+        path: Optional[str | Path] = None,
+        max_age_s: float = 30.0,
+    ) -> None:
+        self._path = Path(path) if path else _DEFAULT_HB_PATH
+        self._max_age_s = max_age_s
+        self._last_tick: float = 0.0
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def max_age_s(self) -> float:
+        return self._max_age_s
+
+    def tick(self) -> None:
+        """Write current timestamp to the heartbeat file.
+
+        Called every 5–10 seconds from the voice loop.  Creates
+        parent directories if needed.  Failures are logged but
+        never propagated.
+        """
+        now = time.time()
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(str(now))
+            self._last_tick = now
+            logger.debug("Heartbeat tick: %.1f → %s", now, self._path)
+        except OSError as exc:
+            logger.warning("Heartbeat tick failed: %s", exc)
+
+    def is_stale(self, max_age_s: Optional[float] = None) -> bool:
+        """Check if the heartbeat is stale.
+
+        Parameters
+        ----------
+        max_age_s:
+            Override the default staleness threshold.
+
+        Returns
+        -------
+        bool
+            ``True`` if the heartbeat file is missing, unreadable,
+            or older than *max_age_s*.
+        """
+        threshold = max_age_s if max_age_s is not None else self._max_age_s
+        try:
+            ts = float(self._path.read_text().strip())
+            age = time.time() - ts
+            stale = age > threshold
+            if stale:
+                logger.warning(
+                    "Heartbeat stale: age=%.1fs > threshold=%.1fs (%s)",
+                    age, threshold, self._path,
+                )
+            return stale
+        except FileNotFoundError:
+            logger.warning("Heartbeat file not found: %s — treating as stale", self._path)
+            return True
+        except (ValueError, OSError) as exc:
+            logger.warning("Heartbeat check error: %s — treating as stale", exc)
+            return True
+
+    @property
+    def last_tick(self) -> float:
+        """Monotonic timestamp of last successful tick (0 if never ticked)."""
+        return self._last_tick
+
+    def clear(self) -> None:
+        """Remove the heartbeat file (for tests / clean shutdown)."""
+        try:
+            self._path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def __repr__(self) -> str:
+        return f"Heartbeat(path={self._path}, max_age_s={self._max_age_s})"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Log Rotation
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class LogRotator:
+    """Voice log rotation — keeps disk usage bounded.
+
+    Parameters
+    ----------
+    log_dir:
+        Directory containing voice logs.
+        Default ``~/.cache/bantz/logs/``.
+    log_name:
+        Base log filename.  Default ``voice.log``.
+    max_files:
+        Maximum number of rotated files to keep.  Default 7.
+    max_size_mb:
+        Maximum size of the current log before rotation.  Default 10.
+    """
+
+    log_dir: Path = field(default_factory=lambda: _DEFAULT_LOG_DIR)
+    log_name: str = "voice.log"
+    max_files: int = 7
+    max_size_mb: float = 10.0
+
+    @property
+    def current_log(self) -> Path:
+        return self.log_dir / self.log_name
+
+    def rotate_if_needed(self) -> bool:
+        """Rotate the current log if it exceeds ``max_size_mb``.
+
+        Returns ``True`` if rotation occurred.
+        """
+        current = self.current_log
+        if not current.exists():
+            return False
+
+        size_mb = current.stat().st_size / (1024 * 1024)
+        if size_mb < self.max_size_mb:
+            return False
+
+        return self._rotate()
+
+    def _rotate(self) -> bool:
+        """Perform the actual rotation.
+
+        voice.log   → voice.log.1
+        voice.log.1 → voice.log.2
+        ...
+        voice.log.N → deleted (if N >= max_files)
+        """
+        try:
+            # Delete oldest if at limit
+            for i in range(self.max_files, 0, -1):
+                src = self.log_dir / f"{self.log_name}.{i}"
+                if i == self.max_files and src.exists():
+                    src.unlink()
+                    logger.debug("Deleted oldest log: %s", src)
+                elif src.exists():
+                    dst = self.log_dir / f"{self.log_name}.{i + 1}"
+                    shutil.move(str(src), str(dst))
+                    logger.debug("Rotated %s → %s", src, dst)
+
+            # Current → .1
+            current = self.current_log
+            if current.exists():
+                dst = self.log_dir / f"{self.log_name}.1"
+                shutil.move(str(current), str(dst))
+                logger.debug("Rotated %s → %s", current, dst)
+
+            logger.info("Log rotation complete for %s", self.log_name)
+            return True
+
+        except OSError as exc:
+            logger.warning("Log rotation failed: %s", exc)
+            return False
+
+    def cleanup_old(self) -> int:
+        """Delete rotated logs beyond ``max_files``.
+
+        Returns the number of files deleted.
+        """
+        deleted = 0
+        for i in range(self.max_files + 1, self.max_files + 100):
+            path = self.log_dir / f"{self.log_name}.{i}"
+            if not path.exists():
+                break
+            try:
+                path.unlink()
+                deleted += 1
+                logger.debug("Cleaned up old log: %s", path)
+            except OSError:
+                pass
+        return deleted
+
+    def list_logs(self) -> list[Path]:
+        """Return all existing log files, sorted by index."""
+        logs: list[Path] = []
+        current = self.current_log
+        if current.exists():
+            logs.append(current)
+        for i in range(1, self.max_files + 1):
+            p = self.log_dir / f"{self.log_name}.{i}"
+            if p.exists():
+                logs.append(p)
+        return logs
+
+    def total_size_mb(self) -> float:
+        """Total size of all log files in MB."""
+        return sum(p.stat().st_size for p in self.list_logs()) / (1024 * 1024)

--- a/systemd/user/bantz-voice-watchdog.service
+++ b/systemd/user/bantz-voice-watchdog.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Bantz Voice Watchdog (audio hang detection + restart)
+Wants=bantz-voice.service
+After=bantz-voice.service
+
+[Service]
+Type=simple
+WorkingDirectory=%h/Desktop/Bantz
+
+# Use repo bash script for watchdog logic
+ExecStart=%h/Desktop/Bantz/scripts/watchdog_voice.sh
+
+# Configuration via environment
+Environment=MAX_AGE=30
+Environment=COOLDOWN=60
+Environment=CHECK_INTERVAL=10
+Environment=MAX_BACKOFF=600
+
+Restart=always
+RestartSec=10
+
+# journald captures all output
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=bantz-voice-watchdog
+
+[Install]
+WantedBy=default.target

--- a/tests/test_issue_301_voice_watchdog.py
+++ b/tests/test_issue_301_voice_watchdog.py
@@ -1,0 +1,318 @@
+"""Tests for Issue #301 — Voice Watchdog (heartbeat + log rotation).
+
+Covers:
+  - Heartbeat: tick, is_stale, clear, missing file, malformed file
+  - LogRotator: rotate_if_needed, cleanup_old, list_logs, total_size
+  - VoicePipeline heartbeat integration (_tick_heartbeat)
+  - Watchdog script existence and permissions
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────
+# Heartbeat
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestHeartbeat:
+    """Heartbeat file management."""
+
+    def test_tick_creates_file(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "hb")
+        hb.tick()
+        assert (tmp_path / "hb").exists()
+        ts = float((tmp_path / "hb").read_text())
+        assert abs(time.time() - ts) < 5
+
+    def test_tick_updates_last_tick(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "hb")
+        assert hb.last_tick == 0.0
+        hb.tick()
+        assert hb.last_tick > 0.0
+
+    def test_tick_creates_parent_dirs(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "deep" / "nested" / "hb")
+        hb.tick()
+        assert (tmp_path / "deep" / "nested" / "hb").exists()
+
+    def test_is_stale_when_no_file(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "nonexistent")
+        assert hb.is_stale() is True
+
+    def test_is_stale_fresh_tick(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "hb", max_age_s=30.0)
+        hb.tick()
+        assert hb.is_stale() is False
+
+    def test_is_stale_old_timestamp(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        path = tmp_path / "hb"
+        # Write a timestamp 60 seconds in the past
+        old_ts = time.time() - 60
+        path.write_text(str(old_ts))
+
+        hb = Heartbeat(path=path, max_age_s=30.0)
+        assert hb.is_stale() is True
+
+    def test_is_stale_custom_threshold(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        path = tmp_path / "hb"
+        # Write a timestamp 10 seconds in the past
+        old_ts = time.time() - 10
+        path.write_text(str(old_ts))
+
+        hb = Heartbeat(path=path, max_age_s=30.0)
+        assert hb.is_stale(max_age_s=5.0) is True
+        assert hb.is_stale(max_age_s=20.0) is False
+
+    def test_is_stale_malformed_file(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        path = tmp_path / "hb"
+        path.write_text("NOT A NUMBER")
+
+        hb = Heartbeat(path=path)
+        assert hb.is_stale() is True
+
+    def test_clear_removes_file(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "hb")
+        hb.tick()
+        assert (tmp_path / "hb").exists()
+        hb.clear()
+        assert not (tmp_path / "hb").exists()
+
+    def test_clear_no_error_when_missing(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "nonexistent")
+        hb.clear()  # Should not raise
+
+    def test_repr(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+
+        hb = Heartbeat(path=tmp_path / "hb", max_age_s=42.0)
+        r = repr(hb)
+        assert "Heartbeat" in r
+        assert "42.0" in r
+
+
+# ─────────────────────────────────────────────────────────────────
+# LogRotator
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLogRotator:
+    """Log rotation mechanics."""
+
+    def test_no_rotation_when_small(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path, max_size_mb=10.0)
+        log = tmp_path / "voice.log"
+        log.write_text("small content\n")
+
+        assert rotator.rotate_if_needed() is False
+
+    def test_rotation_when_large(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path, max_size_mb=0.001)  # ~1KB
+        log = tmp_path / "voice.log"
+        log.write_text("x" * 2000)  # 2KB > 1KB
+
+        assert rotator.rotate_if_needed() is True
+        assert not log.exists()  # current rotated away
+        assert (tmp_path / "voice.log.1").exists()
+
+    def test_cascading_rotation(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path, max_size_mb=0.001)
+
+        # Create existing rotated files
+        (tmp_path / "voice.log.1").write_text("old-1\n")
+        (tmp_path / "voice.log.2").write_text("old-2\n")
+        (tmp_path / "voice.log").write_text("x" * 2000)
+
+        rotator.rotate_if_needed()
+
+        assert (tmp_path / "voice.log.1").exists()
+        assert (tmp_path / "voice.log.2").exists()
+        assert (tmp_path / "voice.log.3").exists()
+        # .1 should be the old current
+        content = (tmp_path / "voice.log.1").read_text()
+        assert "x" * 100 in content
+
+    def test_oldest_deleted_at_max(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path, max_files=3, max_size_mb=0.001)
+
+        # Fill up to max
+        (tmp_path / "voice.log.1").write_text("a\n")
+        (tmp_path / "voice.log.2").write_text("b\n")
+        (tmp_path / "voice.log.3").write_text("c-should-be-deleted\n")
+        (tmp_path / "voice.log").write_text("x" * 2000)
+
+        rotator.rotate_if_needed()
+
+        # .3 was at max_files, so it gets deleted before cascade
+        assert not (tmp_path / "voice.log.4").exists()
+
+    def test_no_rotation_when_file_missing(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path)
+        assert rotator.rotate_if_needed() is False
+
+    def test_list_logs(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path)
+        (tmp_path / "voice.log").write_text("current\n")
+        (tmp_path / "voice.log.1").write_text("old-1\n")
+        (tmp_path / "voice.log.2").write_text("old-2\n")
+
+        logs = rotator.list_logs()
+        assert len(logs) == 3
+        assert logs[0] == tmp_path / "voice.log"
+
+    def test_total_size_mb(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path)
+        (tmp_path / "voice.log").write_text("a" * 1024)
+        (tmp_path / "voice.log.1").write_text("b" * 1024)
+
+        size = rotator.total_size_mb()
+        assert 0.001 < size < 0.01  # ~2KB
+
+    def test_cleanup_old(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path, max_files=3)
+        # Create files beyond max
+        for i in range(1, 8):
+            (tmp_path / f"voice.log.{i}").write_text(f"content-{i}\n")
+
+        deleted = rotator.cleanup_old()
+        assert deleted == 4  # files 4, 5, 6, 7
+        assert not (tmp_path / "voice.log.4").exists()
+        assert (tmp_path / "voice.log.3").exists()
+
+    def test_current_log_property(self, tmp_path):
+        from bantz.voice.heartbeat import LogRotator
+
+        rotator = LogRotator(log_dir=tmp_path, log_name="test.log")
+        assert rotator.current_log == tmp_path / "test.log"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Pipeline integration
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPipelineHeartbeat:
+    """VoicePipeline._tick_heartbeat wiring."""
+
+    def test_tick_heartbeat_creates_heartbeat(self, tmp_path):
+        from bantz.voice.pipeline import VoicePipeline
+
+        hb_path = tmp_path / "hb"
+        pipe = VoicePipeline()
+
+        with mock.patch("bantz.voice.heartbeat.Heartbeat") as MockHB:
+            instance = MockHB.return_value
+            instance.path = hb_path
+            pipe._tick_heartbeat()
+
+            MockHB.assert_called_once()
+            instance.tick.assert_called_once()
+
+    def test_tick_heartbeat_reuses_instance(self, tmp_path):
+        from bantz.voice.heartbeat import Heartbeat
+        from bantz.voice.pipeline import VoicePipeline
+
+        hb = Heartbeat(path=tmp_path / "hb")
+        pipe = VoicePipeline()
+        pipe._heartbeat = hb
+
+        pipe._tick_heartbeat()
+        assert (tmp_path / "hb").exists()
+
+    def test_tick_heartbeat_handles_exception(self):
+        from bantz.voice.pipeline import VoicePipeline
+
+        pipe = VoicePipeline()
+
+        with mock.patch("bantz.voice.heartbeat.Heartbeat", side_effect=RuntimeError("boom")):
+            pipe._tick_heartbeat()  # Should not raise
+
+
+# ─────────────────────────────────────────────────────────────────
+# Watchdog script
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestWatchdogScript:
+    """Verify watchdog script file exists and is executable."""
+
+    def test_script_exists(self):
+        script = Path(__file__).resolve().parents[1] / "scripts" / "watchdog_voice.sh"
+        assert script.exists(), f"Watchdog script not found: {script}"
+
+    def test_script_executable(self):
+        script = Path(__file__).resolve().parents[1] / "scripts" / "watchdog_voice.sh"
+        assert os.access(str(script), os.X_OK), "watchdog_voice.sh is not executable"
+
+    def test_script_has_shebang(self):
+        script = Path(__file__).resolve().parents[1] / "scripts" / "watchdog_voice.sh"
+        first_line = script.read_text().split("\n")[0]
+        assert first_line.startswith("#!/"), f"Missing shebang: {first_line}"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Systemd service
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestSystemdService:
+    """Verify watchdog systemd unit file."""
+
+    def test_service_file_exists(self):
+        svc = Path(__file__).resolve().parents[1] / "systemd" / "user" / "bantz-voice-watchdog.service"
+        assert svc.exists(), f"Service file not found: {svc}"
+
+    def test_service_has_exec_start(self):
+        svc = Path(__file__).resolve().parents[1] / "systemd" / "user" / "bantz-voice-watchdog.service"
+        content = svc.read_text()
+        assert "ExecStart=" in content
+        assert "watchdog_voice.sh" in content
+
+    def test_service_has_restart(self):
+        svc = Path(__file__).resolve().parents[1] / "systemd" / "user" / "bantz-voice-watchdog.service"
+        content = svc.read_text()
+        assert "Restart=always" in content


### PR DESCRIPTION
## Issue #301 — Voice Watchdog

### Deliverables

#### 1. `src/bantz/voice/heartbeat.py`
- **Heartbeat**: writes `time.time()` to `~/.cache/bantz/voice_heartbeat` on every `tick()`, `is_stale(max_age_s=30)` returns True when file is old/missing
- **LogRotator**: cascading rotation (voice.log → .1 → .2 … → deleted), `max_files=7`, `max_size_mb=10`, `cleanup_old()`, `list_logs()`, `total_size_mb()`

#### 2. `scripts/watchdog_voice.sh`
- Bash watchdog that monitors heartbeat file
- Restarts `bantz-voice` systemd service on stale heartbeat
- Exponential back-off (cooldown doubles per consecutive restart, caps at 10min)
- Configurable via env vars: MAX_AGE, COOLDOWN, CHECK_INTERVAL, MAX_BACKOFF

#### 3. `systemd/user/bantz-voice-watchdog.service`
- Type=simple, Restart=always, points to watchdog script

#### 4. Pipeline integration
- `_tick_heartbeat()` called at start of `process_text()`
- Lazy init, best-effort (never blocks pipeline)

#### 5. Tests — 29/29 ✅
- Heartbeat: tick, stale, missing/malformed, clear, repr
- LogRotator: size-based rotation, cascading, max-file deletion, cleanup
- Pipeline integration (mock + real)
- Script existence, executable, shebang
- Systemd unit file content

### Three Rules
1. ✅ Debug trace — heartbeat tick logged at DEBUG
2. ✅ Failure mode — heartbeat/rotation failures logged, never crash pipeline
3. ✅ create_runtime() — pipeline still uses it

Closes #301