### PR TITLE
Fix #596: integrate FSMBridge into OrchestratorLoop

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -381,6 +381,7 @@ class OrchestratorLoop:
         config: Optional[OrchestratorConfig] = None,
         finalizer_llm: Optional[Any] = None,
         audit_logger: Optional[Any] = None,
+        fsm_bridge: Optional[Any] = None,
     ):
         self.orchestrator = orchestrator
         self.tools = tools
@@ -388,6 +389,7 @@ class OrchestratorLoop:
         self.config = config or OrchestratorConfig()
         self.finalizer_llm = finalizer_llm
         self.audit_logger = audit_logger  # For tool execution auditing (Issue #160)
+        self.fsm_bridge = fsm_bridge  # Issue #596: ConversationFSM integration (optional)
 
         # Issue #517: Finalizer wiring invariant — warn if no finalizer
         if finalizer_llm is None:
@@ -565,6 +567,15 @@ class OrchestratorLoop:
         
         start_time = time.time()
 
+        # Issue #596: FSM lifecycle integration (best-effort)
+        try:
+            if self.fsm_bridge is not None:
+                rec = self.fsm_bridge.on_turn_start(int(state.turn_count) + 1)
+                if rec is not None:
+                    state.trace.setdefault("fsm_transitions", []).append(rec.to_trace_line())
+        except Exception:
+            pass
+
         # Issue #417: Build session context once per turn (cached with TTL)
         if not state.session_context:
             state.session_context = self._session_ctx_cache.get_or_build()
@@ -586,6 +597,15 @@ class OrchestratorLoop:
 
                 # Phase 2.5: Verify tool results (Issue #591 / #523)
                 tool_results = self._verify_results_phase(tool_results, state)
+
+                # Issue #596: If confirmation is pending, drive FSM into CONFIRMING.
+                try:
+                    if self.fsm_bridge is not None and state.has_pending_confirmation():
+                        rec = self.fsm_bridge.on_confirmation_needed()
+                        if rec is not None:
+                            state.trace.setdefault("fsm_transitions", []).append(rec.to_trace_line())
+                except Exception:
+                    pass
                 
                 # Phase 3: LLM Finalization (generate final response with tool results)
                 final_output = self._llm_finalization_phase(
@@ -594,6 +614,15 @@ class OrchestratorLoop:
                     tool_results,
                     state,
                 )
+
+            # Issue #596: Finalization complete → response ready (unless we are confirming)
+            try:
+                if self.fsm_bridge is not None and not state.has_pending_confirmation():
+                    rec = self.fsm_bridge.on_finalization_done()
+                    if rec is not None:
+                        state.trace.setdefault("fsm_transitions", []).append(rec.to_trace_line())
+            except Exception:
+                pass
             
             # Phase 4: Update State (rolling summary, conversation history, trace)
             self._update_state_phase(user_input, final_output, tool_results, state)
@@ -648,6 +677,15 @@ class OrchestratorLoop:
         if state is None:
             state = OrchestratorState()
 
+        # Issue #596: FSM lifecycle integration (best-effort)
+        try:
+            if self.fsm_bridge is not None:
+                rec = self.fsm_bridge.on_turn_start(int(state.turn_count) + 1)
+                if rec is not None:
+                    state.trace.setdefault("fsm_transitions", []).append(rec.to_trace_line())
+        except Exception:
+            pass
+
         # Phase 1: plan
         orchestrator_output = self._llm_planning_phase(user_input, state)
 
@@ -662,6 +700,15 @@ class OrchestratorLoop:
             # Phase 2.5: verify
             tool_results = self._verify_results_phase(tool_results, state)
 
+            # Issue #596: If confirmation is pending, drive FSM into CONFIRMING.
+            try:
+                if self.fsm_bridge is not None and state.has_pending_confirmation():
+                    rec = self.fsm_bridge.on_confirmation_needed()
+                    if rec is not None:
+                        state.trace.setdefault("fsm_transitions", []).append(rec.to_trace_line())
+            except Exception:
+                pass
+
             # Phase 3: finalize
             final_output = self._llm_finalization_phase(
                 user_input,
@@ -669,6 +716,15 @@ class OrchestratorLoop:
                 tool_results,
                 state,
             )
+
+        # Issue #596: Finalization complete → response ready (unless we are confirming)
+        try:
+            if self.fsm_bridge is not None and not state.has_pending_confirmation():
+                rec = self.fsm_bridge.on_finalization_done()
+                if rec is not None:
+                    state.trace.setdefault("fsm_transitions", []).append(rec.to_trace_line())
+        except Exception:
+            pass
 
         # Phase 4: update state
         self._update_state_phase(user_input, final_output, tool_results, state)

