### PR TITLE
Fix #595: default finalizer tier to fast

### DIFF
--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -423,7 +423,7 @@ def decide_finalization_tier(
         )
 
         if decision.reason == "tiering_disabled":
-            return True, "quality", "tiering_disabled_default_quality"
+            return False, "fast", "tiering_disabled_default_fast"
 
         use_q = bool(decision.use_quality)
         tier = "quality" if use_q else "fast"
@@ -442,7 +442,7 @@ def decide_finalization_tier(
 
         return use_q, tier, str(decision.reason)
     except Exception:
-        return True, "quality", "tiering_error_default_quality"
+        return False, "fast", "tiering_error_default_fast"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_finalization_pipeline.py
+++ b/tests/test_finalization_pipeline.py
@@ -380,8 +380,8 @@ class TestDecideFinalizationTier:
         assert tier == "quality"
         assert "complex_smalltalk" in reason
 
-    def test_tiering_disabled_defaults_to_quality(self):
-        """When tiering is disabled, defaults to quality."""
+    def test_tiering_disabled_defaults_to_fast(self):
+        """Issue #595: When tiering is disabled, default to fast to avoid cloud spend."""
 
         class FakeTierDecision:
             use_quality = True
@@ -399,8 +399,9 @@ class TestDecideFinalizationTier:
                 user_input="takvim etkinlikleri",
                 has_finalizer=True,
             )
-        assert use_q is True
-        assert tier == "quality"
+        assert use_q is False
+        assert tier == "fast"
+        assert reason == "tiering_disabled_default_fast"
 
     def test_tiering_returns_fast(self):
         """When tiering decides fast tier."""
@@ -424,8 +425,8 @@ class TestDecideFinalizationTier:
         assert not use_q
         assert tier == "fast"
 
-    def test_tiering_error_defaults_quality(self):
-        """If tiered module fails, defaults to quality."""
+    def test_tiering_error_defaults_fast(self):
+        """Issue #595: If tiered module fails, default to fast."""
         with patch(
             "bantz.llm.tiered.decide_tier",
             side_effect=RuntimeError("oops"),
@@ -435,8 +436,8 @@ class TestDecideFinalizationTier:
                 user_input="takvim",
                 has_finalizer=True,
             )
-        assert use_q is True
-        assert tier == "quality"
+        assert use_q is False
+        assert tier == "fast"
         assert "error" in reason
 
 


### PR DESCRIPTION
Issue #595: Tiering is disabled by default, but finalization previously defaulted to quality (Gemini) when tiering was disabled or errored.

- decide_finalization_tier now defaults to fast when tiering is disabled.
- Tiering errors also default to fast to avoid unintended cloud spend.
- Updates unit tests accordingly.

Tests: pytest -q tests/test_finalization_pipeline.py::TestDecideFinalizationTier