### PR TITLE
fix(nlu): Hybrid NLU varsayılan AÇIK + tek singleton + env-var kontrolü (#651)

### DIFF
--- a/src/bantz/nlu/__init__.py
+++ b/src/bantz/nlu/__init__.py
@@ -73,6 +73,7 @@ from bantz.nlu.bridge import (
     resolve_clarification,
     enable_hybrid_nlu,
     is_hybrid_enabled,
+    reset_nlu_instance,
     get_nlu_stats,
     compare_parsers,
 )
@@ -115,6 +116,7 @@ __all__ = [
     "resolve_clarification",
     "enable_hybrid_nlu",
     "is_hybrid_enabled",
+    "reset_nlu_instance",
     "get_nlu_stats",
     "compare_parsers",
 ]


### PR DESCRIPTION
## Issue
Closes #651 — P1: Hybrid NLU varsayılan KAPALI — `_enable_hybrid=False`, tüm sistem dead code

## Sorunlar
1. **`_use_hybrid = False`** → Hybrid NLU hiç devreye girmiyordu, tüm NLU kodu dead code kalıyordu
2. **İki ayrı singleton**: `bridge.py::_nlu_instance` vs `hybrid.py::_default_nlu` → farklı modüllerden import edince farklı instance'lar döndürülüyordu → session context kaybı
3. **`quick_parse()`**: Her çağrıda yeni `HybridNLU()` instance oluşturuyordu, singleton kullanmıyordu

## Çözümler
1. **`_use_hybrid` default `True`**: `BANTZ_HYBRID_NLU` env-var ile kapatılabilir (`0`, `false`, `no`)
2. **Tek canonical singleton**: `bridge.py::get_nlu()` canonical singleton oldu. `hybrid.py::get_nlu()` artık late-import ile `bridge.get_nlu()`'ya delege ediyor → hangi modülden import edilirse edilsin aynı instance
3. **`quick_parse()` fix**: Yeni instance yerine `get_nlu()` singleton'ı kullanıyor
4. **`reset_nlu_instance()`**: Test yardımcı fonksiyonu eklendi

## Değişiklikler
| Dosya | Değişiklik |
|-------|-----------|
| `src/bantz/nlu/bridge.py` | `_use_hybrid` env-var'dan okunuyor (default True), `reset_nlu_instance()` eklendi, docstring'ler güncellendi |
| `src/bantz/nlu/hybrid.py` | `_default_nlu` kaldırıldı, `get_nlu()` → bridge'e delege, `quick_parse()` → singleton kullanıyor |
| `src/bantz/nlu/__init__.py` | `reset_nlu_instance` export eklendi |
| `tests/test_llm_nlu.py` | 16 yeni test (4 sınıf), mevcut test reset düzeltmesi |

## Testler
- 16 yeni test:
  - `TestIssue651HybridNLUDefault` (4 test): env-var kontrolleri (`0`, `false`, `1`, absent)
  - `TestIssue651UnifiedSingleton` (5 test): bridge/hybrid/package get_nlu() aynı instance, enhanced config, reset, set_nlu
  - `TestIssue651QuickParseSingleton` (2 test): quick_parse singleton kullanımı
  - `TestIssue651AdaptiveUsesHybrid` (3 test): adaptive hybrid default, legacy fallback, agreement
- **7903 passed**, 0 failed, 54 deselected