--- a/tests/test_issue_596_fsm_bridge_integration.py
+++ b/tests/test_issue_596_fsm_bridge_integration.py
@@ -1,0 +1,120 @@
+"""Integration tests for Issue #596: FSMBridge wired into OrchestratorLoop.
+
+We verify that OrchestratorLoop calls FSMBridge hooks during a turn:
+- on_turn_start() at the beginning
+- on_confirmation_needed() when pending confirmations exist
+- on_finalization_done() when a response is ready (and not confirming)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import Mock
+
+from bantz.brain.llm_router import OrchestratorOutput
+from bantz.brain.orchestrator_loop import OrchestratorLoop
+from bantz.brain.orchestrator_state import OrchestratorState
+
+
+@dataclass
+class _Rec:
+    line: str
+
+    def to_trace_line(self) -> str:
+        return self.line
+
+
+class FakeFSMBridge:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int | None]] = []
+
+    def on_turn_start(self, turn_number: int):
+        self.calls.append(("on_turn_start", int(turn_number)))
+        return _Rec(f"start turn={turn_number}")
+
+    def on_confirmation_needed(self):
+        self.calls.append(("on_confirmation_needed", None))
+        return _Rec("confirm")
+
+    def on_finalization_done(self):
+        self.calls.append(("on_finalization_done", None))
+        return _Rec("finalize")
+
+
+def _make_loop(*, fsm_bridge: FakeFSMBridge) -> OrchestratorLoop:
+    orchestrator = Mock()
+    tools = Mock()
+    finalizer_llm = Mock()
+    return OrchestratorLoop(
+        orchestrator=orchestrator,
+        tools=tools,
+        finalizer_llm=finalizer_llm,
+        fsm_bridge=fsm_bridge,
+    )
+
+
+def test_fsm_bridge_turn_start_and_finalization_done_preroute(monkeypatch):
+    fsm = FakeFSMBridge()
+    loop = _make_loop(fsm_bridge=fsm)
+
+    # Make process_turn take the preroute bypass path (skip tools + finalization)
+    def _planning(_user_input: str, _state: OrchestratorState) -> OrchestratorOutput:
+        return OrchestratorOutput(
+            route="smalltalk",
+            calendar_intent="none",
+            slots={},
+            confidence=0.9,
+            tool_plan=[],
+            assistant_reply="merhaba",
+            raw_output={"preroute_complete": True},
+        )
+
+    monkeypatch.setattr(loop, "_llm_planning_phase", _planning)
+
+    state = OrchestratorState()
+    out, st = loop.process_turn("merhaba", state)
+
+    assert out.assistant_reply == "merhaba"
+    assert fsm.calls[0] == ("on_turn_start", 1)
+    assert ("on_finalization_done", None) in fsm.calls
+    assert st.turn_count == 1
+    assert "fsm_transitions" in st.trace
+
+
+def test_fsm_bridge_confirmation_needed_skips_finalization_done(monkeypatch):
+    fsm = FakeFSMBridge()
+    loop = _make_loop(fsm_bridge=fsm)
+
+    def _planning(_user_input: str, _state: OrchestratorState) -> OrchestratorOutput:
+        return OrchestratorOutput(
+            route="calendar",
+            calendar_intent="cancel",
+            slots={},
+            confidence=0.9,
+            tool_plan=["calendar.delete_event"],
+            assistant_reply="",
+            requires_confirmation=True,
+            confirmation_prompt="Silmek istiyor musunuz?",
+            raw_output={},
+        )
+
+    def _exec(_output: OrchestratorOutput, state: OrchestratorState):
+        state.add_pending_confirmation({"tool": "calendar.delete_event"})
+        return []
+
+    def _finalize(user_input: str, orchestrator_output: OrchestratorOutput, tool_results, state: OrchestratorState):
+        # Minimal final output
+        return orchestrator_output
+
+    monkeypatch.setattr(loop, "_llm_planning_phase", _planning)
+    monkeypatch.setattr(loop, "_execute_tools_phase", _exec)
+    monkeypatch.setattr(loop, "_verify_results_phase", lambda tr, st: tr)
+    monkeypatch.setattr(loop, "_llm_finalization_phase", _finalize)
+
+    state = OrchestratorState()
+    _out, st = loop.process_turn("etkinliği sil", state)
+
+    assert ("on_turn_start", 1) in fsm.calls
+    assert ("on_confirmation_needed", None) in fsm.calls
+    assert ("on_finalization_done", None) not in fsm.calls
+    assert st.has_pending_confirmation() is True


### PR DESCRIPTION
Wires FSMBridge hooks into OrchestratorLoop so ConversationFSM transitions run during normal turns.

- Calls on_turn_start at beginning of process_turn/run_full_cycle.
- Calls on_confirmation_needed when pending confirmations exist.
- Calls on_finalization_done when a response is ready (and not confirming).
- Stores transition lines in state.trace[fsm_transitions] (best-effort).

Tests: pytest -q tests/test_issue_596_fsm_bridge_integration.py