### PR TITLE
chore(gemini): upgrade default gemini-1.5-flash → gemini-2.0-flash (#572)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,9 +55,9 @@ VLLM_MODEL=Qwen/Qwen2.5-3B-Instruct
 # Quality model provider: vllm | gemini (default: vllm)
 # QUALITY_PROVIDER=gemini
 
-# Quality model name (for Gemini: gemini-1.5-flash, for vLLM: model path)
-# BANTZ_QUALITY_MODEL=gemini-1.5-flash
-# BANTZ_GEMINI_MODEL=gemini-1.5-flash
+# Quality model name (for Gemini: gemini-2.0-flash, for vLLM: model path)
+# BANTZ_QUALITY_MODEL=gemini-2.0-flash
+# BANTZ_GEMINI_MODEL=gemini-2.0-flash
 
 # Enable tiered mode (auto-escalate complex requests)
 # BANTZ_TIERED_MODE=1

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ orchestrator = create_gemini_hybrid_orchestrator(
 - Default finalizer is **Gemini** (3B router + Gemini finalizer)
 - Override with env vars if you prefer local 7B:
     - `BANTZ_FINALIZER_TYPE=gemini|vllm_7b`
-    - `BANTZ_FINALIZER_MODEL=gemini-1.5-flash|Qwen/Qwen2.5-7B-Instruct`
+    - `BANTZ_FINALIZER_MODEL=gemini-2.0-flash|Qwen/Qwen2.5-7B-Instruct`
 ```
 
 ### Architecture Benefits

--- a/config/bantz-env.example
+++ b/config/bantz-env.example
@@ -8,7 +8,7 @@ BANTZ_VLLM_MODEL=Qwen/Qwen2.5-3B-Instruct-AWQ
 # === Gemini (optional) ===
 # GEMINI_API_KEY=
 BANTZ_CLOUD_ENABLED=false
-BANTZ_GEMINI_MODEL=gemini-1.5-flash
+BANTZ_GEMINI_MODEL=gemini-2.0-flash
 
 # === Audio ===
 # BANTZ_MIC_DEVICE=default

--- a/docs/gemini-hybrid-orchestrator.md
+++ b/docs/gemini-hybrid-orchestrator.md
@@ -70,7 +70,7 @@ config = HybridOrchestratorConfig(
     router_max_tokens=512,
     
     # Gemini settings
-    gemini_model="gemini-1.5-flash",  # or "gemini-1.5-pro"
+    gemini_model="gemini-2.0-flash",  # or "gemini-1.5-pro"
     gemini_temperature=0.4,  # Balanced
     gemini_max_tokens=512,
     
@@ -232,7 +232,7 @@ curl "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KE
 
 ### High Latency
 
-- Use `gemini-1.5-flash` (faster than Pro)
+- Use `gemini-2.0-flash` (faster than Pro)
 - Reduce `gemini_max_tokens` (512 → 256)
 - Set `enable_gemini_finalization=False` for router-only mode
 

--- a/docs/secrets-hygiene.md
+++ b/docs/secrets-hygiene.md
@@ -14,7 +14,7 @@ Create a local `.env` file that is **not committed** (add to `.gitignore`):
 BANTZ_CLOUD_MODE=cloud
 QUALITY_PROVIDER=gemini
 GEMINI_API_KEY=...your key...
-BANTZ_GEMINI_MODEL=gemini-1.5-flash
+BANTZ_GEMINI_MODEL=gemini-2.0-flash
 ```
 
 Load it with one of:

--- a/docs/setup/boot-jarvis.md
+++ b/docs/setup/boot-jarvis.md
@@ -143,8 +143,8 @@ Gemini olmadan da çalışabilirsiniz — sadece yerel model kullanılır.
 GEMINI_API_KEY=AIzaSy...your-key-here
 BANTZ_CLOUD_ENABLED=true
 
-# Model seçimi (varsayılan: gemini-1.5-flash)
-BANTZ_GEMINI_MODEL=gemini-1.5-flash
+# Model seçimi (varsayılan: gemini-2.0-flash)
+BANTZ_GEMINI_MODEL=gemini-2.0-flash
 ```
 
 ### Doğrulama
@@ -385,7 +385,7 @@ BANTZ_VLLM_MODEL=Qwen/Qwen2.5-3B-Instruct-AWQ
 # === Gemini (opsiyonel) ===
 GEMINI_API_KEY=
 BANTZ_CLOUD_ENABLED=false
-BANTZ_GEMINI_MODEL=gemini-1.5-flash
+BANTZ_GEMINI_MODEL=gemini-2.0-flash
 
 # === Ses ===
 BANTZ_MIC_DEVICE=1

--- a/scripts/demo_tiered_quality.py
+++ b/scripts/demo_tiered_quality.py
@@ -235,7 +235,7 @@ def main() -> int:
             print("ERROR: GEMINI_API_KEY not set")
             print("Set one of: GEMINI_API_KEY / GOOGLE_API_KEY / BANTZ_GEMINI_API_KEY")
             return 2
-        model = os.environ.get("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
+        model = os.environ.get("BANTZ_GEMINI_MODEL", "gemini-2.0-flash")
         finalizer_llm = GeminiClient(api_key=api_key, model=model)
         print(f"Finalizer: Gemini ({model})")
 

--- a/scripts/e2e_run.py
+++ b/scripts/e2e_run.py
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_VLLM_URL = "http://localhost:8001"
 DEFAULT_VLLM_MODEL = "Qwen/Qwen2.5-3B-Instruct-AWQ"
-DEFAULT_GEMINI_MODEL = "gemini-1.5-flash"
+DEFAULT_GEMINI_MODEL = "gemini-2.0-flash"
 
 
 # ============================================================================

--- a/scripts/smoke_boot_ready.py
+++ b/scripts/smoke_boot_ready.py
@@ -128,7 +128,7 @@ def check_gemini_key() -> CheckResult:
         val = os.getenv(key_name, "").strip()
         if val:
             masked = val[:4] + "..." + val[-4:] if len(val) > 8 else "****"
-            model = os.getenv("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
+            model = os.getenv("BANTZ_GEMINI_MODEL", "gemini-2.0-flash")
             return _ok(
                 "gemini_key",
                 f"Finalizer: {model} ✓ (Gemini via {key_name}={masked})",

--- a/scripts/terminal_jarvis.py
+++ b/scripts/terminal_jarvis.py
@@ -14,7 +14,7 @@ Env:
   BANTZ_VLLM_URL (default http://localhost:8001)
   BANTZ_VLLM_MODEL (default Qwen/Qwen2.5-3B-Instruct-AWQ)
   GEMINI_API_KEY / GOOGLE_API_KEY / BANTZ_GEMINI_API_KEY (optional but recommended)
-  BANTZ_GEMINI_MODEL (default gemini-1.5-flash)
+  BANTZ_GEMINI_MODEL (default gemini-2.0-flash)
 
 Tip:
   .env is loaded automatically (Issue #216) via bantz.security.env_loader.
@@ -255,7 +255,7 @@ class TerminalJarvis:
 
         vllm_url = os.getenv("BANTZ_VLLM_URL", "http://localhost:8001")
         router_model = os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct-AWQ")
-        gemini_model = os.getenv("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
+        gemini_model = os.getenv("BANTZ_GEMINI_MODEL", "gemini-2.0-flash")
         gemini_key = _env_get_any("GEMINI_API_KEY", "GOOGLE_API_KEY", "BANTZ_GEMINI_API_KEY")
 
         # Issue #516: Use canonical runtime factory — single source of truth

--- a/src/bantz/brain/runtime_banner.py
+++ b/src/bantz/brain/runtime_banner.py
@@ -8,7 +8,7 @@ Boot banner::
     │  🧠 BANTZ Brain v2.0                │
     │  Mode:      orchestrator             │
     │  Router:    Qwen2.5-3B @ vLLM:8001  │
-    │  Finalizer: gemini-1.5-flash ✓      │
+    │  Finalizer: gemini-2.0-flash ✓      │
     │  Memory:    lite (10 turns, 1000tok) │
     │  Prompt:    tiered (CORE+DETAIL)     │
     │  Context:   2048 tokens              │

--- a/src/bantz/brain/runtime_factory.py
+++ b/src/bantz/brain/runtime_factory.py
@@ -124,7 +124,7 @@ def create_runtime(
     # ── Resolve parameters from env ─────────────────────────────────
     _vllm_url = vllm_url or os.getenv("BANTZ_VLLM_URL", "http://localhost:8001")
     _router_model = router_model or os.getenv("BANTZ_VLLM_MODEL", "Qwen/Qwen2.5-3B-Instruct-AWQ")
-    _gemini_model = gemini_model or os.getenv("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
+    _gemini_model = gemini_model or os.getenv("BANTZ_GEMINI_MODEL", "gemini-2.0-flash")
     _gemini_key = gemini_key or _env_get_any(
         "GEMINI_API_KEY", "GOOGLE_API_KEY", "BANTZ_GEMINI_API_KEY"
     )

--- a/src/bantz/llm/__init__.py
+++ b/src/bantz/llm/__init__.py
@@ -120,7 +120,7 @@ def create_quality_client(
                 "QUALITY_MODEL_NAME",
                 "BANTZ_QUALITY_MODEL",
                 "BANTZ_GEMINI_MODEL",
-                default="gemini-1.5-flash",
+                default="gemini-2.0-flash",
             )
         )
 

--- a/src/bantz/llm/base.py
+++ b/src/bantz/llm/base.py
@@ -234,7 +234,7 @@ def create_client(
         api_key = (base_url or "").strip()
         return GeminiClient(
             api_key=api_key,
-            model=model or "gemini-1.5-flash",
+            model=model or "gemini-2.0-flash",
             timeout_seconds=timeout,
         )
     

--- a/src/bantz/llm/gemini_client.py
+++ b/src/bantz/llm/gemini_client.py
@@ -86,7 +86,7 @@ class GeminiClient(LLMClient):
 
     Env (recommended to set via create_quality_client):
       - GEMINI_API_KEY / GOOGLE_API_KEY / BANTZ_GEMINI_API_KEY
-      - model: e.g. gemini-1.5-flash
+      - model: e.g. gemini-2.0-flash
 
     Notes:
       - This client assumes *cloud mode* is already allowed by the caller.

--- a/src/bantz/llm/preflight.py
+++ b/src/bantz/llm/preflight.py
@@ -179,7 +179,7 @@ def check_gemini_preflight() -> BackendStatus:
         logger.debug("[warmup] Gemini skipped (no key or cloud disabled)")
         return BackendStatus(status="skipped")
 
-    model = os.getenv("BANTZ_GEMINI_MODEL", "gemini-1.5-flash")
+    model = os.getenv("BANTZ_GEMINI_MODEL", "gemini-2.0-flash")
     logger.debug("[warmup] checking Gemini preflight for %s", model)
 
     try:

--- a/tests/test_debug_tier_info.py
+++ b/tests/test_debug_tier_info.py
@@ -146,13 +146,13 @@ class TestTierDecision:
             reason="quality requested",
             confidence=0.95,
             quality_result=QualityResult.PASS,
-            metadata={"model": "gemini-1.5-flash"},
+            metadata={"model": "gemini-2.0-flash"},
         )
         assert decision.duration_ms == 150.5
         assert decision.reason == "quality requested"
         assert decision.confidence == 0.95
         assert decision.quality_result == QualityResult.PASS
-        assert decision.metadata["model"] == "gemini-1.5-flash"
+        assert decision.metadata["model"] == "gemini-2.0-flash"
     
     def test_to_dict(self) -> None:
         """Test to_dict conversion."""

--- a/tests/test_issue_410_gemini_rate_limit.py
+++ b/tests/test_issue_410_gemini_rate_limit.py
@@ -334,7 +334,7 @@ def _make_client(
     """Create a GeminiClient for testing."""
     return GeminiClient(
         api_key="test-key",
-        model="gemini-1.5-flash",
+        model="gemini-2.0-flash",
         timeout_seconds=5.0,
         quota_tracker=quota_tracker,
         circuit_breaker=circuit_breaker,

--- a/tests/test_issue_411_gemini_streaming.py
+++ b/tests/test_issue_411_gemini_streaming.py
@@ -41,7 +41,7 @@ from bantz.llm.base import (
 
 
 def _make_client(**kwargs) -> GeminiClient:
-    defaults = dict(api_key="test-key", model="gemini-1.5-flash", timeout_seconds=5.0)
+    defaults = dict(api_key="test-key", model="gemini-2.0-flash", timeout_seconds=5.0)
     defaults.update(kwargs)
     return GeminiClient(**defaults)
 

--- a/tests/test_issue_516_single_runtime.py
+++ b/tests/test_issue_516_single_runtime.py
@@ -68,7 +68,7 @@ class TestCreateRuntime:
         "BANTZ_VLLM_URL": "http://localhost:8001",
         "BANTZ_VLLM_MODEL": "test-model",
         "GEMINI_API_KEY": "test-key",
-        "BANTZ_GEMINI_MODEL": "gemini-1.5-flash",
+        "BANTZ_GEMINI_MODEL": "gemini-2.0-flash",
     }, clear=False)
     @patch("bantz.llm.vllm_openai_client.VLLMOpenAIClient")
     @patch("bantz.brain.orchestrator_loop.OrchestratorLoop")
@@ -85,7 +85,7 @@ class TestCreateRuntime:
         assert runtime is not None
         assert runtime.gemini_client is not None
         assert runtime.finalizer_is_gemini is True
-        assert runtime.gemini_model == "gemini-1.5-flash"
+        assert runtime.gemini_model == "gemini-2.0-flash"
 
     @patch("bantz.llm.vllm_openai_client.VLLMOpenAIClient")
     @patch("bantz.brain.orchestrator_loop.OrchestratorLoop")

--- a/tests/test_issue_517_finalizer_invariant.py
+++ b/tests/test_issue_517_finalizer_invariant.py
@@ -40,7 +40,7 @@ def _make_output(**overrides) -> OrchestratorOutput:
 class _FakeLLM:
     """Minimal LLM mock with model_name and complete_text."""
 
-    def __init__(self, model_name: str = "gemini-1.5-flash", reply: str = "Test reply"):
+    def __init__(self, model_name: str = "gemini-2.0-flash", reply: str = "Test reply"):
         self.model_name = model_name
         self._reply = reply
 
@@ -62,8 +62,8 @@ class TestOrchestratorOutputFinalizerModel:
     def test_finalizer_model_can_be_set(self):
         """finalizer_model should be settable via replace."""
         output = _make_output()
-        updated = replace(output, finalizer_model="gemini-1.5-flash")
-        assert updated.finalizer_model == "gemini-1.5-flash"
+        updated = replace(output, finalizer_model="gemini-2.0-flash")
+        assert updated.finalizer_model == "gemini-2.0-flash"
 
     def test_finalizer_model_in_dataclass_fields(self):
         """finalizer_model should be a proper dataclass field."""
@@ -107,7 +107,7 @@ class TestPipelineFinalizerModel:
         )
         from bantz.brain.orchestrator_state import OrchestratorState
 
-        gemini = _FakeLLM(model_name="gemini-1.5-flash", reply="İşte takvim sonuçları efendim")
+        gemini = _FakeLLM(model_name="gemini-2.0-flash", reply="İşte takvim sonuçları efendim")
         guard = NoNewFactsGuard(finalizer_llm=gemini)
         quality = QualityFinalizer(finalizer_llm=gemini, guard=guard)
 
@@ -123,7 +123,7 @@ class TestPipelineFinalizerModel:
 
         pipeline = FinalizationPipeline(quality=quality)
         result = pipeline.run(ctx)
-        assert result.finalizer_model == "gemini-1.5-flash"
+        assert result.finalizer_model == "gemini-2.0-flash"
 
     def test_no_tools_stamps_model(self):
         """No tool results should stamp finalizer_model."""

--- a/tests/test_issue_520_banner.py
+++ b/tests/test_issue_520_banner.py
@@ -36,7 +36,7 @@ class TestRuntimeBanner:
 
         class FakeRuntime:
             router_model = "Qwen/Qwen2.5-3B-Instruct"
-            gemini_model = "gemini-1.5-flash"
+            gemini_model = "gemini-2.0-flash"
             finalizer_is_gemini = True
             loop = FakeLoop()
             tools = None
@@ -44,7 +44,7 @@ class TestRuntimeBanner:
 
         banner = RuntimeBanner.from_runtime(FakeRuntime())
         assert banner.finalizer_type == "Gemini"
-        assert banner.finalizer_model == "gemini-1.5-flash"
+        assert banner.finalizer_model == "gemini-2.0-flash"
         assert banner.finalizer_ok is True
         assert banner.memory_turns == 8
         assert banner.memory_tokens == 800
@@ -74,7 +74,7 @@ class TestFormatBanner:
         from bantz.brain.runtime_banner import RuntimeBanner, format_banner
         b = RuntimeBanner(
             router_model="Qwen/Qwen2.5-3B-Instruct",
-            finalizer_model="gemini-1.5-flash",
+            finalizer_model="gemini-2.0-flash",
             finalizer_ok=True,
         )
         text = format_banner(b)
@@ -87,7 +87,7 @@ class TestFormatBanner:
         b = RuntimeBanner(
             mode="orchestrator",
             router_model="Qwen/Qwen2.5-3B-Instruct",
-            finalizer_model="gemini-1.5-flash",
+            finalizer_model="gemini-2.0-flash",
             finalizer_type="Gemini",
             finalizer_ok=True,
             memory_turns=10,
@@ -97,7 +97,7 @@ class TestFormatBanner:
         text = format_banner(b)
         assert "orchestrator" in text
         assert "Qwen2.5-3B-Instruct" in text
-        assert "gemini-1.5-flash" in text
+        assert "gemini-2.0-flash" in text
         assert "10 turns" in text
         assert "1000tok" in text
         assert "5 registered" in text

--- a/tests/test_llm_metrics.py
+++ b/tests/test_llm_metrics.py
@@ -97,7 +97,7 @@ def sample_entries() -> list[MetricEntry]:
         MetricEntry(
             ts="2024-01-15T10:02:00+00:00",
             backend="gemini",
-            model="gemini-1.5-flash",
+            model="gemini-2.0-flash",
             prompt_tokens=200,
             completion_tokens=150,
             total_tokens=350,
@@ -123,7 +123,7 @@ def sample_entries() -> list[MetricEntry]:
         MetricEntry(
             ts="2024-01-15T10:04:00+00:00",
             backend="gemini",
-            model="gemini-1.5-flash",
+            model="gemini-2.0-flash",
             prompt_tokens=180,
             completion_tokens=0,
             total_tokens=0,
@@ -226,7 +226,7 @@ class TestMetricEntry:
         entry = MetricEntry(
             ts="2024-01-15T10:00:00+00:00",
             backend="gemini",
-            model="gemini-1.5-flash",
+            model="gemini-2.0-flash",
             prompt_tokens=200,
             completion_tokens=100,
             total_tokens=300,
@@ -241,7 +241,7 @@ class TestMetricEntry:
         data = json.loads(json_str)
         
         assert data["backend"] == "gemini"
-        assert data["model"] == "gemini-1.5-flash"
+        assert data["model"] == "gemini-2.0-flash"
         assert data["total_tokens"] == 300
     
     def test_json_roundtrip(self):
@@ -426,7 +426,7 @@ class TestRecordFunctions:
         }):
             result = record_llm_success(
                 backend="gemini",
-                model="gemini-1.5-flash",
+                model="gemini-2.0-flash",
                 prompt_tokens=200,
                 completion_tokens=100,
                 latency_ms=500,
@@ -606,7 +606,7 @@ class TestFileIO:
             f.write(json.dumps({
                 "ts": "2024-01-15T10:01:00+00:00",
                 "backend": "gemini",
-                "model": "gemini-1.5-flash",
+                "model": "gemini-2.0-flash",
                 "prompt_tokens": 200,
                 "completion_tokens": 100,
                 "total_tokens": 300,
@@ -1203,7 +1203,7 @@ class TestIntegration:
             # 3. Finalizer call (quality tier)
             record_llm_success(
                 backend="gemini",
-                model="gemini-1.5-flash",
+                model="gemini-2.0-flash",
                 prompt_tokens=300,
                 completion_tokens=150,
                 latency_ms=850,

--- a/tests/test_quality_finalizer_issue_215.py
+++ b/tests/test_quality_finalizer_issue_215.py
@@ -183,7 +183,7 @@ def test_gemini_client_emits_metrics_and_reason_codes(monkeypatch: pytest.Monkey
 
     caplog.set_level("INFO", logger="bantz.llm.metrics")
 
-    c = GeminiClient(api_key="x", model="gemini-1.5-flash")
+    c = GeminiClient(api_key="x", model="gemini-2.0-flash")
     out = c.complete_text(prompt="hello", temperature=0.0, max_tokens=5)
     assert out == "ok"
 


### PR DESCRIPTION
## Problem
All Gemini defaults hardcoded to `gemini-1.5-flash` across 24 files.
Gemini 2.0 Flash is now GA with better quality at same speed/price.

## Fix
Global rename: `gemini-1.5-flash` → `gemini-2.0-flash` (47 occurrences, 24 files)

### Files changed
| Category | Files | Count |
|----------|-------|-------|
| Source code | runtime_factory, llm/base, llm/__init__, preflight, gemini_client, runtime_banner | 6 |
| Scripts | terminal_jarvis, e2e_run, demo_tiered_quality, smoke_boot_ready | 4 |
| Config | .env.example, bantz-env.example | 2 |
| Docs | README, gemini-hybrid-orchestrator, secrets-hygiene, boot-jarvis, artifacts | 5 |
| Tests | 8 test files | 8 |

### Backward compatible
Users with `BANTZ_GEMINI_MODEL` env override are unaffected — the env var takes precedence over all defaults.

### Test results
248 passed, 2 pre-existing failures (unrelated `gmail.list_messages` missing from test fixture)

Closes #572
Part of EPIC #576