### PR TITLE
fix(orchestrator): replace local _estimate_tokens with canonical token_utils (#686)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -995,8 +995,7 @@ class OrchestratorLoop:
             except Exception:
                 pass
 
-        def _estimate_tokens(s: str) -> int:
-            return max(0, len(s or "") // 4)
+        from bantz.llm.token_utils import estimate_tokens as _estimate_tokens
 
         try:
             budget_tokens = int(getattr(getattr(self, "_memory_tracer", None), "budget", None).max_tokens)  # type: ignore[union-attr]


### PR DESCRIPTION
## Issue
Closes #686

## Problem
`_llm_planning_phase()` defined a local nested `_estimate_tokens` function (`len(s) // 4`) that:
1. Shadowed the module-level version (Python scoping)
2. Ignored the configurable `method` parameter from `bantz.llm.token_utils.estimate_tokens`
3. Was recreated on every call (unnecessary overhead)

## Fix
Replaced the local `def _estimate_tokens` with `from bantz.llm.token_utils import estimate_tokens as _estimate_tokens`. All call sites unchanged — the alias preserves the existing `_estimate_tokens()` name.