### PR TITLE
fix(session_fsm): bound transition history with deque(maxlen=100) (#751)

### DIFF
--- a/src/bantz/voice/session_fsm.py
+++ b/src/bantz/voice/session_fsm.py
@@ -27,6 +27,7 @@ import logging
 import os
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, List, Optional
@@ -132,7 +133,7 @@ class VoiceFSM:
         self._state = VoiceState.WAKE_ONLY
         self._last_activity = self._clock()
         self._state_entered_at = self._clock()
-        self._history: List[StateTransition] = []
+        self._history: deque[StateTransition] = deque(maxlen=100)
         self._lock = threading.Lock()
 
     @property


### PR DESCRIPTION
## Problem
VoiceFSM._history was an unbounded list that grew indefinitely in long-running voice sessions, causing memory leak.

## Solution
Replace `list` with `collections.deque(maxlen=100)` — oldest transitions are automatically evicted when the limit is reached.

Closes #751