### PR TITLE
feat(brain): typed exceptions + correlation ID — no silent exception policy #525

### DIFF
--- a/src/bantz/brain/exceptions.py
+++ b/src/bantz/brain/exceptions.py
@@ -1,0 +1,302 @@
+"""Typed exceptions + correlation ID for the Bantz brain (Issue #525).
+
+Replaces bare ``except Exception: pass`` patterns with structured,
+categorized exception types and per-turn correlation logging.
+
+Exception hierarchy::
+
+    BantzError
+    ├── RouterParseError       — LLM returned unparseable JSON
+    ├── ToolExecutionError     — Tool call failed (timeout, API, etc.)
+    ├── FinalizerError         — Finalization phase failed
+    ├── MemoryError_           — Memory injection / trim failed
+    └── SafetyViolationError   — Policy / safety guard rejection
+
+Correlation ID::
+
+    Every turn gets a unique ``turn_id`` (UUID4 prefix) that appears in
+    all log lines emitted during that turn, enabling log correlation
+    across router → tools → finalizer → memory.
+
+Usage::
+
+    from bantz.brain.exceptions import (
+        RouterParseError,
+        ToolExecutionError,
+        FinalizerError,
+        generate_turn_id,
+    )
+
+    turn_id = generate_turn_id()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RouterParseError(
+            "LLM returned invalid JSON",
+            turn_id=turn_id,
+            raw_text=raw[:200],
+        ) from e
+"""
+
+from __future__ import annotations
+
+import uuid
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "BantzError",
+    "RouterParseError",
+    "ToolExecutionError",
+    "FinalizerError",
+    "MemoryError_",
+    "SafetyViolationError",
+    "generate_turn_id",
+    "ErrorContext",
+]
+
+
+# ── Correlation ID ────────────────────────────────────────────
+
+def generate_turn_id() -> str:
+    """Generate a short, unique turn correlation ID.
+
+    Format: ``t-<8-hex>`` (e.g. ``t-a1b2c3d4``).
+    Short enough for log lines, unique enough for correlation.
+    """
+    return f"t-{uuid.uuid4().hex[:8]}"
+
+
+# ── Error context ─────────────────────────────────────────────
+
+@dataclass
+class ErrorContext:
+    """Structured context attached to every Bantz exception.
+
+    Enables post-mortem debugging without guesswork.
+    """
+
+    turn_id: str = ""
+    phase: str = ""          # "router" | "tool" | "finalizer" | "memory" | "safety"
+    component: str = ""      # e.g. "llm_router._parse_json"
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_log_dict(self) -> Dict[str, Any]:
+        """Flatten to dict for structured logging."""
+        d: Dict[str, Any] = {
+            "turn_id": self.turn_id,
+            "phase": self.phase,
+            "component": self.component,
+            "timestamp": self.timestamp,
+        }
+        d.update(self.metadata)
+        return d
+
+
+# ── Base exception ────────────────────────────────────────────
+
+class BantzError(Exception):
+    """Base exception for all Bantz brain errors.
+
+    Every subclass carries an :class:`ErrorContext` for correlation
+    and structured logging.
+    """
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        turn_id: str = "",
+        phase: str = "",
+        component: str = "",
+        context: Optional[ErrorContext] = None,
+        **metadata: Any,
+    ) -> None:
+        self.bantz_message = message
+        self.context = context or ErrorContext(
+            turn_id=turn_id,
+            phase=phase,
+            component=component,
+            metadata=metadata,
+        )
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        parts = []
+        if self.context.turn_id:
+            parts.append(f"[turn:{self.context.turn_id}]")
+        if self.context.phase:
+            parts.append(f"[{self.context.phase}]")
+        parts.append(self.bantz_message)
+        return " ".join(parts)
+
+    def log(self, level: int = logging.WARNING) -> None:
+        """Emit a structured log line for this error."""
+        logger.log(
+            level,
+            "%s: %s | context=%s",
+            type(self).__name__,
+            self.bantz_message,
+            self.context.to_log_dict(),
+            exc_info=(level >= logging.ERROR),
+        )
+
+
+# ── Typed exceptions ─────────────────────────────────────────
+
+class RouterParseError(BantzError):
+    """LLM router returned unparseable or invalid JSON.
+
+    Attributes
+    ----------
+    raw_text:
+        The raw LLM output that failed to parse (truncated).
+    """
+
+    def __init__(
+        self,
+        message: str = "Router JSON parse failed",
+        *,
+        turn_id: str = "",
+        raw_text: str = "",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            message,
+            turn_id=turn_id,
+            phase="router",
+            component="llm_router._parse_json",
+            raw_text=raw_text[:200],
+            **kwargs,
+        )
+        self.raw_text = raw_text[:200]
+
+
+class ToolExecutionError(BantzError):
+    """Tool call failed during execution.
+
+    Attributes
+    ----------
+    tool_name:
+        Which tool failed.
+    original_error:
+        The underlying exception message.
+    """
+
+    def __init__(
+        self,
+        message: str = "Tool execution failed",
+        *,
+        turn_id: str = "",
+        tool_name: str = "",
+        original_error: str = "",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            message,
+            turn_id=turn_id,
+            phase="tool",
+            component=f"tool.{tool_name}",
+            tool_name=tool_name,
+            original_error=original_error,
+            **kwargs,
+        )
+        self.tool_name = tool_name
+        self.original_error = original_error
+
+
+class FinalizerError(BantzError):
+    """Finalization phase failed (Gemini / 3B / deterministic).
+
+    Attributes
+    ----------
+    finalizer_type:
+        Which finalizer was used ("gemini", "3b", "deterministic").
+    """
+
+    def __init__(
+        self,
+        message: str = "Finalization failed",
+        *,
+        turn_id: str = "",
+        finalizer_type: str = "",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            message,
+            turn_id=turn_id,
+            phase="finalizer",
+            component=f"finalizer.{finalizer_type}",
+            finalizer_type=finalizer_type,
+            **kwargs,
+        )
+        self.finalizer_type = finalizer_type
+
+
+class MemoryError_(BantzError):
+    """Memory injection or trim operation failed.
+
+    Named ``MemoryError_`` (trailing underscore) to avoid shadowing
+    the built-in ``MemoryError``.
+
+    Attributes
+    ----------
+    operation:
+        What failed: "injection", "trim", "summarize".
+    """
+
+    def __init__(
+        self,
+        message: str = "Memory operation failed",
+        *,
+        turn_id: str = "",
+        operation: str = "",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            message,
+            turn_id=turn_id,
+            phase="memory",
+            component=f"memory.{operation}",
+            operation=operation,
+            **kwargs,
+        )
+        self.operation = operation
+
+
+class SafetyViolationError(BantzError):
+    """Safety guard or policy violation detected.
+
+    Attributes
+    ----------
+    violation_type:
+        Kind of violation: "tool_blocked", "route_mismatch", "denylist".
+    tool_name:
+        Tool that triggered the violation (if applicable).
+    """
+
+    def __init__(
+        self,
+        message: str = "Safety violation",
+        *,
+        turn_id: str = "",
+        violation_type: str = "",
+        tool_name: str = "",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            message,
+            turn_id=turn_id,
+            phase="safety",
+            component="safety_guard",
+            violation_type=violation_type,
+            tool_name=tool_name,
+            **kwargs,
+        )
+        self.violation_type = violation_type
+        self.tool_name = tool_name

