### PR TITLE
feat(skills): news briefing with RSS + cache + voice formatter #294

### DIFF
--- a/src/bantz/skills/news_briefing.py
+++ b/src/bantz/skills/news_briefing.py
@@ -1,0 +1,313 @@
+"""News briefing skill — provider, cache, formatter (Issue #294).
+
+Provides news from RSS feeds with caching and voice-friendly output.
+
+Categories::
+
+    ai      — Yapay Zeka (TechCrunch, The Verge AI)
+    tech    — Teknoloji (The Verge, Ars Technica)
+    turkey  — Türkiye Gündemi (NTV, Hürriyet)
+
+Config env vars::
+
+    BANTZ_NEWS_CACHE_TTL=1800      # 30 minutes
+    BANTZ_NEWS_MAX_ITEMS=3
+    BANTZ_NEWS_CATEGORIES=ai,tech,turkey
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import time
+import xml.etree.ElementTree as ET
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "NewsItem",
+    "NewsCategory",
+    "NEWS_CATEGORIES",
+    "NewsProviderBase",
+    "RSSNewsProvider",
+    "NewsCache",
+    "format_news_for_voice",
+    "NewsBriefingConfig",
+]
+
+
+# ── Data models ───────────────────────────────────────────────
+
+@dataclass
+class NewsItem:
+    """A single news article."""
+
+    title: str
+    summary: str = ""
+    source: str = ""
+    url: str = ""
+    published: str = ""
+    category: str = ""
+
+    @property
+    def fingerprint(self) -> str:
+        """Unique fingerprint for deduplication."""
+        raw = f"{self.title}:{self.url}"
+        return hashlib.md5(raw.encode()).hexdigest()[:12]
+
+
+@dataclass
+class NewsCategory:
+    """News category definition."""
+
+    key: str
+    name: str
+    rss_feeds: List[str] = field(default_factory=list)
+    keywords: List[str] = field(default_factory=list)
+
+
+# ── Default categories ────────────────────────────────────────
+
+NEWS_CATEGORIES: Dict[str, NewsCategory] = {
+    "ai": NewsCategory(
+        key="ai",
+        name="Yapay Zeka",
+        rss_feeds=[
+            "https://techcrunch.com/category/artificial-intelligence/feed/",
+            "https://www.theverge.com/ai-artificial-intelligence/rss/index.xml",
+        ],
+        keywords=["AI", "GPT", "LLM", "machine learning", "yapay zeka"],
+    ),
+    "tech": NewsCategory(
+        key="tech",
+        name="Teknoloji",
+        rss_feeds=[
+            "https://www.theverge.com/rss/index.xml",
+            "https://feeds.arstechnica.com/arstechnica/index",
+        ],
+        keywords=["technology", "software", "hardware", "teknoloji"],
+    ),
+    "turkey": NewsCategory(
+        key="turkey",
+        name="Türkiye Gündemi",
+        rss_feeds=[
+            "https://www.ntv.com.tr/son-dakika.rss",
+            "https://www.hurriyet.com.tr/rss/gundem",
+        ],
+        keywords=["Türkiye", "gündem", "son dakika"],
+    ),
+}
+
+
+# ── Config ────────────────────────────────────────────────────
+
+@dataclass
+class NewsBriefingConfig:
+    """News briefing configuration."""
+
+    cache_ttl: int = 1800  # 30 minutes
+    max_items: int = 3
+    categories: List[str] = field(default_factory=lambda: ["ai", "tech", "turkey"])
+    timeout: float = 10.0  # HTTP request timeout
+
+    @classmethod
+    def from_env(cls) -> "NewsBriefingConfig":
+        try:
+            ttl = int(os.getenv("BANTZ_NEWS_CACHE_TTL", "1800"))
+        except ValueError:
+            ttl = 1800
+        try:
+            max_items = int(os.getenv("BANTZ_NEWS_MAX_ITEMS", "3"))
+        except ValueError:
+            max_items = 3
+        raw_cats = os.getenv("BANTZ_NEWS_CATEGORIES", "ai,tech,turkey")
+        cats = [c.strip() for c in raw_cats.split(",") if c.strip()]
+        return cls(cache_ttl=ttl, max_items=max_items, categories=cats)
+
+
+# ── Provider base ─────────────────────────────────────────────
+
+class NewsProviderBase(ABC):
+    """Abstract news provider."""
+
+    @abstractmethod
+    def fetch(self, category: NewsCategory) -> List[NewsItem]:
+        """Fetch news items for a category."""
+        ...
+
+
+# ── RSS provider ──────────────────────────────────────────────
+
+class RSSNewsProvider(NewsProviderBase):
+    """Fetch news from RSS feeds."""
+
+    def __init__(self, timeout: float = 10.0) -> None:
+        self.timeout = timeout
+
+    def fetch(self, category: NewsCategory) -> List[NewsItem]:
+        """Fetch and parse RSS feeds for a category."""
+        items: List[NewsItem] = []
+
+        for feed_url in category.rss_feeds:
+            try:
+                fetched = self._parse_feed(feed_url, category)
+                items.extend(fetched)
+                logger.debug("[news][rss] %d items from %s", len(fetched), feed_url)
+            except Exception:
+                logger.warning("[news][rss] failed to fetch %s", feed_url)
+
+        # Deduplicate by fingerprint
+        seen = set()
+        unique = []
+        for item in items:
+            fp = item.fingerprint
+            if fp not in seen:
+                seen.add(fp)
+                unique.append(item)
+
+        return unique
+
+    def _parse_feed(self, url: str, category: NewsCategory) -> List[NewsItem]:
+        """Parse a single RSS feed URL."""
+        req = Request(url, headers={"User-Agent": "Bantz/1.0 NewsBot"})
+        with urlopen(req, timeout=self.timeout) as resp:
+            data = resp.read()
+
+        return self._parse_xml(data, category, source=url)
+
+    @staticmethod
+    def _parse_xml(data: bytes, category: NewsCategory, source: str = "") -> List[NewsItem]:
+        """Parse RSS/Atom XML into NewsItem list."""
+        items: List[NewsItem] = []
+
+        try:
+            root = ET.fromstring(data)
+        except ET.ParseError:
+            logger.warning("[news][rss] XML parse error for %s", source)
+            return []
+
+        # RSS 2.0 — <channel><item>
+        for item_el in root.iter("item"):
+            title = (item_el.findtext("title") or "").strip()
+            desc = (item_el.findtext("description") or "").strip()
+            link = (item_el.findtext("link") or "").strip()
+            pub = (item_el.findtext("pubDate") or "").strip()
+
+            if title:
+                # Truncate description for voice
+                summary = desc[:200].split(".")[0] + "." if desc else ""
+                items.append(NewsItem(
+                    title=title,
+                    summary=summary,
+                    source=source,
+                    url=link,
+                    published=pub,
+                    category=category.key,
+                ))
+
+        # Atom — <entry>
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        for entry in root.iter("{http://www.w3.org/2005/Atom}entry"):
+            title = (entry.findtext("atom:title", namespaces=ns) or
+                     entry.findtext("{http://www.w3.org/2005/Atom}title") or "").strip()
+            summary_el = entry.find("{http://www.w3.org/2005/Atom}summary")
+            summary_text = (summary_el.text or "") if summary_el is not None else ""
+            link_el = entry.find("{http://www.w3.org/2005/Atom}link")
+            link = link_el.get("href", "") if link_el is not None else ""
+
+            if title:
+                summary = summary_text[:200].split(".")[0] + "." if summary_text else ""
+                items.append(NewsItem(
+                    title=title,
+                    summary=summary,
+                    source=source,
+                    url=link,
+                    category=category.key,
+                ))
+
+        return items
+
+
+# ── Cache ─────────────────────────────────────────────────────
+
+class NewsCache:
+    """In-memory TTL cache for news items.
+
+    Parameters
+    ----------
+    ttl_seconds:
+        Time-to-live for cached items (default: 1800 = 30 min).
+    clock:
+        Injectable clock for testing.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: int = 1800,
+        clock=None,
+    ) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._clock = clock or time.monotonic
+        self._store: Dict[str, tuple[float, List[NewsItem]]] = {}
+
+    def get(self, category: str) -> Optional[List[NewsItem]]:
+        """Get cached items, or None if stale/missing."""
+        entry = self._store.get(category)
+        if entry is None:
+            return None
+        ts, items = entry
+        if self._clock() - ts > self.ttl_seconds:
+            return None
+        return items
+
+    def set(self, category: str, items: List[NewsItem]) -> None:
+        """Store items with current timestamp."""
+        self._store[category] = (self._clock(), items)
+
+    def is_stale(self, category: str) -> bool:
+        """Check if category cache is stale or missing."""
+        return self.get(category) is None
+
+    def clear(self) -> None:
+        """Clear all cached entries."""
+        self._store.clear()
+
+
+# ── Voice formatter ───────────────────────────────────────────
+
+_ORDINALS = ["Birincisi", "İkincisi", "Üçüncüsü", "Dördüncüsü", "Beşincisi"]
+
+
+def format_news_for_voice(
+    items: List[NewsItem],
+    max_items: int = 3,
+    category_name: str = "",
+) -> str:
+    """Format news items for voice output.
+
+    Returns Turkish voice-friendly text with numbered items.
+    """
+    if not items:
+        if category_name:
+            return f"{category_name} kategorisinde şu an güncel haber bulunamadı efendim."
+        return "Şu an güncel haber bulunamadı efendim."
+
+    display = items[:max_items]
+    cat_intro = f"{category_name} dünyasında" if category_name else "Güncel haberlerde"
+
+    lines = [f"{cat_intro} birkaç gelişme var efendim:"]
+    for i, item in enumerate(display):
+        ordinal = _ORDINALS[i] if i < len(_ORDINALS) else f"{i+1}."
+        line = f"{ordinal}, {item.title}."
+        if item.summary:
+            line += f" {item.summary}"
+        lines.append(line)
+
+    lines.append("Detayları ister misiniz?")
+    return "\n".join(lines)

