### PR TITLE
fix(privacy): sync PII patterns — import redact_pii into llm/privacy (#732)

### DIFF
--- a/src/bantz/llm/privacy.py
+++ b/src/bantz/llm/privacy.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from bantz.security.masking import get_default_masker
 from bantz.brain.memory_lite import PIIFilter
+from bantz.privacy.redaction import redact_pii
 
 
 @dataclass(frozen=True)
@@ -80,6 +81,7 @@ def redact_for_cloud(text: str) -> str:
         return text
 
     t = str(text or "")
+    t = redact_pii(t)
     t = PIIFilter.filter(t, enabled=True)
     t = get_default_masker().mask(t)
     return t


### PR DESCRIPTION
## Summary
Import `redact_pii` from `bantz.privacy.redaction` into `bantz.llm.privacy` and apply it as the first step in `redact_for_cloud()`.

## Problem
`llm/privacy.py` used `PIIFilter` and `DataMasker` but did NOT use the Turkish-specific PII patterns (TC Kimlik, IBAN, Turkish phone, credit card, IP) defined in `privacy/redaction.py`. Cloud-bound text could leak Turkish PII.

## Changes
- Added `from bantz.privacy.redaction import redact_pii` import
- Call `redact_pii(t)` before PIIFilter and DataMasker in `redact_for_cloud()`

Closes #732