### PR TITLE
security: use sys.executable instead of bare python in sandbox (#695)

### DIFF
--- a/src/bantz/security/sandbox.py
+++ b/src/bantz/security/sandbox.py
@@ -20,6 +20,7 @@ import logging
 import os
 import shlex
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -335,7 +336,7 @@ class Sandbox:
         
         try:
             result = self.execute_command(
-                ["python", str(script_path)],
+                [sys.executable, str(script_path)],
                 cwd=self.temp_dir,
             )
         finally:


### PR DESCRIPTION
## Issue #695 — [P1][Security] sandbox PATH hijack

### Problem
`execute_python()` bare `python` komutu kullanıyordu. PATH manipülasyonu ile kötü amaçlı interpreter çalıştırılabilirdi.

### Çözüm
`sys.executable` kullanılarak Bantz'ın çalıştığı aynı Python interpreter'ı enforce ediliyor.

### Etki
- venv izolasyonu korunuyor
- PATH manipülasyonuna karşı güvenli

Closes #695