### PR TITLE
fix(#603): GeminiClient — runtime_factory explicit quota_tracker + circuit_breaker

### DIFF
--- a/src/bantz/brain/runtime_factory.py
+++ b/src/bantz/brain/runtime_factory.py
@@ -139,13 +139,24 @@ def create_runtime(
     finalizer_is_gemini = False
     if _gemini_key:
         try:
-            from bantz.llm.gemini_client import GeminiClient
+            from bantz.llm.gemini_client import (
+                GeminiClient,
+                get_default_quota_tracker,
+                get_default_circuit_breaker,
+            )
 
             gemini_client = GeminiClient(
-                api_key=_gemini_key, model=_gemini_model, timeout_seconds=30.0
+                api_key=_gemini_key,
+                model=_gemini_model,
+                timeout_seconds=30.0,
+                quota_tracker=get_default_quota_tracker(),
+                circuit_breaker=get_default_circuit_breaker(),
             )
             finalizer_is_gemini = True
-            logger.info("Finalizer: %s ✓ (Gemini)", _gemini_model)
+            logger.info(
+                "Finalizer: %s ✓ (Gemini, quota_tracker=active, circuit_breaker=active)",
+                _gemini_model,
+            )
         except Exception as e:
             logger.warning("Gemini client init failed: %s — using 3B fallback", e)
     else:

--- a/tests/test_issue_603_gemini_default_gates.py
+++ b/tests/test_issue_603_gemini_default_gates.py
@@ -1,0 +1,82 @@
+"""Tests for Issue #603: GeminiClient default quota_tracker and circuit_breaker.
+
+Verifies that:
+1. GeminiClient wires default gates when use_default_gates=True (default)
+2. runtime_factory passes explicit quota/circuit instances
+3. Gates are actually functional (not None) in production wiring
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestGeminiClientDefaultGates:
+    """Ensure GeminiClient.__init__ activates default gates."""
+
+    def test_default_gates_active(self):
+        """use_default_gates=True (default) should wire quota + circuit."""
+        from bantz.llm.gemini_client import GeminiClient
+
+        client = GeminiClient(
+            api_key="test-key",
+            model="gemini-2.0-flash",
+        )
+        assert client._quota_tracker is not None, "quota_tracker must be active by default"
+        assert client._circuit_breaker is not None, "circuit_breaker must be active by default"
+
+    def test_explicit_none_overrides_default(self):
+        """Caller can explicitly disable gates with use_default_gates=False."""
+        from bantz.llm.gemini_client import GeminiClient
+
+        client = GeminiClient(
+            api_key="test-key",
+            model="gemini-2.0-flash",
+            use_default_gates=False,
+        )
+        assert client._quota_tracker is None
+        assert client._circuit_breaker is None
+
+    def test_explicit_tracker_takes_precedence(self):
+        """Explicitly passed tracker should override default."""
+        from bantz.llm.gemini_client import GeminiClient
+        from bantz.llm.quota_tracker import QuotaTracker
+
+        custom_tracker = QuotaTracker()
+        client = GeminiClient(
+            api_key="test-key",
+            model="gemini-2.0-flash",
+            quota_tracker=custom_tracker,
+        )
+        assert client._quota_tracker is custom_tracker
+
+
+class TestRuntimeFactoryGeminiGates:
+    """Ensure runtime_factory passes explicit gates to GeminiClient."""
+
+    def test_gemini_client_has_gates(self):
+        """GeminiClient created by runtime_factory must have active gates.
+
+        We test this directly by instantiating GeminiClient the same way
+        runtime_factory does — with explicit get_default_* calls.
+        """
+        from bantz.llm.gemini_client import (
+            GeminiClient,
+            get_default_quota_tracker,
+            get_default_circuit_breaker,
+        )
+
+        client = GeminiClient(
+            api_key="test-key",
+            model="gemini-2.0-flash",
+            timeout_seconds=30.0,
+            quota_tracker=get_default_quota_tracker(),
+            circuit_breaker=get_default_circuit_breaker(),
+        )
+        assert client._quota_tracker is not None, "quota_tracker must be active"
+        assert client._circuit_breaker is not None, "circuit_breaker must be active"
+        # Verify they are the shared singletons
+        assert client._quota_tracker is get_default_quota_tracker()
+        assert client._circuit_breaker is get_default_circuit_breaker()


### PR DESCRIPTION
## Sorun
`runtime_factory.py` `GeminiClient`'ı `quota_tracker` ve `circuit_breaker` geçmeden oluşturuyordu. Her ne kadar `GeminiClient.__init__` `use_default_gates=True` ile zaten default'ları aktif etse de, runtime_factory'de explicit geçilmemesi:

1. Kodu okuyanı yanıltıyor ("gates yok mu?")
2. Log'da gate durumu görünmüyor
3. Gelecekte `use_default_gates` default'u değişirse kırılır

## Çözüm
- `runtime_factory.py`: `get_default_quota_tracker()` ve `get_default_circuit_breaker()` import edilip explicit geçildi
- Log mesajı güncellenip gate durumu eklendi
- 4 yeni test eklendi

## Test
```
pytest tests/test_issue_603_gemini_default_gates.py -v  # 4/4 passed
```

Closes #603