### PR TITLE
Fix #598: unify tiering/quality decisions

### DIFF
--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -381,8 +381,9 @@ def decide_finalization_tier(
     """Decide whether to use quality (cloud) or fast (local) finalizer.
 
     Env overrides:
-        BANTZ_FORCE_FINALIZER_TIER=quality  → always use Gemini
-        BANTZ_FORCE_FINALIZER_TIER=fast     → always skip Gemini
+        BANTZ_TIER_FORCE_FINALIZER=quality  → always use Gemini
+        BANTZ_TIER_FORCE_FINALIZER=fast     → always skip Gemini
+        (legacy: BANTZ_FORCE_FINALIZER_TIER)
 
     Returns:
         ``(use_quality, tier_name, tier_reason)``
@@ -391,12 +392,15 @@ def decide_finalization_tier(
         return False, "fast", "no_finalizer"
 
     # Issue #517: env override for forcing finalizer tier
-    forced = os.getenv("BANTZ_FORCE_FINALIZER_TIER", "").strip().lower()
+    forced = (
+        os.getenv("BANTZ_TIER_FORCE_FINALIZER", "")
+        or os.getenv("BANTZ_FORCE_FINALIZER_TIER", "")
+    ).strip().lower()
     if forced in ("quality", "gemini"):
-        logger.info("[TIER] forced=quality via BANTZ_FORCE_FINALIZER_TIER")
+        logger.info("[TIER] forced=quality via tier env override")
         return True, "quality", "forced_quality"
     if forced in ("fast", "3b", "skip"):
-        logger.info("[TIER] forced=fast via BANTZ_FORCE_FINALIZER_TIER")
+        logger.info("[TIER] forced=fast via tier env override")
         return False, "fast", "forced_fast"
 
     # Issue #409: Split smalltalk into simple vs complex

--- a/src/bantz/brain/runtime_banner.py
+++ b/src/bantz/brain/runtime_banner.py
@@ -99,7 +99,10 @@ class RuntimeBanner:
                 router_url = str(client.base_url)
 
         # Forced tier override
-        forced_tier = os.getenv("BANTZ_FORCE_FINALIZER_TIER", "").strip().lower()
+        forced_tier = (
+            os.getenv("BANTZ_TIER_FORCE_FINALIZER", "")
+            or os.getenv("BANTZ_FORCE_FINALIZER_TIER", "")
+        ).strip().lower()
 
         return cls(
             mode="orchestrator",

--- a/src/bantz/brain/runtime_factory.py
+++ b/src/bantz/brain/runtime_factory.py
@@ -204,7 +204,7 @@ def create_runtime(
     if not finalizer_is_gemini:
         logger.warning(
             "⚠ Finalizer is 3B — set GEMINI_API_KEY for quality responses. "
-            "Override: BANTZ_FORCE_FINALIZER_TIER=quality|fast"
+            "Override: BANTZ_TIER_FORCE_FINALIZER=quality|fast (legacy: BANTZ_FORCE_FINALIZER_TIER)"
         )
 
     return runtime


### PR DESCRIPTION
Issue #598

What changed
- Made quality_gating the canonical tier decision engine (tiered.decide_tier delegates to it)
- Added route-aware smalltalk fast/quality split in quality_gating (keeps existing reasons)
- Added BANTZ_TIER_* env vars with legacy fallbacks for older names
- Updated finalizer tier override env var to BANTZ_TIER_FORCE_FINALIZER (legacy supported)

Tests
- pytest -q tests/test_tiered_smalltalk_issue_367.py tests/test_quality_gating.py tests/test_issue_439_quality_gating_threadsafe.py tests/test_tiered_finalization_issue_206.py
