### PR TITLE
fix(orchestrator): stop leaking exception details to user (#688)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -677,7 +677,7 @@ class OrchestratorLoop:
                 slots={},
                 confidence=0.0,
                 tool_plan=[],
-                assistant_reply=f"Efendim, bir sorun oluştu: {e}",
+                assistant_reply="Efendim, bir sorun oluştu. Lütfen tekrar deneyin.",
                 raw_output={"error": str(e)},
             )
             return fallback, state


### PR DESCRIPTION
## Issue
Closes #688

## Problem
`process_turn()` catch-all exception handler included `str(e)` in `assistant_reply`, potentially exposing:
- Python traceback details, file paths, module names
- API keys and connection strings (e.g. Gemini 403 errors)
- Internal architecture details (class/method names)

This is an OWASP "Improper Error Handling" vulnerability.

## Fix
Replaced `f"Efendim, bir sorun oluştu: {e}"` with static `"Efendim, bir sorun oluştu. Lütfen tekrar deneyin."`

Exception details are still available via:
- `logger.exception()` — full traceback in logs
- `raw_output={"error": str(e)}` — internal state
- `event_bus.publish()` — monitoring