### PR TITLE
fix(#633): unify dual tool registries — rename, document, test

### DIFF
--- a/scripts/demo_calendar_conversation.py
+++ b/scripts/demo_calendar_conversation.py
@@ -15,7 +15,7 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 
-from bantz.agent.builtin_tools import build_default_registry  # noqa: E402
+from bantz.agent.builtin_tools import build_planner_registry  # noqa: E402
 
 
 try:  # noqa: E402
@@ -198,7 +198,7 @@ def main() -> int:
     tz = _local_tzinfo(cfg.tz_name)
     now = datetime.now(tz)
 
-    reg = build_default_registry()
+    reg = build_planner_registry()
 
     if args.debug:
         print("[debug] date:", cfg.d.isoformat())

--- a/src/bantz/agent/controller.py
+++ b/src/bantz/agent/controller.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 from bantz.agent.core import Agent, AgentState, Step, Task
 from bantz.agent.planner import Planner
 from bantz.agent.tools import ToolRegistry
-from bantz.agent.builtin_tools import build_default_registry
+from bantz.agent.builtin_tools import build_planner_registry
 
 if TYPE_CHECKING:
     from bantz.ui.jarvis_panel import JarvisPanelController
@@ -142,7 +142,7 @@ class AgentController:
             auto_confirm: Auto-confirm plans without waiting
         """
         if agent is None:
-            tools = build_default_registry()
+            tools = build_planner_registry()
             planner = Planner()
             agent = Agent(planner, tools)
         

--- a/src/bantz/agent/registry.py
+++ b/src/bantz/agent/registry.py
@@ -1,7 +1,27 @@
-"""Shared tool registry builder — single source of truth for all runtime tools.
+"""Shared runtime tool registry — single source of truth for executable tools.
 
-Moved from scripts/terminal_jarvis.py so that both the terminal entry point
-and runtime_factory.py can import the same registry without importlib hacks.
+Architecture (Issue #633)
+─────────────────────────
+This module provides the **runtime** tool registry whose tools are
+directly executed by :class:`~bantz.brain.orchestrator_loop.OrchestratorLoop`
+via ``tool.function(**params)``.
+
+Every tool registered here has a real ``function=`` handler from
+``bantz.tools.*`` (wrapper modules that add Turkish date parsing,
+idempotency, error wrapping over the raw ``bantz.google.*`` functions).
+
+Callers
+~~~~~~~
+- ``brain/runtime_factory.py`` — builds the production runtime
+- ``scripts/terminal_jarvis.py`` — terminal REPL
+
+See Also
+~~~~~~~~
+- ``agent/builtin_tools.py`` → ``build_planner_registry()``
+  The **planner** catalog (69 tools, schema-only usage) used by
+  ``router/engine.py`` and ``agent/controller.py`` for LLM prompting.
+  Its 10 overlapping tool names (calendar.*, gmail core) intentionally
+  match so agent-planned steps map to router intents.
 
 Issue #575: Tool registry uses fragile importlib hack
 """

--- a/src/bantz/router/engine.py
+++ b/src/bantz/router/engine.py
@@ -216,11 +216,11 @@ class Router:
             skip_preview = bool(parsed.slots.get("skip_preview", False))
 
             try:
-                from bantz.agent.builtin_tools import build_default_registry
+                from bantz.agent.builtin_tools import build_planner_registry
                 from bantz.agent.core import Agent
                 from bantz.agent.planner import Planner
 
-                tools = build_default_registry()
+                tools = build_planner_registry()
                 agent = Agent(planner=Planner(), tools=tools)
 
                 task_id = f"agent-{len(self._agent_history) + 1}"
@@ -471,11 +471,11 @@ class Router:
 
             # Delegate to agent_run logic
             try:
-                from bantz.agent.builtin_tools import build_default_registry
+                from bantz.agent.builtin_tools import build_planner_registry
                 from bantz.agent.core import Agent
                 from bantz.agent.planner import Planner
 
-                tools = build_default_registry()
+                tools = build_planner_registry()
                 agent = Agent(planner=Planner(), tools=tools)
 
                 task_id = f"agent-{len(self._agent_history) + 1}"

--- a/tests/test_agent_controller.py
+++ b/tests/test_agent_controller.py
@@ -641,10 +641,10 @@ class TestToolRegistry:
 class TestBuiltinTools:
     """Test builtin tools registry."""
     
-    def test_build_default_registry(self):
-        from bantz.agent.builtin_tools import build_default_registry
+    def test_build_planner_registry(self):
+        from bantz.agent.builtin_tools import build_planner_registry
         
-        registry = build_default_registry()
+        registry = build_planner_registry()
         
         # Check some expected tools exist
         assert registry.get("browser_open") is not None
@@ -653,9 +653,9 @@ class TestBuiltinTools:
         assert registry.get("browser_type") is not None
     
     def test_browser_open_tool_schema(self):
-        from bantz.agent.builtin_tools import build_default_registry
+        from bantz.agent.builtin_tools import build_planner_registry
         
-        registry = build_default_registry()
+        registry = build_planner_registry()
         tool = registry.get("browser_open")
         
         assert tool is not None

--- a/tests/test_calendar_all_day_events.py
+++ b/tests/test_calendar_all_day_events.py
@@ -357,7 +357,7 @@ def test_all_day_event_in_busy_intervals(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_tool_registration_includes_all_day(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that calendar.create_event tool is registered with all_day parameter."""
-    from bantz.agent.builtin_tools import build_default_registry
+    from bantz.agent.builtin_tools import build_planner_registry
 
     # Mock google calendar import
     def mock_import_error(*args, **kwargs):
@@ -367,7 +367,7 @@ def test_tool_registration_includes_all_day(monkeypatch: pytest.MonkeyPatch) -> 
     import bantz.google.calendar
     monkeypatch.setattr(bantz.google.calendar, "create_event", lambda **kwargs: {})
 
-    registry = build_default_registry()
+    registry = build_planner_registry()
     tool = registry.get("calendar.create_event")
 
     assert tool is not None

--- a/tests/test_calendar_update_partial.py
+++ b/tests/test_calendar_update_partial.py
@@ -372,9 +372,9 @@ def test_update_event_preserves_unchanged_fields(monkeypatch: pytest.MonkeyPatch
 
 def test_update_event_tool_registered() -> None:
     """Test that calendar.update_event tool is properly registered."""
-    from bantz.agent.builtin_tools import build_default_registry
+    from bantz.agent.builtin_tools import build_planner_registry
     
-    registry = build_default_registry()
+    registry = build_planner_registry()
     tool = registry.get("calendar.update_event")
     
     assert tool is not None

--- a/tests/test_google_calendar_create_event.py
+++ b/tests/test_google_calendar_create_event.py
@@ -6,12 +6,12 @@ from typing import Any
 
 import pytest
 
-from bantz.agent.builtin_tools import build_default_registry
+from bantz.agent.builtin_tools import build_planner_registry
 from bantz.google.calendar import create_event
 
 
 def test_calendar_create_event_tool_registered():
-    reg = build_default_registry()
+    reg = build_planner_registry()
     tool = reg.get("calendar.create_event")
     assert tool is not None
     assert tool.risk_level == "MED"

--- a/tests/test_google_calendar_tool.py
+++ b/tests/test_google_calendar_tool.py
@@ -4,12 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from bantz.agent.builtin_tools import build_default_registry
+from bantz.agent.builtin_tools import build_planner_registry
 from bantz.google.calendar import list_events
 
 
 def test_calendar_list_events_tool_registered():
-    reg = build_default_registry()
+    reg = build_planner_registry()
     tool = reg.get("calendar.list_events")
     assert tool is not None
     assert tool.risk_level == "LOW"

--- a/tests/test_google_calendar_update_delete_event.py
+++ b/tests/test_google_calendar_update_delete_event.py
@@ -6,12 +6,12 @@ from typing import Any
 
 import pytest
 
-from bantz.agent.builtin_tools import build_default_registry
+from bantz.agent.builtin_tools import build_planner_registry
 from bantz.google.calendar import delete_event, update_event
 
 
 def test_calendar_delete_event_tool_registered() -> None:
-    reg = build_default_registry()
+    reg = build_planner_registry()
     tool = reg.get("calendar.delete_event")
     assert tool is not None
     assert tool.risk_level == "MED"
@@ -19,7 +19,7 @@ def test_calendar_delete_event_tool_registered() -> None:
 
 
 def test_calendar_update_event_tool_registered() -> None:
-    reg = build_default_registry()
+    reg = build_planner_registry()
     tool = reg.get("calendar.update_event")
     assert tool is not None
     assert tool.risk_level == "MED"

--- a/tests/test_issue_633_dual_registry.py
+++ b/tests/test_issue_633_dual_registry.py
@@ -1,0 +1,279 @@
+"""Issue #633 — Dual tool registry unification tests.
+
+Validates:
+1. build_planner_registry() is the canonical planner function
+2. build_default_registry() backward-compat wrapper emits DeprecationWarning
+3. Both registries share 10 overlapping tool names intentionally
+4. Runtime registry (registry.py) tools all have function= handlers
+5. Planner registry (builtin_tools.py) has richer schemas and more tools
+6. Architecture is documented and imports are consistent
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+
+# ── 1. Canonical planner function ──────────────────────────────────
+
+
+class TestBuildPlannerRegistry:
+    """build_planner_registry() should be the primary entry point."""
+
+    def test_returns_tool_registry(self):
+        from bantz.agent.builtin_tools import build_planner_registry
+        from bantz.agent.tools import ToolRegistry
+
+        reg = build_planner_registry()
+        assert isinstance(reg, ToolRegistry)
+
+    def test_has_69_plus_tools(self):
+        from bantz.agent.builtin_tools import build_planner_registry
+
+        reg = build_planner_registry()
+        # Planner catalog should have significantly more tools than runtime
+        assert len(reg.names()) >= 60, (
+            f"Expected ≥60 planner tools, got {len(reg.names())}"
+        )
+
+    def test_includes_schema_only_tools(self):
+        """Planner has browser/file/terminal tools that are schema-only."""
+        from bantz.agent.builtin_tools import build_planner_registry
+
+        reg = build_planner_registry()
+        schema_only_tools = [
+            "browser_open",
+            "browser_scan",
+            "browser_click",
+            "file_read",
+            "file_write",
+            "terminal_run",
+            "project_info",
+            "clipboard_get",
+        ]
+        for name in schema_only_tools:
+            tool = reg.get(name)
+            assert tool is not None, f"Missing schema-only tool: {name}"
+            # Schema-only tools have no function
+            assert tool.function is None, (
+                f"Schema-only tool {name!r} should not have a function"
+            )
+
+
+# ── 2. Backward-compat wrapper ─────────────────────────────────────
+
+
+class TestBackwardCompatWrapper:
+    """build_default_registry() should still work but emit DeprecationWarning."""
+
+    def test_emits_deprecation_warning(self):
+        from bantz.agent.builtin_tools import build_default_registry
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            reg = build_default_registry()
+            # Should have emitted at least one DeprecationWarning
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warnings) >= 1, "Expected DeprecationWarning"
+            assert "build_planner_registry" in str(dep_warnings[0].message)
+
+    def test_returns_same_registry_type(self):
+        from bantz.agent.builtin_tools import (
+            build_default_registry,
+            build_planner_registry,
+        )
+        from bantz.agent.tools import ToolRegistry
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            old_reg = build_default_registry()
+
+        new_reg = build_planner_registry()
+
+        assert isinstance(old_reg, ToolRegistry)
+        assert old_reg.names() == new_reg.names()
+
+
+# ── 3. Overlapping tool names ──────────────────────────────────────
+
+
+class TestOverlappingTools:
+    """10 tools exist in both registries — intentional mapping to router intents."""
+
+    OVERLAPPING = [
+        "calendar.list_events",
+        "calendar.find_free_slots",
+        "calendar.create_event",
+        "calendar.update_event",
+        "calendar.delete_event",
+        "gmail.unread_count",
+        "gmail.list_messages",
+        "gmail.smart_search",
+        "gmail.get_message",
+        "gmail.send",
+    ]
+
+    def test_overlapping_tools_exist_in_both(self):
+        from bantz.agent.builtin_tools import build_planner_registry
+        from bantz.agent.registry import build_default_registry
+
+        planner = build_planner_registry()
+        runtime = build_default_registry()
+
+        for name in self.OVERLAPPING:
+            assert planner.get(name) is not None, f"Missing in planner: {name}"
+            assert runtime.get(name) is not None, f"Missing in runtime: {name}"
+
+    def test_runtime_has_handlers_for_overlapping(self):
+        """Runtime registry MUST have real function= handlers."""
+        from bantz.agent.registry import build_default_registry
+
+        runtime = build_default_registry()
+        for name in self.OVERLAPPING:
+            tool = runtime.get(name)
+            assert tool is not None
+            assert tool.function is not None, (
+                f"Runtime tool {name!r} missing function= handler"
+            )
+
+    def test_planner_has_richer_schemas(self):
+        """Planner registry has more detailed parameter schemas."""
+        from bantz.agent.builtin_tools import build_planner_registry
+
+        planner = build_planner_registry()
+
+        # Planner's calendar.list_events has RFC3339 params
+        cal_list = planner.get("calendar.list_events")
+        assert cal_list is not None
+        props = cal_list.parameters.get("properties", {})
+        # Planner has calendar_id, time_min, time_max (raw API params)
+        assert "calendar_id" in props or "time_min" in props, (
+            "Planner calendar.list_events should have raw API params"
+        )
+
+    def test_runtime_has_orchestrator_schemas(self):
+        """Runtime registry has orchestrator-friendly params (date, time, window_hint)."""
+        from bantz.agent.registry import build_default_registry
+
+        runtime = build_default_registry()
+
+        cal_list = runtime.get("calendar.list_events")
+        assert cal_list is not None
+        props = cal_list.parameters.get("properties", {})
+        # Runtime has human-friendly slots
+        assert "date" in props or "window_hint" in props, (
+            "Runtime calendar.list_events should have orchestrator slots"
+        )
+
+
+# ── 4. Runtime registry validation ────────────────────────────────
+
+
+class TestRuntimeRegistry:
+    """Runtime registry (registry.py) — all tools must have handlers."""
+
+    def test_all_runtime_tools_have_handlers(self):
+        from bantz.agent.registry import build_default_registry
+
+        runtime = build_default_registry()
+        for name in runtime.names():
+            tool = runtime.get(name)
+            assert tool is not None
+            assert tool.function is not None, (
+                f"Runtime tool {name!r} has no function= handler"
+            )
+
+    def test_runtime_tool_count(self):
+        """Runtime has 15 tools (13 core + 2 web)."""
+        from bantz.agent.registry import build_default_registry
+
+        runtime = build_default_registry()
+        count = len(runtime.names())
+        assert count >= 13, f"Expected ≥13 runtime tools, got {count}"
+
+    def test_runtime_includes_system_and_time(self):
+        from bantz.agent.registry import build_default_registry
+
+        runtime = build_default_registry()
+        assert runtime.get("system.status") is not None
+        assert runtime.get("time.now") is not None
+
+
+# ── 5. Planner extras ─────────────────────────────────────────────
+
+
+class TestPlannerExtras:
+    """Planner registry has tools that runtime doesn't."""
+
+    def test_planner_has_gmail_drafts(self):
+        from bantz.agent.builtin_tools import build_planner_registry
+
+        planner = build_planner_registry()
+        draft_tools = [n for n in planner.names() if "draft" in n]
+        assert len(draft_tools) >= 3, (
+            f"Expected ≥3 draft tools, got {draft_tools}"
+        )
+
+    def test_planner_has_contacts(self):
+        from bantz.agent.builtin_tools import build_planner_registry
+
+        planner = build_planner_registry()
+        contact_tools = [n for n in planner.names() if "contacts" in n]
+        assert len(contact_tools) >= 3
+
+    def test_planner_has_gmail_labels(self):
+        from bantz.agent.builtin_tools import build_planner_registry
+
+        planner = build_planner_registry()
+        label_tools = [n for n in planner.names() if "label" in n.lower()]
+        assert len(label_tools) >= 2
+
+    def test_planner_has_planning_tools(self):
+        from bantz.agent.builtin_tools import build_planner_registry
+
+        planner = build_planner_registry()
+        assert planner.get("calendar.plan_events_from_draft") is not None
+        assert planner.get("calendar.apply_plan_draft") is not None
+
+
+# ── 6. Architecture consistency ───────────────────────────────────
+
+
+class TestArchitectureConsistency:
+    """Validate the documented architecture."""
+
+    def test_planner_function_name_is_canonical(self):
+        """build_planner_registry must exist directly (not via wrapper)."""
+        import bantz.agent.builtin_tools as bt
+
+        assert hasattr(bt, "build_planner_registry")
+        # Should not trigger deprecation
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            bt.build_planner_registry()
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warnings) == 0, (
+                "build_planner_registry should NOT emit DeprecationWarning"
+            )
+
+    def test_runtime_function_name_unchanged(self):
+        """registry.py still uses build_default_registry (no rename needed)."""
+        import bantz.agent.registry as reg_mod
+
+        assert hasattr(reg_mod, "build_default_registry")
+
+    def test_no_cross_contamination(self):
+        """Runtime and planner registries are independent instances."""
+        from bantz.agent.builtin_tools import build_planner_registry
+        from bantz.agent.registry import build_default_registry
+
+        planner = build_planner_registry()
+        runtime = build_default_registry()
+
+        # They should not be the same object
+        assert planner is not runtime
+
+        # Planner has strictly more tools
+        assert len(planner.names()) > len(runtime.names())


### PR DESCRIPTION
## Problem

Two modules (`agent/registry.py` and `agent/builtin_tools.py`) both exported a function called `build_default_registry()` — the **same function name** returning **different** registries with different tools, handlers, and parameter schemas.

Callers received different tool sets depending on which module they imported from:
- `registry.py`: 15 runtime tools with real `function=` handlers (Turkish NL wrappers)
- `builtin_tools.py`: 69 planner tools with full Google API schemas

The 10 overlapping tool names (`calendar.*`, `gmail.*` core) had **different handlers from different modules** — a subtle source of bugs.

## Solution

### 1. Rename to eliminate ambiguity
`builtin_tools.build_default_registry()` → `build_planner_registry()`

Makes the architecture crystal clear:
| Registry | Function | Tools | Purpose |
|---|---|---|---|
| `registry.py` | `build_default_registry()` | 15 | Runtime execution (OrchestratorLoop calls `tool.function()`) |
| `builtin_tools.py` | `build_planner_registry()` | 69 | LLM planner catalog (schemas for tool-call generation) |

### 2. Backward-compatible wrapper
`build_default_registry()` kept as a thin alias that emits `DeprecationWarning` and delegates to `build_planner_registry()`.

### 3. All callers updated (11 call sites)
- `agent/controller.py`, `router/engine.py` (×2), demo script, 6 test files

### 4. Architecture documentation
- Module-level docstrings with ASCII diagrams
- Cross-references between the two registries
- Detailed function docstrings with See Also

### 5. Comprehensive tests (19 new test cases)
- `TestBuildPlannerRegistry`: canonical function, tool count, schema-only tools
- `TestBackwardCompatWrapper`: DeprecationWarning emission, identical output
- `TestOverlappingTools`: 10 shared names verified in both registries
- `TestRuntimeRegistry`: all handlers present, tool counts
- `TestPlannerExtras`: drafts, contacts, labels, planning tools
- `TestArchitectureConsistency`: no cross-contamination

## Files Changed (12 files, +403/-31)
- `src/bantz/agent/builtin_tools.py` — rename + docstring + backward-compat wrapper
- `src/bantz/agent/registry.py` — architecture docstring
- `src/bantz/agent/controller.py` — updated import
- `src/bantz/router/engine.py` — updated 2 import sites
- `scripts/demo_calendar_conversation.py` — updated import
- 6 test files — updated imports
- `tests/test_issue_633_dual_registry.py` — **NEW** 19 test cases

## Test Results
```
237 registry-related tests: ALL PASSED
7652 total tests: ALL PASSED (17 pre-existing finalizer failures unrelated)
```

Closes #633