### PR TITLE
feat(#299): Privacy module — local-only default + cloud consent + PII redaction

### DIFF
--- a/src/bantz/privacy/__init__.py
+++ b/src/bantz/privacy/__init__.py
@@ -1,0 +1,21 @@
+"""Privacy module — local-first, explicit cloud consent, PII redaction.
+
+Issue #299: Privacy-first approach for Bantz.
+"""
+
+from bantz.privacy.config import PrivacyConfig, load_privacy_config, save_privacy_config
+from bantz.privacy.consent import ConsentManager, ConsentResult
+from bantz.privacy.redaction import redact_pii, REDACTION_PATTERNS
+from bantz.privacy.indicator import MicIndicator, MicState
+
+__all__ = [
+    "PrivacyConfig",
+    "load_privacy_config",
+    "save_privacy_config",
+    "ConsentManager",
+    "ConsentResult",
+    "redact_pii",
+    "REDACTION_PATTERNS",
+    "MicIndicator",
+    "MicState",
+]

--- a/src/bantz/privacy/config.py
+++ b/src/bantz/privacy/config.py
@@ -1,0 +1,175 @@
+"""Privacy configuration — persisted at ~/.config/bantz/privacy.json (Issue #299).
+
+Default: local-only mode, no cloud calls.
+Cloud features (Gemini, news, web search) require explicit consent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PrivacyConfig",
+    "SkillPermissions",
+    "load_privacy_config",
+    "save_privacy_config",
+    "DEFAULT_CONFIG_PATH",
+]
+
+DEFAULT_CONFIG_DIR = Path(os.getenv("BANTZ_CONFIG_DIR", "~/.config/bantz")).expanduser()
+DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "privacy.json"
+CURRENT_CONSENT_VERSION = "1.0"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Data classes
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SkillPermissions:
+    """Per-skill cloud permission flags.
+
+    Default: all False (local-only).
+    """
+
+    news_web_fetch: bool = False
+    gemini_finalize: bool = False
+    web_search: bool = False
+
+    def any_enabled(self) -> bool:
+        """Return True if any cloud skill is enabled."""
+        return self.news_web_fetch or self.gemini_finalize or self.web_search
+
+    def enable_all(self) -> None:
+        self.news_web_fetch = True
+        self.gemini_finalize = True
+        self.web_search = True
+
+    def disable_all(self) -> None:
+        self.news_web_fetch = False
+        self.gemini_finalize = False
+        self.web_search = False
+
+
+@dataclass
+class PrivacyConfig:
+    """Privacy configuration persisted on disk.
+
+    Attributes
+    ----------
+    cloud_mode:
+        False = strictly local, True = cloud features allowed (with consent).
+    consent_given_at:
+        ISO timestamp when consent was given, or None.
+    consent_version:
+        Version of the consent terms the user agreed to.
+    skills:
+        Per-skill cloud permission flags.
+    data_retention_days:
+        How many days to keep local data (logs, metrics, etc.).
+    """
+
+    cloud_mode: bool = False
+    consent_given_at: Optional[str] = None
+    consent_version: str = CURRENT_CONSENT_VERSION
+    skills: SkillPermissions = field(default_factory=SkillPermissions)
+    data_retention_days: int = 7
+
+    @property
+    def is_local_only(self) -> bool:
+        """True if cloud mode is off (default, privacy-first)."""
+        return not self.cloud_mode
+
+    @property
+    def has_consent(self) -> bool:
+        """True if user has given consent."""
+        return self.consent_given_at is not None and self.cloud_mode
+
+    def is_skill_allowed(self, skill_name: str) -> bool:
+        """Check if a specific cloud skill is allowed.
+
+        Returns False if cloud_mode is off OR the specific skill is disabled.
+        """
+        if not self.cloud_mode:
+            return False
+        return getattr(self.skills, skill_name, False)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary (JSON-friendly)."""
+        d = asdict(self)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PrivacyConfig":
+        """Deserialize from dictionary."""
+        skills_data = data.get("skills", {})
+        if isinstance(skills_data, dict):
+            skills = SkillPermissions(**{
+                k: v for k, v in skills_data.items()
+                if k in SkillPermissions.__dataclass_fields__
+            })
+        else:
+            skills = SkillPermissions()
+
+        return cls(
+            cloud_mode=bool(data.get("cloud_mode", False)),
+            consent_given_at=data.get("consent_given_at"),
+            consent_version=str(data.get("consent_version", CURRENT_CONSENT_VERSION)),
+            skills=skills,
+            data_retention_days=int(data.get("data_retention_days", 7)),
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# I/O
+# ─────────────────────────────────────────────────────────────────
+
+
+def load_privacy_config(path: Optional[Path] = None) -> PrivacyConfig:
+    """Load privacy config from disk.
+
+    If the file does not exist, returns the default (local-only) config.
+    On parse error, logs a warning and returns defaults.
+    """
+    p = Path(path) if path else DEFAULT_CONFIG_PATH
+    if not p.is_file():
+        logger.debug("Privacy config not found at %s — using defaults (local-only)", p)
+        return PrivacyConfig()
+
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        cfg = PrivacyConfig.from_dict(data)
+        logger.debug("Privacy config loaded from %s (cloud_mode=%s)", p, cfg.cloud_mode)
+        return cfg
+    except Exception as exc:
+        logger.warning("Privacy config parse error at %s: %s — using defaults", p, exc)
+        return PrivacyConfig()
+
+
+def save_privacy_config(config: PrivacyConfig, path: Optional[Path] = None) -> bool:
+    """Save privacy config to disk.
+
+    Creates parent directories if needed.
+    Returns True on success, False on error.
+    """
+    p = Path(path) if path else DEFAULT_CONFIG_PATH
+
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            json.dumps(config.to_dict(), indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        logger.debug("Privacy config saved to %s", p)
+        return True
+    except Exception as exc:
+        logger.warning("Privacy config save failed at %s: %s", p, exc)
+        return False

--- a/src/bantz/privacy/consent.py
+++ b/src/bantz/privacy/consent.py
@@ -1,0 +1,245 @@
+"""Consent manager — explicit cloud consent flow (Issue #299).
+
+When a user tries to use a cloud feature (Gemini, web search, news)
+and cloud_mode is off, we:
+1. Prompt the user for consent (voice or text).
+2. If accepted: persist consent, enable cloud_mode.
+3. If declined: use local fallback, don't enable cloud.
+
+The consent flow is designed for both voice and text interfaces.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Optional
+
+from bantz.privacy.config import (
+    CURRENT_CONSENT_VERSION,
+    PrivacyConfig,
+    load_privacy_config,
+    save_privacy_config,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ConsentManager", "ConsentResult", "ConsentStatus"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Data types
+# ─────────────────────────────────────────────────────────────────
+
+
+class ConsentStatus(str, Enum):
+    """Result of a consent check."""
+
+    ALREADY_GRANTED = "already_granted"
+    NEWLY_GRANTED = "newly_granted"
+    DECLINED = "declined"
+    NOT_NEEDED = "not_needed"  # local feature, no consent required
+
+
+@dataclass
+class ConsentResult:
+    """Result of a consent check or request."""
+
+    status: ConsentStatus
+    skill: str = ""
+    message: str = ""
+
+    @property
+    def allowed(self) -> bool:
+        """Whether the operation is allowed to proceed."""
+        return self.status in (
+            ConsentStatus.ALREADY_GRANTED,
+            ConsentStatus.NEWLY_GRANTED,
+            ConsentStatus.NOT_NEEDED,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Consent prompts (Turkish)
+# ─────────────────────────────────────────────────────────────────
+
+CONSENT_PROMPTS = {
+    "gemini_finalize": (
+        "Bu özellik için Gemini AI kullanılacak efendim. "
+        "Bazı veriler Google'a gönderilecek. Onaylıyor musunuz?"
+    ),
+    "news_web_fetch": (
+        "Haberleri getirmek için internet bağlantısı gerekiyor efendim. "
+        "Bazı veriler dış servislere gönderilecek. Onaylıyor musunuz?"
+    ),
+    "web_search": (
+        "Web araması için internet bağlantısı gerekiyor efendim. "
+        "Arama terimi dış servislere gönderilecek. Onaylıyor musunuz?"
+    ),
+    "default": (
+        "Bu özellik için internet bağlantısı gerekiyor efendim. "
+        "Bazı veriler dış servislere gönderilecek. Onaylıyor musunuz?"
+    ),
+}
+
+CONSENT_ACCEPTED_MSG = "Onay kaydedildi efendim. Özellik etkinleştirildi."
+CONSENT_DECLINED_MSG = "Anlaşıldı efendim. Yerel alternatif kullanılacak."
+AFFIRMATIVE_WORDS = frozenset({
+    "evet", "tamam", "olur", "kabul", "onay", "onayla",
+    "onaylıyorum", "yes", "ok", "okay", "yep", "sure",
+    "elbette", "tabi", "tabii", "peki",
+})
+
+
+# ─────────────────────────────────────────────────────────────────
+# Manager
+# ─────────────────────────────────────────────────────────────────
+
+
+class ConsentManager:
+    """Manages user consent for cloud features.
+
+    Parameters
+    ----------
+    config:
+        Privacy config (loaded from disk or created fresh).
+    config_path:
+        Path to persist config changes. None = default.
+    ask_fn:
+        Callback to ask the user a question and get a response.
+        ``ask_fn(prompt: str) -> str``
+        If None, consent is always declined (headless mode).
+    """
+
+    def __init__(
+        self,
+        config: Optional[PrivacyConfig] = None,
+        config_path=None,
+        ask_fn: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self._config = config or load_privacy_config(config_path)
+        self._config_path = config_path
+        self._ask_fn = ask_fn
+
+    @property
+    def config(self) -> PrivacyConfig:
+        return self._config
+
+    def check_skill(self, skill_name: str) -> ConsentResult:
+        """Check if a cloud skill is allowed, requesting consent if needed.
+
+        Flow:
+        1. If skill is already allowed → ALREADY_GRANTED
+        2. If cloud_mode is off → ask for consent
+        3. If consent given → enable skill, persist, NEWLY_GRANTED
+        4. If declined → DECLINED
+        """
+        # Already have consent for this skill
+        if self._config.is_skill_allowed(skill_name):
+            logger.debug("Skill '%s' already allowed", skill_name)
+            return ConsentResult(
+                status=ConsentStatus.ALREADY_GRANTED,
+                skill=skill_name,
+            )
+
+        # Need to ask for consent
+        prompt = CONSENT_PROMPTS.get(skill_name, CONSENT_PROMPTS["default"])
+        logger.info("Consent needed for skill '%s'", skill_name)
+
+        if self._ask_fn is None:
+            logger.debug("No ask_fn — declining consent (headless mode)")
+            return ConsentResult(
+                status=ConsentStatus.DECLINED,
+                skill=skill_name,
+                message=CONSENT_DECLINED_MSG,
+            )
+
+        # Ask the user
+        try:
+            response = self._ask_fn(prompt)
+        except Exception as exc:
+            logger.warning("Consent ask_fn failed: %s — declining", exc)
+            return ConsentResult(
+                status=ConsentStatus.DECLINED,
+                skill=skill_name,
+                message="Onay alınamadı efendim, yerel mod kullanılıyor.",
+            )
+
+        if self._is_affirmative(response):
+            return self._grant_consent(skill_name)
+        else:
+            logger.info("User declined consent for '%s'", skill_name)
+            return ConsentResult(
+                status=ConsentStatus.DECLINED,
+                skill=skill_name,
+                message=CONSENT_DECLINED_MSG,
+            )
+
+    def grant_all(self) -> ConsentResult:
+        """Grant consent for all cloud skills at once."""
+        self._config.cloud_mode = True
+        self._config.consent_given_at = datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat()
+        self._config.consent_version = CURRENT_CONSENT_VERSION
+        self._config.skills.enable_all()
+        self._persist()
+        logger.info("All cloud skills enabled")
+        return ConsentResult(
+            status=ConsentStatus.NEWLY_GRANTED,
+            skill="all",
+            message=CONSENT_ACCEPTED_MSG,
+        )
+
+    def revoke_all(self) -> None:
+        """Revoke all cloud consent — return to local-only mode."""
+        self._config.cloud_mode = False
+        self._config.consent_given_at = None
+        self._config.skills.disable_all()
+        self._persist()
+        logger.info("All cloud consent revoked — local-only mode")
+
+    def revoke_skill(self, skill_name: str) -> None:
+        """Revoke consent for a specific skill."""
+        if hasattr(self._config.skills, skill_name):
+            setattr(self._config.skills, skill_name, False)
+            # If no skills remain, turn off cloud_mode
+            if not self._config.skills.any_enabled():
+                self._config.cloud_mode = False
+            self._persist()
+            logger.info("Consent revoked for '%s'", skill_name)
+
+    def _grant_consent(self, skill_name: str) -> ConsentResult:
+        """Internal: grant consent for a skill and persist."""
+        self._config.cloud_mode = True
+        self._config.consent_given_at = datetime.datetime.now(
+            datetime.timezone.utc
+        ).isoformat()
+        self._config.consent_version = CURRENT_CONSENT_VERSION
+
+        if hasattr(self._config.skills, skill_name):
+            setattr(self._config.skills, skill_name, True)
+
+        self._persist()
+        logger.info("Consent granted for '%s'", skill_name)
+
+        return ConsentResult(
+            status=ConsentStatus.NEWLY_GRANTED,
+            skill=skill_name,
+            message=CONSENT_ACCEPTED_MSG,
+        )
+
+    def _persist(self) -> None:
+        """Save config to disk (best-effort)."""
+        try:
+            save_privacy_config(self._config, self._config_path)
+        except Exception as exc:
+            logger.warning("Failed to persist privacy config: %s", exc)
+
+    @staticmethod
+    def _is_affirmative(response: str) -> bool:
+        """Check if user response is affirmative."""
+        words = (response or "").strip().lower().split()
+        return bool(words and words[0] in AFFIRMATIVE_WORDS)

--- a/src/bantz/privacy/indicator.py
+++ b/src/bantz/privacy/indicator.py
@@ -1,0 +1,152 @@
+"""Mic indicator — shows user when microphone is active (Issue #299).
+
+Provides visual feedback so the user always knows when they're being
+listened to. Supports multiple output modes:
+- Terminal (emoji-based)
+- Callback (for GUI/tray icon integration)
+- Silent (headless/CI)
+
+Usage::
+
+    indicator = MicIndicator()
+    indicator.on_state_change(MicState.LISTENING)
+    # Terminal: "🔴 DİNLENİYOR"
+    indicator.on_state_change(MicState.IDLE)
+    # Terminal: "⚪ HAZIR"
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from enum import Enum
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["MicIndicator", "MicState"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# States
+# ─────────────────────────────────────────────────────────────────
+
+
+class MicState(str, Enum):
+    """Microphone state for the indicator."""
+
+    IDLE = "idle"                    # Not listening
+    LISTENING = "listening"          # Actively listening (ASR)
+    PROCESSING = "processing"       # Processing speech
+    SPEAKING = "speaking"           # TTS is playing
+    ERROR = "error"                 # Mic error
+
+    @property
+    def label_tr(self) -> str:
+        """Turkish label for the state."""
+        labels = {
+            MicState.IDLE: "HAZIR",
+            MicState.LISTENING: "DİNLENİYOR",
+            MicState.PROCESSING: "İŞLENİYOR",
+            MicState.SPEAKING: "KONUŞUYOR",
+            MicState.ERROR: "HATA",
+        }
+        return labels.get(self, "BİLİNMİYOR")
+
+    @property
+    def icon(self) -> str:
+        """Emoji icon for the state."""
+        icons = {
+            MicState.IDLE: "⚪",
+            MicState.LISTENING: "🔴",
+            MicState.PROCESSING: "🟡",
+            MicState.SPEAKING: "🔵",
+            MicState.ERROR: "🟠",
+        }
+        return icons.get(self, "⚫")
+
+
+# ─────────────────────────────────────────────────────────────────
+# Indicator
+# ─────────────────────────────────────────────────────────────────
+
+
+class MicIndicator:
+    """Visual microphone state indicator.
+
+    Parameters
+    ----------
+    mode:
+        Output mode: "terminal", "callback", "silent".
+    callback:
+        Custom callback ``(state: MicState) -> None`` for GUI integration.
+    """
+
+    def __init__(
+        self,
+        mode: str = "terminal",
+        callback: Optional[Callable[["MicState"], None]] = None,
+    ) -> None:
+        self._mode = mode
+        self._callback = callback
+        self._state = MicState.IDLE
+        self._state_since: float = time.time()
+        self._state_history: list[tuple[MicState, float]] = []
+
+    @property
+    def state(self) -> MicState:
+        """Current mic state."""
+        return self._state
+
+    @property
+    def state_duration(self) -> float:
+        """Seconds since last state change."""
+        return time.time() - self._state_since
+
+    @property
+    def state_history(self) -> list[tuple[MicState, float]]:
+        """History of state changes ``(state, timestamp)``."""
+        return list(self._state_history)
+
+    def on_state_change(self, new_state: MicState) -> None:
+        """Notify indicator of a microphone state change.
+
+        Parameters
+        ----------
+        new_state:
+            The new microphone state.
+        """
+        if new_state == self._state:
+            return  # No change
+
+        old = self._state
+        self._state = new_state
+        self._state_since = time.time()
+        self._state_history.append((new_state, self._state_since))
+
+        logger.debug("Mic state: %s → %s", old.value, new_state.value)
+
+        if self._mode == "terminal":
+            self._show_terminal(new_state)
+        elif self._mode == "callback" and self._callback:
+            try:
+                self._callback(new_state)
+            except Exception as exc:
+                logger.warning("Mic indicator callback failed: %s", exc)
+        # silent mode: do nothing
+
+    def _show_terminal(self, state: MicState) -> None:
+        """Show state in terminal with emoji."""
+        indicator = f"{state.icon} {state.label_tr}"
+        # Overwrite current line for clean display
+        if sys.stderr.isatty():
+            sys.stderr.write(f"\r{indicator}   ")
+            sys.stderr.flush()
+        else:
+            logger.info("Mic: %s", indicator)
+
+    def reset(self) -> None:
+        """Reset to idle state."""
+        self.on_state_change(MicState.IDLE)
+        self._state_history.clear()

--- a/src/bantz/privacy/redaction.py
+++ b/src/bantz/privacy/redaction.py
@@ -1,0 +1,144 @@
+"""PII redaction for cloud-bound text (Issue #299).
+
+Removes or masks personally identifiable information before
+sending text to external services (Gemini, web search, etc.).
+
+Patterns are tuned for Turkish users:
+- Turkish ID numbers (11-digit TC Kimlik No)
+- Phone numbers (Turkish formats)
+- Email addresses
+- Credit card numbers
+- IBAN numbers
+
+Usage::
+
+    from bantz.privacy.redaction import redact_pii
+    safe = redact_pii("Aramam gereken numara 05321234567")
+    # → "Aramam gereken numara [TELEFON]"
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["redact_pii", "REDACTION_PATTERNS", "RedactionStats"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Patterns
+# ─────────────────────────────────────────────────────────────────
+
+# (regex, replacement, description)
+REDACTION_PATTERNS: List[Tuple[re.Pattern, str, str]] = [
+    # Phone numbers — Turkish mobile +90 5XX XXX XX XX or 05XX...
+    # Must be before TC Kimlik (also 11 digits) to match correctly.
+    (
+        re.compile(
+            r"(?:\+90[\s.-]?)?0?5\d{2}[\s.-]?\d{3}[\s.-]?\d{2}[\s.-]?\d{2}"
+        ),
+        "[TELEFON]",
+        "Turkish phone",
+    ),
+    # International phone numbers — require + prefix to avoid TC Kimlik clash
+    (re.compile(r"\+\d{10,15}"), "[TELEFON]", "International phone"),
+    # Turkish ID number — 11-digit TC Kimlik No (not starting with 05)
+    (re.compile(r"\b(?!05\d{2})\d{11}\b"), "[TC_KIMLIK]", "Turkish ID (TC Kimlik)"),
+    # Email addresses
+    (
+        re.compile(r"\b[\w.+-]+@[\w.-]+\.\w{2,}\b"),
+        "[EMAIL]",
+        "Email address",
+    ),
+    # Credit card numbers — 4 groups of 4 digits
+    (
+        re.compile(r"\b\d{4}[\s.-]?\d{4}[\s.-]?\d{4}[\s.-]?\d{4}\b"),
+        "[KART]",
+        "Credit card number",
+    ),
+    # IBAN — TR followed by digits
+    (
+        re.compile(r"\bTR\d{2}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{4}\s?\d{2}\b", re.IGNORECASE),
+        "[IBAN]",
+        "IBAN number",
+    ),
+    # IP addresses
+    (
+        re.compile(r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b"),
+        "[IP]",
+        "IP address",
+    ),
+]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Stats
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class RedactionStats:
+    """Statistics about a redaction operation."""
+
+    total_redactions: int = 0
+    patterns_matched: List[str] = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.patterns_matched is None:
+            self.patterns_matched = []
+
+
+# ─────────────────────────────────────────────────────────────────
+# Main function
+# ─────────────────────────────────────────────────────────────────
+
+
+def redact_pii(
+    text: str,
+    *,
+    extra_patterns: List[Tuple[re.Pattern, str, str]] | None = None,
+    collect_stats: bool = False,
+) -> str | Tuple[str, RedactionStats]:
+    """Redact PII from text before sending to cloud.
+
+    Parameters
+    ----------
+    text:
+        Input text (may contain PII).
+    extra_patterns:
+        Additional (pattern, replacement, description) tuples.
+    collect_stats:
+        If True, returns ``(redacted_text, stats)`` tuple.
+
+    Returns
+    -------
+    str or (str, RedactionStats):
+        Redacted text, optionally with statistics.
+    """
+    if not text:
+        if collect_stats:
+            return text, RedactionStats()
+        return text
+
+    result = str(text)
+    stats = RedactionStats() if collect_stats else None
+    patterns = list(REDACTION_PATTERNS)
+    if extra_patterns:
+        patterns.extend(extra_patterns)
+
+    for pattern, replacement, description in patterns:
+        new_result, count = pattern.subn(replacement, result)
+        if count > 0:
+            logger.debug("PII redacted: %s (%d match(es))", description, count)
+            if stats:
+                stats.total_redactions += count
+                stats.patterns_matched.append(description)
+            result = new_result
+
+    if collect_stats:
+        return result, stats
+    return result

--- a/tests/test_issue_299_privacy.py
+++ b/tests/test_issue_299_privacy.py
@@ -1,0 +1,596 @@
+"""Tests for Issue #299 — Privacy: Mic indicator + local-only + cloud consent.
+
+Covers:
+  - PrivacyConfig: defaults, serialization, skill gating
+  - SkillPermissions: enable/disable, any_enabled
+  - load_privacy_config / save_privacy_config: file I/O, error handling
+  - ConsentManager: consent flow, grant/revoke, persistence
+  - ConsentResult / ConsentStatus: allowed property
+  - redact_pii: all PII patterns (phone, email, TC, IBAN, card, IP)
+  - RedactionStats: counting, patterns matched
+  - MicIndicator / MicState: state changes, terminal mode, callback mode
+  - File existence
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────
+# PrivacyConfig
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPrivacyConfig:
+    """Privacy configuration defaults and serialization."""
+
+    def test_defaults_local_only(self):
+        from bantz.privacy.config import PrivacyConfig
+
+        cfg = PrivacyConfig()
+        assert cfg.cloud_mode is False
+        assert cfg.is_local_only is True
+        assert cfg.consent_given_at is None
+        assert cfg.has_consent is False
+        assert cfg.data_retention_days == 7
+
+    def test_skill_not_allowed_when_local(self):
+        from bantz.privacy.config import PrivacyConfig
+
+        cfg = PrivacyConfig(cloud_mode=False)
+        assert cfg.is_skill_allowed("gemini_finalize") is False
+        assert cfg.is_skill_allowed("news_web_fetch") is False
+
+    def test_skill_allowed_when_cloud_and_enabled(self):
+        from bantz.privacy.config import PrivacyConfig, SkillPermissions
+
+        cfg = PrivacyConfig(
+            cloud_mode=True,
+            consent_given_at="2024-01-01T00:00:00Z",
+            skills=SkillPermissions(gemini_finalize=True),
+        )
+        assert cfg.is_skill_allowed("gemini_finalize") is True
+        assert cfg.is_skill_allowed("news_web_fetch") is False
+
+    def test_unknown_skill_returns_false(self):
+        from bantz.privacy.config import PrivacyConfig
+
+        cfg = PrivacyConfig(cloud_mode=True)
+        assert cfg.is_skill_allowed("nonexistent_skill") is False
+
+    def test_has_consent_requires_both(self):
+        from bantz.privacy.config import PrivacyConfig
+
+        # cloud_mode=True but no consent_given_at
+        cfg1 = PrivacyConfig(cloud_mode=True, consent_given_at=None)
+        assert cfg1.has_consent is False
+
+        # consent_given_at set but cloud_mode=False
+        cfg2 = PrivacyConfig(cloud_mode=False, consent_given_at="2024-01-01T00:00:00Z")
+        assert cfg2.has_consent is False
+
+        # Both set → True
+        cfg3 = PrivacyConfig(cloud_mode=True, consent_given_at="2024-01-01T00:00:00Z")
+        assert cfg3.has_consent is True
+
+    def test_to_dict_roundtrip(self):
+        from bantz.privacy.config import PrivacyConfig, SkillPermissions
+
+        orig = PrivacyConfig(
+            cloud_mode=True,
+            consent_given_at="2024-06-15T12:00:00Z",
+            consent_version="1.0",
+            skills=SkillPermissions(gemini_finalize=True, web_search=True),
+            data_retention_days=14,
+        )
+        d = orig.to_dict()
+        restored = PrivacyConfig.from_dict(d)
+        assert restored.cloud_mode is True
+        assert restored.consent_given_at == "2024-06-15T12:00:00Z"
+        assert restored.skills.gemini_finalize is True
+        assert restored.skills.web_search is True
+        assert restored.skills.news_web_fetch is False
+        assert restored.data_retention_days == 14
+
+    def test_from_dict_handles_missing_fields(self):
+        from bantz.privacy.config import PrivacyConfig
+
+        cfg = PrivacyConfig.from_dict({})
+        assert cfg.cloud_mode is False
+        assert cfg.consent_given_at is None
+
+    def test_from_dict_handles_invalid_skills(self):
+        from bantz.privacy.config import PrivacyConfig
+
+        cfg = PrivacyConfig.from_dict({"skills": "invalid"})
+        assert cfg.skills.gemini_finalize is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# SkillPermissions
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestSkillPermissions:
+    """Per-skill cloud permission flags."""
+
+    def test_defaults_all_false(self):
+        from bantz.privacy.config import SkillPermissions
+
+        s = SkillPermissions()
+        assert s.news_web_fetch is False
+        assert s.gemini_finalize is False
+        assert s.web_search is False
+        assert s.any_enabled() is False
+
+    def test_enable_all(self):
+        from bantz.privacy.config import SkillPermissions
+
+        s = SkillPermissions()
+        s.enable_all()
+        assert s.news_web_fetch is True
+        assert s.gemini_finalize is True
+        assert s.web_search is True
+        assert s.any_enabled() is True
+
+    def test_disable_all(self):
+        from bantz.privacy.config import SkillPermissions
+
+        s = SkillPermissions(news_web_fetch=True, gemini_finalize=True, web_search=True)
+        s.disable_all()
+        assert s.any_enabled() is False
+
+    def test_any_enabled_partial(self):
+        from bantz.privacy.config import SkillPermissions
+
+        s = SkillPermissions(web_search=True)
+        assert s.any_enabled() is True
+
+
+# ─────────────────────────────────────────────────────────────────
+# Load / Save
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestLoadSaveConfig:
+    """File I/O for privacy config."""
+
+    def test_load_missing_file_returns_defaults(self, tmp_path):
+        from bantz.privacy.config import load_privacy_config
+
+        cfg = load_privacy_config(tmp_path / "nonexistent.json")
+        assert cfg.cloud_mode is False
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig, SkillPermissions, save_privacy_config, load_privacy_config
+
+        path = tmp_path / "privacy.json"
+        orig = PrivacyConfig(
+            cloud_mode=True,
+            consent_given_at="2024-01-01T00:00:00Z",
+            skills=SkillPermissions(gemini_finalize=True),
+        )
+        assert save_privacy_config(orig, path) is True
+        assert path.is_file()
+
+        loaded = load_privacy_config(path)
+        assert loaded.cloud_mode is True
+        assert loaded.skills.gemini_finalize is True
+
+    def test_save_creates_directories(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig, save_privacy_config
+
+        path = tmp_path / "deep" / "nested" / "privacy.json"
+        assert save_privacy_config(PrivacyConfig(), path) is True
+        assert path.is_file()
+
+    def test_load_corrupt_file_returns_defaults(self, tmp_path):
+        from bantz.privacy.config import load_privacy_config
+
+        path = tmp_path / "bad.json"
+        path.write_text("this is not json!!!", encoding="utf-8")
+        cfg = load_privacy_config(path)
+        assert cfg.cloud_mode is False
+
+    def test_saved_json_readable(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig, save_privacy_config
+
+        path = tmp_path / "privacy.json"
+        save_privacy_config(PrivacyConfig(), path)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["cloud_mode"] is False
+        assert "skills" in data
+
+
+# ─────────────────────────────────────────────────────────────────
+# ConsentManager
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestConsentManager:
+    """Consent flow for cloud features."""
+
+    def test_already_granted_skill(self):
+        from bantz.privacy.config import PrivacyConfig, SkillPermissions
+        from bantz.privacy.consent import ConsentManager, ConsentStatus
+
+        cfg = PrivacyConfig(
+            cloud_mode=True,
+            consent_given_at="2024-01-01T00:00:00Z",
+            skills=SkillPermissions(gemini_finalize=True),
+        )
+        mgr = ConsentManager(config=cfg)
+        result = mgr.check_skill("gemini_finalize")
+        assert result.status == ConsentStatus.ALREADY_GRANTED
+        assert result.allowed is True
+
+    def test_consent_newly_granted(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig
+        from bantz.privacy.consent import ConsentManager, ConsentStatus
+
+        cfg = PrivacyConfig()  # local-only
+        path = tmp_path / "privacy.json"
+        mgr = ConsentManager(
+            config=cfg,
+            config_path=path,
+            ask_fn=lambda _: "evet",
+        )
+        result = mgr.check_skill("gemini_finalize")
+        assert result.status == ConsentStatus.NEWLY_GRANTED
+        assert result.allowed is True
+        assert mgr.config.cloud_mode is True
+        assert mgr.config.skills.gemini_finalize is True
+        # Should be persisted
+        assert path.is_file()
+
+    def test_consent_declined(self):
+        from bantz.privacy.config import PrivacyConfig
+        from bantz.privacy.consent import ConsentManager, ConsentStatus
+
+        cfg = PrivacyConfig()
+        mgr = ConsentManager(config=cfg, ask_fn=lambda _: "hayır")
+        result = mgr.check_skill("web_search")
+        assert result.status == ConsentStatus.DECLINED
+        assert result.allowed is False
+        assert mgr.config.cloud_mode is False
+
+    def test_no_ask_fn_declines(self):
+        from bantz.privacy.config import PrivacyConfig
+        from bantz.privacy.consent import ConsentManager, ConsentStatus
+
+        mgr = ConsentManager(config=PrivacyConfig(), ask_fn=None)
+        result = mgr.check_skill("news_web_fetch")
+        assert result.status == ConsentStatus.DECLINED
+
+    def test_ask_fn_error_declines(self):
+        from bantz.privacy.config import PrivacyConfig
+        from bantz.privacy.consent import ConsentManager, ConsentStatus
+
+        def bad_ask(prompt):
+            raise RuntimeError("broken")
+
+        mgr = ConsentManager(config=PrivacyConfig(), ask_fn=bad_ask)
+        result = mgr.check_skill("gemini_finalize")
+        assert result.status == ConsentStatus.DECLINED
+
+    def test_grant_all(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig
+        from bantz.privacy.consent import ConsentManager, ConsentStatus
+
+        cfg = PrivacyConfig()
+        path = tmp_path / "privacy.json"
+        mgr = ConsentManager(config=cfg, config_path=path)
+        result = mgr.grant_all()
+        assert result.status == ConsentStatus.NEWLY_GRANTED
+        assert result.skill == "all"
+        assert mgr.config.skills.any_enabled() is True
+
+    def test_revoke_all(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig, SkillPermissions
+        from bantz.privacy.consent import ConsentManager
+
+        cfg = PrivacyConfig(
+            cloud_mode=True,
+            consent_given_at="2024-01-01T00:00:00Z",
+            skills=SkillPermissions(gemini_finalize=True, web_search=True),
+        )
+        mgr = ConsentManager(config=cfg, config_path=tmp_path / "p.json")
+        mgr.revoke_all()
+        assert mgr.config.cloud_mode is False
+        assert mgr.config.consent_given_at is None
+        assert mgr.config.skills.any_enabled() is False
+
+    def test_revoke_skill(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig, SkillPermissions
+        from bantz.privacy.consent import ConsentManager
+
+        cfg = PrivacyConfig(
+            cloud_mode=True,
+            skills=SkillPermissions(gemini_finalize=True, web_search=True),
+        )
+        mgr = ConsentManager(config=cfg, config_path=tmp_path / "p.json")
+        mgr.revoke_skill("gemini_finalize")
+        assert mgr.config.skills.gemini_finalize is False
+        assert mgr.config.skills.web_search is True
+        assert mgr.config.cloud_mode is True  # still has web_search
+
+    def test_revoke_last_skill_disables_cloud(self, tmp_path):
+        from bantz.privacy.config import PrivacyConfig, SkillPermissions
+        from bantz.privacy.consent import ConsentManager
+
+        cfg = PrivacyConfig(
+            cloud_mode=True,
+            skills=SkillPermissions(gemini_finalize=True),
+        )
+        mgr = ConsentManager(config=cfg, config_path=tmp_path / "p.json")
+        mgr.revoke_skill("gemini_finalize")
+        assert mgr.config.cloud_mode is False
+
+    def test_affirmative_words(self):
+        from bantz.privacy.consent import ConsentManager
+
+        mgr = ConsentManager.__new__(ConsentManager)
+        for word in ["evet", "tamam", "olur", "kabul", "onay", "yes", "ok", "elbette", "tabi"]:
+            assert mgr._is_affirmative(word) is True, f"'{word}' should be affirmative"
+
+    def test_non_affirmative_words(self):
+        from bantz.privacy.consent import ConsentManager
+
+        mgr = ConsentManager.__new__(ConsentManager)
+        for word in ["hayır", "yok", "no", "istemiyorum", ""]:
+            assert mgr._is_affirmative(word) is False, f"'{word}' should not be affirmative"
+
+
+# ─────────────────────────────────────────────────────────────────
+# ConsentResult
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestConsentResult:
+    """ConsentResult allowed property."""
+
+    def test_granted_is_allowed(self):
+        from bantz.privacy.consent import ConsentResult, ConsentStatus
+
+        assert ConsentResult(status=ConsentStatus.ALREADY_GRANTED).allowed is True
+        assert ConsentResult(status=ConsentStatus.NEWLY_GRANTED).allowed is True
+        assert ConsentResult(status=ConsentStatus.NOT_NEEDED).allowed is True
+
+    def test_declined_not_allowed(self):
+        from bantz.privacy.consent import ConsentResult, ConsentStatus
+
+        assert ConsentResult(status=ConsentStatus.DECLINED).allowed is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# PII Redaction
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestRedaction:
+    """PII redaction patterns."""
+
+    def test_turkish_phone_mobile(self):
+        from bantz.privacy.redaction import redact_pii
+
+        assert "[TELEFON]" in redact_pii("Numaram 05321234567")
+
+    def test_turkish_phone_with_country_code(self):
+        from bantz.privacy.redaction import redact_pii
+
+        assert "[TELEFON]" in redact_pii("Ara +905321234567")
+
+    def test_turkish_phone_with_spaces(self):
+        from bantz.privacy.redaction import redact_pii
+
+        assert "[TELEFON]" in redact_pii("Numaram 0532 123 45 67")
+
+    def test_email(self):
+        from bantz.privacy.redaction import redact_pii
+
+        result = redact_pii("Mail adresim test@example.com")
+        assert "[EMAIL]" in result
+        assert "test@example.com" not in result
+
+    def test_turkish_id(self):
+        from bantz.privacy.redaction import redact_pii
+
+        result = redact_pii("TC numaram 12345678901")
+        assert "[TC_KIMLIK]" in result
+
+    def test_credit_card(self):
+        from bantz.privacy.redaction import redact_pii
+
+        result = redact_pii("Kart: 4532 1234 5678 9012")
+        assert "[KART]" in result
+
+    def test_ip_address(self):
+        from bantz.privacy.redaction import redact_pii
+
+        result = redact_pii("IP: 192.168.1.100")
+        assert "[IP]" in result
+
+    def test_empty_text(self):
+        from bantz.privacy.redaction import redact_pii
+
+        assert redact_pii("") == ""
+
+    def test_no_pii(self):
+        from bantz.privacy.redaction import redact_pii
+
+        text = "Yarın hava nasıl olacak?"
+        assert redact_pii(text) == text
+
+    def test_multiple_pii_in_one_text(self):
+        from bantz.privacy.redaction import redact_pii
+
+        text = "Mail: a@b.com, Tel: 05321234567"
+        result = redact_pii(text)
+        assert "[EMAIL]" in result
+        assert "[TELEFON]" in result
+
+    def test_stats_collection(self):
+        from bantz.privacy.redaction import redact_pii
+
+        result, stats = redact_pii("Mail: test@x.com", collect_stats=True)
+        assert "[EMAIL]" in result
+        assert stats.total_redactions >= 1
+        assert len(stats.patterns_matched) >= 1
+
+    def test_stats_no_pii(self):
+        from bantz.privacy.redaction import redact_pii
+
+        result, stats = redact_pii("Merhaba efendim", collect_stats=True)
+        assert stats.total_redactions == 0
+
+    def test_extra_patterns(self):
+        from bantz.privacy.redaction import redact_pii
+
+        custom = [(re.compile(r"SECRET_\w+"), "[GİZLİ]", "Custom secret")]
+        result = redact_pii("Token: SECRET_abc123", extra_patterns=custom)
+        assert "[GİZLİ]" in result
+
+
+# ─────────────────────────────────────────────────────────────────
+# MicState
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestMicState:
+    """Microphone state enum."""
+
+    def test_states_exist(self):
+        from bantz.privacy.indicator import MicState
+
+        assert MicState.IDLE.value == "idle"
+        assert MicState.LISTENING.value == "listening"
+        assert MicState.PROCESSING.value == "processing"
+        assert MicState.SPEAKING.value == "speaking"
+        assert MicState.ERROR.value == "error"
+
+    def test_turkish_labels(self):
+        from bantz.privacy.indicator import MicState
+
+        assert MicState.LISTENING.label_tr == "DİNLENİYOR"
+        assert MicState.IDLE.label_tr == "HAZIR"
+        assert MicState.PROCESSING.label_tr == "İŞLENİYOR"
+
+    def test_icons(self):
+        from bantz.privacy.indicator import MicState
+
+        assert MicState.LISTENING.icon == "🔴"
+        assert MicState.IDLE.icon == "⚪"
+
+
+# ─────────────────────────────────────────────────────────────────
+# MicIndicator
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestMicIndicator:
+    """Mic state indicator."""
+
+    def test_default_state_idle(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        ind = MicIndicator(mode="silent")
+        assert ind.state == MicState.IDLE
+
+    def test_state_change(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        ind = MicIndicator(mode="silent")
+        ind.on_state_change(MicState.LISTENING)
+        assert ind.state == MicState.LISTENING
+
+    def test_no_change_on_same_state(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        ind = MicIndicator(mode="silent")
+        ind.on_state_change(MicState.LISTENING)
+        history_len = len(ind.state_history)
+        ind.on_state_change(MicState.LISTENING)  # Same state
+        assert len(ind.state_history) == history_len
+
+    def test_state_history_tracked(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        ind = MicIndicator(mode="silent")
+        ind.on_state_change(MicState.LISTENING)
+        ind.on_state_change(MicState.PROCESSING)
+        ind.on_state_change(MicState.SPEAKING)
+        assert len(ind.state_history) == 3
+        assert ind.state_history[0][0] == MicState.LISTENING
+        assert ind.state_history[2][0] == MicState.SPEAKING
+
+    def test_state_duration(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        ind = MicIndicator(mode="silent")
+        ind.on_state_change(MicState.LISTENING)
+        time.sleep(0.05)
+        assert ind.state_duration >= 0.04
+
+    def test_callback_mode(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        received = []
+        ind = MicIndicator(mode="callback", callback=lambda s: received.append(s))
+        ind.on_state_change(MicState.LISTENING)
+        ind.on_state_change(MicState.IDLE)
+        assert len(received) == 2
+        assert received[0] == MicState.LISTENING
+
+    def test_callback_error_handled(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        def bad_cb(s):
+            raise ValueError("broken")
+
+        ind = MicIndicator(mode="callback", callback=bad_cb)
+        ind.on_state_change(MicState.LISTENING)  # Should not raise
+        assert ind.state == MicState.LISTENING
+
+    def test_reset(self):
+        from bantz.privacy.indicator import MicIndicator, MicState
+
+        ind = MicIndicator(mode="silent")
+        ind.on_state_change(MicState.LISTENING)
+        ind.on_state_change(MicState.PROCESSING)
+        ind.reset()
+        assert ind.state == MicState.IDLE
+        assert len(ind.state_history) == 0
+
+
+# ─────────────────────────────────────────────────────────────────
+# File existence
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestFileExistence:
+    """Verify all Issue #299 files exist."""
+
+    ROOT = Path(__file__).resolve().parent.parent
+
+    def test_init_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "privacy" / "__init__.py").is_file()
+
+    def test_config_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "privacy" / "config.py").is_file()
+
+    def test_consent_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "privacy" / "consent.py").is_file()
+
+    def test_redaction_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "privacy" / "redaction.py").is_file()
+
+    def test_indicator_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "privacy" / "indicator.py").is_file()


### PR DESCRIPTION
## Issue #299 — Privacy: Mic indicator + local-only + cloud consent

### New files
- **src/bantz/privacy/__init__.py** — Package exports
- **src/bantz/privacy/config.py** — PrivacyConfig, SkillPermissions, load/save
- **src/bantz/privacy/consent.py** — ConsentManager, consent flow with Turkish prompts
- **src/bantz/privacy/redaction.py** — PII redaction (TC Kimlik, phone, email, card, IBAN, IP)
- **src/bantz/privacy/indicator.py** — MicIndicator + MicState (terminal/callback/silent)
- **tests/test_issue_299_privacy.py** — 59 tests (all pass)

### Privacy config (persisted)
```json
{
  "cloud_mode": false,
  "consent_given_at": null,
  "consent_version": "1.0",
  "skills": {"news_web_fetch": false, "gemini_finalize": false, "web_search": false},
  "data_retention_days": 7
}
```

### Consent flow
1. User tries cloud feature → ConsentManager.check_skill()
2. If local-only → Turkish consent prompt via ask_fn
3. "evet" → persist consent, enable skill
4. "hayır" → local fallback

### PII redaction patterns
TC Kimlik, Turkish phone, email, credit card, IBAN, IP address

### Mic indicator
MicState: IDLE/LISTENING/PROCESSING/SPEAKING/ERROR — Turkish labels + emoji icons

### Tests: 59/59 passed

Closes #299