### PR TITLE
fix(calendar): normalize timezone to UTC before idempotency key hash (#736)

### DIFF
--- a/src/bantz/tools/calendar_idempotency.py
+++ b/src/bantz/tools/calendar_idempotency.py
@@ -358,14 +358,16 @@ def normalize_title(title: str) -> str:
 def normalize_datetime(dt_str: str) -> str:
     """Normalize datetime string for consistent key generation.
     
-    Parses the datetime and formats it in a consistent way.
+    Parses the datetime, converts to UTC, and formats in a consistent way.
+    This ensures that the same moment in time (e.g. Europe/Istanbul vs UTC+3)
+    always produces the same normalized string for idempotency key hashing.
     Falls back to stripping whitespace if parsing fails.
     
     Args:
         dt_str: Datetime string (ISO format expected)
     
     Returns:
-        Normalized datetime string
+        Normalized datetime string (UTC)
     """
     if not dt_str:
         return ""
@@ -378,6 +380,9 @@ def normalize_datetime(dt_str: str) -> str:
         if "T" in dt_str:
             # ISO format with time
             dt = datetime.fromisoformat(dt_str)
+            # Convert to UTC for consistent hashing
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(timezone.utc)
             return dt.isoformat()
         else:
             # Date only


### PR DESCRIPTION
## Summary
Normalize datetimes to UTC before hashing to prevent duplicate events.

## Problem
`normalize_datetime()` preserved the original timezone offset. The same event at `2026-02-01T15:00:00+03:00` (Europe/Istanbul) vs `2026-02-01T12:00:00+00:00` (UTC) produced different hashes, bypassing dedup.

## Changes
- Added `dt.astimezone(timezone.utc)` for timezone-aware datetimes before `.isoformat()`
- Updated docstring

Closes #736