### PR TITLE
[P1][Bug] Separate SQLite tables for profile and episodic stores (#704)

### DIFF
--- a/src/bantz/memory/snippet_manager.py
+++ b/src/bantz/memory/snippet_manager.py
@@ -315,10 +315,10 @@ def create_memory_manager(
         session_store = create_session_store()
     
     if profile_store is None:
-        profile_store = create_persistent_store(db_path)
+        profile_store = create_persistent_store(db_path, table_name="snippets_profile")
     
     if episodic_store is None:
-        episodic_store = create_persistent_store(db_path)
+        episodic_store = create_persistent_store(db_path, table_name="snippets_episodic")
     
     # Create policy
     if write_policy is None:


### PR DESCRIPTION
Closes #704

Profile and episodic stores now use distinct SQLite tables (snippets_profile, snippets_episodic) instead of sharing the same table. Prevents snippet ID collisions and cross-type overwrites.