### PR TITLE
fix(tests): rename TestPlugin fixture to SamplePlugin to avoid pytest warning (#757)

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -47,7 +47,7 @@ from bantz.plugins.registry import (
 # =============================================================================
 
 
-class TestPlugin(BantzPlugin):
+class SamplePlugin(BantzPlugin):
     """A test plugin implementation."""
     
     @property
@@ -364,40 +364,40 @@ class TestBantzPlugin:
     
     def test_plugin_creation(self):
         """Test plugin instantiation."""
-        plugin = TestPlugin()
+        plugin = SamplePlugin()
         assert plugin.metadata.name == "test-plugin"
         assert plugin.metadata.version == "1.0.0"
     
     def test_plugin_intents(self):
         """Test plugin intent patterns."""
-        plugin = TestPlugin()
+        plugin = SamplePlugin()
         intents = plugin.get_intents()
         assert len(intents) == 1
         assert intents[0].intent == "test_action"
     
     def test_plugin_tools(self):
         """Test plugin tools."""
-        plugin = TestPlugin()
+        plugin = SamplePlugin()
         tools = plugin.get_tools()
         assert len(tools) == 1
         assert tools[0].name == "test_tool"
     
     def test_plugin_tool_execution(self):
         """Test plugin tool execution."""
-        plugin = TestPlugin()
+        plugin = SamplePlugin()
         tools = plugin.get_tools()
         result = tools[0].execute(input="hello")
         assert result == {"result": "tested: hello"}
     
     def test_plugin_config(self):
         """Test plugin config access."""
-        plugin = TestPlugin()
+        plugin = SamplePlugin()
         # Test that config attribute exists or can be set
         assert hasattr(plugin, 'config') or hasattr(plugin, '_config')
     
     def test_plugin_lifecycle(self):
         """Test plugin lifecycle hooks."""
-        plugin = TestPlugin()
+        plugin = SamplePlugin()
         
         # These should not raise
         plugin.on_load()
@@ -589,7 +589,7 @@ class TestLoadedPlugin:
     
     def test_loaded_plugin_creation(self):
         """Test loaded plugin creation."""
-        plugin = TestPlugin()
+        plugin = SamplePlugin()
         spec = PluginSpec(
             name="test",
             path=Path("/plugins/test"),
@@ -617,7 +617,7 @@ class TestPluginManager:
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = MockPluginManager([Path(tmpdir)])
             
-            plugin = TestPlugin()
+            plugin = SamplePlugin()
             manager.add_mock_plugin(plugin)
             
             assert "test-plugin" in manager.plugins
@@ -628,7 +628,7 @@ class TestPluginManager:
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = MockPluginManager([Path(tmpdir)])
             
-            plugin = TestPlugin()
+            plugin = SamplePlugin()
             manager.add_mock_plugin(plugin)
             
             # Should start enabled
@@ -647,21 +647,21 @@ class TestPluginManager:
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = MockPluginManager([Path(tmpdir)])
             
-            plugin1 = TestPlugin()
+            plugin1 = SamplePlugin()
             plugin2 = MinimalPlugin()
             
             manager.add_mock_plugin(plugin1)
             manager.add_mock_plugin(plugin2)
             
             intents = manager.get_all_intents()
-            assert len(intents) >= 1  # At least from TestPlugin
+            assert len(intents) >= 1  # At least from SamplePlugin
     
     def test_manager_get_all_tools(self):
         """Test getting tools from all plugins."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = MockPluginManager([Path(tmpdir)])
             
-            plugin = TestPlugin()
+            plugin = SamplePlugin()
             manager.add_mock_plugin(plugin)
             
             tools = manager.get_all_tools()
@@ -672,7 +672,7 @@ class TestPluginManager:
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = MockPluginManager([Path(tmpdir)])
             
-            plugin = TestPlugin()
+            plugin = SamplePlugin()
             manager.add_mock_plugin(plugin)
             
             # The intent gets prefixed with plugin name
@@ -687,7 +687,7 @@ class TestPluginManager:
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = MockPluginManager([Path(tmpdir)])
             
-            plugin = TestPlugin()
+            plugin = SamplePlugin()
             manager.add_mock_plugin(plugin)
             
             assert "test-plugin" in manager.plugins
@@ -1008,7 +1008,7 @@ class TestIntegrationPlugin(BantzPlugin):
             
             # Use mock manager for direct plugin registration
             mock_manager = MockPluginManager([plugins_dir])
-            mock_manager.add_mock_plugin(TestPlugin())
+            mock_manager.add_mock_plugin(SamplePlugin())
             
             # Should be enabled (not in disabled list)
             assert mock_manager.is_enabled("test-plugin")


### PR DESCRIPTION
## Problem
`TestPlugin(BantzPlugin)` in test_plugins.py was a concrete fixture class (not an actual test class) but its 'Test' prefix caused pytest to try collecting it, producing warnings.

## Solution
Renamed to `SamplePlugin(BantzPlugin)` throughout test_plugins.py. All actual test classes (TestPluginMetadata, TestPluginLoader, etc.) remain unchanged.

Closes #757