### PR TITLE
fix(auth): set OAuth token file permissions to 0o600 (#713)

### DIFF
--- a/src/bantz/google/auth.py
+++ b/src/bantz/google/auth.py
@@ -154,5 +154,6 @@ def get_credentials(
 
         cfg.token_path.parent.mkdir(parents=True, exist_ok=True)
         cfg.token_path.write_text(creds.to_json(), encoding="utf-8")
+        os.chmod(cfg.token_path, 0o600)  # owner-only: token grants full Google account access
 
     return creds


### PR DESCRIPTION
## Issue
Closes #713

## Problem
OAuth token file was written with default umask (typically `0o644` = world-readable). The token grants full Google account access (Calendar, Gmail, Drive, etc.) — any user on the same machine could read and abuse it.

## Fix
Added `os.chmod(cfg.token_path, 0o600)` immediately after `write_text()` to restrict file access to owner only (read+write, no group/other).