### PR TITLE
fix(watchdog): vLLM port 8000→8001 + BANTZ_VLLM_URL env var — Closes #563

### DIFF
--- a/src/bantz/llm/vllm_watchdog.py
+++ b/src/bantz/llm/vllm_watchdog.py
@@ -12,7 +12,7 @@ Usage::
     from bantz.llm.vllm_watchdog import VLLMWatchdog, WatchdogConfig
 
     config = WatchdogConfig(
-        vllm_url="http://localhost:8000",
+        vllm_url="http://localhost:8001",
         check_interval=10.0,
         max_restarts=3,
     )
@@ -48,10 +48,16 @@ class VLLMStatus(str, Enum):
     UNKNOWN = "unknown"
 
 
+def _default_vllm_url() -> str:
+    """Read vLLM URL from env, matching runtime_factory / vllm_openai_client."""
+    import os
+    return os.getenv("BANTZ_VLLM_URL", "http://localhost:8001").rstrip("/")
+
+
 @dataclass
 class WatchdogConfig:
     """Configuration for the vLLM watchdog."""
-    vllm_url: str = "http://localhost:8000"
+    vllm_url: str = field(default_factory=_default_vllm_url)
     health_endpoint: str = "/health"
     check_interval: float = 10.0       # seconds between checks
     failure_threshold: int = 3          # consecutive failures before restart

--- a/src/bantz/llm/vllm_watchdog_v0.py
+++ b/src/bantz/llm/vllm_watchdog_v0.py
@@ -63,11 +63,17 @@ class VLLMStatus(Enum):
 
 # ── Config ────────────────────────────────────────────────────────────
 
+def _default_vllm_url() -> str:
+    """Read vLLM URL from env, matching runtime_factory / vllm_openai_client."""
+    import os
+    return os.getenv("BANTZ_VLLM_URL", "http://localhost:8001").rstrip("/")
+
+
 @dataclass
 class WatchdogConfig:
     """Configuration for the vLLM watchdog."""
 
-    vllm_url: str = "http://localhost:8000"
+    vllm_url: str = field(default_factory=_default_vllm_url)
     check_interval: int = 30          # seconds between checks
     consecutive_failures_to_restart: int = 3
     max_restarts_per_hour: int = 3


### PR DESCRIPTION
## Summary

Fix vLLM watchdog default port mismatch (8000→8001) and add env var support.

### Problem
Both `vllm_watchdog.py` and `vllm_watchdog_v0.py` defaulted to port **8000**, while every other component uses **8001**. Watchdog could never find vLLM.

### Changes
- `WatchdogConfig.vllm_url` default: `http://localhost:8000` → `http://localhost:8001`
- Both files now read `BANTZ_VLLM_URL` env var (consistent with `runtime_factory.py`)
- Docstring example updated

### Tests
```
pytest tests/test_vllm_watchdog*.py → 5 passed ✅
```

Closes #563 | Part of EPIC #576