### PR TITLE
feat(voice): session FSM — ACTIVE_LISTEN / WAKE_ONLY / IDLE_SLEEP #290

### DIFF
--- a/src/bantz/voice/session_fsm.py
+++ b/src/bantz/voice/session_fsm.py
@@ -1,0 +1,245 @@
+"""Voice session state machine (Issue #290).
+
+Deterministic FSM for voice service:
+  - ACTIVE_LISTEN: full ASR active (no wake word needed)
+  - WAKE_ONLY: only wake word detection (low CPU)
+  - IDLE_SLEEP: no audio processing (optional, battery save)
+
+State transitions::
+
+    Boot + LLM ready → ACTIVE_LISTEN (TTL: 90s)
+    User speech      → reset TTL
+    Silence timeout  → WAKE_ONLY
+    Dismiss intent   → WAKE_ONLY
+    Wake word        → ACTIVE_LISTEN
+    IDLE enabled     → IDLE_SLEEP (after wake_only timeout)
+
+Config env vars::
+
+    BANTZ_ACTIVE_LISTEN_TTL_S=90
+    BANTZ_SILENCE_TO_WAKE_S=30
+    BANTZ_IDLE_SLEEP_ENABLED=false
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "VoiceState",
+    "VoiceFSM",
+    "FSMConfig",
+    "StateTransition",
+]
+
+
+class VoiceState(Enum):
+    """Voice session states."""
+
+    ACTIVE_LISTEN = "active_listen"
+    WAKE_ONLY = "wake_only"
+    IDLE_SLEEP = "idle_sleep"
+
+
+@dataclass
+class StateTransition:
+    """Record of a state transition."""
+
+    from_state: VoiceState
+    to_state: VoiceState
+    trigger: str
+    timestamp: float = 0.0
+
+
+@dataclass
+class FSMConfig:
+    """FSM configuration.
+
+    Attributes
+    ----------
+    active_listen_ttl:
+        Seconds before ACTIVE_LISTEN → WAKE_ONLY (no speech).
+    silence_threshold:
+        Seconds of silence before transition.
+    idle_sleep_enabled:
+        Whether IDLE_SLEEP state is available.
+    idle_sleep_timeout:
+        Seconds in WAKE_ONLY before → IDLE_SLEEP.
+    """
+
+    active_listen_ttl: float = 90.0
+    silence_threshold: float = 30.0
+    idle_sleep_enabled: bool = False
+    idle_sleep_timeout: float = 300.0
+
+    @classmethod
+    def from_env(cls) -> "FSMConfig":
+        """Load config from environment variables."""
+        def _float(name: str, default: float) -> float:
+            raw = os.getenv(name, "").strip()
+            if not raw:
+                return default
+            try:
+                return float(raw)
+            except ValueError:
+                return default
+
+        def _bool(name: str, default: bool) -> bool:
+            raw = os.getenv(name, "").strip().lower()
+            if not raw:
+                return default
+            return raw in {"1", "true", "yes", "on"}
+
+        return cls(
+            active_listen_ttl=_float("BANTZ_ACTIVE_LISTEN_TTL_S", 90.0),
+            silence_threshold=_float("BANTZ_SILENCE_TO_WAKE_S", 30.0),
+            idle_sleep_enabled=_bool("BANTZ_IDLE_SLEEP_ENABLED", False),
+            idle_sleep_timeout=_float("BANTZ_IDLE_SLEEP_TIMEOUT_S", 300.0),
+        )
+
+
+class VoiceFSM:
+    """Deterministic voice session state machine.
+
+    Parameters
+    ----------
+    config:
+        FSM configuration.
+    clock:
+        Optional clock function for testing. Defaults to time.monotonic.
+    on_transition:
+        Optional callback for state transitions.
+    """
+
+    def __init__(
+        self,
+        config: Optional[FSMConfig] = None,
+        clock: Optional[Callable[[], float]] = None,
+        on_transition: Optional[Callable[[StateTransition], None]] = None,
+    ):
+        self.config = config or FSMConfig()
+        self._clock = clock or time.monotonic
+        self._on_transition = on_transition
+
+        self._state = VoiceState.WAKE_ONLY
+        self._last_activity = self._clock()
+        self._state_entered_at = self._clock()
+        self._history: List[StateTransition] = []
+
+    @property
+    def state(self) -> VoiceState:
+        """Current state."""
+        return self._state
+
+    @property
+    def last_activity(self) -> float:
+        """Timestamp of last user activity."""
+        return self._last_activity
+
+    @property
+    def history(self) -> List[StateTransition]:
+        """State transition history."""
+        return list(self._history)
+
+    def _transition(self, new_state: VoiceState, trigger: str) -> None:
+        """Execute a state transition."""
+        if new_state == self._state:
+            return
+
+        old = self._state
+        now = self._clock()
+        transition = StateTransition(
+            from_state=old,
+            to_state=new_state,
+            trigger=trigger,
+            timestamp=now,
+        )
+
+        logger.debug(
+            "[fsm] %s → %s (trigger: %s)",
+            old.value, new_state.value, trigger,
+        )
+
+        self._state = new_state
+        self._state_entered_at = now
+        self._history.append(transition)
+
+        if self._on_transition:
+            self._on_transition(transition)
+
+    # ── Event handlers ────────────────────────────────────────────
+
+    def on_boot_ready(self) -> None:
+        """LLM warmup complete — enter active listening."""
+        self._transition(VoiceState.ACTIVE_LISTEN, "boot_ready")
+        self._last_activity = self._clock()
+
+    def on_user_speech(self) -> None:
+        """User started speaking — reset TTL."""
+        self._last_activity = self._clock()
+
+        if self._state == VoiceState.WAKE_ONLY:
+            # Should not happen without wake word, but handle gracefully
+            logger.debug("[fsm] speech in WAKE_ONLY — ignoring (need wake word)")
+            return
+
+        if self._state == VoiceState.IDLE_SLEEP:
+            self._transition(VoiceState.ACTIVE_LISTEN, "speech_from_idle")
+            return
+
+        # Already in ACTIVE_LISTEN — just reset timer
+        logger.debug("[fsm] speech in ACTIVE_LISTEN — TTL reset")
+
+    def on_silence_timeout(self) -> None:
+        """Silence detected — transition to wake-only."""
+        if self._state == VoiceState.ACTIVE_LISTEN:
+            self._transition(VoiceState.WAKE_ONLY, "silence_timeout")
+
+    def on_dismiss_intent(self) -> None:
+        """User said goodbye — transition to wake-only."""
+        if self._state == VoiceState.ACTIVE_LISTEN:
+            self._transition(VoiceState.WAKE_ONLY, "dismiss_intent")
+
+    def on_wake_word(self) -> None:
+        """Wake word detected — enter active listening."""
+        self._transition(VoiceState.ACTIVE_LISTEN, "wake_word")
+        self._last_activity = self._clock()
+
+    def tick(self) -> None:
+        """Timer check — call periodically to enforce timeouts.
+
+        Checks if current state has exceeded its TTL and transitions
+        accordingly.
+        """
+        now = self._clock()
+
+        if self._state == VoiceState.ACTIVE_LISTEN:
+            elapsed = now - self._last_activity
+            if elapsed >= self.config.silence_threshold:
+                self._transition(VoiceState.WAKE_ONLY, "silence_timeout")
+
+        elif self._state == VoiceState.WAKE_ONLY and self.config.idle_sleep_enabled:
+            elapsed = now - self._state_entered_at
+            if elapsed >= self.config.idle_sleep_timeout:
+                self._transition(VoiceState.IDLE_SLEEP, "idle_timeout")
+
+    def time_until_timeout(self) -> Optional[float]:
+        """Seconds until next timeout, or None if no timeout pending."""
+        now = self._clock()
+
+        if self._state == VoiceState.ACTIVE_LISTEN:
+            remaining = self.config.silence_threshold - (now - self._last_activity)
+            return max(0.0, remaining)
+
+        if self._state == VoiceState.WAKE_ONLY and self.config.idle_sleep_enabled:
+            remaining = self.config.idle_sleep_timeout - (now - self._state_entered_at)
+            return max(0.0, remaining)
+
+        return None

--- a/tests/test_issue_290_fsm.py
+++ b/tests/test_issue_290_fsm.py
@@ -1,0 +1,211 @@
+"""Tests for Issue #290 — Voice session FSM.
+
+Covers all state transitions, timers, config, and edge cases.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+
+class TestVoiceState:
+    def test_values(self):
+        from bantz.voice.session_fsm import VoiceState
+        assert VoiceState.ACTIVE_LISTEN.value == "active_listen"
+        assert VoiceState.WAKE_ONLY.value == "wake_only"
+        assert VoiceState.IDLE_SLEEP.value == "idle_sleep"
+
+
+class TestFSMConfig:
+    def test_defaults(self):
+        from bantz.voice.session_fsm import FSMConfig
+        c = FSMConfig()
+        assert c.active_listen_ttl == 90.0
+        assert c.silence_threshold == 30.0
+        assert c.idle_sleep_enabled is False
+
+    def test_from_env(self):
+        from bantz.voice.session_fsm import FSMConfig
+        env = {"BANTZ_ACTIVE_LISTEN_TTL_S": "120", "BANTZ_SILENCE_TO_WAKE_S": "15", "BANTZ_IDLE_SLEEP_ENABLED": "true"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = FSMConfig.from_env()
+        assert c.active_listen_ttl == 120.0
+        assert c.silence_threshold == 15.0
+        assert c.idle_sleep_enabled is True
+
+
+class TestFSMInitial:
+    def test_starts_wake_only(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState
+        fsm = VoiceFSM()
+        assert fsm.state == VoiceState.WAKE_ONLY
+
+    def test_empty_history(self):
+        from bantz.voice.session_fsm import VoiceFSM
+        fsm = VoiceFSM()
+        assert fsm.history == []
+
+
+class TestBootReady:
+    def test_boot_to_active(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState
+        fsm = VoiceFSM()
+        fsm.on_boot_ready()
+        assert fsm.state == VoiceState.ACTIVE_LISTEN
+        assert len(fsm.history) == 1
+        assert fsm.history[0].trigger == "boot_ready"
+
+
+class TestUserSpeech:
+    def test_resets_ttl(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState, FSMConfig
+
+        t = [0.0]
+        def clock(): return t[0]
+
+        fsm = VoiceFSM(config=FSMConfig(silence_threshold=30.0), clock=clock)
+        fsm.on_boot_ready()
+        t[0] = 10.0
+        fsm.on_user_speech()
+        assert fsm.last_activity == 10.0
+
+    def test_speech_in_wake_only_ignored(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState
+        fsm = VoiceFSM()
+        fsm.on_user_speech()
+        assert fsm.state == VoiceState.WAKE_ONLY
+
+
+class TestSilenceTimeout:
+    def test_active_to_wake(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState
+        fsm = VoiceFSM()
+        fsm.on_boot_ready()
+        fsm.on_silence_timeout()
+        assert fsm.state == VoiceState.WAKE_ONLY
+
+    def test_tick_triggers_timeout(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState, FSMConfig
+
+        t = [0.0]
+        def clock(): return t[0]
+
+        fsm = VoiceFSM(config=FSMConfig(silence_threshold=5.0), clock=clock)
+        fsm.on_boot_ready()
+        t[0] = 6.0
+        fsm.tick()
+        assert fsm.state == VoiceState.WAKE_ONLY
+
+    def test_no_timeout_if_speech(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState, FSMConfig
+
+        t = [0.0]
+        def clock(): return t[0]
+
+        fsm = VoiceFSM(config=FSMConfig(silence_threshold=5.0), clock=clock)
+        fsm.on_boot_ready()
+        t[0] = 4.0
+        fsm.on_user_speech()
+        t[0] = 8.0
+        fsm.tick()
+        assert fsm.state == VoiceState.ACTIVE_LISTEN  # 8-4=4 < 5
+
+
+class TestDismiss:
+    def test_dismiss_to_wake(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState
+        fsm = VoiceFSM()
+        fsm.on_boot_ready()
+        fsm.on_dismiss_intent()
+        assert fsm.state == VoiceState.WAKE_ONLY
+        assert fsm.history[-1].trigger == "dismiss_intent"
+
+
+class TestWakeWord:
+    def test_wake_to_active(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState
+        fsm = VoiceFSM()
+        fsm.on_wake_word()
+        assert fsm.state == VoiceState.ACTIVE_LISTEN
+
+    def test_full_cycle(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState
+        fsm = VoiceFSM()
+        fsm.on_boot_ready()
+        assert fsm.state == VoiceState.ACTIVE_LISTEN
+        fsm.on_dismiss_intent()
+        assert fsm.state == VoiceState.WAKE_ONLY
+        fsm.on_wake_word()
+        assert fsm.state == VoiceState.ACTIVE_LISTEN
+        fsm.on_silence_timeout()
+        assert fsm.state == VoiceState.WAKE_ONLY
+
+
+class TestIdleSleep:
+    def test_idle_disabled_by_default(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState, FSMConfig
+
+        t = [0.0]
+        def clock(): return t[0]
+
+        fsm = VoiceFSM(config=FSMConfig(idle_sleep_enabled=False), clock=clock)
+        fsm.on_boot_ready()
+        fsm.on_silence_timeout()
+        t[0] = 999.0
+        fsm.tick()
+        assert fsm.state == VoiceState.WAKE_ONLY  # No idle
+
+    def test_idle_enabled(self):
+        from bantz.voice.session_fsm import VoiceFSM, VoiceState, FSMConfig
+
+        t = [0.0]
+        def clock(): return t[0]
+
+        cfg = FSMConfig(idle_sleep_enabled=True, idle_sleep_timeout=60.0, silence_threshold=5.0)
+        fsm = VoiceFSM(config=cfg, clock=clock)
+        fsm.on_boot_ready()
+        t[0] = 6.0
+        fsm.tick()  # → WAKE_ONLY
+        assert fsm.state == VoiceState.WAKE_ONLY
+        t[0] = 67.0
+        fsm.tick()  # → IDLE_SLEEP
+        assert fsm.state == VoiceState.IDLE_SLEEP
+
+
+class TestTimeUntilTimeout:
+    def test_active_listen(self):
+        from bantz.voice.session_fsm import VoiceFSM, FSMConfig
+
+        t = [0.0]
+        def clock(): return t[0]
+
+        fsm = VoiceFSM(config=FSMConfig(silence_threshold=30.0), clock=clock)
+        fsm.on_boot_ready()
+        t[0] = 10.0
+        remaining = fsm.time_until_timeout()
+        assert remaining == 20.0
+
+    def test_wake_only_no_idle(self):
+        from bantz.voice.session_fsm import VoiceFSM
+        fsm = VoiceFSM()
+        assert fsm.time_until_timeout() is None
+
+
+class TestTransitionCallback:
+    def test_callback_called(self):
+        from bantz.voice.session_fsm import VoiceFSM, StateTransition
+        transitions = []
+        fsm = VoiceFSM(on_transition=transitions.append)
+        fsm.on_boot_ready()
+        assert len(transitions) == 1
+        assert transitions[0].trigger == "boot_ready"
+
+
+class TestFileExistence:
+    def test_session_fsm_exists(self):
+        from pathlib import Path
+        ROOT = Path(__file__).resolve().parent.parent
+        assert (ROOT / "src" / "bantz" / "voice" / "session_fsm.py").is_file()


### PR DESCRIPTION
## Summary
Deterministic voice session state machine for Bantz voice service.

### Implementation
- **VoiceState** enum: ACTIVE_LISTEN, WAKE_ONLY, IDLE_SLEEP
- **FSMConfig** with from_env() — env vars for TTL, silence, idle
- **VoiceFSM** class: on_boot_ready, on_user_speech, on_silence_timeout, on_dismiss_intent, on_wake_word, tick, time_until_timeout
- Injectable clock + on_transition callback for testing

### Tests
20 tests covering all state transitions, timers, idle sleep, and edge cases.

Closes #290