### PR TITLE
fix: raise context length fallback from 2048 to 8192 (#680)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -901,7 +901,12 @@ USER: merhaba mesajı gönder
                 ctx = None
 
         if ctx is None or ctx < 256:
-            ctx = 2048
+            ctx = 8192
+            logger.warning(
+                "Could not detect model context length, using fallback %d. "
+                "Set BANTZ_ROUTER_CONTEXT_LEN to override.",
+                ctx,
+            )
 
         self._cached_context_len = int(ctx)
         return int(ctx)


### PR DESCRIPTION
## Issue #680 — Context Length Fallback Çok Düşük

### Problem
vLLM boot sırasında ulaşılamaz olduğunda, router fallback context length olarak **2048** kullanıyordu. Qwen2.5-3B (32K context) için bu çok düşük — prompt'taki tool açıklamaları kesiliyor, routing kalitesi düşüyordu.

### Çözüm
- Fallback: `2048` → `8192` (modern 3B+ modeller için güvenli minimum)
- Fallback kullanıldığında `logger.warning` ile uyarı eklendi
- `BANTZ_ROUTER_CONTEXT_LEN` env var ile override hâlâ mümkün

### Etki
- vLLM geç boot durumunda bile tool açıklamaları tam kalır
- Mevcut env var kullananlar etkilenmez
- `_compute_router_max_tokens` → 768 döner (2048'de 512'ydi)

Closes #680