### PR TITLE
[P1][Security] Elevate read_clipboard risk from LOW to MEDIUM (#700)

### DIFF
--- a/src/bantz/security/action_classifier.py
+++ b/src/bantz/security/action_classifier.py
@@ -53,7 +53,7 @@ class ActionClassifier:
         "calculator": PermissionLevel.LOW,
         "translate": PermissionLevel.LOW,
         "define_word": PermissionLevel.LOW,
-        "read_clipboard": PermissionLevel.LOW,
+        "read_clipboard": PermissionLevel.MEDIUM,
         
         # MEDIUM - External access, first-time ask
         "send_email": PermissionLevel.MEDIUM,


### PR DESCRIPTION
Closes #700

read_clipboard now requires user confirmation (MEDIUM). Clipboard may contain passwords, 2FA codes, API keys, credit card numbers, and PII — reading it without consent risks leaking sensitive data to cloud LLM.