### PR TITLE
fix: resolve 18 pre-existing failing tests on dev

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -1306,6 +1306,12 @@ class OrchestratorLoop:
                 if is_destructive(tool_name):
                     return original
 
+                # Safety-rejected results should never be retried: the args
+                # failed validation and retrying with empty/same params would
+                # bypass the safety guard.
+                if original.get("safety_rejected"):
+                    return original
+
                 tool = self.tools.get(tool_name)
                 if tool is None or tool.function is None:
                     return original
@@ -1666,6 +1672,7 @@ class OrchestratorLoop:
                             "tool": tool_name,
                             "success": False,
                             "error": f"Invalid arguments: {error}",
+                            "safety_rejected": True,
                         })
                         continue
                 

--- a/tests/fixtures/golden_traces/scenario_2_calendar_list.json
+++ b/tests/fixtures/golden_traces/scenario_2_calendar_list.json
@@ -3,7 +3,7 @@
   "user_input": "bugün neler yapacağız bakalım",
   "expected_trace": {
     "route": "calendar",
-    "calendar_intent": "list_events",
+    "calendar_intent": "query",
     "confidence_min": 0.7,
     "tool_plan_len_min": 1,
     "tools_executed_min": 1,

--- a/tests/fixtures/golden_traces/scenario_3_calendar_create.json
+++ b/tests/fixtures/golden_traces/scenario_3_calendar_create.json
@@ -3,7 +3,7 @@
   "user_input": "saat 4 için bir toplantı oluştur",
   "expected_trace": {
     "route": "calendar",
-    "calendar_intent": "create_event",
+    "calendar_intent": "create",
     "confidence_min": 0.7,
     "tool_plan_len_min": 1,
     "requires_confirmation": true,

--- a/tests/test_finalizer_token_budget.py
+++ b/tests/test_finalizer_token_budget.py
@@ -185,8 +185,12 @@ def mock_tools_large_events():
     return registry
 
 
-def test_finalizer_handles_large_tool_results(mock_orchestrator, mock_tools_large_events, caplog):
+def test_finalizer_handles_large_tool_results(mock_orchestrator, mock_tools_large_events, caplog, monkeypatch):
     """Finalizer should handle 200 events by using budget control."""
+    # Issue #647: tiering is ON by default; calendar queries go to fast path.
+    # Force quality so the mock finalizer LLM is actually invoked.
+    monkeypatch.setenv("BANTZ_TIER_FORCE_FINALIZER", "quality")
+
     config = OrchestratorConfig()
     
     # Create a mock finalizer LLM

--- a/tests/test_issue_411_gemini_streaming.py
+++ b/tests/test_issue_411_gemini_streaming.py
@@ -41,7 +41,8 @@ from bantz.llm.base import (
 
 
 def _make_client(**kwargs) -> GeminiClient:
-    defaults = dict(api_key="test-key", model="gemini-2.0-flash", timeout_seconds=5.0)
+    defaults = dict(api_key="test-key", model="gemini-2.0-flash", timeout_seconds=5.0,
+                    use_default_gates=False)
     defaults.update(kwargs)
     return GeminiClient(**defaults)
 

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -151,8 +151,12 @@ class TestSmalltalkFinalizerUsage:
 class TestToolRouteFinalizerUsage:
     """Test that tool routes also use finalizer correctly."""
     
-    def test_tool_route_with_results_uses_finalizer(self, orchestrator_loop, mock_finalizer_llm):
+    def test_tool_route_with_results_uses_finalizer(self, orchestrator_loop, mock_finalizer_llm, monkeypatch):
         """Test that tool route with results uses finalizer."""
+        # Issue #647: tiering is ON by default; calendar routes go to fast
+        # path. Force quality so the mock finalizer LLM is actually invoked.
+        monkeypatch.setenv("BANTZ_TIER_FORCE_FINALIZER", "quality")
+
         from bantz.brain.orchestrator_loop import OrchestratorOutput, OrchestratorState
         
         orchestrator_output = OrchestratorOutput(

--- a/tests/test_regression_golden_traces.py
+++ b/tests/test_regression_golden_traces.py
@@ -90,7 +90,7 @@ def mock_llm() -> MockLLM:
         },
         "bugün neler": {
             "route": "calendar",
-            "calendar_intent": "list_events",
+            "calendar_intent": "query",
             "slots": {"time_range": "today"},
             "confidence": 0.90,
             "tool_plan": [{"name": "calendar.list_events", "args": {"time_min": "2026-01-30T00:00:00", "time_max": "2026-01-30T23:59:59"}}],
@@ -98,7 +98,7 @@ def mock_llm() -> MockLLM:
         },
         "saat 4 için bir toplantı": {
             "route": "calendar",
-            "calendar_intent": "create_event",
+            "calendar_intent": "create",
             "slots": {"time": "16:00", "title": "toplantı"},
             "confidence": 0.85,
             "tool_plan": [{"name": "calendar.create_event", "args": {"title": "toplantı", "start": "2026-01-30T16:00:00"}}],
@@ -188,7 +188,7 @@ class TestGoldenTraceRegression:
         golden = load_golden_trace("scenario_2_calendar_list")
         
         orchestrator = JarvisLLMOrchestrator(llm_client=mock_llm)
-        config = OrchestratorConfig(enable_safety_guard=False)
+        config = OrchestratorConfig(enable_safety_guard=False, enable_preroute=False)
         loop = OrchestratorLoop(orchestrator, mock_tools, event_bus, config)
         
         user_input = golden["user_input"]
@@ -210,7 +210,7 @@ class TestGoldenTraceRegression:
         golden = load_golden_trace("scenario_3_calendar_create")
         
         orchestrator = JarvisLLMOrchestrator(llm_client=mock_llm)
-        config = OrchestratorConfig(enable_safety_guard=False)
+        config = OrchestratorConfig(enable_safety_guard=False, enable_preroute=False)
         loop = OrchestratorLoop(orchestrator, mock_tools, event_bus, config)
         
         user_input = golden["user_input"]

--- a/tests/test_tiered_finalization_issue_206.py
+++ b/tests/test_tiered_finalization_issue_206.py
@@ -101,7 +101,7 @@ def _tools() -> ToolRegistry:
         }
 
     def list_messages(**_kwargs: Any) -> dict[str, Any]:
-        return {"messages": [], "count": 0}
+        return {"messages": [{"id": "m1", "subject": "Test", "snippet": "Hello"}], "count": 1}
 
     reg.register(
         Tool(

--- a/tests/test_tool_results_structure.py
+++ b/tests/test_tool_results_structure.py
@@ -215,8 +215,12 @@ def test_tool_execution_preserves_raw_result(mock_orchestrator, mock_tools):
     assert result["success"] is True
 
 
-def test_finalizer_uses_raw_result(mock_orchestrator, mock_tools):
+def test_finalizer_uses_raw_result(mock_orchestrator, mock_tools, monkeypatch):
     """Finalizer should use raw_result for structured data, not truncated summary."""
+    # Issue #647: tiering is ON by default; calendar queries go to fast path.
+    # Force quality so the mock finalizer LLM is actually invoked.
+    monkeypatch.setenv("BANTZ_TIER_FORCE_FINALIZER", "quality")
+
     config = OrchestratorConfig()
     
     # Create a mock finalizer LLM that will be called


### PR DESCRIPTION
## Summary
Fix all 18 pre-existing failing tests on the dev branch (0 → 18 pass).

## Root Causes (5 categories)

### 1. Circuit Breaker Singleton Leak (9 tests)
- **Files**: `test_issue_411_gemini_streaming.py` (8), `test_quality_finalizer_issue_215.py` (1)
- **Cause**: `_make_client()` and direct `GeminiClient()` used module-level singleton CB via `use_default_gates=True`. Earlier error tests accumulated failures → CB opened → subsequent tests got `CircuitOpen` instead of expected exceptions
- **Fix**: Pass `use_default_gates=False` to isolate each test

### 2. Finalizer Never Called — Tiering Mismatch (6 tests)
- **Files**: `test_finalizer_token_budget.py`, `test_tool_results_structure.py`, `test_orchestrator_loop.py`, `test_quality_finalizer_issue_215.py` (2), `test_tiered_finalization_issue_206.py`
- **Cause**: Issue #647 turned tiering ON by default. Calendar/simple queries scored low on writing/complexity → fast tier → quality finalizer mock never called. Two tests disabled tiering with `BANTZ_TIER_MODE=0` → `tiering_disabled_default_fast` → same result
- **Fix**: Set `BANTZ_TIER_FORCE_FINALIZER=quality` to force quality path. Fix mock `gmail.list_messages` to return non-empty data (avoids `empty_data_guard` intercept)

### 3. Golden Trace Intent Mismatch (2 tests)
- **Files**: `test_regression_golden_traces.py` scenarios 2 & 3
- **Cause**: `router_validation.py` normalizes `calendar_intent` to valid set `{create, modify, cancel, query, none}`. Old traces used `list_events` / `create_event` → normalized to `none` / `create`. PreRouter also intercepted test inputs
- **Fix**: Update MockLLM + golden trace JSON to use valid intents. Disable preroute in test config

### 4. Safety Guard Bypass via Verify Retry (1 test)
- **Files**: `test_orchestrator_safety.py`, `orchestrator_loop.py`
- **Cause**: Safety-rejected tools were retried by `_verify_results_phase` because failed result dict had no `params` key → `_retry_fn` used `params={}` → tool ran with empty args → succeeded
- **Fix**: Mark safety-rejected results with `safety_rejected: True`. Skip retry for such results in `_retry_fn`. **This is also a real bug fix (source code change)**

## Changes
| File | Change |
|------|--------|
| `src/bantz/brain/orchestrator_loop.py` | Add `safety_rejected` flag + skip retry |
| `tests/test_issue_411_gemini_streaming.py` | `use_default_gates=False` |
| `tests/test_quality_finalizer_issue_215.py` | Tier force + CB isolation + mock data |
| `tests/test_finalizer_token_budget.py` | Tier force |
| `tests/test_tool_results_structure.py` | Tier force |
| `tests/test_tiered_finalization_issue_206.py` | Mock data fix |
| `tests/test_orchestrator_loop.py` | Tier force |
| `tests/test_regression_golden_traces.py` | Valid intents + preroute off |
| `tests/fixtures/golden_traces/*.json` | Updated intent values |

## Test Results
```
7691 passed, 0 failed, 0 regressions
```