### PR TITLE
feat(brain): ConversationFSM ↔ OrchestratorLoop integration #522

### DIFF
--- a/src/bantz/brain/fsm_bridge.py
+++ b/src/bantz/brain/fsm_bridge.py
@@ -1,0 +1,270 @@
+"""ConversationFSM ↔ OrchestratorLoop integration (Issue #522).
+
+Bridges the async ConversationFSM with the sync OrchestratorLoop.process_turn(),
+providing automatic state transitions and barge-in detection.
+
+Flow per turn::
+
+    process_turn() called
+      → THINKING  (planning + tool execution)
+      → SPEAKING  (finalization done, response ready)
+      → IDLE      (turn complete)
+
+Barge-in::
+
+    If FSM is in SPEAKING and a new process_turn() arrives,
+    the bridge fires barge_in → LISTENING → THINKING automatically.
+
+EventBus integration::
+
+    Every transition publishes ``fsm.state_changed`` with
+    old_state, new_state, trigger, turn_number.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "FSMBridge",
+    "FSMTransitionRecord",
+]
+
+
+# ── Transition record ────────────────────────────────────────
+
+@dataclass
+class FSMTransitionRecord:
+    """Record of a single FSM state transition."""
+
+    turn_number: int = 0
+    old_state: str = ""
+    new_state: str = ""
+    trigger: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def to_trace_line(self) -> str:
+        return (
+            f"[fsm] {self.old_state} → {self.new_state} "
+            f"trigger={self.trigger} turn={self.turn_number}"
+        )
+
+
+# ── FSM Bridge ───────────────────────────────────────────────
+
+class FSMBridge:
+    """Sync bridge between async ConversationFSM and OrchestratorLoop.
+
+    Parameters
+    ----------
+    fsm :
+        The ConversationFSM instance. If ``None``, all operations are no-ops
+        (graceful degradation for envs without voice/FSM).
+    event_bus :
+        EventBus to publish ``fsm.state_changed`` events.
+    debug :
+        Whether to emit debug log lines for each transition.
+    """
+
+    def __init__(
+        self,
+        fsm: Optional[Any] = None,
+        event_bus: Optional[Any] = None,
+        *,
+        debug: bool = False,
+    ) -> None:
+        self._fsm = fsm
+        self._event_bus = event_bus
+        self._debug = debug
+        self._records: List[FSMTransitionRecord] = []
+        self._current_turn: int = 0
+
+        # Resolve or create an event loop for running async FSM transitions
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    # ── Helpers ───────────────────────────────────────────────
+
+    def _get_loop(self) -> asyncio.AbstractEventLoop:
+        """Get or create an event loop for sync→async bridging."""
+        if self._loop is not None and not self._loop.is_closed():
+            return self._loop
+        try:
+            self._loop = asyncio.get_event_loop()
+            if self._loop.is_closed():
+                raise RuntimeError("closed")
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+        return self._loop
+
+    def _run_transition(self, trigger: str) -> bool:
+        """Run an async FSM transition synchronously.
+
+        Returns True if transition succeeded, False otherwise.
+        """
+        if self._fsm is None:
+            return False
+        try:
+            loop = self._get_loop()
+            if loop.is_running():
+                # Already inside an async context — schedule as task
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    future = pool.submit(self._run_in_new_loop, trigger)
+                    return future.result(timeout=2.0)
+            else:
+                return loop.run_until_complete(self._fsm.transition(trigger))
+        except Exception as e:
+            logger.warning("[fsm-bridge] Transition failed: trigger=%s err=%s", trigger, e)
+            return False
+
+    @staticmethod
+    def _run_in_new_loop_static(fsm: Any, trigger: str) -> bool:
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(fsm.transition(trigger))
+        finally:
+            loop.close()
+
+    def _run_in_new_loop(self, trigger: str) -> bool:
+        return self._run_in_new_loop_static(self._fsm, trigger)
+
+    def _record(self, old: str, new: str, trigger: str) -> FSMTransitionRecord:
+        rec = FSMTransitionRecord(
+            turn_number=self._current_turn,
+            old_state=old,
+            new_state=new,
+            trigger=trigger,
+        )
+        self._records.append(rec)
+        if self._debug:
+            logger.debug(rec.to_trace_line())
+        if self._event_bus is not None:
+            self._event_bus.publish("fsm.state_changed", {
+                "old_state": old,
+                "new_state": new,
+                "trigger": trigger,
+                "turn_number": self._current_turn,
+            })
+        return rec
+
+    @property
+    def current_state(self) -> str:
+        """Current FSM state as a string (or 'unknown')."""
+        if self._fsm is None:
+            return "unknown"
+        return str(self._fsm.current_state)
+
+    @property
+    def records(self) -> List[FSMTransitionRecord]:
+        return list(self._records)
+
+    @property
+    def last(self) -> Optional[FSMTransitionRecord]:
+        return self._records[-1] if self._records else None
+
+    # ── Turn lifecycle ────────────────────────────────────────
+
+    def on_turn_start(self, turn_number: int) -> Optional[FSMTransitionRecord]:
+        """Call at the start of process_turn().
+
+        Transitions:
+        - IDLE → THINKING (normal)
+        - SPEAKING → LISTENING → THINKING (barge-in)
+        """
+        self._current_turn = turn_number
+
+        if self._fsm is None:
+            return None
+
+        old = str(self._fsm.current_state)
+
+        # Barge-in: if still speaking when new turn starts
+        if old == "speaking":
+            self._run_transition("barge_in")       # SPEAKING → LISTENING
+            mid = str(self._fsm.current_state)
+            self._record(old, mid, "barge_in")
+
+            self._run_transition("speech_end")     # LISTENING → THINKING
+            new = str(self._fsm.current_state)
+            return self._record(mid, new, "speech_end")
+
+        # Normal: IDLE → LISTENING → THINKING
+        if old == "idle":
+            self._run_transition("speech_start")   # IDLE → LISTENING
+            mid = str(self._fsm.current_state)
+            self._record(old, mid, "speech_start")
+
+            self._run_transition("speech_end")     # LISTENING → THINKING
+            new = str(self._fsm.current_state)
+            return self._record(mid, new, "speech_end")
+
+        return None
+
+    def on_finalization_done(self) -> Optional[FSMTransitionRecord]:
+        """Call after finalization phase completes (response ready).
+
+        Transitions: THINKING → SPEAKING
+        """
+        if self._fsm is None:
+            return None
+
+        old = str(self._fsm.current_state)
+        if old != "thinking":
+            return None
+
+        self._run_transition("thinking_done")  # THINKING → SPEAKING
+        new = str(self._fsm.current_state)
+        return self._record(old, new, "thinking_done")
+
+    def on_turn_end(self) -> Optional[FSMTransitionRecord]:
+        """Call at the end of process_turn().
+
+        Transitions: SPEAKING → IDLE
+        """
+        if self._fsm is None:
+            return None
+
+        old = str(self._fsm.current_state)
+        if old != "speaking":
+            return None
+
+        self._run_transition("speaking_done")  # SPEAKING → IDLE
+        new = str(self._fsm.current_state)
+        return self._record(old, new, "speaking_done")
+
+    def on_confirmation_needed(self) -> Optional[FSMTransitionRecord]:
+        """Call when a confirmation is required.
+
+        Transitions: THINKING → CONFIRMING
+        """
+        if self._fsm is None:
+            return None
+
+        old = str(self._fsm.current_state)
+        if old != "thinking":
+            return None
+
+        self._run_transition("confirm")  # THINKING → CONFIRMING
+        new = str(self._fsm.current_state)
+        return self._record(old, new, "confirm")
+
+    # ── Utility ───────────────────────────────────────────────
+
+    def clear(self) -> None:
+        """Reset records (not the FSM itself)."""
+        self._records.clear()
+        self._current_turn = 0
+
+    def is_barge_in(self) -> bool:
+        """Whether the current turn started via barge-in."""
+        for rec in self._records:
+            if rec.turn_number == self._current_turn and rec.trigger == "barge_in":
+                return True
+        return False

--- a/tests/test_issue_522_fsm_bridge.py
+++ b/tests/test_issue_522_fsm_bridge.py
@@ -1,0 +1,287 @@
+"""Tests for Issue #522 — ConversationFSM ↔ OrchestratorLoop integration.
+
+Covers:
+  - FSMTransitionRecord: trace line format
+  - FSMBridge: normal turn lifecycle (IDLE→THINKING→SPEAKING→IDLE)
+  - FSMBridge: barge-in (SPEAKING→LISTENING→THINKING)
+  - FSMBridge: confirmation flow (THINKING→CONFIRMING)
+  - FSMBridge: graceful degradation (no FSM)
+  - FSMBridge: EventBus integration (fsm.state_changed)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from bantz.conversation.fsm import ConversationFSM, ConversationState
+from bantz.core.events import EventBus
+
+
+# ═══════════════════════════════════════════════════════════════
+# FSMTransitionRecord
+# ═══════════════════════════════════════════════════════════════
+
+class TestFSMTransitionRecord:
+    def test_defaults(self):
+        from bantz.brain.fsm_bridge import FSMTransitionRecord
+        rec = FSMTransitionRecord()
+        assert rec.turn_number == 0
+        assert rec.old_state == ""
+        assert rec.trigger == ""
+
+    def test_to_trace_line(self):
+        from bantz.brain.fsm_bridge import FSMTransitionRecord
+        rec = FSMTransitionRecord(
+            turn_number=3,
+            old_state="thinking",
+            new_state="speaking",
+            trigger="thinking_done",
+        )
+        line = rec.to_trace_line()
+        assert "[fsm]" in line
+        assert "thinking → speaking" in line
+        assert "trigger=thinking_done" in line
+        assert "turn=3" in line
+
+
+# ═══════════════════════════════════════════════════════════════
+# FSMBridge — Normal Turn Lifecycle
+# ═══════════════════════════════════════════════════════════════
+
+class TestFSMBridgeNormalTurn:
+    """Normal flow: IDLE → LISTENING → THINKING → SPEAKING → IDLE."""
+
+    def test_full_turn_lifecycle(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm, debug=True)
+
+        assert bridge.current_state == "idle"
+
+        # Turn start: IDLE → LISTENING → THINKING
+        bridge.on_turn_start(turn_number=1)
+        assert bridge.current_state == "thinking"
+
+        # Finalization done: THINKING → SPEAKING
+        bridge.on_finalization_done()
+        assert bridge.current_state == "speaking"
+
+        # Turn end: SPEAKING → IDLE
+        bridge.on_turn_end()
+        assert bridge.current_state == "idle"
+
+        # Should have records
+        assert len(bridge.records) >= 3
+
+    def test_multi_turn(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        for turn in range(1, 4):
+            bridge.on_turn_start(turn_number=turn)
+            assert bridge.current_state == "thinking"
+            bridge.on_finalization_done()
+            assert bridge.current_state == "speaking"
+            bridge.on_turn_end()
+            assert bridge.current_state == "idle"
+
+
+# ═══════════════════════════════════════════════════════════════
+# FSMBridge — Barge-in
+# ═══════════════════════════════════════════════════════════════
+
+class TestFSMBridgeBargeIn:
+    """Barge-in: SPEAKING → LISTENING → THINKING (new turn while speaking)."""
+
+    def test_barge_in_during_speaking(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        # Turn 1: normal flow up to SPEAKING
+        bridge.on_turn_start(1)
+        bridge.on_finalization_done()
+        assert bridge.current_state == "speaking"
+
+        # Turn 2: starts while still SPEAKING → barge-in
+        bridge.on_turn_start(2)
+        assert bridge.current_state == "thinking"
+        assert bridge.is_barge_in() is True
+
+    def test_barge_in_records(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        bridge.on_turn_start(1)
+        bridge.on_finalization_done()
+        # Don't call on_turn_end — simulate barge-in
+
+        bridge.on_turn_start(2)
+        # Find barge_in record
+        barge_records = [r for r in bridge.records if r.trigger == "barge_in"]
+        assert len(barge_records) >= 1
+        assert barge_records[0].old_state == "speaking"
+        assert barge_records[0].new_state == "listening"
+
+
+# ═══════════════════════════════════════════════════════════════
+# FSMBridge — Confirmation
+# ═══════════════════════════════════════════════════════════════
+
+class TestFSMBridgeConfirmation:
+    def test_confirmation_flow(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        bridge.on_turn_start(1)
+        assert bridge.current_state == "thinking"
+
+        bridge.on_confirmation_needed()
+        assert bridge.current_state == "confirming"
+
+
+# ═══════════════════════════════════════════════════════════════
+# FSMBridge — Graceful Degradation (no FSM)
+# ═══════════════════════════════════════════════════════════════
+
+class TestFSMBridgeNoFSM:
+    """All operations are no-ops when FSM is None."""
+
+    def test_no_fsm_turn_lifecycle(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        bridge = FSMBridge(fsm=None)
+        assert bridge.current_state == "unknown"
+
+        result = bridge.on_turn_start(1)
+        assert result is None
+        assert bridge.current_state == "unknown"
+
+        result = bridge.on_finalization_done()
+        assert result is None
+
+        result = bridge.on_turn_end()
+        assert result is None
+
+        assert len(bridge.records) == 0
+
+    def test_no_fsm_barge_in(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+        bridge = FSMBridge(fsm=None)
+        assert bridge.is_barge_in() is False
+
+
+# ═══════════════════════════════════════════════════════════════
+# FSMBridge — EventBus Integration
+# ═══════════════════════════════════════════════════════════════
+
+class TestFSMBridgeEventBus:
+    def test_publishes_state_changed(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bus = EventBus()
+
+        captured = []
+        bus.subscribe("fsm.state_changed", lambda e: captured.append(e.data))
+
+        bridge = FSMBridge(fsm=fsm, event_bus=bus)
+        bridge.on_turn_start(1)
+        bridge.on_finalization_done()
+        bridge.on_turn_end()
+
+        # Should have multiple state_changed events
+        assert len(captured) >= 3
+
+        # Check structure of first event
+        first = captured[0]
+        assert "old_state" in first
+        assert "new_state" in first
+        assert "trigger" in first
+        assert "turn_number" in first
+
+    def test_no_event_bus_no_crash(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm, event_bus=None)
+        # Should not raise
+        bridge.on_turn_start(1)
+        bridge.on_finalization_done()
+        bridge.on_turn_end()
+
+
+# ═══════════════════════════════════════════════════════════════
+# FSMBridge — Utility
+# ═══════════════════════════════════════════════════════════════
+
+class TestFSMBridgeUtility:
+    def test_clear_records(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        bridge.on_turn_start(1)
+        assert len(bridge.records) > 0
+
+        bridge.clear()
+        assert len(bridge.records) == 0
+        assert bridge.last is None
+
+    def test_last_record(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        bridge.on_turn_start(1)
+        bridge.on_finalization_done()
+
+        last = bridge.last
+        assert last is not None
+        assert last.new_state == "speaking"
+
+    def test_not_barge_in_on_normal_turn(self):
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        bridge.on_turn_start(1)
+        assert bridge.is_barge_in() is False
+
+    def test_finalization_when_not_thinking_is_noop(self):
+        """on_finalization_done while not in THINKING is a no-op."""
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        # Still IDLE → finalization should be no-op
+        result = bridge.on_finalization_done()
+        assert result is None
+        assert bridge.current_state == "idle"
+
+    def test_turn_end_when_not_speaking_is_noop(self):
+        """on_turn_end while not in SPEAKING is a no-op."""
+        from bantz.brain.fsm_bridge import FSMBridge
+
+        fsm = ConversationFSM()
+        bridge = FSMBridge(fsm=fsm)
+
+        bridge.on_turn_start(1)
+        # In THINKING, not SPEAKING
+        result = bridge.on_turn_end()
+        assert result is None
+        assert bridge.current_state == "thinking"


### PR DESCRIPTION
## Issue #522 — ConversationFSM integration with process_turn()

### Changes
- **FSMBridge**: Sync bridge for async ConversationFSM transitions in OrchestratorLoop
- **Turn lifecycle**: Automatic IDLE→THINKING→SPEAKING→IDLE transitions per turn
- **Barge-in**: Detects SPEAKING + new process_turn() → auto-interrupt flow
- **Confirmation**: THINKING→CONFIRMING when destructive ops need user approval
- **EventBus**: Every transition publishes `fsm.state_changed` event
- **Graceful degradation**: All no-ops when FSM is None (headless/test envs)
- **FSMTransitionRecord**: Per-transition trace lines for debug output

### Files
- `src/bantz/brain/fsm_bridge.py` (new)
- `tests/test_issue_522_fsm_bridge.py` (new, 16 tests)

### Test Results
```
16 passed in 0.11s
```

Closes #522