### PR TITLE
feat(#517): Enhance finalizer visibility — force tier + boot log

### DIFF
--- a/src/bantz/brain/runtime_factory.py
+++ b/src/bantz/brain/runtime_factory.py
@@ -181,15 +181,24 @@ def create_runtime(
         finalizer_llm=effective_finalizer,
     )
 
-    # ── Boot log ────────────────────────────────────────────────────
+    # ── Boot log (Issue #517: visible finalizer status) ───────────
     finalizer_name = _gemini_model if finalizer_is_gemini else _router_model
     finalizer_type = "Gemini" if finalizer_is_gemini else "3B (local)"
+    _forced_tier = os.getenv("BANTZ_FORCE_FINALIZER_TIER", "").strip().lower()
+    tier_note = f", forced_tier={_forced_tier}" if _forced_tier else ""
     logger.info(
-        "🧠 BANTZ Runtime initialized: router=%s, finalizer=%s (%s)",
+        "🧠 BANTZ Runtime: router=%s, finalizer=%s (%s), tools=%d%s",
         _router_model,
         finalizer_name,
         finalizer_type,
+        len(_tools.names()),
+        tier_note,
     )
+    if not finalizer_is_gemini:
+        logger.warning(
+            "⚠ Finalizer is 3B — set GEMINI_API_KEY for quality responses. "
+            "Override: BANTZ_FORCE_FINALIZER_TIER=quality|fast"
+        )
 
     return BantzRuntime(
         router_client=router_client,


### PR DESCRIPTION
## Enhancements
- **`BANTZ_FORCE_FINALIZER_TIER=quality|fast`** env override in `decide_finalization_tier()` for debugging
- Enhanced boot log: shows tool count, forced tier, warning when 3B fallback
- Boot log example: `🧠 BANTZ Runtime: router=Qwen/...-AWQ, finalizer=gemini-2.0-flash (Gemini), tools=12`

Part of EPIC #576 · Ref #517