### PR TITLE
fix(audit): narrow bare except to specific exceptions and log (#753)

### DIFF
--- a/src/bantz/security/audit.py
+++ b/src/bantz/security/audit.py
@@ -573,8 +573,8 @@ class AuditLogger:
                     parsed = urlparse(entry.resource)
                     if parsed.netloc:
                         domains.add(parsed.netloc)
-                except Exception:
-                    pass
+                except (ValueError, AttributeError) as exc:
+                    logger.debug("Failed to parse resource URL %r: %s", entry.resource, exc)
             
             # Track file operations
             if entry.action in ("file_read", "file_write", "file_delete", "file_create"):


### PR DESCRIPTION
## Problem
`get_daily_summary()` URL parsing used `except Exception: pass` which silently swallowed all errors, making audit write failures invisible.

## Solution
- Narrowed to `except (ValueError, AttributeError)` — the expected URL parsing failures
- Added DEBUG-level logging so parsing failures are visible in logs
- Non-fatal for the summary operation but now traceable

Closes #753