### PR TITLE
fix(#564): Unify model name to Qwen2.5-3B-Instruct-AWQ across codebase

### DIFF
--- a/scripts/bench_llm_orchestrator.py
+++ b/scripts/bench_llm_orchestrator.py
@@ -896,7 +896,7 @@ def run_benchmark(
     scenarios: str = "all",
     verbose: bool = False,
     vllm_base_url: str = "http://127.0.0.1:8001",
-    vllm_model: str = "Qwen/Qwen2.5-3B-Instruct",
+    vllm_model: str = "Qwen/Qwen2.5-3B-Instruct-AWQ",
     vllm_final_base_url: str = "",
     vllm_final_model: str = "",
     prompt_profile: str = "bench",
@@ -915,7 +915,7 @@ def run_benchmark(
         """Pick a model ID that actually exists on the vLLM server.
 
         This is important for quantized repos like *-AWQ / *-GPTQ which have
-        different model IDs than the default "Qwen/Qwen2.5-3B-Instruct".
+        different model IDs than the default "Qwen/Qwen2.5-3B-Instruct-AWQ".
         """
         try:
             resp = requests.get(f"{base_url}/v1/models", timeout=2)
@@ -1088,7 +1088,7 @@ def run_qualitative_tests(backend: str) -> None:
 
     # Create LLM client
     base_url = "http://127.0.0.1:8001"
-    preferred_model = "Qwen/Qwen2.5-3B-Instruct"
+    preferred_model = "Qwen/Qwen2.5-3B-Instruct-AWQ"
     resolved_model = resolve_vllm_model_id(base_url, preferred_model)
     if resolved_model != preferred_model:
         print(f"ℹ️ vLLM model override: '{preferred_model}' → '{resolved_model}'")
@@ -1154,7 +1154,7 @@ def main():
     parser.add_argument("--output-md", type=Path, help="Save markdown report")
     parser.add_argument("--qualitative", action="store_true", help="Run qualitative conversation tests (Issue #153)")
     parser.add_argument("--vllm-base-url", default="http://127.0.0.1:8001", help="vLLM OpenAI-compatible server base URL")
-    parser.add_argument("--vllm-model", default="Qwen/Qwen2.5-3B-Instruct", help="Preferred vLLM model id (auto-falls back to server model)")
+    parser.add_argument("--vllm-model", default="Qwen/Qwen2.5-3B-Instruct-AWQ", help="Preferred vLLM model id (auto-falls back to server model)")
     parser.add_argument("--vllm-final-base-url", default="", help="Optional vLLM base URL for hybrid finalizer (8B reply model server)")
     parser.add_argument("--vllm-final-model", default="", help="Optional vLLM model id for hybrid finalizer (8B reply model)")
     parser.add_argument(

--- a/scripts/bench_ttft_monitoring.py
+++ b/scripts/bench_ttft_monitoring.py
@@ -180,7 +180,7 @@ def main():
     )
     parser.add_argument(
         "--model",
-        default=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct"),
+        default=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct-AWQ"),
         help="Model name",
     )
     parser.add_argument(

--- a/scripts/demo_orchestrator.py
+++ b/scripts/demo_orchestrator.py
@@ -297,7 +297,7 @@ def main():
     parser.add_argument("--debug", action="store_true", help="Debug mode (verbose output)")
     parser.add_argument(
         "--model",
-        default="Qwen/Qwen2.5-3B-Instruct",
+        default="Qwen/Qwen2.5-3B-Instruct-AWQ",
         help="Model name (for vLLM)",
     )
     

--- a/scripts/demo_tiered_quality.py
+++ b/scripts/demo_tiered_quality.py
@@ -198,7 +198,7 @@ def run(loop: OrchestratorLoop, scenarios: list[str], debug: bool) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Demo tiered quality behavior (Issue #206)")
     parser.add_argument("--router-backend", choices=["mock", "vllm"], default="mock")
-    parser.add_argument("--router-model", default="Qwen/Qwen2.5-3B-Instruct")
+    parser.add_argument("--router-model", default="Qwen/Qwen2.5-3B-Instruct-AWQ")
     parser.add_argument("--finalizer", choices=["mock", "gemini", "none"], default="mock")
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--no-tiered", action="store_true", help="Disable tiering (legacy always-finalizer behavior)")

--- a/scripts/demo_ttft_realtime.py
+++ b/scripts/demo_ttft_realtime.py
@@ -192,7 +192,7 @@ def main():
     )
     parser.add_argument(
         "--model",
-        default=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct"),
+        default=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct-AWQ"),
         help="Model name",
     )
     parser.add_argument(

--- a/scripts/e2e_run.py
+++ b/scripts/e2e_run.py
@@ -31,7 +31,7 @@ Usage:
 
 Environment:
     BANTZ_VLLM_URL (default: http://localhost:8001)
-    BANTZ_VLLM_MODEL (default: Qwen/Qwen2.5-3B-Instruct)
+    BANTZ_VLLM_MODEL (default: Qwen/Qwen2.5-3B-Instruct-AWQ)
     GEMINI_API_KEY / GOOGLE_API_KEY (for cloud scenarios)
 
 Output:
@@ -69,7 +69,7 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 DEFAULT_VLLM_URL = "http://localhost:8001"
-DEFAULT_VLLM_MODEL = "Qwen/Qwen2.5-3B-Instruct"
+DEFAULT_VLLM_MODEL = "Qwen/Qwen2.5-3B-Instruct-AWQ"
 DEFAULT_GEMINI_MODEL = "gemini-1.5-flash"
 
 

--- a/scripts/terminal_jarvis.py
+++ b/scripts/terminal_jarvis.py
@@ -12,7 +12,7 @@ Run:
 
 Env:
   BANTZ_VLLM_URL (default http://localhost:8001)
-  BANTZ_VLLM_MODEL (default Qwen/Qwen2.5-3B-Instruct)
+  BANTZ_VLLM_MODEL (default Qwen/Qwen2.5-3B-Instruct-AWQ)
   GEMINI_API_KEY / GOOGLE_API_KEY / BANTZ_GEMINI_API_KEY (optional but recommended)
   BANTZ_GEMINI_MODEL (default gemini-1.5-flash)
 
@@ -460,7 +460,7 @@ class TerminalJarvis:
         self._gemini_last_check_at: float = 0.0
 
         vllm_url = os.getenv("BANTZ_VLLM_URL", "http://localhost:8001")
-        router_model = os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct")
+        router_model = os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct-AWQ")
         gemini_model = os.getenv("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
         gemini_key = _env_get_any("GEMINI_API_KEY", "GOOGLE_API_KEY", "BANTZ_GEMINI_API_KEY")
 

--- a/scripts/vllm_mock_server.py
+++ b/scripts/vllm_mock_server.py
@@ -24,7 +24,7 @@ import json
 
 app = Flask(__name__)
 
-MODEL_NAME = "Qwen/Qwen2.5-3B-Instruct"
+MODEL_NAME = "Qwen/Qwen2.5-3B-Instruct-AWQ"
 
 
 @app.route("/v1/models", methods=["GET"])

--- a/scripts/vllm_poc.py
+++ b/scripts/vllm_poc.py
@@ -6,7 +6,7 @@ Issue #132: vLLM PoC — Tek modelle OpenAI-compatible server ayağa kaldır
 Usage:
     # Terminal 1: Start vLLM server
     python -m vllm.entrypoints.openai.api_server \\
-        --model Qwen/Qwen2.5-3B-Instruct \\
+        --model Qwen/Qwen2.5-3B-Instruct-AWQ \\
         --port 8000 \\
         --max-model-len 4096
     
@@ -21,7 +21,7 @@ from typing import Any
 
 
 BASE_URL = "http://127.0.0.1:8001"
-MODEL_NAME = "Qwen/Qwen2.5-3B-Instruct"
+MODEL_NAME = "Qwen/Qwen2.5-3B-Instruct-AWQ"
 
 
 def check_server() -> bool:
@@ -175,7 +175,7 @@ def main():
         print("\n❌ vLLM server is not running!")
         print("\nStart server with:")
         print("  python -m vllm.entrypoints.openai.api_server \\")
-        print("      --model Qwen/Qwen2.5-3B-Instruct \\")
+        print("      --model Qwen/Qwen2.5-3B-Instruct-AWQ \\")
         print("      --port 8000 \\")
         print("      --max-model-len 4096")
         return 1

--- a/src/bantz/brain/runtime_factory.py
+++ b/src/bantz/brain/runtime_factory.py
@@ -123,7 +123,7 @@ def create_runtime(
 
     # ── Resolve parameters from env ─────────────────────────────────
     _vllm_url = vllm_url or os.getenv("BANTZ_VLLM_URL", "http://localhost:8001")
-    _router_model = router_model or os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct")
+    _router_model = router_model or os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct-AWQ")
     _gemini_model = gemini_model or os.getenv("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
     _gemini_key = gemini_key or _env_get_any(
         "GEMINI_API_KEY", "GOOGLE_API_KEY", "BANTZ_GEMINI_API_KEY"

--- a/src/bantz/cli.py
+++ b/src/bantz/cli.py
@@ -426,7 +426,7 @@ Kullanım örnekleri:
     parser.add_argument("--voice-warmup", action="store_true", help="ASR modelini önceden hazırla/indir (voice başlamaz)")
     parser.add_argument("--piper-model", default="", help="Piper .onnx model yolu (zorunlu: --voice)")
     parser.add_argument("--vllm-url", default="http://127.0.0.1:8001", help="vLLM (OpenAI-compatible) base URL")
-    parser.add_argument("--vllm-model", default="Qwen/Qwen2.5-3B-Instruct", help="vLLM model adı")
+    parser.add_argument("--vllm-model", default="Qwen/Qwen2.5-3B-Instruct-AWQ", help="vLLM model adı")
     parser.add_argument(
         "--vllm-quality-url",
         default="http://127.0.0.1:8002",

--- a/src/bantz/core/orchestrator.py
+++ b/src/bantz/core/orchestrator.py
@@ -104,7 +104,7 @@ class OrchestratorConfig:
     
     # LLM (vLLM)
     vllm_url: str = "http://127.0.0.1:8001"
-    vllm_model: str = "Qwen/Qwen2.5-3B-Instruct"
+    vllm_model: str = "Qwen/Qwen2.5-3B-Instruct-AWQ"
     
     # UX
     startup_sound: bool = True
@@ -131,7 +131,7 @@ class OrchestratorConfig:
             language=os.getenv("BANTZ_LANGUAGE", "tr"),
             
             vllm_url=os.getenv("BANTZ_VLLM_URL", "http://127.0.0.1:8001"),
-            vllm_model=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct"),
+            vllm_model=os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct-AWQ"),
         )
 
 

--- a/src/bantz/llm/__init__.py
+++ b/src/bantz/llm/__init__.py
@@ -60,7 +60,7 @@ def create_fast_client(
 
     Env:
       - BANTZ_VLLM_URL (default: http://127.0.0.1:8001)
-      - BANTZ_VLLM_MODEL (default: Qwen/Qwen2.5-3B-Instruct)
+      - BANTZ_VLLM_MODEL (default: Qwen/Qwen2.5-3B-Instruct-AWQ)
 
     Tip: set model to "auto" to pick the first /v1/models entry.
     """
@@ -68,7 +68,7 @@ def create_fast_client(
     return create_client(
         "vllm",
         base_url=(base_url or os.getenv("BANTZ_VLLM_URL") or "http://127.0.0.1:8001"),
-        model=(model or os.getenv("BANTZ_VLLM_MODEL") or "Qwen/Qwen2.5-3B-Instruct"),
+        model=(model or os.getenv("BANTZ_VLLM_MODEL") or "Qwen/Qwen2.5-3B-Instruct-AWQ"),
         timeout=timeout,
     )
 

--- a/src/bantz/llm/base.py
+++ b/src/bantz/llm/base.py
@@ -222,7 +222,7 @@ def create_client(
         from bantz.llm.vllm_openai_client import VLLMOpenAIClient
         return VLLMOpenAIClient(
             base_url=base_url or "http://127.0.0.1:8001",
-            model=model or "Qwen/Qwen2.5-3B-Instruct",
+            model=model or "Qwen/Qwen2.5-3B-Instruct-AWQ",
             timeout_seconds=timeout,
         )
 

--- a/src/bantz/llm/metrics.py
+++ b/src/bantz/llm/metrics.py
@@ -23,7 +23,7 @@ Usage:
     # Record a metric
     record_llm_metric(
         backend="vllm",
-        model="Qwen/Qwen2.5-3B-Instruct",
+        model="Qwen/Qwen2.5-3B-Instruct-AWQ",
         prompt_tokens=150,
         completion_tokens=50,
         latency_ms=245,

--- a/src/bantz/llm/rewriter.py
+++ b/src/bantz/llm/rewriter.py
@@ -57,7 +57,7 @@ class CommandRewriter:
     
     def __init__(
         self,
-        model: str = "Qwen/Qwen2.5-3B-Instruct",
+        model: str = "Qwen/Qwen2.5-3B-Instruct-AWQ",
         base_url: str = "http://127.0.0.1:8001",
         timeout: float = 10.0,
         enabled: bool = True,
@@ -203,7 +203,7 @@ _rewriter: Optional[CommandRewriter] = None
 
 def get_rewriter(
     enabled: bool = True,
-    model: str = "Qwen/Qwen2.5-3B-Instruct",
+    model: str = "Qwen/Qwen2.5-3B-Instruct-AWQ",
     base_url: str = "http://127.0.0.1:8001",
 ) -> CommandRewriter:
     """Get or create the global command rewriter."""

--- a/src/bantz/llm/vllm_openai_client.py
+++ b/src/bantz/llm/vllm_openai_client.py
@@ -23,7 +23,7 @@ Requirements:
     pip install openai
     
 vLLM server must be running:
-    python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-3B-Instruct --port 8001
+    python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-3B-Instruct-AWQ --port 8001
 """
 
 from __future__ import annotations
@@ -70,7 +70,7 @@ class VLLMOpenAIClient(LLMClient):
     
     Attributes:
         base_url: vLLM server URL (e.g., http://localhost:8001)
-        model: Model name (e.g., Qwen/Qwen2.5-3B-Instruct)
+        model: Model name (e.g., Qwen/Qwen2.5-3B-Instruct-AWQ)
         timeout_seconds: Request timeout
         track_ttft: Enable TTFT tracking (default: True)
         ttft_phase: Phase name for TTFT tracking ("router" | "finalizer")
@@ -79,7 +79,7 @@ class VLLMOpenAIClient(LLMClient):
     def __init__(
         self,
         base_url: str = "http://127.0.0.1:8001",
-        model: str = "Qwen/Qwen2.5-3B-Instruct",
+        model: str = "Qwen/Qwen2.5-3B-Instruct-AWQ",
         timeout_seconds: float = 120.0,
         track_ttft: bool = True,
         ttft_phase: str = "router",

--- a/src/bantz/nlu/classifier.py
+++ b/src/bantz/nlu/classifier.py
@@ -50,7 +50,7 @@ class ClassifierConfig:
         cache_ttl_seconds: Cache entry lifetime
     """
     
-    model: str = "Qwen/Qwen2.5-3B-Instruct"
+    model: str = "Qwen/Qwen2.5-3B-Instruct-AWQ"
     temperature: float = 0.1  # Low for consistent classification
     max_tokens: int = 256
     timeout_seconds: float = 30.0

--- a/src/bantz/voice/loop.py
+++ b/src/bantz/voice/loop.py
@@ -13,7 +13,7 @@ class VoiceLoopConfig:
     session: str = "default"
     piper_model_path: str = ""
     vllm_url: str = "http://127.0.0.1:8001"
-    vllm_model: str = "Qwen/Qwen2.5-3B-Instruct"
+    vllm_model: str = "Qwen/Qwen2.5-3B-Instruct-AWQ"
     whisper_model: str = "base"
     # Default to Turkish - English words like "instagram" still work fine
     language: Optional[str] = "tr"


### PR DESCRIPTION
## Problem
All hardcoded model defaults referenced `Qwen/Qwen2.5-3B-Instruct` (non-quantized FP16) while:
- `docker-compose.yml` uses `Qwen/Qwen2.5-3B-Instruct-AWQ`
- `config/model-settings.yaml` uses `Qwen/Qwen2.5-3B-Instruct-AWQ`
- vLLM is actually serving the AWQ variant

This mismatch caused **vLLM 404 model-not-found** errors at runtime.

## Fix
Changed 31 occurrences across 19 files from `Qwen/Qwen2.5-3B-Instruct` → `Qwen/Qwen2.5-3B-Instruct-AWQ`:

**src/ (10 files):** runtime_factory, orchestrator, cli, vllm_openai_client, base, rewriter, llm/__init__, metrics, voice/loop, nlu/classifier

**scripts/ (9 files):** terminal_jarvis, bench_ttft_monitoring, bench_llm_orchestrator, demo_orchestrator, demo_tiered_quality, demo_ttft_realtime, e2e_run, vllm_poc, vllm_mock_server

## Verification
- `grep -rn 'Qwen2.5-3B-Instruct[^-]'` returns only 1 commented-out reference
- All 39 AWQ references consistent
- `pytest tests/` → 177 passed, 0 collection errors (pre-existing unrelated failures excluded)
- `VLLMOpenAIClient().model` → `Qwen/Qwen2.5-3B-Instruct-AWQ` ✅

Part of EPIC #576 · Closes #564