### PR TITLE
feat(#664): Observability & Replay — trace export, viewer, replay, regression

### DIFF
--- a/scripts/generate_weekly_report.py
+++ b/scripts/generate_weekly_report.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Generate weekly regression report from trace data (Issue #664).
+
+Usage:
+    python scripts/generate_weekly_report.py
+    python scripts/generate_weekly_report.py --output artifacts/results/weekly.md
+    python scripts/generate_weekly_report.py --limit 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bantz.brain.trace_exporter import (
+    aggregate_metrics,
+    detect_anomalies,
+    load_traces,
+    replay_golden_traces,
+)
+
+
+def _generate_report(limit: int = 100) -> str:
+    traces = load_traces(limit=limit)
+    metrics = aggregate_metrics(traces)
+    anomalies = detect_anomalies(traces)
+    golden = replay_golden_traces()
+
+    lines: list[str] = []
+    lines.append(f"# Bantz Weekly Regression Report")
+    lines.append(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M')}")
+    lines.append(f"**Traces analyzed:** {metrics.get('total_turns', 0)}")
+    lines.append("")
+
+    # Summary
+    lines.append("## Summary")
+    lines.append(f"| Metric | Value |")
+    lines.append(f"|--------|-------|")
+    lines.append(f"| Total Turns | {metrics.get('total_turns', 0)} |")
+    lines.append(f"| Avg Latency | {metrics.get('avg_latency_ms', 0)}ms |")
+    lines.append(f"| P95 Latency | {metrics.get('p95_latency_ms', 0)}ms |")
+    tsr = metrics.get("tool_success_rate", 1.0)
+    lines.append(f"| Tool Success Rate | {tsr*100:.1f}% |")
+    lines.append(f"| Anomalies | {len(anomalies)} |")
+    lines.append("")
+
+    # Golden flow replay
+    lines.append("## Golden Flow Replay")
+    lines.append(f"| Metric | Value |")
+    lines.append(f"|--------|-------|")
+    lines.append(f"| Total Golden | {golden.get('total', 0)} |")
+    lines.append(f"| Passed | {golden.get('passed', 0)} |")
+    lines.append(f"| Failed | {golden.get('failed', 0)} |")
+    lines.append("")
+
+    if golden.get("diffs"):
+        lines.append("### Failures")
+        for d in golden["diffs"]:
+            lines.append(f"- Turn {d['turn']}: `{d.get('user_input', '')[:50]}` → {d['diff']}")
+        lines.append("")
+
+    # Route distribution
+    rd = metrics.get("route_distribution", {})
+    if rd:
+        lines.append("## Route Distribution")
+        lines.append("| Route | Count |")
+        lines.append("|-------|-------|")
+        for route, count in sorted(rd.items(), key=lambda x: -x[1]):
+            lines.append(f"| {route} | {count} |")
+        lines.append("")
+
+    # Tier distribution
+    td = metrics.get("tier_distribution", {})
+    if td.get("router"):
+        lines.append("## Tier Distribution")
+        lines.append("### Router")
+        lines.append("| Tier | Count |")
+        lines.append("|------|-------|")
+        for tier, count in sorted(td["router"].items(), key=lambda x: -x[1]):
+            lines.append(f"| {tier} | {count} |")
+        lines.append("")
+
+    # Anomalies
+    if anomalies:
+        lines.append("## Anomalies")
+        for a in anomalies[:20]:
+            emoji = {"latency_spike": "🐢", "low_confidence": "⚠️", "tool_failure_burst": "❌"}.get(a["type"], "⚠️")
+            lines.append(f"- {emoji} Turn #{a.get('turn_id', '?')}: **{a['type']}** — {a.get('user_input', '')[:50]}")
+        lines.append("")
+
+    # Regression alerts
+    lines.append("## Regression Alerts")
+    alerts = []
+    if metrics.get("avg_latency_ms", 0) > 2000:
+        alerts.append("🔴 Average latency > 2000ms")
+    if metrics.get("p95_latency_ms", 0) > 4000:
+        alerts.append("🔴 P95 latency > 4000ms")
+    if tsr < 0.90:
+        alerts.append("🔴 Tool success rate < 90%")
+    if golden.get("failed", 0) > 0:
+        alerts.append(f"🔴 Golden flow failures: {golden['failed']}/{golden['total']}")
+    if len(anomalies) > 10:
+        alerts.append(f"🟡 High anomaly count: {len(anomalies)}")
+
+    if alerts:
+        for a in alerts:
+            lines.append(f"- {a}")
+    else:
+        lines.append("- ✅ No regression alerts")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate weekly regression report")
+    parser.add_argument("--output", default="artifacts/results/weekly_report.md")
+    parser.add_argument("--limit", type=int, default=100)
+    args = parser.parse_args()
+
+    report = _generate_report(limit=args.limit)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(report, encoding="utf-8")
+    print(f"📊 Report written to {out}")
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/replay_scenario.py
+++ b/scripts/replay_scenario.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Replay a JSON trace scenario and compare route/tool outputs (Issue #664).
+
+Usage:
+  python scripts/replay_scenario.py --trace artifacts/logs/traces/trace_0001_...json --mode live
+  python scripts/replay_scenario.py --trace tests/golden/sample_trace.json --mode echo
+
+Modes:
+  echo  - do not execute; use expected trace as actual (for CI sanity)
+  live  - run real runtime (requires vLLM/Gemini or local env)
+  mock  - simple heuristic routing (no tools)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bantz.brain.trace_exporter import compare_traces
+
+
+def _load_trace_file(path: Path) -> list[dict[str, Any]]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        return [raw]
+    return []
+
+
+def _mock_plan(user_input: str) -> dict[str, Any]:
+    t = (user_input or "").lower()
+    if any(w in t for w in ["takvim", "etkinlik", "randevu", "toplantı", "yarın", "bugün"]):
+        return {"route": "calendar", "tools": ["calendar.list_events"]}
+    if any(w in t for w in ["mail", "e-posta", "email", "inbox"]):
+        return {"route": "gmail", "tools": ["gmail.list_messages"]}
+    if any(w in t for w in ["saat", "tarih", "sistem", "cpu"]):
+        return {"route": "system", "tools": ["time.now"]}
+    return {"route": "smalltalk", "tools": []}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Replay scenario trace and compare route/tools")
+    parser.add_argument("--trace", required=True, help="Path to trace JSON file")
+    parser.add_argument("--mode", choices=["echo", "live", "mock"], default="echo")
+    parser.add_argument("--limit", type=int, default=None, help="Limit number of turns")
+    parser.add_argument("--json", action="store_true", help="Output JSON diff")
+    args = parser.parse_args()
+
+    trace_path = Path(args.trace)
+    turns = _load_trace_file(trace_path)
+    if args.limit is not None:
+        turns = turns[: args.limit]
+
+    if not turns:
+        print("No turns found in trace file.")
+        return 1
+
+    runtime = None
+    runtime_state = None
+
+    if args.mode == "live":
+        from bantz.brain.runtime_factory import create_runtime
+        runtime = create_runtime(debug=False)
+        runtime_state = None
+
+    diffs = []
+    for idx, turn in enumerate(turns, start=1):
+        expected = {
+            "route": turn.get("route"),
+            "tools": turn.get("tools", []),
+        }
+
+        if args.mode == "echo":
+            actual = expected
+        elif args.mode == "mock":
+            plan = _mock_plan(turn.get("user_input") or "")
+            actual = {"route": plan["route"], "tools": [{"name": t} for t in plan["tools"]]}
+        else:
+            user_input = turn.get("user_input") or ""
+            output, runtime_state = runtime.process_turn(user_input, runtime_state)
+            actual = {"route": output.route, "tools": [{"name": t} for t in (output.tool_plan or [])]}
+
+        diff = compare_traces(expected, actual)
+        if diff:
+            diffs.append({"turn": idx, "diff": diff, "user_input": turn.get("user_input")})
+
+    if args.json:
+        print(json.dumps({"diffs": diffs, "total": len(diffs)}, indent=2, ensure_ascii=False))
+    else:
+        if not diffs:
+            print("✅ Replay OK — no diffs")
+        else:
+            print(f"❌ Replay diffs: {len(diffs)}")
+            for d in diffs:
+                print(f"Turn {d['turn']}: {d['diff']}")
+
+    return 0 if not diffs else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/terminal_jarvis.py
+++ b/scripts/terminal_jarvis.py
@@ -488,7 +488,7 @@ class TerminalJarvis:
         print("BANTZ Terminal Jarvis")
         print("────────────────────")
         print("Sizi tekrardan görmek güzel efendim. Dinliyorum.")
-        print("Komutlar: /help  /status  /trace  /auth  /sleep  /wake  /exit")
+        print("Komutlar: /help  /status  /trace  /trace export <N>  /auth  /sleep  /wake  /exit")
         print()
 
     def help(self) -> None:
@@ -499,6 +499,7 @@ class TerminalJarvis:
                     "  /help   → bu yardım",
                     "  /status → model/bağlantı durumu",
                     "  /trace  → reasoning özeti + tool adımları (aç/kapat)",
+                    "  /trace export <N> → son N turn trace JSON export",
                     "  /auth   → Google OAuth kurulum/yetkilendirme",
                     "  /sleep  → beklemeye al (wake-word emülasyonu)",
                     "  /wake   → beklemeden çık",
@@ -760,6 +761,15 @@ class TerminalJarvis:
             return self.auth(mode="help")
         if text.startswith("/trace") or text.strip() == "trace":
             parts = text.split()
+            if len(parts) >= 2 and parts[1].strip().lower() == "export":
+                try:
+                    from bantz.brain.trace_exporter import export_recent_traces
+                    n = int(parts[2]) if len(parts) >= 3 else 5
+                    path = export_recent_traces(n)
+                    return f"Trace export hazır: {path}"
+                except Exception:
+                    return "Trace export başarısız oldu."
+
             if len(parts) >= 2:
                 v = parts[1].strip().lower()
                 self._trace_enabled = v in {"1", "on", "true", "yes", "aç"}

--- a/scripts/trace_viewer.py
+++ b/scripts/trace_viewer.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Trace Viewer — simple web UI for Bantz orchestrator traces (Issue #664).
+
+Serves a timeline view of recent traces on localhost:5050.
+
+Usage:
+    python scripts/trace_viewer.py                # default: localhost:5050
+    python scripts/trace_viewer.py --port 8080    # custom port
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse, parse_qs
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from bantz.brain.trace_exporter import (
+  aggregate_metrics,
+  build_tool_dag,
+  detect_anomalies,
+  load_traces,
+)
+
+_HTML_TEMPLATE = r"""<!DOCTYPE html>
+<html lang="tr">
+<head>
+<meta charset="UTF-8">
+<title>Bantz Trace Viewer</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+         background: #0d1117; color: #c9d1d9; padding: 20px; }
+  h1 { color: #58a6ff; margin-bottom: 10px; }
+  .summary { display: flex; gap: 20px; margin: 16px 0; flex-wrap: wrap; }
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+          padding: 16px 20px; min-width: 160px; }
+  .card .label { font-size: 12px; color: #8b949e; text-transform: uppercase; }
+  .card .value { font-size: 28px; font-weight: 600; color: #58a6ff; margin-top: 4px; }
+  .card .value.warn { color: #d29922; }
+  .card .value.bad  { color: #f85149; }
+  .timeline { margin-top: 24px; }
+  #dag { height: 360px; border: 1px solid #30363d; border-radius: 8px; background: #0d1117; }
+  .turn { background: #161b22; border: 1px solid #30363d; border-radius: 8px;
+          padding: 16px; margin-bottom: 12px; }
+  .turn-header { display: flex; justify-content: space-between; align-items: center; }
+  .turn-route { font-size: 14px; padding: 2px 10px; border-radius: 12px;
+                font-weight: 600; }
+  .route-calendar { background: #1f3d2e; color: #3fb950; }
+  .route-gmail    { background: #2d1f3d; color: #a371f7; }
+  .route-system   { background: #1f2d3d; color: #58a6ff; }
+  .route-smalltalk{ background: #3d3d1f; color: #d29922; }
+  .route-unknown  { background: #3d1f1f; color: #f85149; }
+  .turn-input { margin: 8px 0; font-style: italic; color: #8b949e; }
+  .turn-reply { margin: 8px 0; color: #c9d1d9; }
+  .turn-tools { margin: 6px 0; }
+  .tool-badge { display: inline-block; font-size: 12px; padding: 2px 8px;
+                border-radius: 4px; margin-right: 6px; margin-bottom: 4px; }
+  .tool-ok   { background: #1f3d2e; color: #3fb950; }
+  .tool-fail { background: #3d1f1f; color: #f85149; }
+  .latency { font-size: 13px; color: #8b949e; }
+  .anomalies { margin: 16px 0; }
+  .anomaly { background: #3d1f1f; border: 1px solid #f85149; border-radius: 8px;
+             padding: 12px; margin-bottom: 8px; color: #f85149; }
+  .tier-badge { font-size: 11px; padding: 1px 6px; border-radius: 4px;
+                background: #1f2d3d; color: #58a6ff; margin-left: 6px; }
+  footer { margin-top: 30px; color: #484f58; font-size: 12px; text-align: center; }
+</style>
+</head>
+<body>
+<h1>🔍 Bantz Trace Viewer</h1>
+<div style="margin:12px 0;">
+  <h2 style="color:#c9d1d9;margin:8px 0">Tool/Intent DAG</h2>
+  <div id="dag"></div>
+</div>
+<div class="summary" id="summary"></div>
+<div class="anomalies" id="anomalies"></div>
+<h2 style="color:#c9d1d9;margin:16px 0 8px">Timeline</h2>
+<div class="timeline" id="timeline"></div>
+<footer>Bantz Observability — Issue #664</footer>
+
+<script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+<script>
+async function load() {
+  const [tracesRes, metricsRes, anomRes] = await Promise.all([
+    fetch('/api/traces?limit=50'),
+    fetch('/api/metrics'),
+    fetch('/api/anomalies'),
+  ]);
+  const traces  = await tracesRes.json();
+  const metrics = await metricsRes.json();
+  const anomalies = await anomRes.json();
+
+  // DAG
+  try {
+    const dagRes = await fetch('/api/dag');
+    const dag = await dagRes.json();
+    const container = document.getElementById('dag');
+    const nodes = new vis.DataSet(dag.nodes.map(n => ({
+      id: n.id,
+      label: n.label,
+      color: n.type === 'route' ? '#58a6ff' : n.type === 'intent' ? '#3fb950' : '#a371f7',
+      shape: n.type === 'tool' ? 'box' : 'ellipse',
+    })));
+    const edges = new vis.DataSet(dag.edges.map(e => ({ from: e.from, to: e.to })));
+    new vis.Network(container, { nodes, edges }, {
+      layout: { improvedLayout: true },
+      interaction: { hover: true },
+      physics: { stabilization: true }
+    });
+  } catch (e) {
+    // Best-effort: DAG is optional
+  }
+
+  // Summary cards
+  const sum = document.getElementById('summary');
+  const cards = [
+    {label:'Turns', value: metrics.total_turns || 0},
+    {label:'Avg Latency', value: (metrics.avg_latency_ms||0)+'ms',
+     cls: (metrics.avg_latency_ms||0) > 2000 ? 'bad' : (metrics.avg_latency_ms||0) > 1000 ? 'warn' : ''},
+    {label:'P95 Latency', value: (metrics.p95_latency_ms||0)+'ms',
+     cls: (metrics.p95_latency_ms||0) > 3000 ? 'bad' : (metrics.p95_latency_ms||0) > 1500 ? 'warn' : ''},
+    {label:'Tool Success', value: ((metrics.tool_success_rate||1)*100).toFixed(1)+'%',
+     cls: (metrics.tool_success_rate||1) < 0.9 ? 'bad' : (metrics.tool_success_rate||1) < 0.95 ? 'warn' : ''},
+    {label:'Anomalies', value: anomalies.length,
+     cls: anomalies.length > 5 ? 'bad' : anomalies.length > 0 ? 'warn' : ''},
+  ];
+  sum.innerHTML = cards.map(c =>
+    `<div class="card"><div class="label">${c.label}</div><div class="value ${c.cls||''}">${c.value}</div></div>`
+  ).join('');
+
+  // Anomalies
+  const aDiv = document.getElementById('anomalies');
+  if (anomalies.length) {
+    aDiv.innerHTML = '<h3 style="color:#f85149;margin-bottom:8px">⚠️ Anomalies</h3>' +
+      anomalies.slice(0,10).map(a =>
+        `<div class="anomaly">Turn #${a.turn_id||'?'}: ${a.type} — ${a.user_input||''}</div>`
+      ).join('');
+  }
+
+  // Timeline
+  const tl = document.getElementById('timeline');
+  tl.innerHTML = traces.map(t => {
+    const route = t.route||'unknown';
+    const routeCls = 'route-'+ ({'calendar':'calendar','gmail':'gmail','system':'system','smalltalk':'smalltalk'}[route]||'unknown');
+    const tools = (t.tools||[]).map(tool =>
+      `<span class="tool-badge ${tool.success?'tool-ok':'tool-fail'}">${tool.name} (${tool.elapsed_ms}ms)</span>`
+    ).join('');
+    const tier = t.tier_decision||{};
+    return `<div class="turn">
+      <div class="turn-header">
+        <span><strong>#${t.turn_id||'?'}</strong> <span class="turn-route ${routeCls}">${route}</span>
+          <span class="tier-badge">R:${tier.router||'?'}</span>
+          <span class="tier-badge">F:${tier.finalizer||'?'}</span></span>
+        <span class="latency">${t.total_elapsed_ms||0}ms</span>
+      </div>
+      <div class="turn-input">💬 ${t.user_input||''}</div>
+      ${tools ? '<div class="turn-tools">'+tools+'</div>' : ''}
+      <div class="turn-reply">🤖 ${(t.assistant_reply||'').substring(0,200)}</div>
+    </div>`;
+  }).join('');
+}
+load();
+</script>
+</body>
+</html>"""
+
+
+class TraceViewerHandler(SimpleHTTPRequestHandler):
+    """HTTP handler for trace viewer API + static HTML."""
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path
+        qs = parse_qs(parsed.query)
+
+        if path == "/" or path == "/index.html":
+            self._respond_html(_HTML_TEMPLATE)
+        elif path == "/api/traces":
+            limit = int(qs.get("limit", ["50"])[0])
+            data = load_traces(limit=limit)
+            self._respond_json(data)
+        elif path == "/api/metrics":
+            data = aggregate_metrics()
+            self._respond_json(data)
+        elif path == "/api/anomalies":
+            data = detect_anomalies()
+            self._respond_json(data)
+        elif path == "/api/dag":
+          data = build_tool_dag()
+          self._respond_json(data)
+        else:
+            self.send_error(404)
+
+    def _respond_json(self, data: Any) -> None:
+        body = json.dumps(data, ensure_ascii=False, indent=2).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _respond_html(self, html: str) -> None:
+        body = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Suppress default access logs
+        pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bantz Trace Viewer")
+    parser.add_argument("--port", type=int, default=5050)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    server = HTTPServer((args.host, args.port), TraceViewerHandler)
+    print(f"🔍 Bantz Trace Viewer → http://{args.host}:{args.port}")
+    print("   Press Ctrl+C to stop")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bantz/brain/trace_exporter.py
+++ b/src/bantz/brain/trace_exporter.py
@@ -1,0 +1,388 @@
+"""Structured trace export for observability (Issue #664).
+
+Exports per-turn JSON traces to artifacts/logs/traces/ and provides helpers
+for replay, trace viewer, golden flow comparison, and regression detection.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+TRACE_DIR = Path(__file__).resolve().parents[3] / "artifacts" / "logs" / "traces"
+TRACE_DIR.mkdir(parents=True, exist_ok=True)
+
+GOLDEN_DIR = Path(__file__).resolve().parents[3] / "tests" / "golden" / "traces"
+
+
+def _default_tier_decision() -> dict[str, str]:
+    return {"router": "unknown", "finalizer": "unknown", "reason": "unknown"}
+
+
+def _trace_filename(turn_id: int, timestamp: str) -> str:
+    ts = timestamp.replace(":", "-").replace(".", "-")
+    return f"trace_{turn_id:04d}_{ts}.json"
+
+
+def build_turn_trace(
+    *,
+    turn_id: int,
+    user_input: str,
+    output: Any,
+    tool_results: list[dict[str, Any]],
+    state_trace: dict[str, Any],
+    total_elapsed_ms: int,
+    timestamp: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a structured turn trace dict.
+
+    Required format:
+    {turn_id, timestamp, user_input, route, intent, confidence,
+     tier_decision, tools: [{name, params, result, elapsed_ms}],
+     finalizer_strategy, assistant_reply, total_elapsed_ms}
+    """
+    ts = timestamp or datetime.now().isoformat()
+    tier_decision = state_trace.get("tier_decision") or _default_tier_decision()
+
+    tools = []
+    for r in tool_results or []:
+        result = None
+        if "raw_result" in r:
+            result = r.get("raw_result")
+        elif "result" in r:
+            result = r.get("result")
+        elif "result_summary" in r:
+            result = r.get("result_summary")
+        elif "error" in r:
+            result = {"error": r.get("error")}
+
+        tools.append({
+            "name": str(r.get("tool") or ""),
+            "params": r.get("params") or {},
+            "result": result,
+            "elapsed_ms": int(r.get("elapsed_ms") or 0),
+            "success": bool(r.get("success", False)),
+            "error": r.get("error") if r.get("error") else None,
+        })
+
+    return {
+        "turn_id": int(turn_id),
+        "timestamp": ts,
+        "user_input": user_input,
+        "route": getattr(output, "route", ""),
+        "intent": getattr(output, "calendar_intent", ""),
+        "confidence": float(getattr(output, "confidence", 0.0)),
+        "tier_decision": tier_decision,
+        "tools": tools,
+        "finalizer_strategy": str(state_trace.get("finalizer_strategy") or ""),
+        "assistant_reply": str(getattr(output, "assistant_reply", "") or ""),
+        "total_elapsed_ms": int(total_elapsed_ms),
+    }
+
+
+def write_turn_trace(trace: dict[str, Any]) -> Path:
+    """Write a single turn trace to TRACE_DIR and return the path."""
+    turn_id = int(trace.get("turn_id") or 0)
+    timestamp = str(trace.get("timestamp") or datetime.now().isoformat())
+    path = TRACE_DIR / _trace_filename(turn_id, timestamp)
+    path.write_text(json.dumps(trace, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path
+
+
+def list_trace_files(limit: Optional[int] = None) -> list[Path]:
+    """List trace files sorted by modified time (newest first)."""
+    files = sorted(TRACE_DIR.glob("trace_*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    if limit is not None:
+        files = files[: int(limit)]
+    return files
+
+
+def load_traces(limit: Optional[int] = None) -> list[dict[str, Any]]:
+    """Load recent traces from disk."""
+    traces: list[dict[str, Any]] = []
+    for p in list_trace_files(limit=limit):
+        try:
+            traces.append(json.loads(p.read_text(encoding="utf-8")))
+        except Exception:
+            continue
+    return traces
+
+
+def export_recent_traces(n: int) -> Path:
+    """Export last N traces into a single JSON file and return the path."""
+    data = load_traces(limit=n)
+    ts = datetime.now().isoformat().replace(":", "-").replace(".", "-")
+    out = TRACE_DIR / f"trace_export_last_{n}_{ts}.json"
+    out.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    return out
+
+
+def compare_traces(expected: dict[str, Any], actual: dict[str, Any]) -> dict[str, Any]:
+    """Compare two traces and return a minimal diff.
+
+    Regression criteria: route and tool names should match.
+    """
+    diff: dict[str, Any] = {}
+    if expected.get("route") != actual.get("route"):
+        diff["route"] = {"expected": expected.get("route"), "actual": actual.get("route")}
+
+    exp_tools = [t.get("name") for t in expected.get("tools", []) if t.get("name")]
+    act_tools = [t.get("name") for t in actual.get("tools", []) if t.get("name")]
+    if exp_tools != act_tools:
+        diff["tools"] = {"expected": exp_tools, "actual": act_tools}
+
+    return diff
+
+
+# ---------------------------------------------------------------------------
+# Golden flow traces (Issue #664 Faz 2)
+# ---------------------------------------------------------------------------
+
+def load_golden_traces() -> list[dict[str, Any]]:
+    """Load all golden flow traces from tests/golden/traces/."""
+    if not GOLDEN_DIR.is_dir():
+        return []
+    traces: list[dict[str, Any]] = []
+    for p in sorted(GOLDEN_DIR.glob("*.json")):
+        try:
+            raw = json.loads(p.read_text(encoding="utf-8"))
+            if isinstance(raw, list):
+                traces.extend(raw)
+            elif isinstance(raw, dict):
+                traces.append(raw)
+        except Exception:
+            continue
+    return traces
+
+
+def replay_golden_traces(
+    router_fn: Any = None,
+) -> dict[str, Any]:
+    """Replay golden traces and return pass/fail summary.
+
+    If *router_fn* is None, uses echo mode (trace vs itself → always pass).
+
+    Returns:
+        {total, passed, failed, diffs: [{turn, diff, user_input}]}
+    """
+    goldens = load_golden_traces()
+    diffs: list[dict[str, Any]] = []
+
+    for idx, golden in enumerate(goldens):
+        if router_fn is None:
+            # Echo mode: expected == actual
+            actual = {"route": golden.get("route"), "tools": golden.get("tools", [])}
+        else:
+            user_input = golden.get("user_input", "")
+            result = router_fn(user_input)
+            actual = {
+                "route": result.get("route", ""),
+                "tools": [{"name": t} for t in result.get("tools", [])],
+            }
+
+        diff = compare_traces(golden, actual)
+        if diff:
+            diffs.append({
+                "turn": idx + 1,
+                "diff": diff,
+                "user_input": golden.get("user_input"),
+            })
+
+    total = len(goldens)
+    return {
+        "total": total,
+        "passed": total - len(diffs),
+        "failed": len(diffs),
+        "diffs": diffs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Metrics aggregation (Issue #664 Faz 4)
+# ---------------------------------------------------------------------------
+
+def aggregate_metrics(traces: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Aggregate metrics from the last N traces.
+
+    Returns:
+        {total_turns, avg_latency_ms, p95_latency_ms, tool_success_rate,
+         tier_distribution: {router: {}, finalizer: {}},
+         route_distribution: {route: count},
+         tool_frequency: {tool: count}}
+    """
+    if traces is None:
+        traces = load_traces(limit=100)
+
+    if not traces:
+        return {"total_turns": 0}
+
+    latencies = [t.get("total_elapsed_ms", 0) for t in traces]
+    tool_counts = {"total": 0, "success": 0}
+    route_dist: dict[str, int] = {}
+    tier_router: dict[str, int] = {}
+    tier_finalizer: dict[str, int] = {}
+    tool_freq: dict[str, int] = {}
+
+    for t in traces:
+        route = t.get("route", "unknown")
+        route_dist[route] = route_dist.get(route, 0) + 1
+
+        td = t.get("tier_decision") or {}
+        r_tier = td.get("router", "unknown")
+        f_tier = td.get("finalizer", "unknown")
+        tier_router[r_tier] = tier_router.get(r_tier, 0) + 1
+        tier_finalizer[f_tier] = tier_finalizer.get(f_tier, 0) + 1
+
+        for tool in t.get("tools", []):
+            tool_counts["total"] += 1
+            if tool.get("success"):
+                tool_counts["success"] += 1
+            name = tool.get("name", "unknown")
+            tool_freq[name] = tool_freq.get(name, 0) + 1
+
+    sorted_latencies = sorted(latencies)
+    p95_idx = int(len(sorted_latencies) * 0.95)
+
+    return {
+        "total_turns": len(traces),
+        "avg_latency_ms": int(statistics.mean(latencies)) if latencies else 0,
+        "p95_latency_ms": sorted_latencies[min(p95_idx, len(sorted_latencies) - 1)] if sorted_latencies else 0,
+        "tool_success_rate": round(tool_counts["success"] / tool_counts["total"], 3) if tool_counts["total"] else 1.0,
+        "tier_distribution": {"router": tier_router, "finalizer": tier_finalizer},
+        "route_distribution": route_dist,
+        "tool_frequency": tool_freq,
+    }
+
+
+def detect_anomalies(
+    traces: list[dict[str, Any]] | None = None,
+    *,
+    latency_threshold_ms: int = 3000,
+    confidence_floor: float = 0.5,
+) -> list[dict[str, Any]]:
+    """Detect anomalies in recent traces.
+
+    Checks:
+    - TTFT / latency spikes above threshold
+    - Tool failure bursts (>50% fail rate in window)
+    - Low-confidence routing
+    """
+    if traces is None:
+        traces = load_traces(limit=100)
+
+    anomalies: list[dict[str, Any]] = []
+
+    # Latency spikes
+    for t in traces:
+        ms = t.get("total_elapsed_ms", 0)
+        if ms > latency_threshold_ms:
+            anomalies.append({
+                "type": "latency_spike",
+                "turn_id": t.get("turn_id"),
+                "value": ms,
+                "threshold": latency_threshold_ms,
+                "user_input": (t.get("user_input") or "")[:60],
+            })
+
+    # Low confidence
+    for t in traces:
+        conf = t.get("confidence", 1.0)
+        if conf < confidence_floor:
+            anomalies.append({
+                "type": "low_confidence",
+                "turn_id": t.get("turn_id"),
+                "value": conf,
+                "threshold": confidence_floor,
+                "route": t.get("route"),
+                "user_input": (t.get("user_input") or "")[:60],
+            })
+
+    # Tool failure burst (any turn with all tools failing)
+    for t in traces:
+        tools = t.get("tools", [])
+        if tools and all(not tool.get("success") for tool in tools):
+            anomalies.append({
+                "type": "tool_failure_burst",
+                "turn_id": t.get("turn_id"),
+                "tools": [tool.get("name") for tool in tools],
+                "user_input": (t.get("user_input") or "")[:60],
+            })
+
+    return anomalies
+
+
+# ---------------------------------------------------------------------------
+# Tool/Intent DAG export (Issue #664 Faz 3)
+# ---------------------------------------------------------------------------
+
+def _parse_enum_values(schema_json: str, field: str) -> list[str]:
+    """Parse enum values from the router schema JSON string.
+
+    Example: field="route" -> ["calendar", "gmail", "smalltalk", "unknown"]
+    """
+    try:
+        # Very lightweight parser: find '"field":"a|b|c"'
+        marker = f"\"{field}\":\""
+        start = schema_json.find(marker)
+        if start == -1:
+            return []
+        start += len(marker)
+        end = schema_json.find("\"", start)
+        if end == -1:
+            return []
+        raw = schema_json[start:end]
+        return [v for v in raw.split("|") if v]
+    except Exception:
+        return []
+
+
+def build_tool_dag() -> dict[str, Any]:
+    """Export a JSON DAG from tool registry + intent catalog.
+
+    Returns:
+        {nodes: [{id, label, type}], edges: [{from, to, type}]}
+    """
+    # Lazy imports to avoid heavy deps during normal trace export
+    from bantz.agent.registry import build_default_registry
+    from bantz.brain.router_output_schema import SLIM_SCHEMA_JSON
+
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+
+    # Routes from schema + system (not in schema but in runtime)
+    routes = set(_parse_enum_values(SLIM_SCHEMA_JSON, "route"))
+    routes.update({"system"})
+    for r in sorted(routes):
+        nodes.append({"id": f"route:{r}", "label": r, "type": "route"})
+
+    # Calendar / Gmail intents from schema
+    cal_intents = _parse_enum_values(SLIM_SCHEMA_JSON, "calendar_intent")
+    for i in cal_intents:
+        nodes.append({"id": f"intent:calendar:{i}", "label": f"calendar.{i}", "type": "intent"})
+        edges.append({"from": "route:calendar", "to": f"intent:calendar:{i}", "type": "route_intent"})
+
+    gmail_intents = _parse_enum_values(SLIM_SCHEMA_JSON, "gmail_intent")
+    for i in gmail_intents:
+        nodes.append({"id": f"intent:gmail:{i}", "label": f"gmail.{i}", "type": "intent"})
+        edges.append({"from": "route:gmail", "to": f"intent:gmail:{i}", "type": "route_intent"})
+
+    # Tools from runtime registry
+    reg = build_default_registry()
+    for tool in reg.list_tools():
+        tool_id = f"tool:{tool.name}"
+        nodes.append({"id": tool_id, "label": tool.name, "type": "tool"})
+
+        # Route mapping by prefix
+        if tool.name.startswith("calendar."):
+            edges.append({"from": "route:calendar", "to": tool_id, "type": "route_tool"})
+        elif tool.name.startswith("gmail."):
+            edges.append({"from": "route:gmail", "to": tool_id, "type": "route_tool"})
+        elif tool.name.startswith("system.") or tool.name.startswith("time."):
+            edges.append({"from": "route:system", "to": tool_id, "type": "route_tool"})
+        else:
+            edges.append({"from": "route:unknown", "to": tool_id, "type": "route_tool"})
+
+    return {"nodes": nodes, "edges": edges}

--- a/tests/golden/traces/golden_calendar_query.json
+++ b/tests/golden/traces/golden_calendar_query.json
@@ -1,0 +1,46 @@
+[
+  {
+    "turn_id": 1,
+    "timestamp": "2026-02-10T10:00:00",
+    "user_input": "yarın takvimimde ne var",
+    "route": "calendar",
+    "intent": "query",
+    "confidence": 0.92,
+    "tier_decision": {"router": "3b", "finalizer": "3b", "reason": "read_only"},
+    "tools": [
+      {
+        "name": "calendar.list_events",
+        "params": {"window_hint": "tomorrow"},
+        "result": {"ok": true, "events": []},
+        "elapsed_ms": 150,
+        "success": true,
+        "error": null
+      }
+    ],
+    "finalizer_strategy": "fast",
+    "assistant_reply": "Yarın takviminizde herhangi bir etkinlik yok efendim.",
+    "total_elapsed_ms": 800
+  },
+  {
+    "turn_id": 2,
+    "timestamp": "2026-02-10T10:01:00",
+    "user_input": "bugünkü etkinliklerimi listele",
+    "route": "calendar",
+    "intent": "query",
+    "confidence": 0.90,
+    "tier_decision": {"router": "3b", "finalizer": "3b", "reason": "read_only"},
+    "tools": [
+      {
+        "name": "calendar.list_events",
+        "params": {"window_hint": "today"},
+        "result": {"ok": true, "events": []},
+        "elapsed_ms": 120,
+        "success": true,
+        "error": null
+      }
+    ],
+    "finalizer_strategy": "fast",
+    "assistant_reply": "Bugün takviminizde etkinlik bulunmuyor efendim.",
+    "total_elapsed_ms": 750
+  }
+]

--- a/tests/golden/traces/golden_gmail_read.json
+++ b/tests/golden/traces/golden_gmail_read.json
@@ -1,0 +1,24 @@
+[
+  {
+    "turn_id": 1,
+    "timestamp": "2026-02-10T10:00:00",
+    "user_input": "okunmamış maillerim var mı",
+    "route": "gmail",
+    "intent": "read",
+    "confidence": 0.93,
+    "tier_decision": {"router": "3b", "finalizer": "3b", "reason": "read_only"},
+    "tools": [
+      {
+        "name": "gmail.unread_count",
+        "params": {},
+        "result": {"ok": true, "unread": 3},
+        "elapsed_ms": 200,
+        "success": true,
+        "error": null
+      }
+    ],
+    "finalizer_strategy": "fast",
+    "assistant_reply": "3 okunmamış mailiniz var efendim.",
+    "total_elapsed_ms": 900
+  }
+]

--- a/tests/golden/traces/golden_smalltalk_system.json
+++ b/tests/golden/traces/golden_smalltalk_system.json
@@ -1,0 +1,37 @@
+[
+  {
+    "turn_id": 1,
+    "timestamp": "2026-02-10T10:00:00",
+    "user_input": "merhaba nasılsın",
+    "route": "smalltalk",
+    "intent": "greeting",
+    "confidence": 0.95,
+    "tier_decision": {"router": "3b", "finalizer": "3b", "reason": "simple_greeting"},
+    "tools": [],
+    "finalizer_strategy": "fast",
+    "assistant_reply": "Merhaba efendim! İyiyim, size nasıl yardımcı olabilirim?",
+    "total_elapsed_ms": 300
+  },
+  {
+    "turn_id": 2,
+    "timestamp": "2026-02-10T10:01:00",
+    "user_input": "saat kaç",
+    "route": "system",
+    "intent": "time_query",
+    "confidence": 0.94,
+    "tier_decision": {"router": "3b", "finalizer": "3b", "reason": "read_only"},
+    "tools": [
+      {
+        "name": "time.now",
+        "params": {},
+        "result": {"ok": true, "time": "10:01", "date": "2026-02-10"},
+        "elapsed_ms": 5,
+        "success": true,
+        "error": null
+      }
+    ],
+    "finalizer_strategy": "fast",
+    "assistant_reply": "Saat 10:01 efendim.",
+    "total_elapsed_ms": 400
+  }
+]

--- a/tests/test_issue_664_observability_replay.py
+++ b/tests/test_issue_664_observability_replay.py
@@ -1,0 +1,84 @@
+"""Tests for Issue #664 — Observability & Replay."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bantz.brain import trace_exporter
+
+
+@dataclass
+class _DummyOutput:
+    route: str = "calendar"
+    calendar_intent: str = "query"
+    confidence: float = 0.9
+    assistant_reply: str = "OK"
+
+
+def test_build_turn_trace_includes_tier_decision_default() -> None:
+    trace = trace_exporter.build_turn_trace(
+        turn_id=1,
+        user_input="test",
+        output=_DummyOutput(),
+        tool_results=[],
+        state_trace={},
+        total_elapsed_ms=123,
+        timestamp="2026-02-10T10:00:00",
+    )
+    assert trace["tier_decision"] == {"router": "unknown", "finalizer": "unknown", "reason": "unknown"}
+    assert trace["route"] == "calendar"
+    assert trace["intent"] == "query"
+
+
+def test_write_turn_trace_writes_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(trace_exporter, "TRACE_DIR", tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+
+    trace = {
+        "turn_id": 2,
+        "timestamp": "2026-02-10T10:01:00",
+        "user_input": "hello",
+        "route": "smalltalk",
+        "intent": "greeting",
+        "confidence": 0.95,
+        "tier_decision": {"router": "3b", "finalizer": "3b", "reason": "simple"},
+        "tools": [],
+        "finalizer_strategy": "fast",
+        "assistant_reply": "Merhaba",
+        "total_elapsed_ms": 50,
+    }
+    path = trace_exporter.write_turn_trace(trace)
+    assert path.exists()
+    assert path.read_text(encoding="utf-8")
+
+
+def test_build_tool_dag_contains_routes_and_tools() -> None:
+    dag = trace_exporter.build_tool_dag()
+    nodes = {n["id"] for n in dag.get("nodes", [])}
+    edges = dag.get("edges", [])
+
+    assert "route:calendar" in nodes
+    assert "route:gmail" in nodes
+    assert "route:system" in nodes
+
+    # Ensure at least one tool node exists
+    assert any(n.startswith("tool:") for n in nodes)
+    # Ensure route->tool edges exist
+    assert any(e.get("type") == "route_tool" for e in edges)
+
+
+def test_replay_golden_traces_echo() -> None:
+    result = trace_exporter.replay_golden_traces()
+    assert result["failed"] == 0
+    assert result["total"] == result["passed"]
+
+
+def test_compare_traces_detects_route_mismatch() -> None:
+    expected = {"route": "calendar", "tools": [{"name": "calendar.list_events"}]}
+    actual = {"route": "gmail", "tools": [{"name": "calendar.list_events"}]}
+    diff = trace_exporter.compare_traces(expected, actual)
+    assert "route" in diff


### PR DESCRIPTION
## Issue #664: Observability & Replay

### Faz 1 — Structured Trace Export
- `trace_exporter.py`: `build_turn_trace()`, `write_turn_trace()`, `export_recent_traces()`
- Her tur sonunda JSON trace `artifacts/logs/traces/` altına yazılıyor
- OrchestratorLoop entegrasyonu (process_turn + _update_state_phase)
- `/trace export <N>` komutu terminal_jarvis.py'ye eklendi

### Faz 2 — Scenario Replay
- `scripts/replay_scenario.py`: echo/live/mock modları
- Golden flow traces: `tests/golden/traces/` (3 senaryo, 5 turn)
- `compare_traces()`: route + tool regression check
- `replay_golden_traces()`: CI-friendly echo mode

### Faz 3 — Trace Viewer (Web UI)
- `scripts/trace_viewer.py` → localhost:5050
- vis-network ile Tool/Intent DAG görselleştirme
- Summary cards, anomaly panel, timeline view
- API: /api/traces, /api/metrics, /api/anomalies, /api/dag

### Faz 4 — Regression Dashboard
- `aggregate_metrics()`: avg/p95 latency, tool success rate, tier distribution
- `detect_anomalies()`: latency spike, low confidence, tool failure burst
- `scripts/generate_weekly_report.py` → markdown rapor
- `build_tool_dag()`: route→intent→tool DAG export

### Değişen Dosyalar (10 dosya, 1114 ekleme)
| Dosya | Değişiklik |
|-------|-----------|
| `src/bantz/brain/trace_exporter.py` | Yeni: tüm trace/metrics/anomaly/dag/golden |
| `src/bantz/brain/orchestrator_loop.py` | Trace export entegrasyonu |
| `scripts/terminal_jarvis.py` | /trace export <N> komutu |
| `scripts/trace_viewer.py` | Web UI (localhost:5050) |
| `scripts/replay_scenario.py` | Scenario replay (echo/live/mock) |
| `scripts/generate_weekly_report.py` | Weekly regression report |
| `tests/golden/traces/*.json` | 3 golden flow trace dosyası |
| `tests/test_issue_664_observability_replay.py` | 5 yeni test |

### Test Sonuçları
**8056 passed**, 0 failed

Closes #664