### PR TITLE
fix(orchestrator): remove duplicate gmail_intent assignment (#685)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -538,7 +538,6 @@ class OrchestratorLoop:
             return output
         
         # Issue #317: Check gmail_intent first for gmail route
-        gmail_intent = getattr(output, "gmail_intent", None) or ""
         if output.route == "gmail" and gmail_intent and gmail_intent != "none":
             mandatory_tools = self._gmail_intent_map.get(gmail_intent)
             if mandatory_tools:


### PR DESCRIPTION
## Issue
Closes #685

## Problem
`gmail_intent` was defined twice in `_force_tool_plan()`:
1. Line 522: `gmail_intent = (...).strip().lower()` — normalized ✅
2. Line 541: `gmail_intent = getattr(...) or ""` — **NOT** normalized ❌

The second assignment overwrote the normalized value, causing potential case-mismatch in `_gmail_intent_map.get()` lookups.

## Fix
Removed the second redundant assignment. The normalized value from line 522 is now used consistently throughout the method.