### PR TITLE
Fix #600: fast finalizer on tool-less turns

### DIFF
--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -535,7 +535,14 @@ class FinalizationPipeline:
                 response_tier_reason=ctx.tier_reason or "fast_ok",
                 finalizer_used=False,
             )
-            if ctx.tool_results and not output.ask_user:
+            should_fast_finalize = (
+                (not output.ask_user)
+                and (
+                    bool(ctx.tool_results)
+                    or not (output.assistant_reply or "").strip()
+                )
+            )
+            if should_fast_finalize:
                 text = self._fast.finalize(ctx)
                 if text:
                     return replace(output, assistant_reply=text, finalizer_model=_fast_model or "fast")


### PR DESCRIPTION
Issue #600

What changed
- FinalizationPipeline fast path now runs even when there are no tool results if assistant_reply is empty

Tests
- pytest -q tests/test_finalization_pipeline.py
