### PR TITLE
fix(secrets_hygiene): redact exc_text in LoggerRedactionHandler (#728)

### DIFF
--- a/src/bantz/security/secrets_hygiene.py
+++ b/src/bantz/security/secrets_hygiene.py
@@ -418,6 +418,10 @@ class LoggerRedactionHandler(logging.Handler):
                 exc_info=record.exc_info,
             )
             
+            # Redact exception text (traceback strings may contain secrets)
+            if record.exc_text:
+                new_record.exc_text = self._redact(record.exc_text)
+            
             # Forward to wrapped handler
             self.wrapped.emit(new_record)
         except Exception:


### PR DESCRIPTION
## Summary

`emit()` only redacted `record.msg` but passed `exc_text` (traceback strings) through unmasked. Secrets in exception messages or HTTP error URLs would leak to logs.

## Changes

Added `record.exc_text` redaction in `emit()` before forwarding to wrapped handler.

Closes #728