### PR TITLE
feat(#298): Controls — PTT hotkey + mic mute + status indicator

### DIFF
--- a/src/bantz/controls/__init__.py
+++ b/src/bantz/controls/__init__.py
@@ -1,0 +1,22 @@
+"""Controls module — PTT hotkey, mic mute, status indicator (Issue #298).
+
+Provides alternative control mechanisms for the voice pipeline:
+- Push-to-talk (PTT) hotkey
+- Mic mute/unmute toggle
+- Status indicator (terminal / callback)
+"""
+
+from bantz.controls.hotkeys import HotkeyConfig, HotkeyManager
+from bantz.controls.ptt import PTTController, PTTState
+from bantz.controls.mute import MuteController
+from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+__all__ = [
+    "HotkeyConfig",
+    "HotkeyManager",
+    "PTTController",
+    "PTTState",
+    "MuteController",
+    "StatusIndicator",
+    "VoiceStatus",
+]

--- a/src/bantz/controls/hotkeys.py
+++ b/src/bantz/controls/hotkeys.py
@@ -1,0 +1,211 @@
+"""Hotkey configuration and manager (Issue #298).
+
+Reads keybinds from environment variables and provides a platform-safe
+keyboard hook that works on Linux (X11 and Wayland fallback).
+
+Env vars::
+
+    BANTZ_PTT_KEY=ctrl+space        # Push-to-talk
+    BANTZ_MUTE_KEY=ctrl+shift+m     # Mute toggle
+    BANTZ_STATUS_KEY=ctrl+shift+s   # Show status
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HotkeyConfig", "HotkeyManager"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Config
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class HotkeyConfig:
+    """Keybind configuration from env vars.
+
+    Attributes
+    ----------
+    ptt_key:
+        Push-to-talk key combo (e.g. ``ctrl+space``).
+    mute_key:
+        Mic mute/unmute toggle (e.g. ``ctrl+shift+m``).
+    status_key:
+        Show status (e.g. ``ctrl+shift+s``).
+    enabled:
+        Master toggle for hotkey listener.
+    """
+
+    ptt_key: str = "ctrl+space"
+    mute_key: str = "ctrl+shift+m"
+    status_key: str = "ctrl+shift+s"
+    enabled: bool = True
+
+    @classmethod
+    def from_env(cls) -> "HotkeyConfig":
+        """Load hotkey config from environment variables."""
+        return cls(
+            ptt_key=os.getenv("BANTZ_PTT_KEY", "ctrl+space").strip().lower(),
+            mute_key=os.getenv("BANTZ_MUTE_KEY", "ctrl+shift+m").strip().lower(),
+            status_key=os.getenv("BANTZ_STATUS_KEY", "ctrl+shift+s").strip().lower(),
+            enabled=os.getenv("BANTZ_HOTKEYS_ENABLED", "true").strip().lower()
+            not in {"0", "false", "no", "off"},
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Manager
+# ─────────────────────────────────────────────────────────────────
+
+
+class HotkeyManager:
+    """Platform-safe keyboard hook manager.
+
+    Registers callbacks for key combinations. Uses ``pynput`` if
+    available, otherwise falls back to a no-op mode (headless/CI).
+
+    Parameters
+    ----------
+    config:
+        Hotkey configuration.
+    """
+
+    def __init__(self, config: Optional[HotkeyConfig] = None) -> None:
+        self._config = config or HotkeyConfig.from_env()
+        self._callbacks: Dict[str, Callable[[], None]] = {}
+        self._listener: Optional[object] = None
+        self._running = False
+        self._pressed_keys: set[str] = set()
+
+    @property
+    def config(self) -> HotkeyConfig:
+        return self._config
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    def register(self, key_combo: str, callback: Callable[[], None]) -> None:
+        """Register a callback for a key combination.
+
+        Parameters
+        ----------
+        key_combo:
+            Key combination string (e.g. ``ctrl+space``).
+        callback:
+            Function to call when the combo is triggered.
+        """
+        normalized = key_combo.strip().lower()
+        self._callbacks[normalized] = callback
+        logger.debug("Hotkey registered: %s", normalized)
+
+    def unregister(self, key_combo: str) -> None:
+        """Remove a registered hotkey."""
+        normalized = key_combo.strip().lower()
+        self._callbacks.pop(normalized, None)
+
+    def start(self) -> bool:
+        """Start listening for hotkeys.
+
+        Returns True if started, False if disabled or pynput unavailable.
+        """
+        if not self._config.enabled:
+            logger.debug("Hotkeys disabled")
+            return False
+
+        if self._running:
+            return True
+
+        try:
+            from pynput import keyboard  # type: ignore[import-untyped]
+
+            def on_press(key):
+                try:
+                    k = self._key_to_str(key)
+                    if k:
+                        self._pressed_keys.add(k)
+                        combo = "+".join(sorted(self._pressed_keys))
+                        cb = self._callbacks.get(combo)
+                        if cb:
+                            cb()
+                except Exception as exc:
+                    logger.debug("Hotkey press error: %s", exc)
+
+            def on_release(key):
+                try:
+                    k = self._key_to_str(key)
+                    if k:
+                        self._pressed_keys.discard(k)
+                except Exception:
+                    pass
+
+            self._listener = keyboard.Listener(
+                on_press=on_press,
+                on_release=on_release,
+            )
+            self._listener.start()  # type: ignore[union-attr]
+            self._running = True
+            logger.info("Hotkey listener started")
+            return True
+
+        except ImportError:
+            logger.debug("pynput not available — hotkeys disabled (headless mode)")
+            self._running = False
+            return False
+        except Exception as exc:
+            logger.warning("Hotkey listener failed to start: %s", exc)
+            self._running = False
+            return False
+
+    def stop(self) -> None:
+        """Stop listening for hotkeys."""
+        if self._listener and hasattr(self._listener, "stop"):
+            try:
+                self._listener.stop()  # type: ignore[union-attr]
+            except Exception:
+                pass
+        self._running = False
+        self._pressed_keys.clear()
+        logger.debug("Hotkey listener stopped")
+
+    def simulate_combo(self, key_combo: str) -> bool:
+        """Simulate a key combination (for testing).
+
+        Returns True if a callback was triggered.
+        """
+        normalized = key_combo.strip().lower()
+        cb = self._callbacks.get(normalized)
+        if cb:
+            cb()
+            return True
+        return False
+
+    @staticmethod
+    def _key_to_str(key) -> Optional[str]:
+        """Convert a pynput key to a normalized string."""
+        try:
+            # Special keys (ctrl, shift, alt, space, etc.)
+            if hasattr(key, "name"):
+                name = key.name
+                # Normalize modifier names
+                if name in ("ctrl_l", "ctrl_r"):
+                    return "ctrl"
+                if name in ("shift_l", "shift_r", "shift"):
+                    return "shift"
+                if name in ("alt_l", "alt_r", "alt_gr"):
+                    return "alt"
+                return name.lower()
+            # Regular character keys
+            if hasattr(key, "char") and key.char:
+                return key.char.lower()
+        except Exception:
+            pass
+        return None

--- a/src/bantz/controls/indicator.py
+++ b/src/bantz/controls/indicator.py
@@ -1,0 +1,145 @@
+"""Status indicator for voice pipeline state (Issue #298).
+
+Displays the current voice state in the terminal or via a callback.
+Supports multiple output modes: terminal, callback, silent.
+
+Usage::
+
+    indicator = StatusIndicator()
+    indicator.update(VoiceStatus.LISTENING)
+    # Terminal: "[BANTZ] 🎤 DİNLİYOR"
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from enum import Enum
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["StatusIndicator", "VoiceStatus"]
+
+
+class VoiceStatus(str, Enum):
+    """Voice pipeline status."""
+
+    WAKE_ONLY = "wake_only"      # Waiting for wake word
+    LISTENING = "listening"       # Actively listening
+    PROCESSING = "processing"    # Processing speech
+    SPEAKING = "speaking"        # TTS playing
+    IDLE_SLEEP = "idle_sleep"    # Idle / sleeping
+    MUTED = "muted"              # Mic muted
+    ERROR = "error"              # Error state
+
+    @property
+    def label_tr(self) -> str:
+        """Turkish label."""
+        labels = {
+            VoiceStatus.WAKE_ONLY: "BEKLEMEDE",
+            VoiceStatus.LISTENING: "DİNLİYOR",
+            VoiceStatus.PROCESSING: "İŞLENİYOR",
+            VoiceStatus.SPEAKING: "KONUŞUYOR",
+            VoiceStatus.IDLE_SLEEP: "UYUYOR",
+            VoiceStatus.MUTED: "SESSİZ",
+            VoiceStatus.ERROR: "HATA",
+        }
+        return labels.get(self, "BİLİNMİYOR")
+
+    @property
+    def icon(self) -> str:
+        """Emoji icon."""
+        icons = {
+            VoiceStatus.WAKE_ONLY: "💤",
+            VoiceStatus.LISTENING: "🎤",
+            VoiceStatus.PROCESSING: "🟡",
+            VoiceStatus.SPEAKING: "🔊",
+            VoiceStatus.IDLE_SLEEP: "😴",
+            VoiceStatus.MUTED: "🔇",
+            VoiceStatus.ERROR: "🟠",
+        }
+        return icons.get(self, "❓")
+
+
+class StatusIndicator:
+    """Voice status display.
+
+    Parameters
+    ----------
+    mode:
+        Output mode: "terminal", "callback", "silent".
+    callback:
+        Custom callback ``(status: VoiceStatus) -> None``.
+    """
+
+    def __init__(
+        self,
+        mode: str = "terminal",
+        callback: Optional[Callable[["VoiceStatus"], None]] = None,
+    ) -> None:
+        self._mode = mode
+        self._callback = callback
+        self._status = VoiceStatus.IDLE_SLEEP
+        self._status_since: float = time.time()
+        self._update_count = 0
+
+    @property
+    def status(self) -> VoiceStatus:
+        return self._status
+
+    @property
+    def status_duration(self) -> float:
+        """Seconds since last status change."""
+        return time.time() - self._status_since
+
+    @property
+    def update_count(self) -> int:
+        return self._update_count
+
+    def update(self, new_status: VoiceStatus) -> None:
+        """Update the displayed status.
+
+        Parameters
+        ----------
+        new_status:
+            New voice pipeline status.
+        """
+        if new_status == self._status:
+            return
+
+        old = self._status
+        self._status = new_status
+        self._status_since = time.time()
+        self._update_count += 1
+
+        logger.debug("Status: %s → %s", old.value, new_status.value)
+
+        if self._mode == "terminal":
+            self._display_terminal(new_status)
+        elif self._mode == "callback" and self._callback:
+            try:
+                self._callback(new_status)
+            except Exception as exc:
+                logger.warning("Status callback failed: %s", exc)
+        # silent: do nothing
+
+    def _display_terminal(self, status: VoiceStatus) -> None:
+        """Show status in terminal."""
+        text = f"[BANTZ] {status.icon} {status.label_tr}"
+        if sys.stderr.isatty():
+            sys.stderr.write(f"\r{text}   ")
+            sys.stderr.flush()
+        else:
+            logger.info("Status: %s", text)
+
+    def get_status_line(self) -> str:
+        """Return a formatted status line string."""
+        return f"{self._status.icon} {self._status.label_tr}"
+
+    def reset(self) -> None:
+        """Reset to idle/sleep state."""
+        self._status = VoiceStatus.IDLE_SLEEP
+        self._status_since = time.time()
+        self._update_count = 0

--- a/src/bantz/controls/mute.py
+++ b/src/bantz/controls/mute.py
@@ -1,0 +1,101 @@
+"""Mic mute/unmute toggle controller (Issue #298).
+
+Provides a simple mute toggle for the microphone. When muted,
+the voice pipeline should not process any audio input.
+
+Usage::
+
+    mute = MuteController(on_mute=pause_mic, on_unmute=resume_mic)
+    mute.toggle()   # Mute
+    mute.toggle()   # Unmute
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["MuteController"]
+
+
+class MuteController:
+    """Mic mute/unmute toggle.
+
+    Parameters
+    ----------
+    on_mute:
+        Callback when mic is muted.
+    on_unmute:
+        Callback when mic is unmuted.
+    initially_muted:
+        Start in muted state.
+    """
+
+    def __init__(
+        self,
+        on_mute: Optional[Callable[[], None]] = None,
+        on_unmute: Optional[Callable[[], None]] = None,
+        initially_muted: bool = False,
+    ) -> None:
+        self._on_mute = on_mute
+        self._on_unmute = on_unmute
+        self._muted = initially_muted
+        self._toggle_count = 0
+        self._last_toggle: Optional[float] = None
+
+    @property
+    def muted(self) -> bool:
+        return self._muted
+
+    @property
+    def toggle_count(self) -> int:
+        return self._toggle_count
+
+    @property
+    def last_toggle_time(self) -> Optional[float]:
+        return self._last_toggle
+
+    def toggle(self) -> bool:
+        """Toggle mute state.
+
+        Returns the new muted state (True = muted, False = unmuted).
+        """
+        self._muted = not self._muted
+        self._toggle_count += 1
+        self._last_toggle = time.time()
+
+        if self._muted:
+            logger.info("🔇 Mikrofon kapatıldı")
+            if self._on_mute:
+                try:
+                    self._on_mute()
+                except Exception as exc:
+                    logger.warning("on_mute callback failed: %s", exc)
+        else:
+            logger.info("🔊 Mikrofon açıldı")
+            if self._on_unmute:
+                try:
+                    self._on_unmute()
+                except Exception as exc:
+                    logger.warning("on_unmute callback failed: %s", exc)
+
+        return self._muted
+
+    def mute(self) -> None:
+        """Force mute (no-op if already muted)."""
+        if not self._muted:
+            self.toggle()
+
+    def unmute(self) -> None:
+        """Force unmute (no-op if already unmuted)."""
+        if self._muted:
+            self.toggle()
+
+    def reset(self) -> None:
+        """Reset to unmuted state with zero count."""
+        self._muted = False
+        self._toggle_count = 0
+        self._last_toggle = None

--- a/src/bantz/controls/ptt.py
+++ b/src/bantz/controls/ptt.py
@@ -1,0 +1,147 @@
+"""Push-to-talk controller (Issue #298).
+
+PTT mode: user holds a key to speak, releases to stop.
+While held → voice pipeline enters ACTIVE_LISTEN.
+On release → process what was said, return to WAKE_ONLY.
+
+Usage::
+
+    ptt = PTTController(on_start=start_listening, on_stop=stop_listening)
+    ptt.press()   # Start listening
+    ptt.release() # Stop listening, process audio
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from enum import Enum
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PTTController", "PTTState"]
+
+
+class PTTState(str, Enum):
+    """Push-to-talk state."""
+
+    IDLE = "idle"          # Not pressed
+    HELD = "held"          # Key held — listening
+    PROCESSING = "processing"  # Released — processing captured audio
+
+
+class PTTController:
+    """Push-to-talk controller.
+
+    Parameters
+    ----------
+    on_start:
+        Callback when PTT key is pressed (start listening).
+    on_stop:
+        Callback when PTT key is released (stop listening, process).
+    min_hold_ms:
+        Minimum hold time to consider valid speech (avoids accidental taps).
+    """
+
+    def __init__(
+        self,
+        on_start: Optional[Callable[[], None]] = None,
+        on_stop: Optional[Callable[[], None]] = None,
+        min_hold_ms: int = 200,
+    ) -> None:
+        self._on_start = on_start
+        self._on_stop = on_stop
+        self._min_hold_ms = min_hold_ms
+        self._state = PTTState.IDLE
+        self._press_time: Optional[float] = None
+        self._press_count = 0
+        self._total_hold_ms = 0.0
+
+    @property
+    def state(self) -> PTTState:
+        return self._state
+
+    @property
+    def press_count(self) -> int:
+        """Total number of valid PTT activations."""
+        return self._press_count
+
+    @property
+    def total_hold_ms(self) -> float:
+        """Total accumulated hold time in ms."""
+        return self._total_hold_ms
+
+    @property
+    def is_held(self) -> bool:
+        return self._state == PTTState.HELD
+
+    def press(self) -> bool:
+        """PTT key pressed — start listening.
+
+        Returns True if state changed to HELD.
+        """
+        if self._state != PTTState.IDLE:
+            return False
+
+        self._state = PTTState.HELD
+        self._press_time = time.time()
+        logger.info("🎤 PTT basıldı — dinleniyor...")
+
+        if self._on_start:
+            try:
+                self._on_start()
+            except Exception as exc:
+                logger.warning("PTT on_start callback failed: %s", exc)
+
+        return True
+
+    def release(self) -> bool:
+        """PTT key released — stop listening and process.
+
+        Returns True if valid hold (>= min_hold_ms), False if too short.
+        """
+        if self._state != PTTState.HELD:
+            return False
+
+        hold_ms = 0.0
+        if self._press_time:
+            hold_ms = (time.time() - self._press_time) * 1000
+
+        if hold_ms < self._min_hold_ms:
+            logger.debug(
+                "PTT too short: %.0fms < %dms — ignoring",
+                hold_ms, self._min_hold_ms,
+            )
+            self._state = PTTState.IDLE
+            self._press_time = None
+            return False
+
+        self._state = PTTState.PROCESSING
+        self._press_count += 1
+        self._total_hold_ms += hold_ms
+        logger.info("🎤 PTT bırakıldı — işleniyor (%.0fms)", hold_ms)
+
+        if self._on_stop:
+            try:
+                self._on_stop()
+            except Exception as exc:
+                logger.warning("PTT on_stop callback failed: %s", exc)
+
+        self._state = PTTState.IDLE
+        self._press_time = None
+        return True
+
+    def cancel(self) -> None:
+        """Cancel current PTT without processing."""
+        if self._state == PTTState.HELD:
+            logger.debug("PTT cancelled")
+        self._state = PTTState.IDLE
+        self._press_time = None
+
+    def reset(self) -> None:
+        """Reset all stats."""
+        self._state = PTTState.IDLE
+        self._press_time = None
+        self._press_count = 0
+        self._total_hold_ms = 0.0

--- a/tests/test_issue_298_controls.py
+++ b/tests/test_issue_298_controls.py
@@ -1,0 +1,475 @@
+"""Tests for Issue #298 — Controls: PTT hotkey + mic mute + status indicator.
+
+Covers:
+  - HotkeyConfig: defaults, from_env, custom values
+  - HotkeyManager: register, unregister, simulate_combo, start/stop
+  - PTTController: press/release, min_hold_ms, cancel, reset, stats
+  - PTTState: enum values
+  - MuteController: toggle, mute/unmute, callbacks, reset
+  - StatusIndicator: update, terminal/callback/silent, status_line
+  - VoiceStatus: enum, labels, icons
+  - File existence
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────
+# HotkeyConfig
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestHotkeyConfig:
+    """Hotkey configuration from env vars."""
+
+    def test_defaults(self):
+        from bantz.controls.hotkeys import HotkeyConfig
+
+        cfg = HotkeyConfig()
+        assert cfg.ptt_key == "ctrl+space"
+        assert cfg.mute_key == "ctrl+shift+m"
+        assert cfg.status_key == "ctrl+shift+s"
+        assert cfg.enabled is True
+
+    def test_from_env(self):
+        from bantz.controls.hotkeys import HotkeyConfig
+
+        env = {
+            "BANTZ_PTT_KEY": "alt+space",
+            "BANTZ_MUTE_KEY": "f9",
+            "BANTZ_STATUS_KEY": "f10",
+            "BANTZ_HOTKEYS_ENABLED": "false",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            cfg = HotkeyConfig.from_env()
+        assert cfg.ptt_key == "alt+space"
+        assert cfg.mute_key == "f9"
+        assert cfg.status_key == "f10"
+        assert cfg.enabled is False
+
+    def test_enabled_truthy(self):
+        from bantz.controls.hotkeys import HotkeyConfig
+
+        with mock.patch.dict(os.environ, {"BANTZ_HOTKEYS_ENABLED": "1"}, clear=True):
+            cfg = HotkeyConfig.from_env()
+        assert cfg.enabled is True
+
+
+# ─────────────────────────────────────────────────────────────────
+# HotkeyManager
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestHotkeyManager:
+    """Hotkey manager — register, simulate, start/stop."""
+
+    def test_register_and_simulate(self):
+        from bantz.controls.hotkeys import HotkeyManager, HotkeyConfig
+
+        mgr = HotkeyManager(config=HotkeyConfig(enabled=False))
+        results = []
+        mgr.register("ctrl+space", lambda: results.append("ptt"))
+        assert mgr.simulate_combo("ctrl+space") is True
+        assert results == ["ptt"]
+
+    def test_simulate_unregistered(self):
+        from bantz.controls.hotkeys import HotkeyManager, HotkeyConfig
+
+        mgr = HotkeyManager(config=HotkeyConfig(enabled=False))
+        assert mgr.simulate_combo("ctrl+x") is False
+
+    def test_unregister(self):
+        from bantz.controls.hotkeys import HotkeyManager, HotkeyConfig
+
+        mgr = HotkeyManager(config=HotkeyConfig(enabled=False))
+        mgr.register("ctrl+space", lambda: None)
+        mgr.unregister("ctrl+space")
+        assert mgr.simulate_combo("ctrl+space") is False
+
+    def test_start_disabled(self):
+        from bantz.controls.hotkeys import HotkeyManager, HotkeyConfig
+
+        mgr = HotkeyManager(config=HotkeyConfig(enabled=False))
+        assert mgr.start() is False
+        assert mgr.running is False
+
+    def test_stop_idempotent(self):
+        from bantz.controls.hotkeys import HotkeyManager, HotkeyConfig
+
+        mgr = HotkeyManager(config=HotkeyConfig(enabled=False))
+        mgr.stop()  # Should not raise
+        assert mgr.running is False
+
+    def test_config_property(self):
+        from bantz.controls.hotkeys import HotkeyManager, HotkeyConfig
+
+        cfg = HotkeyConfig(ptt_key="f5")
+        mgr = HotkeyManager(config=cfg)
+        assert mgr.config.ptt_key == "f5"
+
+    def test_normalize_key_combo(self):
+        from bantz.controls.hotkeys import HotkeyManager, HotkeyConfig
+
+        mgr = HotkeyManager(config=HotkeyConfig(enabled=False))
+        results = []
+        mgr.register("CTRL+SPACE", lambda: results.append("hit"))
+        assert mgr.simulate_combo("ctrl+space") is True
+
+
+# ─────────────────────────────────────────────────────────────────
+# PTTState
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPTTState:
+    """PTT state enum."""
+
+    def test_values(self):
+        from bantz.controls.ptt import PTTState
+
+        assert PTTState.IDLE.value == "idle"
+        assert PTTState.HELD.value == "held"
+        assert PTTState.PROCESSING.value == "processing"
+
+
+# ─────────────────────────────────────────────────────────────────
+# PTTController
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPTTController:
+    """Push-to-talk controller."""
+
+    def test_initial_state_idle(self):
+        from bantz.controls.ptt import PTTController, PTTState
+
+        ptt = PTTController()
+        assert ptt.state == PTTState.IDLE
+        assert ptt.is_held is False
+        assert ptt.press_count == 0
+
+    def test_press_enters_held(self):
+        from bantz.controls.ptt import PTTController, PTTState
+
+        ptt = PTTController()
+        assert ptt.press() is True
+        assert ptt.state == PTTState.HELD
+        assert ptt.is_held is True
+
+    def test_double_press_ignored(self):
+        from bantz.controls.ptt import PTTController
+
+        ptt = PTTController()
+        ptt.press()
+        assert ptt.press() is False
+
+    def test_release_after_hold(self):
+        from bantz.controls.ptt import PTTController, PTTState
+
+        ptt = PTTController(min_hold_ms=0)
+        ptt.press()
+        time.sleep(0.01)
+        assert ptt.release() is True
+        assert ptt.state == PTTState.IDLE
+        assert ptt.press_count == 1
+
+    def test_release_too_short(self):
+        from bantz.controls.ptt import PTTController
+
+        ptt = PTTController(min_hold_ms=5000)  # 5 seconds
+        ptt.press()
+        assert ptt.release() is False  # Way too short
+        assert ptt.press_count == 0
+
+    def test_release_without_press(self):
+        from bantz.controls.ptt import PTTController
+
+        ptt = PTTController()
+        assert ptt.release() is False
+
+    def test_callbacks_called(self):
+        from bantz.controls.ptt import PTTController
+
+        events = []
+        ptt = PTTController(
+            on_start=lambda: events.append("start"),
+            on_stop=lambda: events.append("stop"),
+            min_hold_ms=0,
+        )
+        ptt.press()
+        time.sleep(0.01)
+        ptt.release()
+        assert events == ["start", "stop"]
+
+    def test_callback_error_handled(self):
+        from bantz.controls.ptt import PTTController
+
+        def bad_start():
+            raise RuntimeError("broken")
+
+        ptt = PTTController(on_start=bad_start)
+        ptt.press()  # Should not raise
+        assert ptt.is_held is True
+
+    def test_cancel(self):
+        from bantz.controls.ptt import PTTController, PTTState
+
+        ptt = PTTController()
+        ptt.press()
+        ptt.cancel()
+        assert ptt.state == PTTState.IDLE
+        assert ptt.press_count == 0
+
+    def test_reset(self):
+        from bantz.controls.ptt import PTTController
+
+        ptt = PTTController(min_hold_ms=0)
+        ptt.press()
+        time.sleep(0.01)
+        ptt.release()
+        assert ptt.press_count == 1
+        ptt.reset()
+        assert ptt.press_count == 0
+        assert ptt.total_hold_ms == 0.0
+
+    def test_total_hold_ms(self):
+        from bantz.controls.ptt import PTTController
+
+        ptt = PTTController(min_hold_ms=0)
+        ptt.press()
+        time.sleep(0.05)
+        ptt.release()
+        assert ptt.total_hold_ms >= 40  # ~50ms
+
+
+# ─────────────────────────────────────────────────────────────────
+# MuteController
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestMuteController:
+    """Mic mute/unmute toggle."""
+
+    def test_default_unmuted(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController()
+        assert ctrl.muted is False
+        assert ctrl.toggle_count == 0
+
+    def test_toggle_mutes(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController()
+        result = ctrl.toggle()
+        assert result is True  # Now muted
+        assert ctrl.muted is True
+        assert ctrl.toggle_count == 1
+
+    def test_double_toggle_unmutes(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController()
+        ctrl.toggle()  # Mute
+        ctrl.toggle()  # Unmute
+        assert ctrl.muted is False
+        assert ctrl.toggle_count == 2
+
+    def test_mute_method(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController()
+        ctrl.mute()
+        assert ctrl.muted is True
+        ctrl.mute()  # Already muted — no-op
+        assert ctrl.toggle_count == 1
+
+    def test_unmute_method(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController(initially_muted=True)
+        ctrl.unmute()
+        assert ctrl.muted is False
+        ctrl.unmute()  # Already unmuted — no-op
+        assert ctrl.toggle_count == 1
+
+    def test_callbacks(self):
+        from bantz.controls.mute import MuteController
+
+        events = []
+        ctrl = MuteController(
+            on_mute=lambda: events.append("muted"),
+            on_unmute=lambda: events.append("unmuted"),
+        )
+        ctrl.toggle()  # Mute
+        ctrl.toggle()  # Unmute
+        assert events == ["muted", "unmuted"]
+
+    def test_callback_error_handled(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController(on_mute=lambda: 1 / 0)
+        ctrl.toggle()  # Should not raise
+        assert ctrl.muted is True
+
+    def test_initially_muted(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController(initially_muted=True)
+        assert ctrl.muted is True
+
+    def test_reset(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController()
+        ctrl.toggle()
+        ctrl.toggle()
+        ctrl.reset()
+        assert ctrl.muted is False
+        assert ctrl.toggle_count == 0
+        assert ctrl.last_toggle_time is None
+
+    def test_last_toggle_time(self):
+        from bantz.controls.mute import MuteController
+
+        ctrl = MuteController()
+        assert ctrl.last_toggle_time is None
+        ctrl.toggle()
+        assert ctrl.last_toggle_time is not None
+
+
+# ─────────────────────────────────────────────────────────────────
+# VoiceStatus
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestVoiceStatus:
+    """Voice status enum."""
+
+    def test_values(self):
+        from bantz.controls.indicator import VoiceStatus
+
+        assert VoiceStatus.WAKE_ONLY.value == "wake_only"
+        assert VoiceStatus.LISTENING.value == "listening"
+        assert VoiceStatus.MUTED.value == "muted"
+
+    def test_turkish_labels(self):
+        from bantz.controls.indicator import VoiceStatus
+
+        assert VoiceStatus.LISTENING.label_tr == "DİNLİYOR"
+        assert VoiceStatus.WAKE_ONLY.label_tr == "BEKLEMEDE"
+        assert VoiceStatus.MUTED.label_tr == "SESSİZ"
+
+    def test_icons(self):
+        from bantz.controls.indicator import VoiceStatus
+
+        assert VoiceStatus.LISTENING.icon == "🎤"
+        assert VoiceStatus.MUTED.icon == "🔇"
+        assert VoiceStatus.SPEAKING.icon == "🔊"
+
+
+# ─────────────────────────────────────────────────────────────────
+# StatusIndicator
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestStatusIndicator:
+    """Status display indicator."""
+
+    def test_default_idle_sleep(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        ind = StatusIndicator(mode="silent")
+        assert ind.status == VoiceStatus.IDLE_SLEEP
+
+    def test_update_changes_status(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        ind = StatusIndicator(mode="silent")
+        ind.update(VoiceStatus.LISTENING)
+        assert ind.status == VoiceStatus.LISTENING
+        assert ind.update_count == 1
+
+    def test_same_status_no_op(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        ind = StatusIndicator(mode="silent")
+        ind.update(VoiceStatus.LISTENING)
+        ind.update(VoiceStatus.LISTENING)
+        assert ind.update_count == 1
+
+    def test_callback_mode(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        received = []
+        ind = StatusIndicator(mode="callback", callback=lambda s: received.append(s))
+        ind.update(VoiceStatus.LISTENING)
+        ind.update(VoiceStatus.SPEAKING)
+        assert received == [VoiceStatus.LISTENING, VoiceStatus.SPEAKING]
+
+    def test_callback_error_handled(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        ind = StatusIndicator(mode="callback", callback=lambda s: 1 / 0)
+        ind.update(VoiceStatus.LISTENING)  # Should not raise
+        assert ind.status == VoiceStatus.LISTENING
+
+    def test_status_duration(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        ind = StatusIndicator(mode="silent")
+        ind.update(VoiceStatus.LISTENING)
+        time.sleep(0.05)
+        assert ind.status_duration >= 0.04
+
+    def test_get_status_line(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        ind = StatusIndicator(mode="silent")
+        ind.update(VoiceStatus.LISTENING)
+        line = ind.get_status_line()
+        assert "🎤" in line
+        assert "DİNLİYOR" in line
+
+    def test_reset(self):
+        from bantz.controls.indicator import StatusIndicator, VoiceStatus
+
+        ind = StatusIndicator(mode="silent")
+        ind.update(VoiceStatus.LISTENING)
+        ind.update(VoiceStatus.SPEAKING)
+        ind.reset()
+        assert ind.status == VoiceStatus.IDLE_SLEEP
+        assert ind.update_count == 0
+
+
+# ─────────────────────────────────────────────────────────────────
+# File existence
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestFileExistence:
+    """Verify all Issue #298 files exist."""
+
+    ROOT = Path(__file__).resolve().parent.parent
+
+    def test_init_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "controls" / "__init__.py").is_file()
+
+    def test_hotkeys_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "controls" / "hotkeys.py").is_file()
+
+    def test_ptt_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "controls" / "ptt.py").is_file()
+
+    def test_mute_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "controls" / "mute.py").is_file()
+
+    def test_indicator_exists(self):
+        assert (self.ROOT / "src" / "bantz" / "controls" / "indicator.py").is_file()


### PR DESCRIPTION
## Issue #298 — Controls: PTT + Mute + Status

### New files
- **src/bantz/controls/__init__.py** — Package exports
- **src/bantz/controls/hotkeys.py** — HotkeyConfig + HotkeyManager (pynput-based)
- **src/bantz/controls/ptt.py** — PTTController (press/release, min_hold_ms)
- **src/bantz/controls/mute.py** — MuteController (toggle/mute/unmute)
- **src/bantz/controls/indicator.py** — StatusIndicator + VoiceStatus
- **tests/test_issue_298_controls.py** — 48 tests (all pass)

### Keybinds (env vars)
| Env var | Default | Description |
|---------|---------|-------------|
| BANTZ_PTT_KEY | ctrl+space | Push-to-talk |
| BANTZ_MUTE_KEY | ctrl+shift+m | Mute toggle |
| BANTZ_STATUS_KEY | ctrl+shift+s | Show status |

### Tests: 48/48 passed
Closes #298