### PR TITLE
fix: lower quality gating thresholds for 3B router (#681)

### DIFF
--- a/src/bantz/brain/quality_gating.py
+++ b/src/bantz/brain/quality_gating.py
@@ -125,13 +125,13 @@ class PolicyConfig:
     
     All values can be overridden via environment variables.
     """
-    # Score thresholds
-    quality_threshold: float = 2.5  # Total score >= this → quality tier
-    fast_max_threshold: float = 1.5  # Total score <= this → always fast
+    # Score thresholds (tuned for 3B router – Issue #681)
+    quality_threshold: float = 1.8  # Total score >= this → quality tier
+    fast_max_threshold: float = 0.8  # Total score <= this → always fast
     
     # Component thresholds
-    min_complexity_for_quality: int = 4
-    min_writing_for_quality: int = 4
+    min_complexity_for_quality: int = 3
+    min_writing_for_quality: int = 3
     
     # Rate limiting
     quality_rate_limit: int = 30  # Max quality requests per window
@@ -209,19 +209,19 @@ class PolicyConfig:
         return cls(
             quality_threshold=env_float(
                 "BANTZ_TIER_QUALITY_THRESHOLD",
-                env_float("BANTZ_QUALITY_SCORE_THRESHOLD", 2.5),
+                env_float("BANTZ_QUALITY_SCORE_THRESHOLD", 1.8),
             ),
             fast_max_threshold=env_float(
                 "BANTZ_TIER_FAST_MAX_THRESHOLD",
-                env_float("BANTZ_FAST_MAX_THRESHOLD", 1.5),
+                env_float("BANTZ_FAST_MAX_THRESHOLD", 0.8),
             ),
             min_complexity_for_quality=env_int(
                 "BANTZ_TIER_MIN_COMPLEXITY_FOR_QUALITY",
-                env_int("BANTZ_MIN_COMPLEXITY_FOR_QUALITY", 4),
+                env_int("BANTZ_MIN_COMPLEXITY_FOR_QUALITY", 3),
             ),
             min_writing_for_quality=env_int(
                 "BANTZ_TIER_MIN_WRITING_FOR_QUALITY",
-                env_int("BANTZ_MIN_WRITING_FOR_QUALITY", 4),
+                env_int("BANTZ_MIN_WRITING_FOR_QUALITY", 3),
             ),
             quality_rate_limit=env_int(
                 "BANTZ_TIER_QUALITY_RATE_LIMIT",


### PR DESCRIPTION
## Issue #681 — Quality Gating Eşikleri 3B İçin Çok Yüksek

### Problem
Önceki eşikler (quality=2.5, fast_max=1.5, min_complexity=4, min_writing=4) 7B+ modeller için kalibre edilmişti. 3B Qwen router ile neredeyse tüm sorgular 2.5'in altında kalıyor ve quality tier'a hiç ulaşılamıyordu.

### Yeni Eşikler
| Parametre | Eski | Yeni |
|-----------|------|------|
| quality_threshold | 2.5 | 1.8 |
| fast_max_threshold | 1.5 | 0.8 |
| min_complexity | 4 | 3 |
| min_writing | 4 | 3 |

### Etki
- Karmaşık sorgular (e-posta yazma, takvim muhakemesi) Gemini'ye yönlendirilir
- Basit sorgular fast path'te kalır
- Tüm değerler BANTZ_TIER_* env var'ları ile override edilebilir

Closes #681