### PR TITLE
fix(session_fsm): use active_listen_ttl for ACTIVE_LISTEN timeout (#717)

### DIFF
--- a/src/bantz/voice/session_fsm.py
+++ b/src/bantz/voice/session_fsm.py
@@ -233,7 +233,7 @@ class VoiceFSM:
 
             if self._state == VoiceState.ACTIVE_LISTEN:
                 elapsed = now - self._last_activity
-                if elapsed >= self.config.silence_threshold:
+                if elapsed >= self.config.active_listen_ttl:
                     self._transition(VoiceState.WAKE_ONLY, "silence_timeout")
 
             elif self._state == VoiceState.WAKE_ONLY and self.config.idle_sleep_enabled:
@@ -247,7 +247,7 @@ class VoiceFSM:
             now = self._clock()
 
             if self._state == VoiceState.ACTIVE_LISTEN:
-                remaining = self.config.silence_threshold - (now - self._last_activity)
+                remaining = self.config.active_listen_ttl - (now - self._last_activity)
                 return max(0.0, remaining)
 
             if self._state == VoiceState.WAKE_ONLY and self.config.idle_sleep_enabled:


### PR DESCRIPTION
## Summary

`tick()` and `time_until_timeout()` were using `silence_threshold` (30s) instead of `active_listen_ttl` (90s) for the ACTIVE_LISTEN → WAKE_ONLY transition. The `active_listen_ttl` config field (`BANTZ_ACTIVE_LISTEN_TTL_S` env var) existed in `FSMConfig` but was never referenced — a dead config.

## Changes

- **`tick()`**: `self.config.silence_threshold` → `self.config.active_listen_ttl`
- **`time_until_timeout()`**: `self.config.silence_threshold` → `self.config.active_listen_ttl`

## Impact

Users now get the intended 90-second active listening window before the FSM drops to wake-only mode, instead of the incorrect 30-second timeout.

Closes #717