### PR TITLE
fix(memory): replace deprecated datetime.utcnow() with timezone-aware UTC (#734)

### DIFF
--- a/src/bantz/memory/persistent.py
+++ b/src/bantz/memory/persistent.py
@@ -23,7 +23,7 @@ import logging
 import os
 import sqlite3
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -223,7 +223,7 @@ class PersistentMemoryStore:
 
     def update_access(self, item_id: str) -> bool:
         """Bump access count and timestamp for a memory item."""
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         with self._lock:
             cur = self._conn.execute(
                 "UPDATE memory_item SET access_count = access_count + 1, "
@@ -269,7 +269,7 @@ class PersistentMemoryStore:
 
     def close_session(self, session_id: str, summary: str = "") -> bool:
         """Close a session (set end_time and summary)."""
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         with self._lock:
             cur = self._conn.execute(
                 "UPDATE session SET end_time = ?, summary = ? WHERE id = ?",
@@ -357,7 +357,7 @@ class PersistentMemoryStore:
 
     def set_profile(self, key: str, value: str) -> str:
         """Set (upsert) a user-profile entry.  Returns the profile row id."""
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         with self._lock:
             row = self._conn.execute(
                 "SELECT id FROM user_profile WHERE key = ?", (key,)


### PR DESCRIPTION
## Summary
Replace all `datetime.utcnow()` calls with `datetime.now(timezone.utc)` in `persistent.py`.

## Problem
`datetime.utcnow()` is deprecated since Python 3.12 — it returns a naive datetime object with no timezone info, which can cause subtle bugs when mixed with timezone-aware datetimes.

## Changes
- Added `timezone` to `from datetime import datetime, timezone`
- Replaced 3 occurrences of `datetime.utcnow().isoformat()` with `datetime.now(timezone.utc).isoformat()`:
  - `update_access()`
  - `close_session()`
  - `set_profile()`

Closes #734