### PR TITLE
fix(brain): log swallowed exceptions in llm_router.py (#635)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -476,8 +476,8 @@ USER: merhaba mesajı gönder
                     "reason": "router_unhealthy",
                     "input_len": len(user_input),
                 })
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("[ROUTER] event_bus.publish failed: %s", exc)
         
         return OrchestratorOutput(
             route="unknown",
@@ -1409,8 +1409,8 @@ class HybridJarvisLLMOrchestrator:
                 from dataclasses import replace
 
                 return replace(planned, assistant_reply=reply)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("[HYBRID] Finalizer error (swallowed): %s", exc)
 
         return planned
 


### PR DESCRIPTION
Replaced bare `except Exception: pass` with proper logging in llm_router.py:

- **Hybrid finalizer error** (L1412): `logger.warning('[HYBRID] Finalizer error...')` — previously invisible Gemini timeout/quota/parse errors
- **Event bus publish** (L479): `logger.debug('[ROUTER] event_bus.publish failed...')` — telemetry emission failures

Other `except Exception` blocks already have `as e` and logging, or are intentionally trivial (int parsing, context serialization) with safe fallbacks.

Fixes #635