### PR TITLE
fix(llm_router): raise JSON repair confidence penalty 0.7→0.9 (#684)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -38,7 +38,7 @@ class RepairTracker:
     and exposes a ``repairs_per_100`` metric for dashboards.
     """
 
-    CONFIDENCE_PENALTY: float = 0.7  # multiply confidence when repair is applied
+    CONFIDENCE_PENALTY: float = 0.9  # multiply confidence when repair is applied
 
     def __init__(self) -> None:
         self._lock = threading.Lock()


### PR DESCRIPTION
## Issue
Closes #684

## Problem
`RepairTracker.CONFIDENCE_PENALTY = 0.7` was too aggressive for 3B models that frequently produce minor JSON errors. A legitimate 0.85 confidence dropped to 0.595 — below the 0.7 threshold — causing unnecessary `ask_user` clarifications instead of tool execution.

## Fix
Changed `CONFIDENCE_PENALTY` from `0.7` to `0.9`. Minor JSON repairs now only reduce confidence by 10% instead of 30%.