### PR TITLE
fix(#570): Voice pipeline now flows through brain (via #567)

### DIFF
--- a/src/bantz/voice/loop.py
+++ b/src/bantz/voice/loop.py
@@ -86,6 +86,10 @@ def run_voice_loop(cfg: VoiceLoopConfig) -> int:
     - SPACE basılı tut: kaydet
     - SPACE bırak: transcribe -> daemon'a gönder -> TTS konuş
 
+    Architecture (Issue #570):
+      Voice → ASR → autocorrect → send_to_server() → brain (default since #567)
+      LLM fallback only triggers if server returns empty/error.
+
     Eğer global key hook çalışmazsa (Wayland/X kısıtları), Enter tabanlı fallback var.
     """
 
@@ -425,7 +429,8 @@ def run_voice_loop(cfg: VoiceLoopConfig) -> int:
             print("🤖 Seni yanlış duymuş olabilirim. Tekrar söyler misin?")
             return
 
-        # 2) Eğer daemon cevap veremediyse LLM fallback
+        # 2) LLM fallback: only if server/brain couldn't answer (Issue #570).
+        #    Primary path is send_to_server → brain pipeline (#567).
         if cfg.enable_llm_fallback and (not reply or not ok):
             try:
                 nonlocal llm_fast, llm_quality


### PR DESCRIPTION
## Context
With #567 merged (PR #581), server defaults to brain pipeline. Since voice/loop.py sends commands via `send_to_server()`, voice commands now automatically flow through brain.

## Changes
- Updated docstring in `run_voice_loop()` to document the new architecture
- Clarified LLM fallback role: it's a last-resort, not the primary path

## Architecture
```
Voice → ASR → autocorrect → send_to_server() → brain pipeline (#567)
                                                  ↓ (if brain fails)
                                              legacy Router fallback
```

Depends on: #567 (merged) · Part of EPIC #576 · Closes #570