### PR TITLE
feat(intents): dismiss/stop intent detection + polite goodbye #293

### DIFF
--- a/src/bantz/intents/__init__.py
+++ b/src/bantz/intents/__init__.py
@@ -1,0 +1,1 @@
+"""Intents package (Issue #293)."""

--- a/src/bantz/intents/dismiss.py
+++ b/src/bantz/intents/dismiss.py
@@ -1,0 +1,154 @@
+"""Dismiss / stop intent detection (Issue #293).
+
+Local intent classification — fast regex-based, no LLM call.
+Detects Turkish dismiss phrases and returns a polite goodbye.
+
+Example flow::
+
+    User: "Teşekkürler şimdilik"
+    Bantz: "Size iyi çalışmalar efendim. İhtiyacınız olursa buradayım."
+    FSM → WAKE_ONLY
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DismissIntentDetector",
+    "DismissResult",
+    "DISMISS_PHRASES",
+    "DISMISS_RESPONSES",
+]
+
+# ── Turkish dismiss phrases (regex patterns) ──────────────────
+
+DISMISS_PHRASES: List[str] = [
+    # Explicit dismiss
+    r"teşekkür(ler)?\s*(ederim)?\s*(şimdilik|artık)?",
+    r"şimdilik\s*(sana)?\s*ihtiyacım?\s*yok",
+    r"görüşürüz",
+    r"hoşça\s*kal",
+    r"kapat\s*(kendini)?",
+    r"sus\s*artık",
+    r"tamam\s*(bu\s*kadar)?",
+    r"yeter\s*(bu\s*kadar)?",
+    r"iyi\s*çalışmalar",
+    # Polite dismiss
+    r"sağ\s*ol\s*(bantz)?",
+    r"eyvallah",
+    r"güle\s*güle",
+    # Short forms
+    r"bay\s*bay",
+    r"hadi\s*görüşürüz",
+    r"sonra\s*görüşürüz",
+]
+
+# Compiled patterns (case-insensitive)
+_COMPILED_PHRASES = [re.compile(p, re.IGNORECASE) for p in DISMISS_PHRASES]
+
+# ── Polite goodbye responses ──────────────────────────────────
+
+DISMISS_RESPONSES: List[str] = [
+    "Size iyi çalışmalar efendim. İhtiyacınız olursa buradayım.",
+    "Görüşmek üzere efendim.",
+    "Anlaşıldı efendim, beklemedeyim.",
+    "Tabii efendim, iyi günler.",
+    "İyi çalışmalar efendim.",
+    "Anlaşıldı, ihtiyacınız olursa buradayım efendim.",
+]
+
+
+# ── Result dataclass ──────────────────────────────────────────
+
+@dataclass
+class DismissResult:
+    """Result of dismiss intent detection."""
+
+    is_dismiss: bool
+    confidence: float
+    matched_phrase: Optional[str] = None
+    response: Optional[str] = None
+
+
+# ── Intent detector ───────────────────────────────────────────
+
+class DismissIntentDetector:
+    """Local regex-based dismiss intent detector.
+
+    Parameters
+    ----------
+    phrases:
+        Override default dismiss phrases (compiled regex list).
+    responses:
+        Override default goodbye responses.
+    confirmation_threshold:
+        Confidence range [low, high) that requires user confirmation.
+    """
+
+    def __init__(
+        self,
+        phrases: Optional[List[re.Pattern]] = None,
+        responses: Optional[List[str]] = None,
+        confirmation_threshold: Tuple[float, float] = (0.5, 0.8),
+    ) -> None:
+        self._phrases = phrases or _COMPILED_PHRASES
+        self._responses = responses or DISMISS_RESPONSES
+        self._conf_low, self._conf_high = confirmation_threshold
+
+    def detect(self, text: str) -> DismissResult:
+        """Detect dismiss intent in user text.
+
+        Parameters
+        ----------
+        text:
+            User utterance (Turkish).
+
+        Returns
+        -------
+        DismissResult with is_dismiss, confidence, matched phrase, response.
+        """
+        if not text or not text.strip():
+            return DismissResult(is_dismiss=False, confidence=0.0)
+
+        cleaned = text.strip().lower()
+
+        for pattern in self._phrases:
+            match = pattern.search(cleaned)
+            if match:
+                matched = match.group(0)
+                # Full-sentence match → high confidence
+                # Partial match → medium confidence
+                ratio = len(matched) / max(len(cleaned), 1)
+                confidence = min(1.0, 0.6 + ratio * 0.4)
+
+                response = random.choice(self._responses)
+                logger.info(
+                    "[dismiss] detected: '%s' (conf=%.2f) in '%s'",
+                    matched, confidence, cleaned,
+                )
+                return DismissResult(
+                    is_dismiss=True,
+                    confidence=confidence,
+                    matched_phrase=matched,
+                    response=response,
+                )
+
+        return DismissResult(is_dismiss=False, confidence=0.0)
+
+    def needs_confirmation(self, confidence: float) -> bool:
+        """Check if confidence requires user confirmation.
+
+        Returns True when confidence is in the ambiguous zone.
+        """
+        return self._conf_low < confidence < self._conf_high
+
+    def pick_response(self) -> str:
+        """Pick a random goodbye response."""
+        return random.choice(self._responses)

--- a/tests/test_issue_293_dismiss.py
+++ b/tests/test_issue_293_dismiss.py
@@ -1,0 +1,160 @@
+"""Tests for Issue #293 — Dismiss / stop intent detection.
+
+Covers all Turkish dismiss phrases, confidence scoring,
+confirmation threshold, response selection, and edge cases.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ── Phrase detection ──────────────────────────────────────────
+
+class TestDismissPhrases:
+    """Ensure all specified Turkish phrases are detected."""
+
+    @pytest.mark.parametrize("text", [
+        "teşekkürler şimdilik",
+        "teşekkür ederim",
+        "teşekkürler artık",
+        "şimdilik sana ihtiyacım yok",
+        "görüşürüz",
+        "hoşça kal",
+        "kapat kendini",
+        "kapat",
+        "sus artık",
+        "tamam bu kadar",
+        "tamam",
+        "yeter bu kadar",
+        "yeter",
+        "iyi çalışmalar",
+        "sağ ol bantz",
+        "sağ ol",
+        "eyvallah",
+        "güle güle",
+        "bay bay",
+        "hadi görüşürüz",
+        "sonra görüşürüz",
+    ])
+    def test_phrase_detected(self, text):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        result = det.detect(text)
+        assert result.is_dismiss, f"'{text}' should be detected as dismiss"
+        assert result.confidence > 0.5
+        assert result.response is not None
+
+    @pytest.mark.parametrize("text", [
+        "hava durumu nasıl",
+        "toplantım saat kaçta",
+        "python ile nasıl dosya açarım",
+        "bu projede kaç test var",
+        "",
+        "   ",
+    ])
+    def test_non_dismiss(self, text):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        result = det.detect(text)
+        assert not result.is_dismiss
+        assert result.confidence == 0.0
+
+
+# ── Case insensitive ─────────────────────────────────────────
+
+class TestCaseInsensitive:
+    def test_uppercase(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        result = det.detect("GÖRÜŞÜRÜZ")
+        assert result.is_dismiss
+
+    def test_mixed_case(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        result = det.detect("Teşekkürler Şimdilik")
+        assert result.is_dismiss
+
+
+# ── Confidence scoring ────────────────────────────────────────
+
+class TestConfidence:
+    def test_exact_phrase_high_confidence(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        result = det.detect("görüşürüz")
+        assert result.confidence >= 0.9
+
+    def test_phrase_in_sentence_lower_confidence(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        result = det.detect("ben şimdi başka bir şey yapacağım tamam bu kadar yardım için teşekkürler")
+        assert result.is_dismiss
+        assert result.confidence >= 0.6
+
+
+# ── Confirmation threshold ────────────────────────────────────
+
+class TestConfirmation:
+    def test_high_confidence_no_confirm(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        assert not det.needs_confirmation(0.95)
+
+    def test_low_confidence_no_confirm(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        assert not det.needs_confirmation(0.3)
+
+    def test_ambiguous_needs_confirm(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        assert det.needs_confirmation(0.65)
+
+
+# ── Response pool ─────────────────────────────────────────────
+
+class TestResponses:
+    def test_pick_response(self):
+        from bantz.intents.dismiss import DismissIntentDetector
+        det = DismissIntentDetector()
+        resp = det.pick_response()
+        assert isinstance(resp, str)
+        assert "efendim" in resp
+
+    def test_all_responses_have_efendim(self):
+        from bantz.intents.dismiss import DISMISS_RESPONSES
+        for r in DISMISS_RESPONSES:
+            assert "efendim" in r, f"Response missing 'efendim': {r}"
+
+
+# ── DismissResult ─────────────────────────────────────────────
+
+class TestDismissResult:
+    def test_fields(self):
+        from bantz.intents.dismiss import DismissResult
+        r = DismissResult(is_dismiss=True, confidence=0.9, matched_phrase="görüşürüz", response="Bye")
+        assert r.is_dismiss
+        assert r.confidence == 0.9
+        assert r.matched_phrase == "görüşürüz"
+
+    def test_false_result(self):
+        from bantz.intents.dismiss import DismissResult
+        r = DismissResult(is_dismiss=False, confidence=0.0)
+        assert not r.is_dismiss
+        assert r.matched_phrase is None
+
+
+# ── File existence ────────────────────────────────────────────
+
+class TestFileExistence:
+    def test_dismiss_py_exists(self):
+        from pathlib import Path
+        ROOT = Path(__file__).resolve().parent.parent
+        assert (ROOT / "src" / "bantz" / "intents" / "dismiss.py").is_file()
+
+    def test_intents_init_exists(self):
+        from pathlib import Path
+        ROOT = Path(__file__).resolve().parent.parent
+        assert (ROOT / "src" / "bantz" / "intents" / "__init__.py").is_file()


### PR DESCRIPTION
## Summary
Local regex-based dismiss intent detector for Turkish phrases with polite goodbye responses.

### Implementation
- **DismissIntentDetector**: 16 Turkish dismiss patterns, confidence scoring
- **DismissResult** dataclass: is_dismiss, confidence, matched_phrase, response
- **DISMISS_RESPONSES**: 6 polite goodbye variants (all with 'efendim')
- needs_confirmation() for ambiguous confidence zone
- New `src/bantz/intents/` package

### Tests
40 tests: 21 phrase variants, case insensitivity, confidence, confirmation, responses, file existence.

Closes #293