### PR TITLE
fix(tests): add test coverage for ipc/ and scheduler/ modules (#758)

### DIFF
--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,0 +1,329 @@
+"""
+Tests for bantz.ipc module — IPC protocol, messages, encoding/decoding.
+"""
+
+import json
+import pytest
+
+from bantz.ipc.protocol import (
+    IPC_VERSION,
+    MessageType,
+    OverlayState,
+    OverlayPosition,
+    ActionType,
+    EventType,
+    EventReason,
+    BaseMessage,
+    StateMessage,
+    ActionMessage,
+    EventMessage,
+    AckMessage,
+    PingMessage,
+    PongMessage,
+    encode_message,
+    decode_message,
+    parse_message,
+    get_socket_path,
+    state_idle,
+    state_wake,
+    state_listening,
+    state_thinking,
+    state_speaking,
+    event_timeout,
+    event_dismissed,
+    action_preview,
+    action_cursor_dot,
+    action_highlight_rect,
+)
+
+
+# ── Enum tests ──────────────────────────────────────────────────
+
+
+class TestMessageType:
+    def test_values(self):
+        assert MessageType.STATE.value == "state"
+        assert MessageType.ACTION.value == "action"
+        assert MessageType.EVENT.value == "event"
+        assert MessageType.PING.value == "ping"
+        assert MessageType.PONG.value == "pong"
+        assert MessageType.ACK.value == "ack"
+
+
+class TestOverlayState:
+    def test_values(self):
+        assert OverlayState.IDLE.value == "idle"
+        assert OverlayState.WAKE.value == "wake"
+        assert OverlayState.LISTENING.value == "listening"
+        assert OverlayState.THINKING.value == "thinking"
+        assert OverlayState.SPEAKING.value == "speaking"
+
+
+class TestOverlayPosition:
+    def test_values(self):
+        assert OverlayPosition.CENTER.value == "center"
+        assert OverlayPosition.TOP_RIGHT.value == "top_right"
+        assert OverlayPosition.TOP_LEFT.value == "top_left"
+        assert OverlayPosition.BOTTOM_RIGHT.value == "bottom_right"
+        assert OverlayPosition.BOTTOM_LEFT.value == "bottom_left"
+
+
+class TestActionType:
+    def test_values(self):
+        assert ActionType.PREVIEW.value == "preview"
+        assert ActionType.CURSOR_DOT.value == "cursor_dot"
+        assert ActionType.HIGHLIGHT.value == "highlight"
+
+
+class TestEventType:
+    def test_values(self):
+        assert EventType.TIMEOUT.value == "timeout"
+        assert EventType.DISMISSED.value == "dismissed"
+
+
+class TestEventReason:
+    def test_values(self):
+        assert EventReason.NO_SPEECH.value == "no_speech"
+        assert EventReason.USER_CLOSE.value == "user_close"
+        assert EventReason.INTERNAL.value == "internal"
+
+
+# ── Message dataclass tests ─────────────────────────────────────
+
+
+class TestBaseMessage:
+    def test_defaults(self):
+        msg = BaseMessage()
+        assert msg.v == IPC_VERSION
+        assert msg.type == ""
+        assert isinstance(msg.id, str) and len(msg.id) == 12
+        assert isinstance(msg.ts, int)
+
+    def test_to_dict(self):
+        msg = BaseMessage(type="test")
+        d = msg.to_dict()
+        assert d["type"] == "test"
+        assert d["v"] == IPC_VERSION
+        assert "id" in d
+        assert "ts" in d
+
+
+class TestStateMessage:
+    def test_defaults(self):
+        msg = StateMessage()
+        assert msg.type == MessageType.STATE.value
+        assert msg.state == OverlayState.IDLE.value
+        assert msg.position == OverlayPosition.CENTER.value
+        assert msg.sticky is False
+        assert msg.priority == 10
+
+    def test_auto_icon(self):
+        msg = StateMessage(state=OverlayState.LISTENING.value)
+        assert msg.icon == OverlayState.LISTENING.value
+
+    def test_custom_icon(self):
+        msg = StateMessage(state=OverlayState.IDLE.value, icon="custom")
+        assert msg.icon == "custom"
+
+    def test_with_text_and_timeout(self):
+        msg = StateMessage(text="Hello", timeout_ms=5000)
+        d = msg.to_dict()
+        assert d["text"] == "Hello"
+        assert d["timeout_ms"] == 5000
+
+
+class TestActionMessage:
+    def test_defaults(self):
+        msg = ActionMessage()
+        assert msg.type == MessageType.ACTION.value
+        assert msg.action == ActionType.PREVIEW.value
+        assert msg.duration_ms == 1200
+
+    def test_with_coordinates(self):
+        msg = ActionMessage(action=ActionType.CURSOR_DOT.value, x=100, y=200)
+        d = msg.to_dict()
+        assert d["x"] == 100
+        assert d["y"] == 200
+
+    def test_with_rect(self):
+        msg = ActionMessage(
+            action=ActionType.HIGHLIGHT.value,
+            rect_x=10, rect_y=20, rect_w=100, rect_h=50,
+        )
+        d = msg.to_dict()
+        assert d["rect_x"] == 10
+        assert d["rect_w"] == 100
+
+
+class TestEventMessage:
+    def test_defaults(self):
+        msg = EventMessage()
+        assert msg.type == MessageType.EVENT.value
+        assert msg.event == EventType.TIMEOUT.value
+        assert msg.reason == EventReason.INTERNAL.value
+
+
+class TestAckMessage:
+    def test_defaults(self):
+        msg = AckMessage()
+        assert msg.type == MessageType.ACK.value
+
+
+class TestPingPong:
+    def test_ping(self):
+        msg = PingMessage()
+        assert msg.type == MessageType.PING.value
+
+    def test_pong(self):
+        msg = PongMessage()
+        assert msg.type == MessageType.PONG.value
+
+
+# ── Encode / Decode ─────────────────────────────────────────────
+
+
+class TestEncoding:
+    def test_encode_returns_bytes(self):
+        msg = StateMessage(text="test")
+        raw = encode_message(msg)
+        assert isinstance(raw, bytes)
+        assert raw.endswith(b"\n")
+
+    def test_encode_is_valid_json(self):
+        msg = StateMessage(text="merhaba")
+        raw = encode_message(msg)
+        parsed = json.loads(raw.decode("utf-8"))
+        assert parsed["text"] == "merhaba"
+        assert parsed["type"] == "state"
+
+    def test_roundtrip_state(self):
+        msg = StateMessage(text="hello", state=OverlayState.SPEAKING.value)
+        raw = encode_message(msg)
+        decoded = decode_message(raw)
+        assert decoded is not None
+        assert decoded["text"] == "hello"
+        assert decoded["state"] == "speaking"
+
+    def test_decode_invalid_bytes(self):
+        result = decode_message(b"not-json\n")
+        assert result is None
+
+    def test_decode_empty(self):
+        result = decode_message(b"")
+        assert result is None
+
+    def test_unicode_support(self):
+        msg = StateMessage(text="Düşünüyorum efendim...")
+        raw = encode_message(msg)
+        decoded = decode_message(raw)
+        assert decoded["text"] == "Düşünüyorum efendim..."
+
+
+# ── parse_message ────────────────────────────────────────────────
+
+
+class TestParseMessage:
+    def test_parse_state(self):
+        data = {"type": "state", "state": "listening", "text": "ok"}
+        msg = parse_message(data)
+        assert isinstance(msg, StateMessage)
+        assert msg.state == "listening"
+
+    def test_parse_action(self):
+        data = {"type": "action", "action": "preview", "text": "hi"}
+        msg = parse_message(data)
+        assert isinstance(msg, ActionMessage)
+        assert msg.text == "hi"
+
+    def test_parse_event(self):
+        data = {"type": "event", "event": "timeout", "reason": "no_speech"}
+        msg = parse_message(data)
+        assert isinstance(msg, EventMessage)
+        assert msg.reason == "no_speech"
+
+    def test_parse_ack(self):
+        data = {"type": "ack", "id": "abc123"}
+        msg = parse_message(data)
+        assert isinstance(msg, AckMessage)
+
+    def test_parse_ping(self):
+        msg = parse_message({"type": "ping"})
+        assert isinstance(msg, PingMessage)
+
+    def test_parse_pong(self):
+        msg = parse_message({"type": "pong"})
+        assert isinstance(msg, PongMessage)
+
+    def test_parse_invalid_type(self):
+        assert parse_message({"type": "unknown"}) is None
+
+    def test_parse_empty(self):
+        assert parse_message({}) is None
+        assert parse_message(None) is None
+
+
+# ── Convenience constructors ─────────────────────────────────────
+
+
+class TestConvenienceFunctions:
+    def test_state_idle(self):
+        msg = state_idle()
+        assert msg.state == "idle"
+        assert msg.position == "center"
+
+    def test_state_wake(self):
+        msg = state_wake("Merhaba")
+        assert msg.state == "wake"
+        assert msg.text == "Merhaba"
+        assert msg.timeout_ms == 8000
+
+    def test_state_listening(self):
+        msg = state_listening()
+        assert msg.state == "listening"
+
+    def test_state_thinking(self):
+        msg = state_thinking()
+        assert msg.state == "thinking"
+
+    def test_state_speaking(self):
+        msg = state_speaking("Anlattım efendim")
+        assert msg.state == "speaking"
+        assert msg.text == "Anlattım efendim"
+
+    def test_event_timeout(self):
+        msg = event_timeout()
+        assert msg.event == "timeout"
+        assert msg.reason == "no_speech"
+
+    def test_event_dismissed(self):
+        msg = event_dismissed()
+        assert msg.event == "dismissed"
+        assert msg.reason == "user_close"
+
+    def test_action_preview(self):
+        msg = action_preview("test", duration_ms=2000)
+        assert msg.action == "preview"
+        assert msg.text == "test"
+        assert msg.duration_ms == 2000
+
+    def test_action_cursor_dot(self):
+        msg = action_cursor_dot(100, 200)
+        assert msg.x == 100
+        assert msg.y == 200
+
+    def test_action_highlight_rect(self):
+        msg = action_highlight_rect(10, 20, 100, 50)
+        assert msg.rect_x == 10
+        assert msg.rect_y == 20
+        assert msg.rect_w == 100
+        assert msg.rect_h == 50
+
+
+# ── Socket path ──────────────────────────────────────────────────
+
+
+class TestSocketPath:
+    def test_get_socket_path_returns_path(self):
+        path = get_socket_path()
+        assert str(path).endswith("overlay.sock")
+        assert "bantz" in str(path)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,190 @@
+"""
+Tests for bantz.scheduler module — ReminderManager and CheckinManager.
+"""
+
+import sqlite3
+import pytest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from bantz.scheduler.reminder import ReminderManager
+from bantz.scheduler.checkin import CheckinManager
+
+
+# ── ReminderManager ─────────────────────────────────────────────
+
+
+class TestReminderManager:
+    @pytest.fixture
+    def manager(self, tmp_path):
+        db_path = tmp_path / "test_reminders.db"
+        return ReminderManager(db_path=db_path)
+
+    def test_init_creates_db(self, manager):
+        assert manager.db_path.exists()
+
+    def test_add_reminder_relative_time(self, manager):
+        result = manager.add_reminder("5 dakika sonra", "Test hatırlatma")
+        assert result["ok"] is True
+        assert "eklendi" in result["text"]
+
+    def test_add_reminder_absolute_time(self, manager):
+        # Use a future time today
+        future = (datetime.now() + timedelta(hours=2)).strftime("%H:%M")
+        result = manager.add_reminder(future, "Toplantı")
+        assert result["ok"] is True
+
+    def test_add_reminder_invalid_time(self, manager):
+        result = manager.add_reminder("geçen hafta", "Geçersiz")
+        assert result["ok"] is False
+        assert "anlayamadım" in result["text"]
+
+    def test_list_reminders_empty(self, manager):
+        result = manager.list_reminders()
+        assert result["ok"] is True
+        assert "yok" in result["text"]
+
+    def test_list_reminders_after_add(self, manager):
+        manager.add_reminder("10 dakika sonra", "Test mesaj")
+        result = manager.list_reminders()
+        assert result["ok"] is True
+        assert "Test mesaj" in result["text"]
+
+    def test_delete_reminder(self, manager):
+        add_result = manager.add_reminder("5 dakika sonra", "Silinecek")
+        # Extract reminder ID from the text
+        result = manager.delete_reminder(1)
+        assert result["ok"] is True
+        assert "silindi" in result["text"]
+
+    def test_delete_nonexistent(self, manager):
+        result = manager.delete_reminder(9999)
+        assert result["ok"] is False
+        assert "bulunamadı" in result["text"]
+
+    def test_snooze_reminder(self, manager):
+        manager.add_reminder("5 dakika sonra", "Ertelenecek")
+        result = manager.snooze_reminder(1, minutes=15)
+        assert result["ok"] is True
+        assert "ertelendi" in result["text"]
+
+    def test_snooze_nonexistent(self, manager):
+        result = manager.snooze_reminder(9999, minutes=10)
+        assert result["ok"] is False
+
+    def test_parse_time_dakika_sonra(self, manager):
+        dt = manager._parse_time("5 dakika sonra")
+        assert dt is not None
+        assert dt > datetime.now()
+
+    def test_parse_time_saat_sonra(self, manager):
+        dt = manager._parse_time("2 saat sonra")
+        assert dt is not None
+        diff = (dt - datetime.now()).total_seconds()
+        assert 7100 < diff < 7300  # ~2 hours
+
+    def test_parse_time_yarin(self, manager):
+        dt = manager._parse_time("yarın 09:00")
+        assert dt is not None
+        assert dt.hour == 9
+        assert dt.minute == 0
+        assert dt.date() == (datetime.now() + timedelta(days=1)).date()
+
+    def test_parse_time_invalid(self, manager):
+        dt = manager._parse_time("bilinmeyen format")
+        assert dt is None
+
+    def test_multiple_reminders(self, manager):
+        manager.add_reminder("5 dakika sonra", "Birinci")
+        manager.add_reminder("10 dakika sonra", "İkinci")
+        manager.add_reminder("15 dakika sonra", "Üçüncü")
+        result = manager.list_reminders()
+        assert result["ok"] is True
+        assert "Birinci" in result["text"]
+        assert "İkinci" in result["text"]
+        assert "Üçüncü" in result["text"]
+
+    def test_db_schema(self, manager):
+        with sqlite3.connect(manager.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+            tables = {row[0] for row in cursor.fetchall()}
+            assert "reminders" in tables
+
+
+# ── CheckinManager ──────────────────────────────────────────────
+
+
+class TestCheckinManager:
+    @pytest.fixture
+    def manager(self, tmp_path):
+        db_path = tmp_path / "test_checkins.db"
+        return CheckinManager(db_path=db_path)
+
+    def test_init_creates_db(self, manager):
+        assert manager.db_path.exists()
+
+    def test_db_schema(self, manager):
+        with sqlite3.connect(manager.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+            tables = {row[0] for row in cursor.fetchall()}
+            assert "checkins" in tables
+
+    def test_parse_schedule_dakika(self, manager):
+        dt, schedule = manager._parse_schedule("5 dakika sonra")
+        assert dt is not None
+        assert dt > datetime.now()
+        assert "once" in schedule
+
+    def test_parse_schedule_saat(self, manager):
+        dt, schedule = manager._parse_schedule("2 saat sonra")
+        assert dt is not None
+        diff = (dt - datetime.now()).total_seconds()
+        assert 7100 < diff < 7300
+
+    def test_parse_schedule_in_minutes(self, manager):
+        dt, schedule = manager._parse_schedule("in 10 minutes")
+        assert dt is not None
+        assert "once" in schedule
+
+    def test_parse_schedule_daily(self, manager):
+        dt, schedule = manager._parse_schedule("daily 21:00")
+        assert dt is not None
+        assert dt.hour == 21
+        assert dt.minute == 0
+
+    def test_parse_schedule_her_gun(self, manager):
+        dt, schedule = manager._parse_schedule("her gün 09:00")
+        assert dt is not None
+        assert dt.hour == 9
+
+    def test_parse_schedule_invalid(self, manager):
+        dt, error = manager._parse_schedule("bilinmeyen format")
+        assert dt is None
+        assert isinstance(error, str)
+
+    def test_add_checkin(self, manager):
+        result = manager.add_checkin("5 dakika sonra", "Nasılsın?")
+        assert result["ok"] is True
+        assert "eklendi" in result["text"]
+
+    def test_list_checkins_empty(self, manager):
+        result = manager.list_checkins()
+        assert result["ok"] is True
+
+    def test_list_checkins_after_add(self, manager):
+        manager.add_checkin("10 dakika sonra", "Check-in mesajı")
+        result = manager.list_checkins()
+        assert result["ok"] is True
+
+    def test_delete_checkin(self, manager):
+        manager.add_checkin("5 dakika sonra", "Silinecek")
+        result = manager.delete_checkin(1)
+        assert result["ok"] is True
+
+    def test_delete_nonexistent_checkin(self, manager):
+        result = manager.delete_checkin(9999)
+        assert result["ok"] is False


### PR DESCRIPTION
Closes #758

## Changes
- **tests/test_ipc.py** — 44 tests covering:
  - All Enums (MessageType, OverlayState, OverlayPosition, ActionType, EventType, EventReason)
  - Message dataclasses (BaseMessage, StateMessage, ActionMessage, EventMessage, AckMessage, PingPong)
  - Encode/Decode (bytes output, JSON validity, roundtrip, unicode, invalid input)
  - parse_message (all message types + edge cases)
  - Convenience functions (state_idle, state_wake, etc.)
  - Socket path configuration

- **tests/test_scheduler.py** — 29 tests covering:
  - ReminderManager: init, add/list/delete/snooze, _parse_time (dakika/saat/yarın/invalid), DB schema
  - CheckinManager: init, add/list/delete, _parse_schedule (Turkish + English formats, daily, invalid), DB schema

All 73 tests passing.