### PR TITLE
fix(voice): guard WAKE_ONLY→IDLE_SLEEP transition with activity check (#741)

### DIFF
--- a/src/bantz/voice/session_fsm.py
+++ b/src/bantz/voice/session_fsm.py
@@ -238,7 +238,10 @@ class VoiceFSM:
 
             elif self._state == VoiceState.WAKE_ONLY and self.config.idle_sleep_enabled:
                 elapsed = now - self._state_entered_at
-                if elapsed >= self.config.idle_sleep_timeout:
+                # Guard: don't sleep if there was recent activity (e.g.
+                # user speaking without a wake word match).
+                since_activity = now - self._last_activity
+                if elapsed >= self.config.idle_sleep_timeout and since_activity >= self.config.idle_sleep_timeout:
                     self._transition(VoiceState.IDLE_SLEEP, "idle_timeout")
 
     def time_until_timeout(self) -> Optional[float]:


### PR DESCRIPTION
## Summary
Prevent IDLE_SLEEP transition when there is recent user activity.

## Problem
`tick()` transitioned from WAKE_ONLY→IDLE_SLEEP based solely on time since entering WAKE_ONLY state. It didn't check if there was recent audio activity, so the system could go to sleep while the user was speaking (without a wake word match).

## Changes
- Added `since_activity = now - self._last_activity` check
- IDLE_SLEEP transition now requires BOTH `elapsed >= idle_sleep_timeout` AND `since_activity >= idle_sleep_timeout`

Closes #741