### PR TITLE
feat(#867): Web Dashboard + Gemini API Key + Telefon Erişimi

### DIFF
--- a/src/bantz/api/__init__.py
+++ b/src/bantz/api/__init__.py
@@ -1,11 +1,16 @@
-"""Bantz REST API — HTTP server for external access (Issue #834).
+"""Bantz REST API — HTTP server & web dashboard (Issues #834 + #867).
 
 Provides:
-- POST /api/v1/chat      — Send a message, get a response
-- GET  /api/v1/health     — Health check
-- GET  /api/v1/skills     — List registered skills
-- WS   /ws/chat           — WebSocket streaming chat
-- GET  /api/v1/notifications — SSE notification stream
+- GET  /                          — Web dashboard
+- POST /api/v1/chat               — Send a message, get a response
+- GET  /api/v1/health             — Health check
+- GET  /api/v1/skills             — List registered skills
+- GET  /api/v1/settings/status    — Key & system status
+- POST /api/v1/settings/gemini-key — Store Gemini API key
+- DELETE /api/v1/settings/gemini-key — Remove Gemini API key
+- GET  /api/v1/qrcode             — QR code for phone access
+- WS   /ws/chat                   — WebSocket streaming chat
+- GET  /api/v1/notifications      — SSE notification stream
 
 Start via CLI:
     bantz --serve --http

--- a/src/bantz/api/settings.py
+++ b/src/bantz/api/settings.py
@@ -1,0 +1,283 @@
+"""Settings API router — Gemini API Key management & system info (Issue #867).
+
+Endpoints:
+    GET  /api/v1/settings/status     — Key status + system info (never returns actual keys)
+    POST /api/v1/settings/gemini-key — Store Gemini API key in Fernet vault
+    DELETE /api/v1/settings/gemini-key — Remove Gemini API key from vault + env
+    GET  /api/v1/qrcode              — QR code PNG for LAN access URL
+"""
+from __future__ import annotations
+
+import io
+import logging
+import os
+import socket
+import time
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, Response
+
+from bantz.api.auth import require_auth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["settings"])
+
+# ── Constants ────────────────────────────────────────────────────
+GEMINI_KEY_VAULT_NAME = "GEMINI_API_KEY"
+
+
+# ─────────────────────────────────────────────────────────────────
+# GET /api/v1/settings/status
+# ─────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/api/v1/settings/status",
+    summary="System & key status",
+    description="Returns which API keys are configured, system info, and LAN access URL. Never exposes actual key values.",
+)
+async def settings_status(
+    request: Request,
+    _token: Optional[str] = Depends(require_auth),
+) -> JSONResponse:
+    """Return settings status — safe for UI consumption."""
+    gemini_set = _is_gemini_key_set()
+    api_token_set = bool(os.getenv("BANTZ_API_TOKEN", "").strip())
+    uptime = time.time() - request.app.state.start_time
+
+    # Detect brain/finalizer info
+    server = request.app.state.bantz_server
+    brain_active = server is not None and getattr(server, "_brain", None) is not None
+    finalizer = "Gemini 2.0 Flash" if gemini_set else "3B (local)"
+    router_model = _get_router_model(server)
+    tool_count = _count_tools(server)
+
+    # LAN access URL
+    access_url = _get_lan_url(request)
+
+    return JSONResponse(content={
+        "gemini_key_set": gemini_set,
+        "api_token_set": api_token_set,
+        "version": "0.3.0",
+        "uptime_seconds": round(uptime, 2),
+        "brain_active": brain_active,
+        "finalizer": finalizer,
+        "router_model": router_model,
+        "tool_count": tool_count,
+        "access_url": access_url,
+    })
+
+
+# ─────────────────────────────────────────────────────────────────
+# POST /api/v1/settings/gemini-key
+# ─────────────────────────────────────────────────────────────────
+
+@router.post(
+    "/api/v1/settings/gemini-key",
+    summary="Store Gemini API key",
+    description="Encrypts the key with Fernet and stores it in the vault. Also injects it into the runtime environment.",
+)
+async def save_gemini_key(
+    request: Request,
+    _token: Optional[str] = Depends(require_auth),
+) -> JSONResponse:
+    """Store Gemini API key in vault and inject to env."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            status_code=400,
+            content={"ok": False, "error": "Geçersiz JSON body"},
+        )
+
+    key = body.get("key", "").strip()
+    if not key:
+        return JSONResponse(
+            status_code=400,
+            content={"ok": False, "error": "API key boş olamaz"},
+        )
+
+    if not key.startswith("AIza"):
+        return JSONResponse(
+            status_code=400,
+            content={"ok": False, "error": "Geçersiz key formatı — AIza... ile başlamalı"},
+        )
+
+    try:
+        vault = _get_vault()
+        from bantz.security.vault import SecretType
+
+        vault.store(
+            GEMINI_KEY_VAULT_NAME,
+            key,
+            secret_type=SecretType.API_KEY,
+            metadata={"source": "web_dashboard", "set_at": time.strftime("%Y-%m-%dT%H:%M:%S")},
+        )
+
+        # Inject into runtime env so LLM clients pick it up immediately
+        os.environ["GEMINI_API_KEY"] = key
+        os.environ["GOOGLE_API_KEY"] = key
+
+        logger.info("Gemini API key stored in vault and injected to runtime (source=web_dashboard)")
+        return JSONResponse(content={"ok": True, "message": "Key kaydedildi ve aktifleştirildi"})
+
+    except Exception as exc:
+        logger.exception("Failed to store Gemini API key: %s", exc)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": f"Key kaydedilemedi: {exc}"},
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# DELETE /api/v1/settings/gemini-key
+# ─────────────────────────────────────────────────────────────────
+
+@router.delete(
+    "/api/v1/settings/gemini-key",
+    summary="Delete Gemini API key",
+    description="Removes the key from vault and runtime environment.",
+)
+async def delete_gemini_key(
+    _token: Optional[str] = Depends(require_auth),
+) -> JSONResponse:
+    """Delete Gemini API key from vault and env."""
+    try:
+        vault = _get_vault()
+        deleted = vault.delete(GEMINI_KEY_VAULT_NAME)
+
+        # Remove from runtime env
+        os.environ.pop("GEMINI_API_KEY", None)
+        os.environ.pop("GOOGLE_API_KEY", None)
+
+        if deleted:
+            logger.info("Gemini API key deleted from vault and runtime")
+            return JSONResponse(content={"ok": True, "message": "Key silindi"})
+        else:
+            return JSONResponse(content={"ok": True, "message": "Key zaten kayıtlı değildi"})
+
+    except Exception as exc:
+        logger.exception("Failed to delete Gemini API key: %s", exc)
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": f"Key silinemedi: {exc}"},
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# GET /api/v1/qrcode
+# ─────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/api/v1/qrcode",
+    summary="QR code for phone access",
+    description="Returns a PNG QR code encoding the LAN access URL for phone scanning.",
+    responses={200: {"content": {"image/png": {}}}, 501: {}},
+)
+async def qrcode(request: Request) -> Response:
+    """Generate QR code for the LAN URL."""
+    url = _get_lan_url(request)
+
+    try:
+        import qrcode as qr_lib
+        from qrcode.image.pil import PilImage
+
+        qr = qr_lib.QRCode(version=1, box_size=8, border=2)
+        qr.add_data(url)
+        qr.make(fit=True)
+        img: PilImage = qr.make_image(fill_color="#7c3aed", back_color="#0f0f23")
+
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        return Response(content=buf.read(), media_type="image/png")
+
+    except ImportError:
+        # qrcode or Pillow not installed — return URL as plain text
+        logger.debug("qrcode package not installed — QR generation skipped")
+        return JSONResponse(
+            status_code=501,
+            content={"error": "qrcode paketi yüklü değil", "url": url},
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# Helper functions
+# ─────────────────────────────────────────────────────────────────
+
+def _get_vault():
+    """Get or create a SecretsVault instance."""
+    from bantz.security.vault import SecretsVault
+
+    return SecretsVault()
+
+
+def _is_gemini_key_set() -> bool:
+    """Check if Gemini API key is set in env or vault."""
+    # Check env first (could be set externally)
+    if os.getenv("GEMINI_API_KEY", "").strip():
+        return True
+    if os.getenv("GOOGLE_API_KEY", "").strip():
+        return True
+
+    # Check vault
+    try:
+        vault = _get_vault()
+        return vault.exists(GEMINI_KEY_VAULT_NAME)
+    except Exception:
+        return False
+
+
+def _get_lan_url(request: Request) -> str:
+    """Build the LAN-accessible URL for this server."""
+    # Try to detect local IP
+    ip = _get_local_ip()
+    port = request.url.port or 8088
+    return f"http://{ip}:{port}"
+
+
+def _get_local_ip() -> str:
+    """Get the machine's LAN IP address."""
+    try:
+        # Connect to a public DNS to find our outbound interface
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(1.0)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return "127.0.0.1"
+
+
+def _get_router_model(server: Any) -> str:
+    """Get the router model name from the brain."""
+    if server is None:
+        return "-"
+    brain = getattr(server, "_brain", None)
+    if brain is None:
+        return "-"
+    # Try to get model from brain config
+    config = getattr(brain, "config", None) or getattr(brain, "_config", None)
+    if config:
+        model = getattr(config, "router_model", None) or getattr(config, "model", None)
+        if model:
+            return str(model)
+    return getattr(brain, "model_name", "-")
+
+
+def _count_tools(server: Any) -> int:
+    """Count registered tools."""
+    if server is None:
+        return 0
+    brain = getattr(server, "_brain", None)
+    if brain is None:
+        return 0
+    tools = getattr(brain, "tools", None)
+    if tools is None:
+        return 0
+    try:
+        return len(tools.list_tools())
+    except Exception:
+        return 0

