### PR TITLE
feat(brain): runtime banner + turn trace debug output #520

### DIFF
--- a/src/bantz/brain/runtime_banner.py
+++ b/src/bantz/brain/runtime_banner.py
@@ -1,0 +1,224 @@
+"""Runtime banner + turn trace (Issue #520).
+
+Boot banner showing brain configuration and per-turn debug trace.
+
+Boot banner::
+
+    ╭──────────────────────────────────────╮
+    │  🧠 BANTZ Brain v2.0                │
+    │  Mode:      orchestrator             │
+    │  Router:    Qwen2.5-3B @ vLLM:8001  │
+    │  Finalizer: gemini-1.5-flash ✓      │
+    │  Memory:    lite (10 turns, 1000tok) │
+    │  Prompt:    tiered (CORE+DETAIL)     │
+    │  Context:   2048 tokens              │
+    ╰──────────────────────────────────────╯
+
+Turn trace (debug mode)::
+
+    [turn] route=calendar intent=query conf=0.92 prompt=1340tok
+           finalizer=gemini tools=[calendar.list_events] elapsed=1.2s
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RuntimeBanner",
+    "TurnTrace",
+    "TurnTraceRecord",
+    "format_banner",
+    "format_turn_trace",
+]
+
+
+# ── Banner ────────────────────────────────────────────────────
+
+
+@dataclass
+class RuntimeBanner:
+    """Structured brain configuration for boot banner."""
+
+    mode: str = "orchestrator"
+    router_model: str = ""
+    router_url: str = "http://localhost:8001"
+    finalizer_model: str = ""
+    finalizer_type: str = "3B (local)"  # "Gemini" or "3B (local)"
+    finalizer_ok: bool = False
+    memory_turns: int = 10
+    memory_tokens: int = 1000
+    prompt_strategy: str = "tiered (CORE+DETAIL)"
+    context_window: int = 2048
+    tools_registered: int = 0
+    debug: bool = False
+
+    @classmethod
+    def from_runtime(cls, runtime: Any) -> "RuntimeBanner":
+        """Build banner from BantzRuntime."""
+        finalizer_type = "Gemini" if runtime.finalizer_is_gemini else "3B (local)"
+        finalizer_model = (
+            runtime.gemini_model if runtime.finalizer_is_gemini else runtime.router_model
+        )
+
+        # Extract config from loop if available
+        memory_turns = 10
+        memory_tokens = 1000
+        tools_count = 0
+        debug = False
+
+        if hasattr(runtime, "loop") and runtime.loop is not None:
+            loop = runtime.loop
+            if hasattr(loop, "config"):
+                cfg = loop.config
+                memory_turns = getattr(cfg, "memory_max_turns", 10)
+                memory_tokens = getattr(cfg, "memory_max_tokens", 1000)
+                debug = getattr(cfg, "debug", False)
+            if hasattr(loop, "_tools"):
+                tools_count = len(getattr(loop._tools, "_tools", {}))
+
+        # Try to get tools count from runtime.tools
+        if tools_count == 0 and hasattr(runtime, "tools"):
+            tools_obj = runtime.tools
+            if hasattr(tools_obj, "_tools"):
+                tools_count = len(tools_obj._tools)
+
+        # Extract vLLM URL from router_client
+        router_url = "http://localhost:8001"
+        if hasattr(runtime, "router_client"):
+            client = runtime.router_client
+            if hasattr(client, "base_url"):
+                router_url = str(client.base_url)
+
+        return cls(
+            mode="orchestrator",
+            router_model=runtime.router_model,
+            router_url=router_url,
+            finalizer_model=finalizer_model,
+            finalizer_type=finalizer_type,
+            finalizer_ok=runtime.finalizer_is_gemini,
+            memory_turns=memory_turns,
+            memory_tokens=memory_tokens,
+            tools_registered=tools_count,
+            debug=debug,
+        )
+
+
+def format_banner(b: RuntimeBanner) -> str:
+    """Format a pretty box banner for terminal output."""
+    ok_mark = "✓" if b.finalizer_ok else "✗"
+    router_short = b.router_model.split("/")[-1] if "/" in b.router_model else b.router_model
+    # Extract port from URL
+    port = b.router_url.split(":")[-1].rstrip("/") if ":" in b.router_url else "8001"
+
+    lines = [
+        f"  🧠 BANTZ Brain v2.0",
+        f"  Mode:      {b.mode}",
+        f"  Router:    {router_short} @ vLLM:{port}",
+        f"  Finalizer: {b.finalizer_model} {ok_mark} ({b.finalizer_type})",
+        f"  Memory:    lite ({b.memory_turns} turns, {b.memory_tokens}tok)",
+        f"  Prompt:    {b.prompt_strategy}",
+        f"  Context:   {b.context_window} tokens",
+        f"  Tools:     {b.tools_registered} registered",
+    ]
+    if b.debug:
+        lines.append(f"  Debug:     ON")
+
+    width = max(len(line) for line in lines) + 2
+    top = "╭" + "─" * width + "╮"
+    bottom = "╰" + "─" * width + "╯"
+    body = "\n".join(f"│{line.ljust(width)}│" for line in lines)
+    return f"{top}\n{body}\n{bottom}"
+
+
+# ── Turn trace ────────────────────────────────────────────────
+
+
+@dataclass
+class TurnTraceRecord:
+    """Single turn trace record for debug output."""
+
+    turn_number: int = 0
+    route: str = ""
+    intent: str = ""
+    confidence: float = 0.0
+    prompt_tokens: int = 0
+    finalizer: str = ""
+    tools_called: List[str] = field(default_factory=list)
+    tools_ok: int = 0
+    tools_failed: int = 0
+    elapsed_s: float = 0.0
+    memory_injected: bool = False
+    memory_tokens: int = 0
+    tier: str = ""
+    prerouted: bool = False
+
+    def to_trace_line(self) -> str:
+        """Format as single-line debug trace."""
+        parts = [f"[turn #{self.turn_number}]"]
+        if self.prerouted:
+            parts.append("prerouted=true")
+        else:
+            parts.append(f"route={self.route}")
+            parts.append(f"intent={self.intent}")
+            parts.append(f"conf={self.confidence:.2f}")
+        parts.append(f"prompt={self.prompt_tokens}tok")
+        parts.append(f"finalizer={self.finalizer}")
+        if self.tools_called:
+            parts.append(f"tools=[{','.join(self.tools_called)}]")
+        parts.append(f"ok={self.tools_ok}")
+        if self.tools_failed:
+            parts.append(f"fail={self.tools_failed}")
+        if self.memory_injected:
+            parts.append(f"mem={self.memory_tokens}tok")
+        if self.tier:
+            parts.append(f"tier={self.tier}")
+        parts.append(f"elapsed={self.elapsed_s:.2f}s")
+        return " ".join(parts)
+
+
+class TurnTrace:
+    """Accumulates trace data across a single turn.
+
+    Call methods as each phase completes, then finalize with ``record()``.
+    """
+
+    def __init__(self, turn_number: int = 0, finalizer_name: str = "") -> None:
+        self._data = TurnTraceRecord(
+            turn_number=turn_number,
+            finalizer=finalizer_name,
+        )
+        self._start = time.monotonic()
+
+    def set_route(self, route: str, intent: str, confidence: float) -> None:
+        self._data.route = route
+        self._data.intent = intent
+        self._data.confidence = confidence
+
+    def set_prerouted(self) -> None:
+        self._data.prerouted = True
+
+    def set_prompt_tokens(self, tokens: int) -> None:
+        self._data.prompt_tokens = tokens
+
+    def set_tools(self, names: List[str], ok: int, failed: int) -> None:
+        self._data.tools_called = names
+        self._data.tools_ok = ok
+        self._data.tools_failed = failed
+
+    def set_memory(self, injected: bool, tokens: int) -> None:
+        self._data.memory_injected = injected
+        self._data.memory_tokens = tokens
+
+    def set_tier(self, tier: str) -> None:
+        self._data.tier = tier
+
+    def record(self) -> TurnTraceRecord:
+        """Finalize and return the trace record."""
+        self._data.elapsed_s = time.monotonic() - self._start
+        return self._data

--- a/tests/test_issue_520_banner.py
+++ b/tests/test_issue_520_banner.py
@@ -1,0 +1,219 @@
+"""Tests for Issue #520 — Runtime banner + turn trace.
+
+Covers RuntimeBanner, format_banner, TurnTraceRecord, TurnTrace.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest import mock
+
+import pytest
+
+
+# ── RuntimeBanner ─────────────────────────────────────────────
+
+class TestRuntimeBanner:
+    def test_defaults(self):
+        from bantz.brain.runtime_banner import RuntimeBanner
+        b = RuntimeBanner()
+        assert b.mode == "orchestrator"
+        assert b.memory_turns == 10
+        assert b.memory_tokens == 1000
+        assert b.debug is False
+
+    def test_from_runtime(self):
+        from bantz.brain.runtime_banner import RuntimeBanner
+
+        @dataclass
+        class FakeConfig:
+            memory_max_turns: int = 8
+            memory_max_tokens: int = 800
+            debug: bool = True
+
+        class FakeLoop:
+            config = FakeConfig()
+
+        class FakeRuntime:
+            router_model = "Qwen/Qwen2.5-3B-Instruct"
+            gemini_model = "gemini-1.5-flash"
+            finalizer_is_gemini = True
+            loop = FakeLoop()
+            tools = None
+            router_client = None
+
+        banner = RuntimeBanner.from_runtime(FakeRuntime())
+        assert banner.finalizer_type == "Gemini"
+        assert banner.finalizer_model == "gemini-1.5-flash"
+        assert banner.finalizer_ok is True
+        assert banner.memory_turns == 8
+        assert banner.memory_tokens == 800
+        assert banner.debug is True
+        assert banner.router_model == "Qwen/Qwen2.5-3B-Instruct"
+
+    def test_from_runtime_no_gemini(self):
+        from bantz.brain.runtime_banner import RuntimeBanner
+
+        class FakeRuntime:
+            router_model = "Qwen/Qwen2.5-3B-Instruct"
+            gemini_model = ""
+            finalizer_is_gemini = False
+            loop = None
+            tools = None
+            router_client = None
+
+        banner = RuntimeBanner.from_runtime(FakeRuntime())
+        assert banner.finalizer_type == "3B (local)"
+        assert banner.finalizer_ok is False
+
+
+# ── format_banner ─────────────────────────────────────────────
+
+class TestFormatBanner:
+    def test_contains_box_chars(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(
+            router_model="Qwen/Qwen2.5-3B-Instruct",
+            finalizer_model="gemini-1.5-flash",
+            finalizer_ok=True,
+        )
+        text = format_banner(b)
+        assert "╭" in text
+        assert "╰" in text
+        assert "BANTZ Brain" in text
+
+    def test_contains_all_fields(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(
+            mode="orchestrator",
+            router_model="Qwen/Qwen2.5-3B-Instruct",
+            finalizer_model="gemini-1.5-flash",
+            finalizer_type="Gemini",
+            finalizer_ok=True,
+            memory_turns=10,
+            memory_tokens=1000,
+            tools_registered=5,
+        )
+        text = format_banner(b)
+        assert "orchestrator" in text
+        assert "Qwen2.5-3B-Instruct" in text
+        assert "gemini-1.5-flash" in text
+        assert "10 turns" in text
+        assert "1000tok" in text
+        assert "5 registered" in text
+
+    def test_debug_flag(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(debug=True)
+        text = format_banner(b)
+        assert "Debug" in text
+        assert "ON" in text
+
+    def test_no_debug_flag(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(debug=False)
+        text = format_banner(b)
+        assert "Debug" not in text
+
+
+# ── TurnTraceRecord ───────────────────────────────────────────
+
+class TestTurnTraceRecord:
+    def test_basic_trace_line(self):
+        from bantz.brain.runtime_banner import TurnTraceRecord
+        r = TurnTraceRecord(
+            turn_number=1,
+            route="calendar",
+            intent="query",
+            confidence=0.92,
+            prompt_tokens=1340,
+            finalizer="gemini",
+            tools_called=["calendar.list_events"],
+            tools_ok=1,
+            elapsed_s=1.2,
+        )
+        line = r.to_trace_line()
+        assert "route=calendar" in line
+        assert "intent=query" in line
+        assert "conf=0.92" in line
+        assert "prompt=1340tok" in line
+        assert "finalizer=gemini" in line
+        assert "calendar.list_events" in line
+        assert "elapsed=1.20s" in line
+
+    def test_prerouted(self):
+        from bantz.brain.runtime_banner import TurnTraceRecord
+        r = TurnTraceRecord(turn_number=2, prerouted=True, elapsed_s=0.01)
+        line = r.to_trace_line()
+        assert "prerouted=true" in line
+        assert "route=" not in line
+
+    def test_memory_in_trace(self):
+        from bantz.brain.runtime_banner import TurnTraceRecord
+        r = TurnTraceRecord(
+            turn_number=3,
+            memory_injected=True,
+            memory_tokens=142,
+            elapsed_s=0.5,
+        )
+        line = r.to_trace_line()
+        assert "mem=142tok" in line
+
+    def test_failed_tools(self):
+        from bantz.brain.runtime_banner import TurnTraceRecord
+        r = TurnTraceRecord(tools_ok=2, tools_failed=1, elapsed_s=0.3)
+        line = r.to_trace_line()
+        assert "fail=1" in line
+
+    def test_tier(self):
+        from bantz.brain.runtime_banner import TurnTraceRecord
+        r = TurnTraceRecord(tier="quality", elapsed_s=0.3)
+        line = r.to_trace_line()
+        assert "tier=quality" in line
+
+
+# ── TurnTrace ─────────────────────────────────────────────────
+
+class TestTurnTrace:
+    def test_accumulate_and_record(self):
+        from bantz.brain.runtime_banner import TurnTrace
+        trace = TurnTrace(turn_number=5, finalizer_name="gemini")
+        trace.set_route("calendar", "query", 0.85)
+        trace.set_prompt_tokens(1200)
+        trace.set_tools(["calendar.list_events"], ok=1, failed=0)
+        trace.set_memory(injected=True, tokens=100)
+        trace.set_tier("quality")
+        rec = trace.record()
+        assert rec.turn_number == 5
+        assert rec.route == "calendar"
+        assert rec.confidence == 0.85
+        assert rec.prompt_tokens == 1200
+        assert rec.tools_called == ["calendar.list_events"]
+        assert rec.tools_ok == 1
+        assert rec.memory_injected is True
+        assert rec.memory_tokens == 100
+        assert rec.elapsed_s >= 0.0
+
+    def test_prerouted(self):
+        from bantz.brain.runtime_banner import TurnTrace
+        trace = TurnTrace(turn_number=1)
+        trace.set_prerouted()
+        rec = trace.record()
+        assert rec.prerouted is True
+
+    def test_elapsed_positive(self):
+        import time
+        from bantz.brain.runtime_banner import TurnTrace
+        trace = TurnTrace()
+        time.sleep(0.01)
+        rec = trace.record()
+        assert rec.elapsed_s > 0
+
+
+# ── File existence ────────────────────────────────────────────
+
+class TestFileExistence:
+    def test_runtime_banner_exists(self):
+        from pathlib import Path
+        ROOT = Path(__file__).resolve().parent.parent
+        assert (ROOT / "src" / "bantz" / "brain" / "runtime_banner.py").is_file()


### PR DESCRIPTION
## Summary
Boot banner showing brain configuration and per-turn debug trace.

### Implementation
- **RuntimeBanner**: structured brain config with from_runtime() factory
- **format_banner()**: pretty box terminal output (mode, router, finalizer, memory, tools, debug)
- **TurnTraceRecord**: single-line per-turn trace (route, intent, confidence, tokens, tools, elapsed)
- **TurnTrace**: phase-by-phase accumulator for building trace records

### Tests
16 tests covering banner construction, formatting, trace records, and accumulation.

Closes #520