--- a/tests/test_issue_294_news.py
+++ b/tests/test_issue_294_news.py
@@ -1,0 +1,262 @@
+"""Tests for Issue #294 — News briefing skill.
+
+Covers data models, RSS parsing, cache TTL, voice formatting,
+config, provider base, and edge cases.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from unittest import mock
+
+import pytest
+
+
+# ── NewsItem ──────────────────────────────────────────────────
+
+class TestNewsItem:
+    def test_fields(self):
+        from bantz.skills.news_briefing import NewsItem
+        item = NewsItem(title="Test", summary="Sum", source="rss", url="http://x")
+        assert item.title == "Test"
+        assert item.summary == "Sum"
+
+    def test_fingerprint_deterministic(self):
+        from bantz.skills.news_briefing import NewsItem
+        a = NewsItem(title="AI News", url="http://example.com/1")
+        b = NewsItem(title="AI News", url="http://example.com/1")
+        assert a.fingerprint == b.fingerprint
+
+    def test_fingerprint_differs(self):
+        from bantz.skills.news_briefing import NewsItem
+        a = NewsItem(title="AI News", url="http://example.com/1")
+        b = NewsItem(title="Tech News", url="http://example.com/2")
+        assert a.fingerprint != b.fingerprint
+
+
+# ── NewsCategory ──────────────────────────────────────────────
+
+class TestNewsCategory:
+    def test_defaults(self):
+        from bantz.skills.news_briefing import NewsCategory
+        c = NewsCategory(key="test", name="Test")
+        assert c.rss_feeds == []
+        assert c.keywords == []
+
+    def test_builtin_categories(self):
+        from bantz.skills.news_briefing import NEWS_CATEGORIES
+        assert "ai" in NEWS_CATEGORIES
+        assert "tech" in NEWS_CATEGORIES
+        assert "turkey" in NEWS_CATEGORIES
+        assert NEWS_CATEGORIES["ai"].name == "Yapay Zeka"
+
+
+# ── Config ────────────────────────────────────────────────────
+
+class TestNewsBriefingConfig:
+    def test_defaults(self):
+        from bantz.skills.news_briefing import NewsBriefingConfig
+        c = NewsBriefingConfig()
+        assert c.cache_ttl == 1800
+        assert c.max_items == 3
+        assert c.categories == ["ai", "tech", "turkey"]
+
+    def test_from_env(self):
+        from bantz.skills.news_briefing import NewsBriefingConfig
+        env = {
+            "BANTZ_NEWS_CACHE_TTL": "3600",
+            "BANTZ_NEWS_MAX_ITEMS": "5",
+            "BANTZ_NEWS_CATEGORIES": "ai,turkey",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = NewsBriefingConfig.from_env()
+        assert c.cache_ttl == 3600
+        assert c.max_items == 5
+        assert c.categories == ["ai", "turkey"]
+
+    def test_from_env_invalid(self):
+        from bantz.skills.news_briefing import NewsBriefingConfig
+        env = {"BANTZ_NEWS_CACHE_TTL": "abc", "BANTZ_NEWS_MAX_ITEMS": "xyz"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            c = NewsBriefingConfig.from_env()
+        assert c.cache_ttl == 1800
+        assert c.max_items == 3
+
+
+# ── NewsProviderBase ──────────────────────────────────────────
+
+class TestProviderBase:
+    def test_abstract(self):
+        from bantz.skills.news_briefing import NewsProviderBase
+        with pytest.raises(TypeError):
+            NewsProviderBase()
+
+
+# ── RSS parsing (offline XML) ─────────────────────────────────
+
+RSS_SAMPLE = textwrap.dedent("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <item>
+      <title>AI Model Released</title>
+      <description>A new AI model was released today. It performs well.</description>
+      <link>http://example.com/1</link>
+      <pubDate>Mon, 01 Jan 2025 12:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Tech Update</title>
+      <description>Latest tech news summary. More details inside.</description>
+      <link>http://example.com/2</link>
+    </item>
+  </channel>
+</rss>
+""")
+
+ATOM_SAMPLE = textwrap.dedent("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Feed</title>
+  <entry>
+    <title>Atom Article</title>
+    <summary>Atom summary text. More info here.</summary>
+    <link href="http://example.com/atom/1"/>
+  </entry>
+</feed>
+""")
+
+
+class TestRSSParsing:
+    def test_parse_rss(self):
+        from bantz.skills.news_briefing import RSSNewsProvider, NewsCategory
+        prov = RSSNewsProvider()
+        cat = NewsCategory(key="test", name="Test")
+        items = prov._parse_xml(RSS_SAMPLE.encode(), cat, source="test")
+        assert len(items) == 2
+        assert items[0].title == "AI Model Released"
+        assert items[0].category == "test"
+        assert "http://example.com/1" in items[0].url
+
+    def test_parse_atom(self):
+        from bantz.skills.news_briefing import RSSNewsProvider, NewsCategory
+        prov = RSSNewsProvider()
+        cat = NewsCategory(key="atom", name="Atom")
+        items = prov._parse_xml(ATOM_SAMPLE.encode(), cat, source="test")
+        assert len(items) == 1
+        assert items[0].title == "Atom Article"
+
+    def test_parse_invalid_xml(self):
+        from bantz.skills.news_briefing import RSSNewsProvider, NewsCategory
+        prov = RSSNewsProvider()
+        cat = NewsCategory(key="bad", name="Bad")
+        items = prov._parse_xml(b"not xml at all", cat, source="test")
+        assert items == []
+
+    def test_deduplication(self):
+        from bantz.skills.news_briefing import RSSNewsProvider, NewsCategory
+        # Same item twice in one feed
+        double_rss = RSS_SAMPLE.replace("</channel>",
+            "<item><title>AI Model Released</title><link>http://example.com/1</link></item></channel>")
+        prov = RSSNewsProvider()
+        cat = NewsCategory(key="test", name="Test", rss_feeds=[])
+        items_raw = prov._parse_xml(double_rss.encode(), cat, source="test")
+        # Manual dedup via fetch logic
+        seen = set()
+        unique = []
+        for i in items_raw:
+            if i.fingerprint not in seen:
+                seen.add(i.fingerprint)
+                unique.append(i)
+        assert len(unique) == 2  # AI Model + Tech Update
+
+
+# ── Cache ─────────────────────────────────────────────────────
+
+class TestNewsCache:
+    def test_empty_cache(self):
+        from bantz.skills.news_briefing import NewsCache
+        cache = NewsCache(ttl_seconds=60)
+        assert cache.get("ai") is None
+        assert cache.is_stale("ai") is True
+
+    def test_set_and_get(self):
+        from bantz.skills.news_briefing import NewsCache, NewsItem
+        cache = NewsCache(ttl_seconds=60)
+        items = [NewsItem(title="Test")]
+        cache.set("ai", items)
+        assert cache.get("ai") == items
+        assert not cache.is_stale("ai")
+
+    def test_ttl_expiry(self):
+        from bantz.skills.news_briefing import NewsCache, NewsItem
+        t = [0.0]
+        cache = NewsCache(ttl_seconds=60, clock=lambda: t[0])
+        cache.set("ai", [NewsItem(title="Test")])
+        assert cache.get("ai") is not None
+
+        t[0] = 61.0
+        assert cache.get("ai") is None
+        assert cache.is_stale("ai") is True
+
+    def test_clear(self):
+        from bantz.skills.news_briefing import NewsCache, NewsItem
+        cache = NewsCache()
+        cache.set("ai", [NewsItem(title="A")])
+        cache.set("tech", [NewsItem(title="B")])
+        cache.clear()
+        assert cache.get("ai") is None
+        assert cache.get("tech") is None
+
+
+# ── Voice formatter ───────────────────────────────────────────
+
+class TestFormatNewsForVoice:
+    def test_empty_items(self):
+        from bantz.skills.news_briefing import format_news_for_voice
+        text = format_news_for_voice([])
+        assert "bulunamadı" in text
+
+    def test_empty_with_category(self):
+        from bantz.skills.news_briefing import format_news_for_voice
+        text = format_news_for_voice([], category_name="Yapay Zeka")
+        assert "Yapay Zeka" in text
+        assert "bulunamadı" in text
+
+    def test_three_items(self):
+        from bantz.skills.news_briefing import format_news_for_voice, NewsItem
+        items = [
+            NewsItem(title="AI Model Released", summary="New model is fast."),
+            NewsItem(title="Tech Update", summary="Big tech news."),
+            NewsItem(title="Turkey News", summary="Local developments."),
+        ]
+        text = format_news_for_voice(items, max_items=3, category_name="Yapay Zeka")
+        assert "Birincisi" in text
+        assert "İkincisi" in text
+        assert "Üçüncüsü" in text
+        assert "AI Model Released" in text
+        assert "Detayları ister misiniz?" in text
+
+    def test_max_items_limit(self):
+        from bantz.skills.news_briefing import format_news_for_voice, NewsItem
+        items = [NewsItem(title=f"Item {i}") for i in range(10)]
+        text = format_news_for_voice(items, max_items=2)
+        assert "Birincisi" in text
+        assert "İkincisi" in text
+        assert "Üçüncüsü" not in text
+
+    def test_efendim_in_output(self):
+        from bantz.skills.news_briefing import format_news_for_voice, NewsItem
+        items = [NewsItem(title="Test")]
+        text = format_news_for_voice(items)
+        assert "efendim" in text
+
+
+# ── File existence ────────────────────────────────────────────
+
+class TestFileExistence:
+    def test_news_briefing_exists(self):
+        from pathlib import Path
+        ROOT = Path(__file__).resolve().parent.parent
+        assert (ROOT / "src" / "bantz" / "skills" / "news_briefing.py").is_file()


### PR DESCRIPTION
## Summary
News briefing skill with RSS/Atom parsing, TTL cache, and Turkish voice-friendly output.

### Implementation
- **NewsItem** dataclass with fingerprint deduplication
- **NEWS_CATEGORIES**: ai (Yapay Zeka), tech (Teknoloji), turkey (Gündem)
- **RSSNewsProvider**: RSS 2.0 + Atom feed parsing
- **NewsCache**: TTL-based (30min default), injectable clock
- **format_news_for_voice()**: Turkish ordinals, max_items, efendim
- **NewsBriefingConfig**: from_env() with cache TTL, max items, categories

### Tests
23 tests: data models, RSS/Atom parsing, cache TTL/expiry, voice formatter, config.

Closes #294