--- a/src/bantz/api/static/index.html
+++ b/src/bantz/api/static/index.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html lang="tr" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="theme-color" content="#0f0f23">
+<title>Bantz — Personal AI Assistant</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>">
+<link rel="manifest" href="/manifest.json">
+<style>
+/* ── Reset & Base ─────────────────────────────────── */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0f0f23;--bg2:#1a1a3e;--bg3:#252550;
+  --fg:#e2e2f0;--fg2:#8888aa;--fg3:#555577;
+  --accent:#7c3aed;--accent2:#a78bfa;--accent-glow:rgba(124,58,237,.25);
+  --green:#22c55e;--red:#ef4444;--yellow:#eab308;--cyan:#06b6d4;
+  --radius:12px;--radius-sm:8px;
+  --shadow:0 4px 24px rgba(0,0,0,.4);
+  --font:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  --mono:'SF Mono','Cascadia Code','Fira Code',monospace;
+}
+html{font-size:16px;-webkit-text-size-adjust:100%}
+body{font-family:var(--font);background:var(--bg);color:var(--fg);min-height:100dvh;overflow:hidden}
+a{color:var(--accent2);text-decoration:none}
+button{cursor:pointer;font-family:var(--font);border:none;outline:none}
+input,textarea{font-family:var(--font);outline:none}
+::-webkit-scrollbar{width:6px}
+::-webkit-scrollbar-track{background:transparent}
+::-webkit-scrollbar-thumb{background:var(--fg3);border-radius:3px}
+
+/* ── Layout ───────────────────────────────────────── */
+.app{display:flex;height:100dvh;width:100vw}
+.sidebar{width:280px;background:var(--bg2);border-right:1px solid var(--bg3);display:flex;flex-direction:column;flex-shrink:0;transition:transform .3s}
+.main{flex:1;display:flex;flex-direction:column;min-width:0}
+
+/* ── Sidebar ──────────────────────────────────────── */
+.sidebar-header{padding:20px;border-bottom:1px solid var(--bg3);text-align:center}
+.sidebar-header h1{font-size:1.4rem;font-weight:700;background:linear-gradient(135deg,var(--accent2),var(--cyan));-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.sidebar-header .subtitle{font-size:.75rem;color:var(--fg2);margin-top:4px}
+
+.sidebar-nav{flex:1;overflow-y:auto;padding:12px}
+.nav-item{display:flex;align-items:center;gap:10px;padding:10px 14px;border-radius:var(--radius-sm);color:var(--fg2);font-size:.9rem;transition:all .15s;cursor:pointer}
+.nav-item:hover,.nav-item.active{background:var(--bg3);color:var(--fg)}
+.nav-item .icon{font-size:1.1rem;width:24px;text-align:center}
+.nav-badge{margin-left:auto;background:var(--accent);color:#fff;font-size:.7rem;padding:2px 7px;border-radius:10px;min-width:20px;text-align:center}
+
+.sidebar-footer{padding:16px;border-top:1px solid var(--bg3)}
+.status-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.status-item{display:flex;align-items:center;gap:6px;font-size:.75rem;color:var(--fg2)}
+.status-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.status-dot.ok{background:var(--green)}
+.status-dot.degraded{background:var(--yellow)}
+.status-dot.down{background:var(--red)}
+.status-dot.unknown{background:var(--fg3)}
+
+/* ── Mobile Sidebar Toggle ────────────────────────── */
+.sidebar-toggle{display:none;position:fixed;top:12px;left:12px;z-index:100;background:var(--bg2);border:1px solid var(--bg3);border-radius:var(--radius-sm);padding:8px 12px;color:var(--fg);font-size:1.2rem}
+.sidebar-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.5);z-index:49}
+
+/* ── Chat Panel ───────────────────────────────────── */
+.chat-header{padding:16px 20px;border-bottom:1px solid var(--bg3);display:flex;align-items:center;gap:12px;background:var(--bg)}
+.chat-header h2{font-size:1.1rem;font-weight:600}
+.chat-header .route-badge{font-size:.7rem;background:var(--bg3);color:var(--fg2);padding:3px 8px;border-radius:6px}
+.conn-status{margin-left:auto;display:flex;align-items:center;gap:6px;font-size:.75rem;color:var(--fg2)}
+
+.chat-messages{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:12px}
+.msg{max-width:80%;padding:12px 16px;border-radius:var(--radius);font-size:.95rem;line-height:1.5;word-break:break-word;animation:msgIn .25s ease}
+@keyframes msgIn{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+.msg.user{align-self:flex-end;background:var(--accent);color:#fff;border-bottom-right-radius:4px}
+.msg.assistant{align-self:flex-start;background:var(--bg2);border:1px solid var(--bg3);border-bottom-left-radius:4px}
+.msg .meta{font-size:.7rem;color:var(--fg3);margin-top:6px;display:flex;gap:8px}
+.msg.assistant .meta{color:var(--fg3)}
+.msg.user .meta{color:rgba(255,255,255,.6)}
+.msg.system{align-self:center;background:transparent;color:var(--fg2);font-size:.8rem;padding:6px;text-align:center}
+.msg pre{background:var(--bg);padding:8px 10px;border-radius:6px;overflow-x:auto;font-family:var(--mono);font-size:.85rem;margin-top:8px}
+.typing{align-self:flex-start;color:var(--fg2);font-size:.85rem;display:flex;align-items:center;gap:8px;padding:8px 16px}
+.typing-dots{display:flex;gap:4px}
+.typing-dots span{width:6px;height:6px;border-radius:50%;background:var(--fg3);animation:blink 1.4s infinite both}
+.typing-dots span:nth-child(2){animation-delay:.2s}
+.typing-dots span:nth-child(3){animation-delay:.4s}
+@keyframes blink{0%,80%,100%{opacity:.3}40%{opacity:1}}
+
+.chat-input{padding:16px 20px;border-top:1px solid var(--bg3);background:var(--bg)}
+.input-row{display:flex;gap:10px;align-items:flex-end}
+.input-row textarea{flex:1;background:var(--bg2);border:1px solid var(--bg3);border-radius:var(--radius);padding:12px 16px;color:var(--fg);font-size:.95rem;resize:none;min-height:44px;max-height:120px;transition:border-color .15s}
+.input-row textarea:focus{border-color:var(--accent)}
+.input-row textarea::placeholder{color:var(--fg3)}
+.send-btn{background:var(--accent);color:#fff;border-radius:var(--radius);padding:12px 20px;font-size:.95rem;font-weight:600;transition:all .15s;flex-shrink:0}
+.send-btn:hover{background:var(--accent2);transform:translateY(-1px)}
+.send-btn:active{transform:translateY(0)}
+.send-btn:disabled{opacity:.4;cursor:not-allowed;transform:none}
+
+/* ── Settings Panel ───────────────────────────────── */
+.panel{display:none;flex:1;flex-direction:column;overflow-y:auto;padding:24px}
+.panel.active{display:flex}
+.panel-title{font-size:1.3rem;font-weight:700;margin-bottom:20px}
+.card{background:var(--bg2);border:1px solid var(--bg3);border-radius:var(--radius);padding:20px;margin-bottom:16px}
+.card-title{font-size:1rem;font-weight:600;margin-bottom:12px;display:flex;align-items:center;gap:8px}
+.card-title .icon{font-size:1.2rem}
+
+.form-group{margin-bottom:16px}
+.form-group label{display:block;font-size:.85rem;color:var(--fg2);margin-bottom:6px}
+.form-group input[type=text],.form-group input[type=password]{width:100%;background:var(--bg);border:1px solid var(--bg3);border-radius:var(--radius-sm);padding:10px 14px;color:var(--fg);font-size:.9rem;transition:border-color .15s}
+.form-group input:focus{border-color:var(--accent)}
+.form-group .hint{font-size:.75rem;color:var(--fg3);margin-top:4px}
+
+.btn{padding:10px 20px;border-radius:var(--radius-sm);font-size:.9rem;font-weight:500;transition:all .15s}
+.btn-primary{background:var(--accent);color:#fff}
+.btn-primary:hover{background:var(--accent2)}
+.btn-danger{background:var(--red);color:#fff}
+.btn-danger:hover{opacity:.85}
+.btn-outline{background:transparent;border:1px solid var(--bg3);color:var(--fg2)}
+.btn-outline:hover{border-color:var(--accent);color:var(--fg)}
+.btn-row{display:flex;gap:10px;flex-wrap:wrap}
+
+.key-status{display:flex;align-items:center;gap:8px;padding:12px;background:var(--bg);border-radius:var(--radius-sm);margin-bottom:16px}
+.key-status.set{border-left:3px solid var(--green)}
+.key-status.unset{border-left:3px solid var(--yellow)}
+
+/* ── Skills Panel ─────────────────────────────────── */
+.skill-list{display:grid;gap:10px}
+.skill-card{background:var(--bg);border:1px solid var(--bg3);border-radius:var(--radius-sm);padding:14px;display:flex;align-items:center;gap:12px}
+.skill-card .skill-icon{font-size:1.4rem;width:36px;text-align:center}
+.skill-card .skill-name{font-weight:500}
+.skill-card .skill-desc{font-size:.8rem;color:var(--fg2);margin-top:2px}
+.skill-card .skill-source{margin-left:auto;font-size:.7rem;background:var(--bg3);padding:2px 8px;border-radius:4px;color:var(--fg2)}
+
+/* ── Inbox Panel ──────────────────────────────────── */
+.inbox-item{background:var(--bg);border:1px solid var(--bg3);border-radius:var(--radius-sm);padding:14px;display:flex;align-items:flex-start;gap:12px;margin-bottom:8px}
+.inbox-item.unread{border-left:3px solid var(--accent)}
+.inbox-item .inbox-icon{font-size:1.2rem;flex-shrink:0;margin-top:2px}
+.inbox-item .inbox-text{flex:1;font-size:.9rem}
+.inbox-item .inbox-time{font-size:.7rem;color:var(--fg3);margin-top:4px}
+.inbox-item .inbox-mark{font-size:.75rem;color:var(--accent2);cursor:pointer;flex-shrink:0}
+.inbox-empty{text-align:center;color:var(--fg3);padding:40px}
+
+/* ── QR Panel ─────────────────────────────────────── */
+.qr-container{text-align:center;padding:20px}
+.qr-container img{max-width:200px;border-radius:var(--radius);border:2px solid var(--bg3)}
+.qr-url{font-family:var(--mono);font-size:.85rem;color:var(--accent2);margin-top:12px;word-break:break-all}
+
+/* ── Toast ────────────────────────────────────────── */
+.toast{position:fixed;bottom:24px;right:24px;background:var(--bg2);border:1px solid var(--bg3);border-radius:var(--radius);padding:14px 20px;color:var(--fg);font-size:.9rem;box-shadow:var(--shadow);z-index:200;animation:toastIn .3s ease;max-width:360px}
+.toast.success{border-left:3px solid var(--green)}
+.toast.error{border-left:3px solid var(--red)}
+@keyframes toastIn{from{opacity:0;transform:translateY(20px)}to{opacity:1;transform:none}}
+
+/* ── Mobile ───────────────────────────────────────── */
+@media(max-width:768px){
+  .sidebar{position:fixed;left:0;top:0;bottom:0;z-index:50;transform:translateX(-100%)}
+  .sidebar.open{transform:none}
+  .sidebar-toggle{display:block}
+  .sidebar-overlay.open{display:block}
+  .msg{max-width:90%}
+  .chat-header{padding-left:52px}
+  .panel{padding:16px}
+}
+</style>
+</head>
+<body>
+
+<button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Menu">☰</button>
+<div class="sidebar-overlay" id="sidebarOverlay" onclick="toggleSidebar()"></div>
+
+<div class="app">
+  <!-- Sidebar -->
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+      <h1>🧠 Bantz</h1>
+      <div class="subtitle">Personal AI Assistant</div>
+    </div>
+    <nav class="sidebar-nav">
+      <div class="nav-item active" onclick="showPanel('chat')" data-panel="chat">
+        <span class="icon">💬</span> Chat
+      </div>
+      <div class="nav-item" onclick="showPanel('settings')" data-panel="settings">
+        <span class="icon">⚙️</span> Ayarlar
+      </div>
+      <div class="nav-item" onclick="showPanel('skills')" data-panel="skills">
+        <span class="icon">🔧</span> Yetenekler
+        <span class="nav-badge" id="skillCount">-</span>
+      </div>
+      <div class="nav-item" onclick="showPanel('inbox')" data-panel="inbox">
+        <span class="icon">📥</span> Inbox
+        <span class="nav-badge" id="inboxBadge" style="display:none">0</span>
+      </div>
+      <div class="nav-item" onclick="showPanel('access')" data-panel="access">
+        <span class="icon">📱</span> Telefon Erişimi
+      </div>
+    </nav>
+    <div class="sidebar-footer">
+      <div class="status-grid" id="statusGrid">
+        <div class="status-item"><span class="status-dot unknown"></span>Brain</div>
+        <div class="status-item"><span class="status-dot unknown"></span>vLLM</div>
+        <div class="status-item"><span class="status-dot unknown"></span>Gemini</div>
+        <div class="status-item"><span class="status-dot unknown"></span>API</div>
+      </div>
+    </div>
+  </aside>
+
+  <!-- Main Content -->
+  <div class="main">
+    <!-- Chat Panel -->
+    <div class="panel active" id="panel-chat" style="padding:0;display:flex">
+      <div style="flex:1;display:flex;flex-direction:column">
+        <div class="chat-header">
+          <h2>💬 Chat</h2>
+          <span class="route-badge" id="lastRoute">ready</span>
+          <div class="conn-status">
+            <span class="status-dot" id="wsDot"></span>
+            <span id="wsLabel">bağlanıyor...</span>
+          </div>
+        </div>
+        <div class="chat-messages" id="chatMessages">
+          <div class="msg system">Bantz'a hoş geldin! Bir şey sor veya komut yaz.</div>
+        </div>
+        <div class="chat-input">
+          <div class="input-row">
+            <textarea id="chatInput" placeholder="Mesajını yaz..." rows="1" onkeydown="handleInputKey(event)"></textarea>
+            <button class="send-btn" id="sendBtn" onclick="sendMessage()">Gönder</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Settings Panel -->
+    <div class="panel" id="panel-settings">
+      <h2 class="panel-title">⚙️ Ayarlar</h2>
+
+      <div class="card">
+        <div class="card-title"><span class="icon">🔑</span> Gemini API Key</div>
+        <div class="key-status unset" id="geminiStatus">
+          <span class="status-dot yellow"></span>
+          <span id="geminiStatusText">Kontrol ediliyor...</span>
+        </div>
+        <div class="form-group">
+          <label for="geminiKeyInput">API Key</label>
+          <input type="password" id="geminiKeyInput" placeholder="AIza... (Google AI Studio'dan al)">
+          <div class="hint">Key Fernet ile şifrelenerek vault'a kaydedilir. Asla plain text olarak saklanmaz.</div>
+        </div>
+        <div class="btn-row">
+          <button class="btn btn-primary" onclick="saveGeminiKey()">💾 Kaydet</button>
+          <button class="btn btn-danger" onclick="deleteGeminiKey()" id="deleteKeyBtn" style="display:none">🗑️ Sil</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="icon">🔒</span> API Token</div>
+        <div class="key-status" id="apiTokenStatus">
+          <span class="status-dot"></span>
+          <span id="apiTokenStatusText">Kontrol ediliyor...</span>
+        </div>
+        <div class="form-group">
+          <div class="hint">BANTZ_API_TOKEN env var ile ayarlanır. Aktifse tüm API çağrıları Bearer token gerektirir.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="icon">📊</span> Sistem Bilgisi</div>
+        <div id="systemInfo" style="font-size:.85rem;color:var(--fg2)">Yükleniyor...</div>
+      </div>
+    </div>
+
+    <!-- Skills Panel -->
+    <div class="panel" id="panel-skills">
+      <h2 class="panel-title">🔧 Yetenekler</h2>
+      <div class="skill-list" id="skillList">
+        <div style="color:var(--fg2)">Yükleniyor...</div>
+      </div>
+    </div>
+
+    <!-- Inbox Panel -->
+    <div class="panel" id="panel-inbox">
+      <h2 class="panel-title">📥 Inbox</h2>
+      <div id="inboxList">
+        <div class="inbox-empty">📭 Inbox boş</div>
+      </div>
+    </div>
+
+    <!-- Phone Access Panel -->
+    <div class="panel" id="panel-access">
+      <h2 class="panel-title">📱 Telefon Erişimi</h2>
+      <div class="card">
+        <div class="card-title"><span class="icon">📶</span> LAN Erişim Adresi</div>
+        <p style="font-size:.9rem;color:var(--fg2);margin-bottom:16px">Telefonundan aynı WiFi üzerinden bu adrese git:</p>
+        <div class="qr-container">
+          <img id="qrImage" alt="QR Code" style="display:none">
+          <div class="qr-url" id="accessUrl">Yükleniyor...</div>
+        </div>
+        <div style="margin-top:16px;text-align:center">
+          <button class="btn btn-outline" onclick="copyAccessUrl()">📋 URL'yi Kopyala</button>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-title"><span class="icon">💡</span> Nasıl Kullanılır?</div>
+        <ol style="font-size:.9rem;color:var(--fg2);padding-left:20px;line-height:1.8">
+          <li>Bilgisayarın ve telefonun aynı WiFi ağında olmalı</li>
+          <li>Yukarıdaki adresi telefon tarayıcında aç</li>
+          <li>Safari/Chrome: "Ana Ekrana Ekle" ile uygulama gibi kullan</li>
+          <li>Tüm özellikler telefondan da çalışır</li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ── State ────────────────────────────────────────── */
+let ws = null;
+let wsReconnectTimer = null;
+const API = window.location.origin;
+
+/* ── Sidebar ──────────────────────────────────────── */
+function toggleSidebar(){
+  document.getElementById('sidebar').classList.toggle('open');
+  document.getElementById('sidebarOverlay').classList.toggle('open');
+}
+function showPanel(name){
+  document.querySelectorAll('.panel').forEach(p=>p.classList.remove('active'));
+  document.querySelectorAll('.nav-item').forEach(n=>n.classList.remove('active'));
+  const panel = document.getElementById('panel-'+name);
+  if(panel){panel.classList.add('active');if(name==='chat')panel.style.display='flex'}
+  document.querySelector(`.nav-item[data-panel="${name}"]`)?.classList.add('active');
+  // Close mobile sidebar
+  document.getElementById('sidebar').classList.remove('open');
+  document.getElementById('sidebarOverlay').classList.remove('open');
+  // Load data for panel
+  if(name==='settings')loadSettings();
+  if(name==='skills')loadSkills();
+  if(name==='inbox')loadInbox();
+  if(name==='access')loadAccess();
+}
+
+/* ── WebSocket ────────────────────────────────────── */
+function connectWS(){
+  const proto = location.protocol==='https:'?'wss:':'ws:';
+  const url = `${proto}//${location.host}/ws/chat`;
+  try{ ws = new WebSocket(url) }catch(e){ setWSStatus('down','hata');return }
+  ws.onopen = ()=>{ setWSStatus('ok','bağlı'); if(wsReconnectTimer){clearTimeout(wsReconnectTimer);wsReconnectTimer=null} };
+  ws.onclose = ()=>{ setWSStatus('down','koptu'); scheduleReconnect() };
+  ws.onerror = ()=>{ setWSStatus('down','hata') };
+  ws.onmessage = (e)=>{
+    try{
+      const msg = JSON.parse(e.data);
+      if(msg.type==='chat'){
+        hideTyping();
+        addMessage('assistant', msg.data.response||'(boş yanıt)', msg.data.route);
+        document.getElementById('lastRoute').textContent = msg.data.route||'unknown';
+      } else if(msg.type==='event'){
+        // Orchestrator trace events — could show in future
+      } else if(msg.type==='error'){
+        hideTyping();
+        addMessage('system', '⚠️ '+( msg.data.error||'Bilinmeyen hata'));
+      }
+    }catch(err){ console.error('WS parse error',err) }
+  };
+}
+function scheduleReconnect(){
+  if(!wsReconnectTimer) wsReconnectTimer = setTimeout(()=>{wsReconnectTimer=null;connectWS()}, 3000);
+}
+function setWSStatus(status, label){
+  const dot = document.getElementById('wsDot');
+  const lbl = document.getElementById('wsLabel');
+  dot.className = 'status-dot '+status;
+  lbl.textContent = label;
+}
+
+/* ── Chat ─────────────────────────────────────────── */
+function sendMessage(){
+  const input = document.getElementById('chatInput');
+  const text = input.value.trim();
+  if(!text) return;
+  addMessage('user', text);
+  input.value='';
+  autoResize(input);
+  showTyping();
+  if(ws && ws.readyState===WebSocket.OPEN){
+    ws.send(JSON.stringify({type:'chat',message:text}));
+  } else {
+    // Fallback to REST
+    fetch(API+'/api/v1/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:text})})
+      .then(r=>r.json())
+      .then(d=>{hideTyping();addMessage('assistant',d.response||d.text||'(boş)',d.route);document.getElementById('lastRoute').textContent=d.route||'unknown'})
+      .catch(e=>{hideTyping();addMessage('system','⚠️ Bağlantı hatası: '+e.message)});
+  }
+}
+function addMessage(role, text, route){
+  const container = document.getElementById('chatMessages');
+  const div = document.createElement('div');
+  div.className = 'msg '+role;
+  // Simple markdown: bold, code blocks, inline code
+  let html = escapeHtml(text);
+  html = html.replace(/```([\s\S]*?)```/g,'<pre>$1</pre>');
+  html = html.replace(/`([^`]+)`/g,'<code style="background:var(--bg);padding:2px 5px;border-radius:3px;font-family:var(--mono);font-size:.85em">$1</code>');
+  html = html.replace(/\*\*(.+?)\*\*/g,'<strong>$1</strong>');
+  html = html.replace(/\n/g,'<br>');
+  div.innerHTML = html;
+  // Meta
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  meta.textContent = new Date().toLocaleTimeString('tr-TR',{hour:'2-digit',minute:'2-digit'});
+  if(route && role==='assistant') meta.textContent += ' · '+route;
+  div.appendChild(meta);
+  container.appendChild(div);
+  container.scrollTop = container.scrollHeight;
+}
+function showTyping(){
+  if(document.getElementById('typingIndicator'))return;
+  const container = document.getElementById('chatMessages');
+  const div = document.createElement('div');
+  div.className='typing';div.id='typingIndicator';
+  div.innerHTML='<div class="typing-dots"><span></span><span></span><span></span></div> Düşünüyor...';
+  container.appendChild(div);
+  container.scrollTop = container.scrollHeight;
+  document.getElementById('sendBtn').disabled = true;
+}
+function hideTyping(){
+  document.getElementById('typingIndicator')?.remove();
+  document.getElementById('sendBtn').disabled = false;
+}
+function handleInputKey(e){
+  if(e.key==='Enter'&&!e.shiftKey){e.preventDefault();sendMessage();return}
+  autoResize(e.target);
+}
+function autoResize(el){el.style.height='auto';el.style.height=Math.min(el.scrollHeight,120)+'px'}
+function escapeHtml(t){const d=document.createElement('div');d.textContent=t;return d.innerHTML}
+
+/* ── Settings ─────────────────────────────────────── */
+function loadSettings(){
+  fetch(API+'/api/v1/settings/status').then(r=>r.json()).then(d=>{
+    // Gemini status
+    const gs = document.getElementById('geminiStatus');
+    const gt = document.getElementById('geminiStatusText');
+    const db = document.getElementById('deleteKeyBtn');
+    if(d.gemini_key_set){
+      gs.className='key-status set';
+      gs.querySelector('.status-dot').className='status-dot ok';
+      gt.textContent='✓ Gemini API Key ayarlanmış — Finalizer aktif';
+      db.style.display='inline-block';
+    } else {
+      gs.className='key-status unset';
+      gs.querySelector('.status-dot').className='status-dot yellow';
+      gt.textContent='⚠ Gemini API Key ayarlanmamış — 3B fallback kullanılıyor';
+      db.style.display='none';
+    }
+    // API token
+    const ats = document.getElementById('apiTokenStatus');
+    const att = document.getElementById('apiTokenStatusText');
+    if(d.api_token_set){
+      ats.className='key-status set';
+      ats.querySelector('.status-dot').className='status-dot ok';
+      att.textContent='✓ API Token aktif — Bearer auth gerekli';
+    } else {
+      ats.className='key-status unset';
+      ats.querySelector('.status-dot').className='status-dot yellow';
+      att.textContent='⚠ API Token ayarlanmamış — auth devre dışı (dev mode)';
+    }
+    // System info
+    const si = document.getElementById('systemInfo');
+    si.innerHTML = `
+      <div style="display:grid;grid-template-columns:auto 1fr;gap:6px 16px">
+        <span>Versiyon:</span><span>${d.version||'0.3.0'}</span>
+        <span>Uptime:</span><span>${formatUptime(d.uptime_seconds||0)}</span>
+        <span>Brain:</span><span>${d.brain_active?'✓ Aktif':'⚠ Legacy'}</span>
+        <span>Finalizer:</span><span>${d.finalizer||'3B (local)'}</span>
+        <span>Router Model:</span><span style="font-family:var(--mono);font-size:.8rem">${d.router_model||'-'}</span>
+        <span>Tools:</span><span>${d.tool_count||0} kayıtlı</span>
+      </div>`;
+  }).catch(()=>{
+    document.getElementById('geminiStatusText').textContent='Bağlantı hatası';
+    document.getElementById('systemInfo').textContent='Yüklenemedi';
+  });
+}
+function saveGeminiKey(){
+  const key = document.getElementById('geminiKeyInput').value.trim();
+  if(!key){showToast('API key boş olamaz','error');return}
+  if(!key.startsWith('AIza')){showToast('Geçersiz key formatı (AIza... ile başlamalı)','error');return}
+  fetch(API+'/api/v1/settings/gemini-key',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({key:key})})
+    .then(r=>r.json())
+    .then(d=>{
+      if(d.ok){
+        showToast('✓ Gemini API Key kaydedildi ve aktifleştirildi','success');
+        document.getElementById('geminiKeyInput').value='';
+        loadSettings();
+        loadHealth();
+      } else {
+        showToast('✗ Hata: '+(d.error||'Bilinmeyen'),'error');
+      }
+    }).catch(e=>showToast('✗ Bağlantı hatası','error'));
+}
+function deleteGeminiKey(){
+  if(!confirm('Gemini API Key silinecek. Emin misin?'))return;
+  fetch(API+'/api/v1/settings/gemini-key',{method:'DELETE'})
+    .then(r=>r.json())
+    .then(d=>{
+      if(d.ok){showToast('✓ Key silindi','success');loadSettings();loadHealth();}
+      else showToast('✗ '+d.error,'error');
+    }).catch(e=>showToast('✗ Bağlantı hatası','error'));
+}
+
+/* ── Skills ────────────────────────────────────────── */
+function loadSkills(){
+  fetch(API+'/api/v1/skills').then(r=>r.json()).then(d=>{
+    document.getElementById('skillCount').textContent=d.count||0;
+    const list = document.getElementById('skillList');
+    if(!d.skills||!d.skills.length){list.innerHTML='<div style="color:var(--fg2)">Kayıtlı yetenek yok</div>';return}
+    list.innerHTML = d.skills.map(s=>`
+      <div class="skill-card">
+        <div class="skill-icon">${s.source==='declarative'?'📝':'🔧'}</div>
+        <div>
+          <div class="skill-name">${escapeHtml(s.name)}</div>
+          <div class="skill-desc">${escapeHtml(s.description||'')}</div>
+        </div>
+        <span class="skill-source">${s.source}</span>
+      </div>`).join('');
+  }).catch(()=>{document.getElementById('skillList').innerHTML='<div style="color:var(--red)">Yüklenemedi</div>'});
+}
+
+/* ── Inbox ─────────────────────────────────────────── */
+function loadInbox(){
+  fetch(API+'/api/v1/inbox').then(r=>r.json()).then(d=>{
+    const badge = document.getElementById('inboxBadge');
+    if(d.unread>0){badge.textContent=d.unread;badge.style.display='inline'}
+    else badge.style.display='none';
+    const list = document.getElementById('inboxList');
+    if(!d.items||!d.items.length){list.innerHTML='<div class="inbox-empty">📭 Inbox boş</div>';return}
+    list.innerHTML = d.items.map(it=>`
+      <div class="inbox-item ${it.read?'':'unread'}">
+        <span class="inbox-icon">${it.kind==='reminder'?'⏰':it.kind==='checkin'?'👋':'📢'}</span>
+        <div>
+          <div class="inbox-text">${escapeHtml(it.text)}</div>
+          <div class="inbox-time">${new Date(it.ts||it.timestamp).toLocaleString('tr-TR')}</div>
+        </div>
+        ${it.read?'':'<span class="inbox-mark" onclick="markRead('+it.id+')">✓ okundu</span>'}
+      </div>`).join('');
+  }).catch(()=>{document.getElementById('inboxList').innerHTML='<div class="inbox-empty" style="color:var(--red)">Yüklenemedi</div>'});
+}
+function markRead(id){
+  fetch(API+'/api/v1/inbox/'+id+'/read',{method:'POST'}).then(()=>loadInbox()).catch(()=>{});
+}
+
+/* ── Phone Access ──────────────────────────────────── */
+function loadAccess(){
+  fetch(API+'/api/v1/settings/status').then(r=>r.json()).then(d=>{
+    const url = d.access_url || ('http://'+location.hostname+':'+location.port);
+    document.getElementById('accessUrl').textContent = url;
+    // Try QR code
+    const qrImg = document.getElementById('qrImage');
+    fetch(API+'/api/v1/qrcode').then(r=>{
+      if(r.ok) return r.blob();
+      throw new Error('no qr');
+    }).then(blob=>{
+      qrImg.src=URL.createObjectURL(blob);
+      qrImg.style.display='block';
+    }).catch(()=>{qrImg.style.display='none'});
+  }).catch(()=>{document.getElementById('accessUrl').textContent='Yüklenemedi'});
+}
+function copyAccessUrl(){
+  const url = document.getElementById('accessUrl').textContent;
+  navigator.clipboard.writeText(url).then(()=>showToast('✓ URL kopyalandı','success')).catch(()=>showToast('Kopyalanamadı','error'));
+}
+
+/* ── Health ─────────────────────────────────────────── */
+function loadHealth(){
+  fetch(API+'/api/v1/health').then(r=>r.json()).then(d=>{
+    const grid = document.getElementById('statusGrid');
+    const comps = d.components||[];
+    const getStatus = (name)=>{const c=comps.find(x=>x.name===name);return c?c.status:'unknown'};
+    grid.innerHTML = `
+      <div class="status-item"><span class="status-dot ${getStatus('brain')}"></span>Brain</div>
+      <div class="status-item"><span class="status-dot ${getStatus('vllm')}"></span>vLLM</div>
+      <div class="status-item"><span class="status-dot ${getStatus('gemini')||'unknown'}"></span>Gemini</div>
+      <div class="status-item"><span class="status-dot ok"></span>API</div>`;
+  }).catch(()=>{});
+}
+
+/* ── Toast ─────────────────────────────────────────── */
+function showToast(text,type='success'){
+  const old = document.querySelector('.toast');if(old)old.remove();
+  const div = document.createElement('div');
+  div.className='toast '+type;
+  div.textContent=text;
+  document.body.appendChild(div);
+  setTimeout(()=>div.remove(),4000);
+}
+
+/* ── Helpers ───────────────────────────────────────── */
+function formatUptime(s){
+  if(s<60)return Math.floor(s)+'sn';
+  if(s<3600)return Math.floor(s/60)+'dk';
+  const h=Math.floor(s/3600),m=Math.floor((s%3600)/60);
+  return h+'sa '+m+'dk';
+}
+
+/* ── Init ──────────────────────────────────────────── */
+window.addEventListener('DOMContentLoaded',()=>{
+  connectWS();
+  loadHealth();
+  // Auto-refresh health every 30s
+  setInterval(loadHealth, 30000);
+  // Load initial data
+  fetch(API+'/api/v1/skills').then(r=>r.json()).then(d=>{document.getElementById('skillCount').textContent=d.count||0}).catch(()=>{});
+  fetch(API+'/api/v1/inbox').then(r=>r.json()).then(d=>{const b=document.getElementById('inboxBadge');if(d.unread>0){b.textContent=d.unread;b.style.display='inline'}}).catch(()=>{});
+  // Focus input
+  document.getElementById('chatInput').focus();
+});
+</script>
+</body>
+</html>

--- a/src/bantz/api/static/manifest.json
+++ b/src/bantz/api/static/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Bantz AI Assistant",
+  "short_name": "Bantz",
+  "description": "Kişisel AI asistanınız — komutlar, takvim, notlar ve daha fazlası",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f0f23",
+  "theme_color": "#0f0f23",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/tests/test_web_dashboard.py
+++ b/tests/test_web_dashboard.py
@@ -1,0 +1,592 @@
+"""Tests for the Web Dashboard & Settings API (Issue #867).
+
+Coverage:
+- GET / — dashboard HTML served
+- GET /api/v1/settings/status — returns key/system status
+- POST /api/v1/settings/gemini-key — stores key in vault + env
+- DELETE /api/v1/settings/gemini-key — removes key from vault + env
+- GET /api/v1/qrcode — returns QR code (or 501 if no qrcode lib)
+- GET /api/v1/health — now includes gemini component
+- Static file serving (manifest.json)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ─────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure Gemini keys are clean before each test."""
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("BANTZ_API_TOKEN", raising=False)
+
+
+def _make_mock_server() -> MagicMock:
+    """Create a mock BantzServer."""
+    mock = MagicMock()
+    mock._brain = None
+    mock.handle_command.return_value = {
+        "ok": True,
+        "text": "test response",
+        "route": "test",
+    }
+    return mock
+
+
+def _make_mock_vault(has_key: bool = False, stored_key: str = ""):
+    """Create a mock SecretsVault."""
+    vault = MagicMock()
+    vault.exists.return_value = has_key
+    vault.retrieve.return_value = stored_key if has_key else None
+    vault.store.return_value = None
+    vault.delete.return_value = has_key
+    return vault
+
+
+def _create_test_client(server: Any = None) -> TestClient:
+    """Create a FastAPI TestClient with mocked BantzServer."""
+    from bantz.api.server import create_app
+
+    if server is None:
+        server = _make_mock_server()
+
+    # Mock event bus
+    bus = MagicMock()
+    bus._history = []
+
+    app = create_app(bantz_server=server, event_bus=bus)
+    return TestClient(app)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Dashboard serving
+# ─────────────────────────────────────────────────────────────────
+
+class TestDashboard:
+    """GET / — dashboard HTML."""
+
+    def test_root_returns_html(self):
+        """Root URL should return the dashboard HTML."""
+        client = _create_test_client()
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+
+    def test_root_contains_bantz_branding(self):
+        """Dashboard should contain Bantz branding."""
+        client = _create_test_client()
+        resp = client.get("/")
+        assert "Bantz" in resp.text
+
+    def test_root_contains_chat_panel(self):
+        """Dashboard should have the chat panel elements."""
+        client = _create_test_client()
+        resp = client.get("/")
+        assert "chatMessages" in resp.text
+        assert "chatInput" in resp.text
+
+    def test_root_contains_settings_panel(self):
+        """Dashboard should have settings panel."""
+        client = _create_test_client()
+        resp = client.get("/")
+        assert "geminiKeyInput" in resp.text
+        assert "geminiStatus" in resp.text
+
+    def test_root_mobile_responsive(self):
+        """Dashboard should have viewport meta for mobile."""
+        client = _create_test_client()
+        resp = client.get("/")
+        assert "viewport" in resp.text
+        assert "width=device-width" in resp.text
+
+    def test_root_pwa_manifest(self):
+        """Dashboard should reference PWA manifest."""
+        client = _create_test_client()
+        resp = client.get("/")
+        assert "manifest.json" in resp.text
+
+    def test_root_no_auth_required(self):
+        """Dashboard root should be accessible without auth."""
+        os.environ["BANTZ_API_TOKEN"] = "test-secret-token"
+        try:
+            client = _create_test_client()
+            resp = client.get("/")
+            assert resp.status_code == 200
+        finally:
+            del os.environ["BANTZ_API_TOKEN"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Static files
+# ─────────────────────────────────────────────────────────────────
+
+class TestStaticFiles:
+    """Static file serving."""
+
+    def test_manifest_json_served(self):
+        """manifest.json should be served from /static/."""
+        client = _create_test_client()
+        resp = client.get("/static/manifest.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["short_name"] == "Bantz"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Settings status
+# ─────────────────────────────────────────────────────────────────
+
+class TestSettingsStatus:
+    """GET /api/v1/settings/status."""
+
+    def test_status_returns_json(self):
+        """Settings status should return JSON."""
+        client = _create_test_client()
+        resp = client.get("/api/v1/settings/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "gemini_key_set" in data
+        assert "api_token_set" in data
+        assert "version" in data
+
+    def test_status_gemini_not_set(self):
+        """Gemini key should show as not set when env is empty."""
+        with patch("bantz.api.settings._is_gemini_key_set", return_value=False):
+            client = _create_test_client()
+            resp = client.get("/api/v1/settings/status")
+            data = resp.json()
+            assert data["gemini_key_set"] is False
+
+    def test_status_gemini_set_via_env(self):
+        """Gemini key should show as set when in env."""
+        os.environ["GEMINI_API_KEY"] = "AIzaFakeKey123"
+        try:
+            client = _create_test_client()
+            resp = client.get("/api/v1/settings/status")
+            data = resp.json()
+            assert data["gemini_key_set"] is True
+        finally:
+            del os.environ["GEMINI_API_KEY"]
+
+    def test_status_api_token_not_set(self):
+        """API token should show as not set."""
+        client = _create_test_client()
+        resp = client.get("/api/v1/settings/status")
+        data = resp.json()
+        assert data["api_token_set"] is False
+
+    def test_status_api_token_set(self):
+        """API token should show as set when env has it."""
+        os.environ["BANTZ_API_TOKEN"] = "test-token"
+        try:
+            client = _create_test_client()
+            resp = client.get("/api/v1/settings/status")
+            data = resp.json()
+            assert data["api_token_set"] is True
+        finally:
+            del os.environ["BANTZ_API_TOKEN"]
+
+    def test_status_includes_uptime(self):
+        """Status should include uptime."""
+        client = _create_test_client()
+        resp = client.get("/api/v1/settings/status")
+        data = resp.json()
+        assert "uptime_seconds" in data
+        assert isinstance(data["uptime_seconds"], (int, float))
+
+    def test_status_includes_access_url(self):
+        """Status should include LAN access URL."""
+        client = _create_test_client()
+        resp = client.get("/api/v1/settings/status")
+        data = resp.json()
+        assert "access_url" in data
+        assert data["access_url"].startswith("http://")
+
+    def test_status_includes_system_info(self):
+        """Status should include brain/finalizer/tools info."""
+        client = _create_test_client()
+        resp = client.get("/api/v1/settings/status")
+        data = resp.json()
+        assert "brain_active" in data
+        assert "finalizer" in data
+        assert "tool_count" in data
+
+    def test_status_never_exposes_keys(self):
+        """Status should NEVER expose actual key values."""
+        os.environ["GEMINI_API_KEY"] = "AIzaSuperSecretKey"
+        os.environ["BANTZ_API_TOKEN"] = "secret-bearer-token"
+        try:
+            client = _create_test_client()
+            resp = client.get("/api/v1/settings/status")
+            text = resp.text
+            assert "AIzaSuperSecretKey" not in text
+            assert "secret-bearer-token" not in text
+        finally:
+            del os.environ["GEMINI_API_KEY"]
+            del os.environ["BANTZ_API_TOKEN"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# Save Gemini key
+# ─────────────────────────────────────────────────────────────────
+
+class TestSaveGeminiKey:
+    """POST /api/v1/settings/gemini-key."""
+
+    def test_save_valid_key(self):
+        """Valid key should be stored successfully."""
+        mock_vault = _make_mock_vault()
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            resp = client.post(
+                "/api/v1/settings/gemini-key",
+                json={"key": "AIzaFakeTestKey1234567890"},
+            )
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["ok"] is True
+            mock_vault.store.assert_called_once()
+
+    def test_save_key_injects_to_env(self):
+        """Saved key should be injected to os.environ."""
+        mock_vault = _make_mock_vault()
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            client.post(
+                "/api/v1/settings/gemini-key",
+                json={"key": "AIzaFakeTestKey1234567890"},
+            )
+            assert os.environ.get("GEMINI_API_KEY") == "AIzaFakeTestKey1234567890"
+            assert os.environ.get("GOOGLE_API_KEY") == "AIzaFakeTestKey1234567890"
+
+    def test_save_empty_key_rejected(self):
+        """Empty key should be rejected."""
+        client = _create_test_client()
+        resp = client.post(
+            "/api/v1/settings/gemini-key",
+            json={"key": ""},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_save_invalid_prefix_rejected(self):
+        """Key not starting with AIza should be rejected."""
+        client = _create_test_client()
+        resp = client.post(
+            "/api/v1/settings/gemini-key",
+            json={"key": "sk-invalid-openai-key"},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_save_no_body_rejected(self):
+        """Missing JSON body should be rejected."""
+        client = _create_test_client()
+        resp = client.post(
+            "/api/v1/settings/gemini-key",
+            content="not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+
+    def test_save_missing_key_field_rejected(self):
+        """JSON without key field should be rejected."""
+        client = _create_test_client()
+        resp = client.post(
+            "/api/v1/settings/gemini-key",
+            json={"not_key": "value"},
+        )
+        assert resp.status_code == 400
+
+    def test_save_vault_error_returns_500(self):
+        """Vault errors should return 500."""
+        mock_vault = _make_mock_vault()
+        mock_vault.store.side_effect = Exception("vault explosion")
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            resp = client.post(
+                "/api/v1/settings/gemini-key",
+                json={"key": "AIzaFakeTestKey1234567890"},
+            )
+            assert resp.status_code == 500
+            assert resp.json()["ok"] is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# Delete Gemini key
+# ─────────────────────────────────────────────────────────────────
+
+class TestDeleteGeminiKey:
+    """DELETE /api/v1/settings/gemini-key."""
+
+    def test_delete_existing_key(self):
+        """Deleting an existing key should succeed."""
+        mock_vault = _make_mock_vault(has_key=True)
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            resp = client.delete("/api/v1/settings/gemini-key")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["ok"] is True
+            mock_vault.delete.assert_called_once()
+
+    def test_delete_removes_from_env(self):
+        """Delete should remove key from os.environ."""
+        os.environ["GEMINI_API_KEY"] = "AIzaToBeDeleted"
+        os.environ["GOOGLE_API_KEY"] = "AIzaToBeDeleted"
+        mock_vault = _make_mock_vault(has_key=True)
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            client.delete("/api/v1/settings/gemini-key")
+            assert os.environ.get("GEMINI_API_KEY") is None
+            assert os.environ.get("GOOGLE_API_KEY") is None
+
+    def test_delete_nonexistent_key(self):
+        """Deleting a non-existent key should still succeed."""
+        mock_vault = _make_mock_vault(has_key=False)
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            resp = client.delete("/api/v1/settings/gemini-key")
+            assert resp.status_code == 200
+            assert resp.json()["ok"] is True
+
+    def test_delete_vault_error_returns_500(self):
+        """Vault errors during delete should return 500."""
+        mock_vault = _make_mock_vault()
+        mock_vault.delete.side_effect = Exception("vault error")
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            resp = client.delete("/api/v1/settings/gemini-key")
+            assert resp.status_code == 500
+
+
+# ─────────────────────────────────────────────────────────────────
+# QR code
+# ─────────────────────────────────────────────────────────────────
+
+class TestQRCode:
+    """GET /api/v1/qrcode."""
+
+    def test_qrcode_returns_png_or_501(self):
+        """QR code should return PNG if qrcode lib is installed, 501 otherwise."""
+        client = _create_test_client()
+        resp = client.get("/api/v1/qrcode")
+        assert resp.status_code in (200, 501)
+        if resp.status_code == 200:
+            assert resp.headers["content-type"] == "image/png"
+        else:
+            # 501 means qrcode lib not installed — still valid
+            data = resp.json()
+            assert "url" in data
+
+    def test_qrcode_without_lib(self):
+        """QR code endpoint should return 501 if qrcode is not installed."""
+        import importlib
+
+        with patch.dict(sys.modules, {"qrcode": None, "qrcode.image.pil": None}):
+            # Need to force import failure
+            with patch("builtins.__import__", side_effect=_mock_import_no_qrcode):
+                client = _create_test_client()
+                resp = client.get("/api/v1/qrcode")
+                # May still succeed if qrcode was already imported
+                assert resp.status_code in (200, 501)
+
+
+def _mock_import_no_qrcode(name, *args, **kwargs):
+    """Mock import that fails for qrcode."""
+    if name in ("qrcode", "qrcode.image.pil"):
+        raise ImportError(f"No module named '{name}'")
+    return original_import(name, *args, **kwargs)
+
+original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+
+# ─────────────────────────────────────────────────────────────────
+# Health endpoint — Gemini component
+# ─────────────────────────────────────────────────────────────────
+
+class TestHealthGemini:
+    """GET /api/v1/health — Gemini component."""
+
+    def test_health_includes_gemini_component(self):
+        """Health response should include gemini component."""
+        client = _create_test_client()
+        resp = client.get("/api/v1/health")
+        data = resp.json()
+        component_names = [c["name"] for c in data["components"]]
+        assert "gemini" in component_names
+
+    def test_health_gemini_ok_when_key_set(self):
+        """Gemini should be OK when API key is in env."""
+        os.environ["GEMINI_API_KEY"] = "AIzaTestKey"
+        try:
+            client = _create_test_client()
+            resp = client.get("/api/v1/health")
+            data = resp.json()
+            gemini = next(c for c in data["components"] if c["name"] == "gemini")
+            assert gemini["status"] == "ok"
+        finally:
+            del os.environ["GEMINI_API_KEY"]
+
+    def test_health_gemini_down_when_no_key(self):
+        """Gemini should be DOWN when no API key is configured."""
+        with patch("bantz.security.vault.SecretsVault.exists", return_value=False):
+            client = _create_test_client()
+            resp = client.get("/api/v1/health")
+            data = resp.json()
+            gemini = next(c for c in data["components"] if c["name"] == "gemini")
+            assert gemini["status"] == "down"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Auth integration with settings
+# ─────────────────────────────────────────────────────────────────
+
+class TestSettingsAuth:
+    """Auth behavior for settings endpoints."""
+
+    def test_settings_status_requires_auth_when_enabled(self):
+        """Settings status should require auth when token is set."""
+        os.environ["BANTZ_API_TOKEN"] = "test-auth-token"
+        try:
+            from bantz.api.auth import reset_token_cache
+            reset_token_cache()
+
+            client = _create_test_client()
+            resp = client.get("/api/v1/settings/status")
+            assert resp.status_code == 401
+
+            # With valid token
+            resp = client.get(
+                "/api/v1/settings/status",
+                headers={"Authorization": "Bearer test-auth-token"},
+            )
+            assert resp.status_code == 200
+        finally:
+            del os.environ["BANTZ_API_TOKEN"]
+            from bantz.api.auth import reset_token_cache
+            reset_token_cache()
+
+    def test_save_gemini_key_requires_auth_when_enabled(self):
+        """Save key should require auth when token is set."""
+        os.environ["BANTZ_API_TOKEN"] = "test-auth-token"
+        try:
+            from bantz.api.auth import reset_token_cache
+            reset_token_cache()
+
+            client = _create_test_client()
+            resp = client.post(
+                "/api/v1/settings/gemini-key",
+                json={"key": "AIzaFakeKey"},
+            )
+            assert resp.status_code == 401
+        finally:
+            del os.environ["BANTZ_API_TOKEN"]
+            from bantz.api.auth import reset_token_cache
+            reset_token_cache()
+
+
+# ─────────────────────────────────────────────────────────────────
+# Integration: vault key lifecycle
+# ─────────────────────────────────────────────────────────────────
+
+class TestVaultKeyLifecycle:
+    """Full lifecycle: save → check status → delete."""
+
+    def test_full_lifecycle(self):
+        """Save key → status shows set → delete → status shows unset."""
+        mock_vault = _make_mock_vault(has_key=False)
+
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+
+            # Step 1: Status before save
+            with patch("bantz.api.settings._is_gemini_key_set", return_value=False):
+                resp = client.get("/api/v1/settings/status")
+                assert resp.json()["gemini_key_set"] is False
+
+            # Step 2: Save key
+            resp = client.post(
+                "/api/v1/settings/gemini-key",
+                json={"key": "AIzaTestLifecycleKey123456"},
+            )
+            assert resp.json()["ok"] is True
+            assert os.environ.get("GEMINI_API_KEY") == "AIzaTestLifecycleKey123456"
+
+            # Step 3: Status after save (key is in env now)
+            resp = client.get("/api/v1/settings/status")
+            assert resp.json()["gemini_key_set"] is True
+
+            # Step 4: Delete key
+            mock_vault.delete.return_value = True
+            resp = client.delete("/api/v1/settings/gemini-key")
+            assert resp.json()["ok"] is True
+            assert os.environ.get("GEMINI_API_KEY") is None
+
+    def test_key_stored_with_correct_type(self):
+        """Vault store should be called with SecretType.API_KEY."""
+        mock_vault = _make_mock_vault()
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            client.post(
+                "/api/v1/settings/gemini-key",
+                json={"key": "AIzaTestTypeKey123456789"},
+            )
+            call_args = mock_vault.store.call_args
+            assert call_args is not None
+            # Check the secret_type kwarg
+            from bantz.security.vault import SecretType
+            assert call_args.kwargs.get("secret_type") == SecretType.API_KEY or \
+                   (len(call_args.args) > 2 and call_args.args[2] == SecretType.API_KEY)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Edge cases
+# ─────────────────────────────────────────────────────────────────
+
+class TestEdgeCases:
+    """Edge cases and robustness."""
+
+    def test_save_whitespace_only_key_rejected(self):
+        """Whitespace-only key should be rejected."""
+        client = _create_test_client()
+        resp = client.post(
+            "/api/v1/settings/gemini-key",
+            json={"key": "   "},
+        )
+        assert resp.status_code == 400
+
+    def test_save_key_with_whitespace_trimmed(self):
+        """Key with leading/trailing whitespace should be trimmed."""
+        mock_vault = _make_mock_vault()
+        with patch("bantz.api.settings._get_vault", return_value=mock_vault):
+            client = _create_test_client()
+            resp = client.post(
+                "/api/v1/settings/gemini-key",
+                json={"key": "  AIzaKeyWithSpaces  "},
+            )
+            assert resp.status_code == 200
+            # Verify trimmed key was stored
+            stored_key = mock_vault.store.call_args[0][1]
+            assert stored_key == "AIzaKeyWithSpaces"
+
+    def test_concurrent_dashboard_requests(self):
+        """Multiple simultaneous dashboard requests should work."""
+        client = _create_test_client()
+        responses = [client.get("/") for _ in range(5)]
+        for resp in responses:
+            assert resp.status_code == 200


### PR DESCRIPTION
## Issue #867 — Web Dashboard + Gemini API Key Kurulumu + Telefon Erişimi

### Değişiklikler

**Web Dashboard (GET /)**
- Dark-themed, responsive single-page web UI
- Chat paneli: WebSocket real-time + REST fallback
- Ayarlar paneli: Gemini API key güvenli şekilde kaydet/sil
- Yetenekler paneli: kayıtlı tools listesi
- Inbox paneli: bildirimler (SSE-based)
- Telefon erişimi paneli: LAN URL + QR code
- PWA manifest — telefonda 'Ana Ekrana Ekle' ile uygulama gibi kullan

**Settings API**
- `POST /api/v1/settings/gemini-key` — Fernet vault'a şifreli kaydet + runtime inject
- `DELETE /api/v1/settings/gemini-key` — vault + env'den sil
- `GET /api/v1/settings/status` — key durumu, system info (key değerini ASLA göstermez)
- `GET /api/v1/qrcode` — PNG QR code telefon taraması için

**Health Endpoint Güncellemesi**
- Gemini component durumu eklendi
- Vault'tan otomatik key yükleme
- Startup banner'da dashboard URL + LAN telefon URL

### Dosyalar
| Dosya | Değişiklik |
|---|---|
| `src/bantz/api/static/index.html` | Yeni — Web dashboard |
| `src/bantz/api/static/manifest.json` | Yeni — PWA manifest |
| `src/bantz/api/settings.py` | Yeni — Settings API router |
| `src/bantz/api/server.py` | Mod — GET /, static mount, settings router, Gemini health |
| `src/bantz/api/__init__.py` | Mod — endpoint listesi güncellendi |
| `tests/test_web_dashboard.py` | Yeni — 40 test |

### Test Sonuçları
- ✅ 40 yeni test — tümü geçti
- ✅ 70 mevcut API testi — etkilenmedi
- ✅ Toplam: 110 API testi başarılı

### Nasıl Test Edilir
```bash
bantz --serve --http          # Dashboard: http://localhost:8088
bantz --http-only --port 9000  # Sadece HTTP: http://localhost:9000

# Telefondan: aynı WiFi, gösterilen LAN adresini tarayıcıda aç
```

Closes #867