### PR TITLE
fix(calendar_idempotency): increase hash truncation 16→32 hex chars (#715)

### DIFF
--- a/src/bantz/tools/calendar_idempotency.py
+++ b/src/bantz/tools/calendar_idempotency.py
@@ -405,7 +405,7 @@ def generate_idempotency_key(
     canonical = f"{norm_title}|{norm_start}|{norm_end}|{norm_calendar}"
     
     # Hash to fixed-length key
-    key = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    key = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
     
     return key
 


### PR DESCRIPTION
## Issue
Closes #715

## Problem
`generate_idempotency_key()` truncated SHA-256 to `[:16]` hex chars = 64-bit entropy. Birthday paradox gives ~50% collision probability at ~4 billion entries. Even within a TTL window, different calendar events could be incorrectly flagged as duplicates.

## Fix
Changed `hexdigest()[:16]` → `hexdigest()[:32]` (128-bit entropy). Collision probability is now negligible — requires ~^{64}$ entries for 50% chance.

## Compatibility
Existing idempotency records with 16-char keys will naturally expire via TTL and be replaced by new 32-char keys. No migration needed.