### PR TITLE
fix(pyproject): add core deps and fix Python version (#571)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,13 @@ name = "bantz"
 version = "0.1.0"
 description = "Bantz - Local Jarvis (text-first)"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [{ name = "Bantz" }]
-dependencies = []
+dependencies = [
+	"requests>=2.31.0",
+	"openai>=1.40.0",
+	"pydantic>=2.0.0",
+]
 
 [project.optional-dependencies]
 browser = [


### PR DESCRIPTION
## Problem
- `dependencies = []` — empty! `pip install bantz` installs nothing; core imports fail at runtime.
- `requires-python = '>=3.11'` — actual runtime is Python 3.10.12.

## Fix
### Core dependencies added
| Package | Min version | Why core |
|---------|-------------|----------|
| requests | >=2.31.0 | Top-level import in `llm/base.py`; used for vLLM health checks and Gemini REST calls |
| openai | >=1.40.0 | Lazy-imported in `create_fast_client()` / `create_quality_client()` — every LLM call |
| pydantic | >=2.0.0 | Top-level import in `router/schemas.py`, `llm/json_repair.py` — startup crash without it |

### NOT added (correctly optional)
- `pyyaml` — all imports guarded with `try/except`, JSON fallback
- `jsonschema` — `try/except` guarded
- `vllm`/`torch`/`transformers`/`autoawq` — server-side inference deps

### Python version
`>=3.11` → `>=3.10` to match actual runtime (3.10.12).

Closes #571
Part of EPIC #576