### PR TITLE
fix(vault): create secrets file with 0o600 from the start (#719)

### DIFF
--- a/src/bantz/security/vault.py
+++ b/src/bantz/security/vault.py
@@ -185,10 +185,13 @@ class SecretsVault:
     def _save(self) -> None:
         """Save secrets to storage."""
         try:
-            with open(self._storage_path, "w") as f:
+            fd = os.open(
+                str(self._storage_path),
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w") as f:
                 json.dump(self._secrets, f, indent=2)
-            # Set restrictive permissions
-            os.chmod(self._storage_path, 0o600)
         except IOError:
             pass
     


### PR DESCRIPTION
## Summary

`_save()` was using `open()` (default 0o644) followed by `os.chmod(0o600)`, creating a TOCTOU race where another process could read the secrets file between creation and permission restriction.

## Changes

Replaced `open() + chmod()` with `os.open(path, O_WRONLY|O_CREAT|O_TRUNC, 0o600)` so the file is created with owner-only permissions atomically.

## Files
- `src/bantz/security/vault.py`

Closes #719