### PR TITLE
feat(brain): tool-call trace viewer — ring buffer + /tools command #524

### DIFF
--- a/src/bantz/brain/tool_trace.py
+++ b/src/bantz/brain/tool_trace.py
@@ -1,0 +1,219 @@
+"""Tool-call trace viewer — ring buffer + per-tool debug trace (Issue #524).
+
+Provides:
+  - ``ToolCallLog``: Ring buffer (collections.deque, maxlen=20) storing
+    per-tool-call metadata.
+  - ``ToolCallEntry``: Single tool call record with name, params, result,
+    success, elapsed_ms, timestamp.
+  - ``format_tools_command()``: Renders ``/tools`` output for terminal.
+  - Per-tool trace line: ``[tool] calendar.list_events ok 340ms → 3 events``
+
+Usage::
+
+    log = ToolCallLog()
+    log.record("calendar.list_events", {"date": "2025-01-15"}, "3 events", True, 340)
+    print(log.format_table())
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ToolCallEntry",
+    "ToolCallLog",
+    "format_tools_command",
+]
+
+
+# ── Entry ─────────────────────────────────────────────────────
+
+@dataclass
+class ToolCallEntry:
+    """Single tool call record.
+
+    Attributes
+    ----------
+    tool_name:
+        Fully qualified tool name (e.g. ``calendar.list_events``).
+    params:
+        Parameters passed to the tool.
+    result_summary:
+        Short summary of the result (≤100 chars).
+    success:
+        Whether the tool call succeeded.
+    elapsed_ms:
+        Execution time in milliseconds.
+    timestamp:
+        When the call was made.
+    turn_number:
+        Which conversation turn triggered this call.
+    retried:
+        Whether this was a retry attempt.
+    error:
+        Error message if success=False.
+    """
+
+    tool_name: str = ""
+    params: Dict[str, Any] = field(default_factory=dict)
+    result_summary: str = ""
+    success: bool = True
+    elapsed_ms: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    turn_number: int = 0
+    retried: bool = False
+    error: str = ""
+
+    def to_trace_line(self) -> str:
+        """Format as per-tool debug trace line.
+
+        Example: ``[tool] calendar.list_events ok 340ms → 3 events``
+        """
+        status = "ok" if self.success else "FAIL"
+        summary = self.result_summary[:60] if self.result_summary else ""
+        if self.error and not self.success:
+            summary = self.error[:60]
+        retry_tag = " (retry)" if self.retried else ""
+        return f"[tool] {self.tool_name} {status} {self.elapsed_ms}ms → {summary}{retry_tag}"
+
+    def to_table_row(self) -> str:
+        """Format as table row for /tools command."""
+        status = "✓" if self.success else "✗"
+        summary = self.result_summary[:40] if self.result_summary else ""
+        if self.error and not self.success:
+            summary = self.error[:40]
+        return f"  {status} {self.tool_name:<30} {self.elapsed_ms:>5}ms  {summary}"
+
+
+# ── Ring buffer ───────────────────────────────────────────────
+
+class ToolCallLog:
+    """Ring buffer of recent tool calls.
+
+    Parameters
+    ----------
+    maxlen:
+        Maximum entries to keep (default: 20).
+    """
+
+    def __init__(self, maxlen: int = 20) -> None:
+        self._entries: deque[ToolCallEntry] = deque(maxlen=maxlen)
+        self._maxlen = maxlen
+
+    def record(
+        self,
+        tool_name: str,
+        params: Optional[Dict[str, Any]] = None,
+        result_summary: str = "",
+        success: bool = True,
+        elapsed_ms: int = 0,
+        *,
+        turn_number: int = 0,
+        retried: bool = False,
+        error: str = "",
+    ) -> ToolCallEntry:
+        """Record a tool call.
+
+        Returns the created entry.
+        """
+        entry = ToolCallEntry(
+            tool_name=tool_name,
+            params=params or {},
+            result_summary=result_summary,
+            success=success,
+            elapsed_ms=elapsed_ms,
+            turn_number=turn_number,
+            retried=retried,
+            error=error,
+        )
+        self._entries.append(entry)
+
+        if success:
+            logger.debug(entry.to_trace_line())
+        else:
+            logger.warning(entry.to_trace_line())
+
+        return entry
+
+    @property
+    def entries(self) -> List[ToolCallEntry]:
+        """All entries (oldest first)."""
+        return list(self._entries)
+
+    @property
+    def last(self) -> Optional[ToolCallEntry]:
+        """Most recent entry."""
+        return self._entries[-1] if self._entries else None
+
+    def for_turn(self, turn_number: int) -> List[ToolCallEntry]:
+        """Get entries for a specific turn."""
+        return [e for e in self._entries if e.turn_number == turn_number]
+
+    def stats(self) -> Dict[str, Any]:
+        """Aggregate stats across all entries."""
+        total = len(self._entries)
+        ok = sum(1 for e in self._entries if e.success)
+        fail = total - ok
+        retries = sum(1 for e in self._entries if e.retried)
+        avg_ms = (
+            sum(e.elapsed_ms for e in self._entries) // total
+            if total > 0
+            else 0
+        )
+        return {
+            "total": total,
+            "ok": ok,
+            "fail": fail,
+            "retries": retries,
+            "avg_ms": avg_ms,
+        }
+
+    def format_table(self) -> str:
+        """Format entries as a table for /tools command output.
+
+        Returns
+        -------
+        Formatted table string with header and rows.
+        """
+        if not self._entries:
+            return "  (no tool calls recorded)"
+
+        lines = [
+            f"  Tool Call Log (last {len(self._entries)}/{self._maxlen}):",
+            f"  {'─' * 60}",
+        ]
+        for entry in self._entries:
+            lines.append(entry.to_table_row())
+        lines.append(f"  {'─' * 60}")
+
+        s = self.stats()
+        lines.append(
+            f"  Total: {s['total']}  OK: {s['ok']}  Fail: {s['fail']}  "
+            f"Retries: {s['retries']}  Avg: {s['avg_ms']}ms"
+        )
+        return "\n".join(lines)
+
+    def clear(self) -> None:
+        """Clear all entries."""
+        self._entries.clear()
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+# ── /tools command formatter ──────────────────────────────────
+
+def format_tools_command(log: ToolCallLog) -> str:
+    """Format the output for the ``/tools`` terminal command.
+
+    Returns a user-friendly summary with table + stats.
+    """
+    header = "🔧 Tool Call Trace Viewer"
+    body = log.format_table()
+    return f"{header}\n{body}"

--- a/tests/test_issue_524_tool_trace.py
+++ b/tests/test_issue_524_tool_trace.py
@@ -1,0 +1,242 @@
+"""Tests for Issue #524 — Tool-call trace viewer.
+
+Covers:
+  - ToolCallEntry: trace line + table row format
+  - ToolCallLog: ring buffer (maxlen=20), record, stats, format_table
+  - format_tools_command: /tools output
+  - Ring buffer eviction (maxlen overflow)
+  - Turn filtering, retry tracking
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════
+# ToolCallEntry
+# ═══════════════════════════════════════════════════════════════
+
+class TestToolCallEntry:
+    def test_defaults(self):
+        from bantz.brain.tool_trace import ToolCallEntry
+        e = ToolCallEntry()
+        assert e.tool_name == ""
+        assert e.success is True
+        assert e.elapsed_ms == 0
+        assert e.retried is False
+
+    def test_trace_line_ok(self):
+        from bantz.brain.tool_trace import ToolCallEntry
+        e = ToolCallEntry(
+            tool_name="calendar.list_events",
+            success=True,
+            elapsed_ms=340,
+            result_summary="3 events",
+        )
+        line = e.to_trace_line()
+        assert "[tool]" in line
+        assert "calendar.list_events" in line
+        assert "ok" in line
+        assert "340ms" in line
+        assert "3 events" in line
+
+    def test_trace_line_fail(self):
+        from bantz.brain.tool_trace import ToolCallEntry
+        e = ToolCallEntry(
+            tool_name="gmail.send",
+            success=False,
+            elapsed_ms=50,
+            error="auth error",
+        )
+        line = e.to_trace_line()
+        assert "FAIL" in line
+        assert "auth error" in line
+
+    def test_trace_line_retry(self):
+        from bantz.brain.tool_trace import ToolCallEntry
+        e = ToolCallEntry(
+            tool_name="test.tool",
+            success=True,
+            elapsed_ms=100,
+            result_summary="recovered",
+            retried=True,
+        )
+        line = e.to_trace_line()
+        assert "(retry)" in line
+
+    def test_table_row_ok(self):
+        from bantz.brain.tool_trace import ToolCallEntry
+        e = ToolCallEntry(tool_name="time.now", success=True, elapsed_ms=5, result_summary="14:30")
+        row = e.to_table_row()
+        assert "✓" in row
+        assert "time.now" in row
+
+    def test_table_row_fail(self):
+        from bantz.brain.tool_trace import ToolCallEntry
+        e = ToolCallEntry(tool_name="test.tool", success=False, error="timeout")
+        row = e.to_table_row()
+        assert "✗" in row
+        assert "timeout" in row
+
+
+# ═══════════════════════════════════════════════════════════════
+# ToolCallLog — Basic
+# ═══════════════════════════════════════════════════════════════
+
+class TestToolCallLogBasic:
+    def test_empty_log(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        assert len(log) == 0
+        assert log.last is None
+        assert log.entries == []
+
+    def test_record_single(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        entry = log.record("calendar.list_events", {"date": "2025-01-15"}, "3 events", True, 340)
+        assert len(log) == 1
+        assert log.last.tool_name == "calendar.list_events"
+        assert entry.success is True
+        assert entry.elapsed_ms == 340
+
+    def test_record_multiple(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        log.record("time.now", success=True, elapsed_ms=5, result_summary="14:30")
+        log.record("calendar.list_events", success=True, elapsed_ms=340, result_summary="3 events")
+        log.record("gmail.send", success=False, elapsed_ms=50, error="auth")
+        assert len(log) == 3
+        assert log.last.tool_name == "gmail.send"
+
+
+# ═══════════════════════════════════════════════════════════════
+# ToolCallLog — Ring Buffer
+# ═══════════════════════════════════════════════════════════════
+
+class TestToolCallLogRingBuffer:
+    def test_maxlen_default_20(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        assert log._maxlen == 20
+
+    def test_maxlen_custom(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog(maxlen=5)
+        assert log._maxlen == 5
+
+    def test_eviction_on_overflow(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog(maxlen=3)
+        for i in range(5):
+            log.record(f"tool_{i}", success=True, elapsed_ms=i * 10, result_summary=f"result_{i}")
+        assert len(log) == 3
+        # Oldest should be tool_2 (0, 1 evicted)
+        names = [e.tool_name for e in log.entries]
+        assert names == ["tool_2", "tool_3", "tool_4"]
+
+
+# ═══════════════════════════════════════════════════════════════
+# ToolCallLog — Stats
+# ═══════════════════════════════════════════════════════════════
+
+class TestToolCallLogStats:
+    def test_stats_empty(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        s = log.stats()
+        assert s["total"] == 0
+        assert s["ok"] == 0
+        assert s["avg_ms"] == 0
+
+    def test_stats_mixed(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        log.record("a", success=True, elapsed_ms=100)
+        log.record("b", success=False, elapsed_ms=200, error="fail")
+        log.record("c", success=True, elapsed_ms=300, retried=True)
+        s = log.stats()
+        assert s["total"] == 3
+        assert s["ok"] == 2
+        assert s["fail"] == 1
+        assert s["retries"] == 1
+        assert s["avg_ms"] == 200  # (100+200+300)//3
+
+
+# ═══════════════════════════════════════════════════════════════
+# ToolCallLog — Turn Filtering
+# ═══════════════════════════════════════════════════════════════
+
+class TestToolCallLogTurnFilter:
+    def test_for_turn(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        log.record("a", success=True, turn_number=1)
+        log.record("b", success=True, turn_number=1)
+        log.record("c", success=True, turn_number=2)
+        turn1 = log.for_turn(1)
+        assert len(turn1) == 2
+        turn2 = log.for_turn(2)
+        assert len(turn2) == 1
+
+    def test_for_turn_empty(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        log.record("a", success=True, turn_number=1)
+        assert log.for_turn(99) == []
+
+
+# ═══════════════════════════════════════════════════════════════
+# ToolCallLog — Format Table
+# ═══════════════════════════════════════════════════════════════
+
+class TestToolCallLogFormatTable:
+    def test_empty_table(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        table = log.format_table()
+        assert "no tool calls" in table
+
+    def test_table_with_entries(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        log.record("calendar.list_events", success=True, elapsed_ms=340, result_summary="3 events")
+        log.record("gmail.send", success=False, elapsed_ms=50, error="auth")
+        table = log.format_table()
+        assert "Tool Call Log" in table
+        assert "calendar.list_events" in table
+        assert "gmail.send" in table
+        assert "Total:" in table
+        assert "OK: 1" in table
+        assert "Fail: 1" in table
+
+
+# ═══════════════════════════════════════════════════════════════
+# format_tools_command
+# ═══════════════════════════════════════════════════════════════
+
+class TestFormatToolsCommand:
+    def test_format_empty(self):
+        from bantz.brain.tool_trace import ToolCallLog, format_tools_command
+        log = ToolCallLog()
+        out = format_tools_command(log)
+        assert "Tool Call Trace Viewer" in out
+        assert "no tool calls" in out
+
+    def test_format_with_entries(self):
+        from bantz.brain.tool_trace import ToolCallLog, format_tools_command
+        log = ToolCallLog()
+        log.record("time.now", success=True, elapsed_ms=5, result_summary="14:30")
+        out = format_tools_command(log)
+        assert "🔧" in out
+        assert "time.now" in out
+
+    def test_clear(self):
+        from bantz.brain.tool_trace import ToolCallLog
+        log = ToolCallLog()
+        log.record("a", success=True)
+        log.record("b", success=True)
+        assert len(log) == 2
+        log.clear()
+        assert len(log) == 0


### PR DESCRIPTION
## Issue #524 — Tool-call trace viewer

### Changes
- **ToolCallLog**: Ring buffer (`collections.deque`, maxlen=20) storing per-tool-call metadata
- **ToolCallEntry**: Single call record with tool_name, params, result_summary, success, elapsed_ms, turn_number, retried, error
- **Per-tool trace line**: `[tool] calendar.list_events ok 340ms → 3 events`
- **format_tools_command()**: Renders `/tools` terminal output with table, stats summary
- Turn-based filtering (`log.for_turn(n)`)
- Aggregate stats: total/ok/fail/retries/avg_ms
- Ring buffer eviction when maxlen exceeded

### Files
- `src/bantz/brain/tool_trace.py` (new)
- `tests/test_issue_524_tool_trace.py` (new, 21 tests)

### Test Results
```
21 passed in 0.11s
```

Closes #524