### PR TITLE
chore: upgrade minimum Python to 3.11+ (#217)

### DIFF
--- a/docs/setup/boot-jarvis.md
+++ b/docs/setup/boot-jarvis.md
@@ -11,7 +11,7 @@ ulaşabilirsiniz.
 | Bileşen          | Minimum                          | Önerilen                          |
 |------------------|----------------------------------|-----------------------------------|
 | **İşletim Sistemi** | Ubuntu 22.04+ / Linux (systemd) | Ubuntu 24.04 LTS                 |
-| **Python**        | 3.10+                            | 3.12                              |
+| **Python**        | 3.11+                            | 3.12                              |
 | **GPU**           | —                                | NVIDIA RTX 4060+ (vLLM için)     |
 | **RAM**           | 8 GB                             | 16 GB+                            |
 | **Disk**          | 20 GB boş                        | 50 GB+                            |

--- a/docs/setup/python311-upgrade.md
+++ b/docs/setup/python311-upgrade.md
@@ -1,0 +1,77 @@
+# Python 3.11+ Upgrade Guide
+
+## Neden 3.11+?
+
+1. **Google API uyarıları** — Google libs Python 3.10 EOL uyarısı veriyor
+2. **Performans** — Python 3.11 ortalama %25 daha hızlı (CPython speedup)
+3. **Dil özellikleri** — `ExceptionGroup`, `tomllib`, `StrEnum` built-in
+4. **Gelecek uyumluluk** — Büyük kütüphaneler 3.10 desteğini bırakıyor
+
+## Kurulum (pyenv ile)
+
+```bash
+# pyenv kur (yoksa)
+curl https://pyenv.run | bash
+
+# Shell'e ekle (~/.bashrc veya ~/.zshrc)
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+
+# Python 3.11 kur
+pyenv install 3.11.11
+pyenv local 3.11.11
+
+# Doğrula
+python --version  # Python 3.11.11
+```
+
+## Kurulum (uv ile — önerilen)
+
+```bash
+# uv kur
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Proje ortamı oluştur
+cd /path/to/bantz
+uv venv --python 3.11
+source .venv/bin/activate
+
+# Bağımlılıkları kur
+uv pip install -r requirements-all.txt
+
+# Doğrula
+python --version
+```
+
+## Kurulum (apt ile — Ubuntu 22.04+)
+
+```bash
+sudo apt update
+sudo apt install -y python3.11 python3.11-venv python3.11-dev
+
+# Sanal ortam
+python3.11 -m venv .venv
+source .venv/bin/activate
+
+pip install -r requirements-all.txt
+```
+
+## Doğrulama
+
+```bash
+# Versiyon kontrolü
+python -c "import sys; assert sys.version_info >= (3, 11), f'Need 3.11+, got {sys.version}'; print(f'✓ Python {sys.version}')"
+
+# Google API uyarı kontrolü
+python -c "import warnings; warnings.filterwarnings('error'); import google.auth; print('✓ Google API: no warnings')" 2>/dev/null || echo "Google API not installed (OK if not using cloud)"
+
+# Pip install temiz kurulum
+pip install -e . 2>&1 | tail -1
+```
+
+## Notlar
+
+- `pyproject.toml` artık `requires-python = ">=3.11"` içerir
+- Mevcut `.venv` 3.10 ise silip yeniden oluşturun
+- CI (varsa) Python 3.11'de çalışmalıdır

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "bantz"
 version = "0.1.0"
 description = "Bantz - Local Jarvis (text-first)"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [{ name = "Bantz" }]
 dependencies = []
 

--- a/tests/test_issue_217_python311.py
+++ b/tests/test_issue_217_python311.py
@@ -1,0 +1,47 @@
+"""Tests for Issue #217 — Python 3.11+ upgrade.
+
+Verifies pyproject.toml requires-python, docs, and module compatibility.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestPython311Upgrade:
+    """Verify Python 3.11+ requirement is set."""
+
+    def test_pyproject_requires_311(self):
+        content = (ROOT / "pyproject.toml").read_text()
+        assert '>=3.11' in content
+
+    def test_upgrade_guide_exists(self):
+        assert (ROOT / "docs" / "setup" / "python311-upgrade.md").is_file()
+
+    def test_upgrade_guide_content(self):
+        doc = (ROOT / "docs" / "setup" / "python311-upgrade.md").read_text()
+        assert "pyenv" in doc
+        assert "uv" in doc
+        assert "3.11" in doc
+
+    def test_boot_jarvis_updated(self):
+        doc = (ROOT / "docs" / "setup" / "boot-jarvis.md").read_text()
+        assert "3.11+" in doc
+
+    def test_current_python_compat(self):
+        """Current runtime must be >= 3.10 (existing env)."""
+        assert sys.version_info >= (3, 10)
+
+    def test_no_310_only_features_in_pyproject(self):
+        """pyproject.toml should not reference 3.10 as minimum."""
+        content = (ROOT / "pyproject.toml").read_text()
+        # The only 3.10 refs should be in dependency version specs (e.g. pytesseract>=0.3.10)
+        lines = content.split("\n")
+        for line in lines:
+            if "requires-python" in line:
+                assert "3.10" not in line, "requires-python should be >=3.11"


### PR DESCRIPTION
Closes #217 — Updates requires-python to >=3.11, adds upgrade guide (pyenv/uv/apt), 6 tests.