### PR TITLE
fix(#588): Boot banner / runtime diagnostics — print at every startup

### DIFF
--- a/src/bantz/server.py
+++ b/src/bantz/server.py
@@ -446,15 +446,20 @@ class BantzServer:
 
                 self._brain = create_runtime()
                 self._brain_state = OrchestratorState()
-                logging.getLogger(__name__).info(
-                    "🧠 Server brain enabled: router=%s, finalizer=%s",
-                    self._brain.router_model,
-                    "Gemini" if self._brain.finalizer_is_gemini else "3B",
-                )
+                # Banner is printed by create_runtime() (Issue #588)
             except Exception as e:
                 logging.getLogger(__name__).warning(
                     "Brain init failed, falling back to legacy Router: %s", e
                 )
+                _brain_enabled = False
+
+        if not _brain_enabled:
+            from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+
+            legacy_banner = RuntimeBanner(active_path="legacy", mode="router")
+            banner_text = format_banner(legacy_banner)
+            print(banner_text, flush=True)
+            logging.getLogger(__name__).info("\n%s", banner_text)
 
         # Proactive inbox (FIFO) for bantz_message events
         self._inbox = InboxStore(maxlen=200)

--- a/tests/test_issue_520_banner.py
+++ b/tests/test_issue_520_banner.py
@@ -1,6 +1,7 @@
-"""Tests for Issue #520 — Runtime banner + turn trace.
+"""Tests for Issue #520 + #588 — Runtime banner + turn trace.
 
-Covers RuntimeBanner, format_banner, TurnTraceRecord, TurnTrace.
+Covers RuntimeBanner, format_banner, TurnTraceRecord, TurnTrace,
+and boot-banner diagnostics (active path, vLLM URL, forced tier).
 """
 
 from __future__ import annotations
@@ -18,8 +19,10 @@ class TestRuntimeBanner:
         from bantz.brain.runtime_banner import RuntimeBanner
         b = RuntimeBanner()
         assert b.mode == "orchestrator"
+        assert b.active_path == "brain"
         assert b.memory_turns == 10
         assert b.memory_tokens == 1000
+        assert b.forced_tier == ""
         assert b.debug is False
 
     def test_from_runtime(self):
@@ -50,6 +53,7 @@ class TestRuntimeBanner:
         assert banner.memory_tokens == 800
         assert banner.debug is True
         assert banner.router_model == "Qwen/Qwen2.5-3B-Instruct"
+        assert banner.active_path == "brain"
 
     def test_from_runtime_no_gemini(self):
         from bantz.brain.runtime_banner import RuntimeBanner
@@ -65,6 +69,38 @@ class TestRuntimeBanner:
         banner = RuntimeBanner.from_runtime(FakeRuntime())
         assert banner.finalizer_type == "3B (local)"
         assert banner.finalizer_ok is False
+
+    def test_from_runtime_forced_tier(self):
+        from bantz.brain.runtime_banner import RuntimeBanner
+
+        class FakeRuntime:
+            router_model = "Qwen/Qwen2.5-3B-Instruct"
+            gemini_model = ""
+            finalizer_is_gemini = False
+            loop = None
+            tools = None
+            router_client = None
+
+        with mock.patch.dict("os.environ", {"BANTZ_FORCE_FINALIZER_TIER": "quality"}):
+            banner = RuntimeBanner.from_runtime(FakeRuntime())
+        assert banner.forced_tier == "quality"
+
+    def test_from_runtime_router_url_extraction(self):
+        from bantz.brain.runtime_banner import RuntimeBanner
+
+        class FakeClient:
+            base_url = "http://gpu-box:8001"
+
+        class FakeRuntime:
+            router_model = "Qwen/Qwen2.5-3B-Instruct"
+            gemini_model = ""
+            finalizer_is_gemini = False
+            loop = None
+            tools = None
+            router_client = FakeClient()
+
+        banner = RuntimeBanner.from_runtime(FakeRuntime())
+        assert banner.router_url == "http://gpu-box:8001"
 
 
 # ── format_banner ─────────────────────────────────────────────
@@ -86,7 +122,9 @@ class TestFormatBanner:
         from bantz.brain.runtime_banner import RuntimeBanner, format_banner
         b = RuntimeBanner(
             mode="orchestrator",
+            active_path="brain",
             router_model="Qwen/Qwen2.5-3B-Instruct",
+            router_url="http://localhost:8001",
             finalizer_model="gemini-2.0-flash",
             finalizer_type="Gemini",
             finalizer_ok=True,
@@ -96,11 +134,38 @@ class TestFormatBanner:
         )
         text = format_banner(b)
         assert "orchestrator" in text
+        assert "brain (default)" in text
         assert "Qwen2.5-3B-Instruct" in text
+        assert "http://localhost:8001" in text
         assert "gemini-2.0-flash" in text
         assert "10 turns" in text
         assert "1000tok" in text
         assert "5 registered" in text
+
+    def test_legacy_path(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(active_path="legacy", mode="router")
+        text = format_banner(b)
+        assert "legacy" in text
+        assert "brain (default)" not in text
+
+    def test_forced_tier(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(forced_tier="quality")
+        text = format_banner(b)
+        assert "quality (forced)" in text
+
+    def test_no_forced_tier(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(forced_tier="")
+        text = format_banner(b)
+        assert "Tier:" not in text
+
+    def test_vllm_url_displayed(self):
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+        b = RuntimeBanner(router_url="http://gpu-box:8001")
+        text = format_banner(b)
+        assert "http://gpu-box:8001" in text
 
     def test_debug_flag(self):
         from bantz.brain.runtime_banner import RuntimeBanner, format_banner
@@ -217,3 +282,73 @@ class TestFileExistence:
         from pathlib import Path
         ROOT = Path(__file__).resolve().parent.parent
         assert (ROOT / "src" / "bantz" / "brain" / "runtime_banner.py").is_file()
+
+
+# ── Issue #588: Banner printed at startup ─────────────────────
+
+class TestBannerPrintedAtStartup:
+    """Verify format_banner() is actually called from create_runtime()."""
+
+    def test_create_runtime_prints_banner(self):
+        """create_runtime() should print the ASCII banner box."""
+        from unittest.mock import patch, MagicMock
+        import builtins
+
+        printed = []
+        original_print = builtins.print
+
+        def capture_print(*args, **kwargs):
+            printed.append(" ".join(str(a) for a in args))
+
+        with patch("builtins.print", side_effect=capture_print):
+            with patch.dict("os.environ", {
+                "BANTZ_VLLM_URL": "http://test:8001",
+                "BANTZ_VLLM_MODEL": "test-model",
+                "GEMINI_API_KEY": "",
+            }):
+                try:
+                    from bantz.brain.runtime_factory import create_runtime
+                    runtime = create_runtime()
+                except Exception:
+                    pytest.skip("create_runtime requires live dependencies")
+
+        banner_output = "\n".join(printed)
+        assert "╭" in banner_output or "BANTZ Brain" in banner_output
+
+    def test_legacy_banner_shows_legacy_path(self):
+        """Legacy path banner should say 'legacy' not 'brain (default)'."""
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+
+        b = RuntimeBanner(active_path="legacy", mode="router")
+        text = format_banner(b)
+        assert "legacy" in text
+        assert "brain (default)" not in text
+        assert "╭" in text
+        assert "╰" in text
+
+    def test_brain_banner_shows_brain_path(self):
+        """Brain path banner should say 'brain (default)'."""
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+
+        b = RuntimeBanner(active_path="brain")
+        text = format_banner(b)
+        assert "brain (default)" in text
+        assert "Path:" in text
+
+    def test_banner_includes_vllm_url(self):
+        """Banner should show vLLM URL for quick confirmation."""
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+
+        b = RuntimeBanner(router_url="http://192.168.1.100:8001")
+        text = format_banner(b)
+        assert "http://192.168.1.100:8001" in text
+        assert "vLLM:" in text
+
+    def test_banner_forced_tier_visible(self):
+        """If BANTZ_FORCE_FINALIZER_TIER is set, banner should show it."""
+        from bantz.brain.runtime_banner import RuntimeBanner, format_banner
+
+        b = RuntimeBanner(forced_tier="fast")
+        text = format_banner(b)
+        assert "fast (forced)" in text
+        assert "Tier:" in text


### PR DESCRIPTION
## Summary
Wires the existing `RuntimeBanner` + `format_banner()` (Issue #520) into **every boot path** so diagnostics are always visible.

## What Changed

### `runtime_banner.py`
- Added `active_path` field (`"brain"` / `"legacy"`)
- Added `forced_tier` field (e.g. `"quality"`, `"fast"`)
- `format_banner()` now shows: **Path**, **vLLM URL**, **Router**, **Finalizer**, **Tools**, **Forced Tier**
- `from_runtime()` reads `BANTZ_FORCE_FINALIZER_TIER` env var

### `runtime_factory.py`
- `create_runtime()` builds `RuntimeBanner.from_runtime()` and prints the ASCII box via `print()` + `logger.info()`
- Replaces the old plain `logger.info("🧠 BANTZ Runtime: ...")` one-liner

### `server.py`
- Brain path: banner already printed by `create_runtime()` (no duplicate)
- Legacy path: prints its own banner with `active_path="legacy"`
- Brain init failure now falls back to legacy banner

### Tests (`test_issue_520_banner.py`)
- **6 new tests** for #588: path labels, vLLM URL, forced tier, banner printing
- **27 total** — all pass

## Boot Output Example
```
╭────────────────────────────────────────────────╮
│  🧠 BANTZ Brain v2.0                          │
│  Path:      brain (default)                    │
│  Mode:      orchestrator                       │
│  Router:    Qwen2.5-3B-Instruct-AWQ           │
│  vLLM:      http://localhost:8001              │
│  Finalizer: gemini-2.0-flash ✓ (Gemini)       │
│  Memory:    lite (10 turns, 1000tok)           │
│  Tools:     12 registered                      │
╰────────────────────────────────────────────────╯
```

Closes #588