### PR TITLE
fix(tests): replace assert True no-op with real assertions (#756)

### DIFF
--- a/tests/test_continuous_listening.py
+++ b/tests/test_continuous_listening.py
@@ -1345,8 +1345,11 @@ class TestEdgeCases:
         for _ in range(len(pattern)):
             segmenter.process(audio_chunk)
         
-        # Should not crash
-        assert True
+        # After rapid transitions the segmenter must reach a stable state
+        # (pattern ends with silence → should not be speaking)
+        assert segmenter.is_speaking is False
+        # segment_count may be 0 or more, but must be a valid non-negative int
+        assert segmenter.segment_count >= 0
     
     def test_listener_multiple_wake_words(self):
         from bantz.voice.continuous import ContinuousListener, ListenerState


### PR DESCRIPTION
## Problem
`test_segmenter_rapid_transitions` used `assert True` as a placeholder that always passed without validating anything.

## Solution
Replaced with real assertions:
- `segmenter.is_speaking is False` (pattern ends with silence)
- `segmenter.segment_count >= 0` (valid state after processing)

Closes #756