--- a/tests/test_issue_525_exceptions.py
+++ b/tests/test_issue_525_exceptions.py
@@ -1,0 +1,296 @@
+"""Tests for Issue #525 — No silent exception policy.
+
+Covers:
+  - generate_turn_id: format, uniqueness
+  - ErrorContext: structured log dict
+  - BantzError: base exception with correlation + log
+  - RouterParseError: raw_text truncation, phase=router
+  - ToolExecutionError: tool_name, original_error
+  - FinalizerError: finalizer_type
+  - MemoryError_: operation tracking
+  - SafetyViolationError: violation_type, tool_name
+  - Exception hierarchy: all subclass BantzError
+  - Structured message format: [turn:X] [phase] message
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════
+# generate_turn_id
+# ═══════════════════════════════════════════════════════════════
+
+class TestGenerateTurnId:
+    def test_format(self):
+        from bantz.brain.exceptions import generate_turn_id
+        tid = generate_turn_id()
+        assert tid.startswith("t-")
+        assert len(tid) == 10  # "t-" + 8 hex chars
+
+    def test_uniqueness(self):
+        from bantz.brain.exceptions import generate_turn_id
+        ids = {generate_turn_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_hex_chars(self):
+        from bantz.brain.exceptions import generate_turn_id
+        tid = generate_turn_id()
+        hex_part = tid[2:]
+        assert re.match(r"^[0-9a-f]{8}$", hex_part)
+
+
+# ═══════════════════════════════════════════════════════════════
+# ErrorContext
+# ═══════════════════════════════════════════════════════════════
+
+class TestErrorContext:
+    def test_defaults(self):
+        from bantz.brain.exceptions import ErrorContext
+        ctx = ErrorContext()
+        assert ctx.turn_id == ""
+        assert ctx.phase == ""
+        assert ctx.component == ""
+        assert ctx.timestamp  # non-empty
+
+    def test_to_log_dict(self):
+        from bantz.brain.exceptions import ErrorContext
+        ctx = ErrorContext(
+            turn_id="t-abc12345",
+            phase="router",
+            component="llm_router._parse_json",
+            metadata={"raw_text": "bad json"},
+        )
+        d = ctx.to_log_dict()
+        assert d["turn_id"] == "t-abc12345"
+        assert d["phase"] == "router"
+        assert d["component"] == "llm_router._parse_json"
+        assert d["raw_text"] == "bad json"
+        assert "timestamp" in d
+
+
+# ═══════════════════════════════════════════════════════════════
+# BantzError
+# ═══════════════════════════════════════════════════════════════
+
+class TestBantzError:
+    def test_basic(self):
+        from bantz.brain.exceptions import BantzError
+        err = BantzError("something broke")
+        assert "something broke" in str(err)
+        assert err.bantz_message == "something broke"
+
+    def test_with_turn_id(self):
+        from bantz.brain.exceptions import BantzError
+        err = BantzError("bad", turn_id="t-12345678", phase="router")
+        msg = str(err)
+        assert "[turn:t-12345678]" in msg
+        assert "[router]" in msg
+
+    def test_context_attached(self):
+        from bantz.brain.exceptions import BantzError, ErrorContext
+        ctx = ErrorContext(turn_id="t-aabbccdd", phase="tool")
+        err = BantzError("fail", context=ctx)
+        assert err.context.turn_id == "t-aabbccdd"
+
+    def test_log_method(self, caplog):
+        from bantz.brain.exceptions import BantzError
+        err = BantzError("test error", turn_id="t-logtest1", phase="test")
+        with caplog.at_level(logging.WARNING):
+            err.log(logging.WARNING)
+        assert "BantzError" in caplog.text
+        assert "test error" in caplog.text
+
+    def test_is_exception(self):
+        from bantz.brain.exceptions import BantzError
+        assert issubclass(BantzError, Exception)
+
+
+# ═══════════════════════════════════════════════════════════════
+# RouterParseError
+# ═══════════════════════════════════════════════════════════════
+
+class TestRouterParseError:
+    def test_basic(self):
+        from bantz.brain.exceptions import RouterParseError
+        err = RouterParseError(turn_id="t-rp123456", raw_text='{"bad json')
+        assert err.raw_text == '{"bad json'
+        assert err.context.phase == "router"
+        assert "llm_router._parse_json" in err.context.component
+
+    def test_raw_text_truncation(self):
+        from bantz.brain.exceptions import RouterParseError
+        long_text = "x" * 500
+        err = RouterParseError(raw_text=long_text)
+        assert len(err.raw_text) == 200
+
+    def test_subclass(self):
+        from bantz.brain.exceptions import BantzError, RouterParseError
+        assert issubclass(RouterParseError, BantzError)
+
+    def test_message_format(self):
+        from bantz.brain.exceptions import RouterParseError
+        err = RouterParseError("custom msg", turn_id="t-fmt12345")
+        assert "[turn:t-fmt12345]" in str(err)
+        assert "[router]" in str(err)
+        assert "custom msg" in str(err)
+
+
+# ═══════════════════════════════════════════════════════════════
+# ToolExecutionError
+# ═══════════════════════════════════════════════════════════════
+
+class TestToolExecutionError:
+    def test_basic(self):
+        from bantz.brain.exceptions import ToolExecutionError
+        err = ToolExecutionError(
+            "calendar API timeout",
+            turn_id="t-te123456",
+            tool_name="calendar.list_events",
+            original_error="ReadTimeout",
+        )
+        assert err.tool_name == "calendar.list_events"
+        assert err.original_error == "ReadTimeout"
+        assert err.context.phase == "tool"
+        assert "calendar.list_events" in err.context.component
+
+    def test_subclass(self):
+        from bantz.brain.exceptions import BantzError, ToolExecutionError
+        assert issubclass(ToolExecutionError, BantzError)
+
+
+# ═══════════════════════════════════════════════════════════════
+# FinalizerError
+# ═══════════════════════════════════════════════════════════════
+
+class TestFinalizerError:
+    def test_basic(self):
+        from bantz.brain.exceptions import FinalizerError
+        err = FinalizerError(
+            "Gemini rate limited",
+            turn_id="t-fe123456",
+            finalizer_type="gemini",
+        )
+        assert err.finalizer_type == "gemini"
+        assert err.context.phase == "finalizer"
+        assert "gemini" in err.context.component
+
+    def test_subclass(self):
+        from bantz.brain.exceptions import BantzError, FinalizerError
+        assert issubclass(FinalizerError, BantzError)
+
+
+# ═══════════════════════════════════════════════════════════════
+# MemoryError_
+# ═══════════════════════════════════════════════════════════════
+
+class TestMemoryError:
+    def test_basic(self):
+        from bantz.brain.exceptions import MemoryError_
+        err = MemoryError_(
+            "Token budget overflow",
+            turn_id="t-me123456",
+            operation="trim",
+        )
+        assert err.operation == "trim"
+        assert err.context.phase == "memory"
+        assert "trim" in err.context.component
+
+    def test_no_shadow_builtin(self):
+        """MemoryError_ does NOT shadow built-in MemoryError."""
+        from bantz.brain.exceptions import MemoryError_
+        assert MemoryError_ is not MemoryError
+
+    def test_subclass(self):
+        from bantz.brain.exceptions import BantzError, MemoryError_
+        assert issubclass(MemoryError_, BantzError)
+
+
+# ═══════════════════════════════════════════════════════════════
+# SafetyViolationError
+# ═══════════════════════════════════════════════════════════════
+
+class TestSafetyViolationError:
+    def test_basic(self):
+        from bantz.brain.exceptions import SafetyViolationError
+        err = SafetyViolationError(
+            "Tool blocked by denylist",
+            turn_id="t-sv123456",
+            violation_type="denylist",
+            tool_name="system.exec",
+        )
+        assert err.violation_type == "denylist"
+        assert err.tool_name == "system.exec"
+        assert err.context.phase == "safety"
+
+    def test_subclass(self):
+        from bantz.brain.exceptions import BantzError, SafetyViolationError
+        assert issubclass(SafetyViolationError, BantzError)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Hierarchy
+# ═══════════════════════════════════════════════════════════════
+
+class TestExceptionHierarchy:
+    def test_all_subclass_bantz_error(self):
+        from bantz.brain.exceptions import (
+            BantzError,
+            FinalizerError,
+            MemoryError_,
+            RouterParseError,
+            SafetyViolationError,
+            ToolExecutionError,
+        )
+        for cls in [RouterParseError, ToolExecutionError, FinalizerError, MemoryError_, SafetyViolationError]:
+            assert issubclass(cls, BantzError), f"{cls.__name__} should subclass BantzError"
+            assert issubclass(cls, Exception), f"{cls.__name__} should subclass Exception"
+
+    def test_catch_all_bantz_error(self):
+        """All typed exceptions can be caught with `except BantzError`."""
+        from bantz.brain.exceptions import (
+            BantzError,
+            FinalizerError,
+            MemoryError_,
+            RouterParseError,
+            SafetyViolationError,
+            ToolExecutionError,
+        )
+        for cls in [RouterParseError, ToolExecutionError, FinalizerError, MemoryError_, SafetyViolationError]:
+            try:
+                raise cls("test")
+            except BantzError:
+                pass  # Expected
+            except Exception:
+                pytest.fail(f"{cls.__name__} not caught by BantzError")
+
+    def test_five_typed_exceptions(self):
+        """Issue #525 requires at least 5 typed exception classes."""
+        from bantz.brain import exceptions
+        error_classes = [
+            attr for attr in dir(exceptions)
+            if isinstance(getattr(exceptions, attr), type)
+            and issubclass(getattr(exceptions, attr), Exception)
+            and getattr(exceptions, attr) is not Exception
+        ]
+        # BantzError + 5 subtypes = 6+
+        assert len(error_classes) >= 6, f"Expected ≥6, got {len(error_classes)}: {error_classes}"
+
+    def test_chaining_from_json_error(self):
+        """RouterParseError can chain from json.JSONDecodeError."""
+        import json
+        from bantz.brain.exceptions import RouterParseError
+        try:
+            try:
+                json.loads("{bad")
+            except json.JSONDecodeError as e:
+                raise RouterParseError(
+                    "parse failed", turn_id="t-chain123", raw_text="{bad"
+                ) from e
+        except RouterParseError as rpe:
+            assert rpe.__cause__ is not None
+            assert isinstance(rpe.__cause__, json.JSONDecodeError)


### PR DESCRIPTION
## Issue #525 — No silent exception policy

### Changes
- **BantzError**: Base exception with `ErrorContext` (turn_id, phase, component, metadata)
- **RouterParseError**: LLM JSON parse failures with raw_text truncation (≤200 chars)
- **ToolExecutionError**: Captures tool_name + original_error for debugging
- **FinalizerError**: Tracks finalizer_type (gemini/3b/deterministic)
- **MemoryError_**: Operation tracking (injection/trim/summarize) — trailing underscore avoids shadowing builtin
- **SafetyViolationError**: violation_type + tool_name for policy violations
- **generate_turn_id()**: `t-<8hex>` correlation ID for all log lines in a turn
- **ErrorContext.to_log_dict()**: Structured logging support
- **BantzError.log()**: Convenience method for consistent log emission

### Files
- `src/bantz/brain/exceptions.py` (new)
- `tests/test_issue_525_exceptions.py` (new, 27 tests)

### Test Results
```
27 passed in 0.11s
```

Closes #525