### PR TITLE
fix(tts): check Piper subprocess exit code before playing audio (#711)

### DIFF
--- a/src/bantz/voice/tts.py
+++ b/src/bantz/voice/tts.py
@@ -44,10 +44,16 @@ class PiperTTS:
                 [piper_path, "-m", self.cfg.model_path, "-f", out_wav],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
                 text=True,
             )
-            p.communicate(text)
+            _, stderr_output = p.communicate(text)
+
+            if p.returncode != 0:
+                raise RuntimeError(
+                    f"Piper TTS failed (exit code {p.returncode}): "
+                    f"{(stderr_output or '').strip()[:200]}"
+                )
 
             player = shutil.which("paplay") or shutil.which("aplay")
             if not player:


### PR DESCRIPTION
## Issue
Closes #711

## Problem
`p.communicate(text)` was called on the Piper TTS subprocess but `p.returncode` was never checked. If Piper crashed (wrong model path, missing binary, OOM), a corrupt/empty WAV file was silently played — the user heard silence or noise with no error reported.

## Fix
- Changed `stderr=subprocess.DEVNULL` → `stderr=subprocess.PIPE` to capture error output
- Check `p.returncode != 0` after `communicate()`
- Raise `RuntimeError` with exit code and truncated stderr snippet (max 200 chars)
- The exception is caught by the `finally` block which still cleans up the temp WAV file