### PR TITLE
fix(voice): truncate LLM chat history in wake word loop (#740)

### DIFF
--- a/src/bantz/voice/loop.py
+++ b/src/bantz/voice/loop.py
@@ -811,6 +811,7 @@ def run_wake_word_loop(cfg: VoiceLoopConfig) -> int:
                     llm = llm_fast
                 
                 print("🤖 LLM'e soruluyor...")
+                history[:] = history[-20:]
                 history.append(LLMMessage("user", text))
                 
                 try:


### PR DESCRIPTION
## Summary
Add sliding window truncation to LLM chat history in `run_wake_word_loop()`.

## Problem
The wake word loop's `history` list grew without bound on each voice turn. Long sessions would exhaust memory and exceed the LLM context window, causing timeouts or OOM crashes.

## Changes
- Added `history[:] = history[-20:]` before appending new user messages (matching the existing PTT loop behavior)

Closes #740