### PR TITLE
feat(#845): Planner-Runtime Tool Gap Closure — 69/69 tools with real handlers

### DIFF
--- a/src/bantz/agent/registry.py
+++ b/src/bantz/agent/registry.py
@@ -1,7 +1,7 @@
 """Shared runtime tool registry — single source of truth for executable tools.
 
-Architecture (Issue #633)
-─────────────────────────
+Architecture (Issue #633, extended by Issue #845)
+─────────────────────────────────────────────────
 This module provides the **runtime** tool registry whose tools are
 directly executed by :class:`~bantz.brain.orchestrator_loop.OrchestratorLoop`
 via ``tool.function(**params)``.
@@ -9,6 +9,21 @@ via ``tool.function(**params)``.
 Every tool registered here has a real ``function=`` handler from
 ``bantz.tools.*`` (wrapper modules that add Turkish date parsing,
 idempotency, error wrapping over the raw ``bantz.google.*`` functions).
+
+Issue #845 expanded coverage from 17 → 67 runtime tools:
+  - Browser (11): browser_open, scan, click, type, back, info, detail,
+    wait, search, scroll_down, scroll_up — via ExtensionBridge
+  - PC Control (6): pc_hotkey, mouse_move, mouse_click, mouse_scroll,
+    clipboard_set, clipboard_get — via xdotool/xclip
+  - File System (6): file_read, write, edit, create, undo, search — sandboxed
+  - Terminal (4): terminal_run, background, background_list, background_kill
+    — policy.json enforced
+  - Code/Project (6): code_format, code_replace_function, project_info,
+    project_tree, project_symbols, project_search_symbol
+  - Gmail Extended (13): labels, archive, mark_read/unread, batch_modify,
+    download_attachment, drafts (CRUD), generate_reply
+  - Contacts (4): upsert, resolve, list, delete
+  - Gmail Send-to-Contact (1)
 
 Callers
 ~~~~~~~
@@ -20,10 +35,8 @@ See Also
 - ``agent/builtin_tools.py`` → ``build_planner_registry()``
   The **planner** catalog (69 tools, schema-only usage) used by
   ``router/engine.py`` and ``agent/controller.py`` for LLM prompting.
-  Its 10 overlapping tool names (calendar.*, gmail core) intentionally
-  match so agent-planned steps map to router intents.
-
-Issue #575: Tool registry uses fragile importlib hack
+  Its overlapping tool names intentionally match so agent-planned
+  steps map to router intents.
 """
 
 from __future__ import annotations
@@ -47,6 +60,67 @@ from bantz.tools.gmail_tools import (
 )
 from bantz.tools.system_tools import system_screenshot_tool, system_status
 from bantz.tools.time_tools import time_now_tool
+
+# Issue #845: New tool imports ────────────────────────────────────────
+from bantz.tools.browser_tools import (
+    browser_back_tool,
+    browser_click_tool,
+    browser_detail_tool,
+    browser_info_tool,
+    browser_open_tool,
+    browser_scan_tool,
+    browser_scroll_down_tool,
+    browser_scroll_up_tool,
+    browser_search_tool,
+    browser_type_tool,
+    browser_wait_tool,
+)
+from bantz.tools.pc_tools import (
+    clipboard_get_tool,
+    clipboard_set_tool,
+    pc_hotkey_tool,
+    pc_mouse_click_tool,
+    pc_mouse_move_tool,
+    pc_mouse_scroll_tool,
+)
+from bantz.tools.file_tools import (
+    file_create_tool,
+    file_edit_tool,
+    file_read_tool,
+    file_search_tool,
+    file_undo_tool,
+    file_write_tool,
+)
+from bantz.tools.terminal_tools import (
+    terminal_background_kill_tool,
+    terminal_background_list_tool,
+    terminal_background_tool,
+    terminal_run_tool,
+)
+from bantz.tools.code_tools import (
+    code_format_tool,
+    code_replace_function_tool,
+    project_info_tool,
+    project_search_symbol_tool,
+    project_symbols_tool,
+    project_tree_tool,
+)
+from bantz.tools.gmail_extended_tools import (
+    gmail_add_label_tool,
+    gmail_archive_tool,
+    gmail_batch_modify_tool,
+    gmail_create_draft_tool,
+    gmail_delete_draft_tool,
+    gmail_download_attachment_tool,
+    gmail_generate_reply_tool,
+    gmail_list_drafts_tool,
+    gmail_list_labels_tool,
+    gmail_mark_read_tool,
+    gmail_mark_unread_tool,
+    gmail_remove_label_tool,
+    gmail_send_draft_tool,
+    gmail_update_draft_tool,
+)
 
 
 def build_default_registry() -> ToolRegistry:
@@ -360,5 +434,736 @@ def build_default_registry() -> ToolRegistry:
 
     # ── Web tools ───────────────────────────────────────────────────
     register_web_tools(reg)
+
+    # ════════════════════════════════════════════════════════════════
+    # Issue #845: 50 new runtime tools — close planner-runtime gap
+    # ════════════════════════════════════════════════════════════════
+
+    # ── Browser tools (11) ──────────────────────────────────────────
+    reg.register(
+        Tool(
+            name="browser_open",
+            description="Open a site or URL in Firefox (via extension bridge)",
+            parameters={
+                "type": "object",
+                "properties": {"url": {"type": "string", "description": "Site name (youtube) or full URL"}},
+                "required": ["url"],
+            },
+            function=browser_open_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_scan",
+            description="Scan current page and list clickable elements",
+            parameters={"type": "object", "properties": {}},
+            function=browser_scan_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_click",
+            description="Click an element by index (preferred) or by text",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "text": {"type": "string"},
+                },
+            },
+            function=browser_click_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_type",
+            description="Type text into the page (optionally into an element index)",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string"},
+                    "index": {"type": "integer"},
+                    "submit": {"type": "boolean"},
+                },
+                "required": ["text"],
+            },
+            function=browser_type_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_back",
+            description="Navigate back in browser history",
+            parameters={"type": "object", "properties": {}},
+            function=browser_back_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_info",
+            description="Get current page info (title/url)",
+            parameters={"type": "object", "properties": {}},
+            function=browser_info_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_detail",
+            description="Get detailed info about a scanned element by index",
+            parameters={
+                "type": "object",
+                "properties": {"index": {"type": "integer"}},
+                "required": ["index"],
+            },
+            function=browser_detail_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_wait",
+            description="Wait for a few seconds (1-30)",
+            parameters={
+                "type": "object",
+                "properties": {"seconds": {"type": "integer"}},
+                "required": ["seconds"],
+            },
+            function=browser_wait_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_search",
+            description="Search within the current site/page context",
+            parameters={
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+            function=browser_search_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_scroll_down",
+            description="Scroll down on the page",
+            parameters={"type": "object", "properties": {}},
+            function=browser_scroll_down_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="browser_scroll_up",
+            description="Scroll up on the page",
+            parameters={"type": "object", "properties": {}},
+            function=browser_scroll_up_tool,
+        )
+    )
+
+    # ── PC Control tools (6) ────────────────────────────────────────
+    reg.register(
+        Tool(
+            name="pc_hotkey",
+            description="Press a safe hotkey combo (e.g. alt+tab)",
+            parameters={
+                "type": "object",
+                "properties": {"combo": {"type": "string", "description": "e.g. alt+tab"}},
+                "required": ["combo"],
+            },
+            function=pc_hotkey_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="pc_mouse_move",
+            description="Move mouse to screen coordinate",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                    "duration_ms": {"type": "integer"},
+                },
+                "required": ["x", "y"],
+            },
+            function=pc_mouse_move_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="pc_mouse_click",
+            description="Mouse click (optionally at x,y)",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "x": {"type": "integer"},
+                    "y": {"type": "integer"},
+                    "button": {"type": "string"},
+                    "double": {"type": "boolean"},
+                },
+            },
+            function=pc_mouse_click_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="pc_mouse_scroll",
+            description="Scroll mouse wheel",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "direction": {"type": "string", "description": "up|down"},
+                    "amount": {"type": "integer"},
+                },
+                "required": ["direction"],
+            },
+            function=pc_mouse_scroll_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="clipboard_set",
+            description="Copy text to clipboard",
+            parameters={
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+            },
+            function=clipboard_set_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="clipboard_get",
+            description="Read current clipboard text",
+            parameters={"type": "object", "properties": {}},
+            function=clipboard_get_tool,
+        )
+    )
+
+    # ── File System tools (6) ───────────────────────────────────────
+    reg.register(
+        Tool(
+            name="file_read",
+            description="Read contents of a file (sandboxed). Can read specific line ranges.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path"},
+                    "start_line": {"type": "integer", "description": "Starting line (1-indexed)"},
+                    "end_line": {"type": "integer", "description": "Ending line (inclusive)"},
+                },
+                "required": ["path"],
+            },
+            function=file_read_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="file_write",
+            description="Write content to a file (sandboxed, auto-backup)",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path"},
+                    "content": {"type": "string", "description": "File content"},
+                },
+                "required": ["path", "content"],
+            },
+            function=file_write_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="file_edit",
+            description="Replace a specific string in a file (unique match required)",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path"},
+                    "old_string": {"type": "string", "description": "Exact text to find"},
+                    "new_string": {"type": "string", "description": "Replacement text"},
+                },
+                "required": ["path", "old_string", "new_string"],
+            },
+            function=file_edit_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="file_create",
+            description="Create a new file with optional initial content",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "description": "File path"},
+                    "content": {"type": "string", "description": "Initial content"},
+                },
+                "required": ["path"],
+            },
+            function=file_create_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="file_undo",
+            description="Undo the last edit to a file by restoring from backup",
+            parameters={
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            function=file_undo_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="file_search",
+            description="Search for files by name pattern, optionally matching content",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "pattern": {"type": "string", "description": "Glob pattern (e.g. '*.py')"},
+                    "content": {"type": "string", "description": "Search within file content (regex)"},
+                },
+                "required": ["pattern"],
+            },
+            function=file_search_tool,
+        )
+    )
+
+    # ── Terminal tools (4) ──────────────────────────────────────────
+    reg.register(
+        Tool(
+            name="terminal_run",
+            description="Run a shell command (policy.json enforced)",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string", "description": "Shell command to run"},
+                    "timeout": {"type": "integer", "description": "Timeout in seconds"},
+                },
+                "required": ["command"],
+            },
+            function=terminal_run_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="terminal_background",
+            description="Start a command in background (for servers, watch, etc.)",
+            parameters={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+            },
+            function=terminal_background_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="terminal_background_list",
+            description="List all running background processes",
+            parameters={"type": "object", "properties": {}},
+            function=terminal_background_list_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="terminal_background_kill",
+            description="Kill a background process by ID",
+            parameters={
+                "type": "object",
+                "properties": {"id": {"type": "integer"}},
+                "required": ["id"],
+            },
+            function=terminal_background_kill_tool,
+        )
+    )
+
+    # ── Code / Project tools (6) ────────────────────────────────────
+    reg.register(
+        Tool(
+            name="code_format",
+            description="Format code using appropriate formatter (black, prettier, etc.)",
+            parameters={
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            function=code_format_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="code_replace_function",
+            description="Replace an entire function in a Python file",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "function_name": {"type": "string"},
+                    "new_code": {"type": "string"},
+                },
+                "required": ["path", "function_name", "new_code"],
+            },
+            function=code_replace_function_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="project_info",
+            description="Get project information (type, name, dependencies)",
+            parameters={"type": "object", "properties": {}},
+            function=project_info_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="project_tree",
+            description="Get project file tree structure",
+            parameters={
+                "type": "object",
+                "properties": {"max_depth": {"type": "integer"}},
+            },
+            function=project_tree_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="project_symbols",
+            description="Get symbols (functions, classes) from a Python file",
+            parameters={
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+            function=project_symbols_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="project_search_symbol",
+            description="Search for a symbol across the project",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Symbol name (partial match)"},
+                    "type": {"type": "string", "description": "Filter by type (function, class)"},
+                },
+                "required": ["name"],
+            },
+            function=project_search_symbol_tool,
+        )
+    )
+
+    # ── Gmail Extended tools (13) ───────────────────────────────────
+    reg.register(
+        Tool(
+            name="gmail.list_labels",
+            description="Gmail: list labels (read-only)",
+            parameters={"type": "object", "properties": {}},
+            function=gmail_list_labels_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.add_label",
+            description="Gmail: add a label to a message",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message_id": {"type": "string"},
+                    "label": {"type": "string"},
+                },
+                "required": ["message_id", "label"],
+            },
+            function=gmail_add_label_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.remove_label",
+            description="Gmail: remove a label from a message",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message_id": {"type": "string"},
+                    "label": {"type": "string"},
+                },
+                "required": ["message_id", "label"],
+            },
+            function=gmail_remove_label_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.mark_read",
+            description="Gmail: mark a message as read",
+            parameters={
+                "type": "object",
+                "properties": {"message_id": {"type": "string"}},
+                "required": ["message_id"],
+            },
+            function=gmail_mark_read_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.mark_unread",
+            description="Gmail: mark a message as unread",
+            parameters={
+                "type": "object",
+                "properties": {"message_id": {"type": "string"}},
+                "required": ["message_id"],
+            },
+            function=gmail_mark_unread_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.archive",
+            description="Gmail: archive a message (remove INBOX label). Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {"message_id": {"type": "string"}},
+                "required": ["message_id"],
+            },
+            function=gmail_archive_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.batch_modify",
+            description="Gmail: batch add/remove labels across messages. Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message_ids": {"type": "array", "items": {"type": "string"}},
+                    "add_labels": {"type": "array", "items": {"type": "string"}},
+                    "remove_labels": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["message_ids"],
+            },
+            function=gmail_batch_modify_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.download_attachment",
+            description="Gmail: download an attachment. Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message_id": {"type": "string"},
+                    "attachment_id": {"type": "string"},
+                    "save_path": {"type": "string"},
+                    "overwrite": {"type": "boolean"},
+                },
+                "required": ["message_id", "attachment_id", "save_path"],
+            },
+            function=gmail_download_attachment_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.create_draft",
+            description="Gmail: create a draft",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "to": {"type": "string"},
+                    "subject": {"type": "string"},
+                    "body": {"type": "string"},
+                },
+                "required": ["to", "subject", "body"],
+            },
+            function=gmail_create_draft_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.list_drafts",
+            description="Gmail: list drafts (read-only)",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "max_results": {"type": "integer"},
+                    "page_token": {"type": "string"},
+                },
+            },
+            function=gmail_list_drafts_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.update_draft",
+            description="Gmail: update a draft",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "draft_id": {"type": "string"},
+                    "updates": {"type": "object"},
+                },
+                "required": ["draft_id", "updates"],
+            },
+            function=gmail_update_draft_tool,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.send_draft",
+            description="Gmail: send a draft. Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {"draft_id": {"type": "string"}},
+                "required": ["draft_id"],
+            },
+            function=gmail_send_draft_tool,
+            requires_confirmation=True,
+        )
+    )
+    reg.register(
+        Tool(
+            name="gmail.delete_draft",
+            description="Gmail: delete a draft",
+            parameters={
+                "type": "object",
+                "properties": {"draft_id": {"type": "string"}},
+                "required": ["draft_id"],
+            },
+            function=gmail_delete_draft_tool,
+        )
+    )
+
+    # ── Gmail Generate Reply (1) ────────────────────────────────────
+    reg.register(
+        Tool(
+            name="gmail.generate_reply",
+            description="Gmail: generate reply suggestions and create reply draft. Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "message_id": {"type": "string"},
+                    "user_intent": {"type": "string"},
+                    "base": {"type": "string"},
+                    "reply_all": {"type": "boolean"},
+                    "include_quote": {"type": "boolean"},
+                },
+                "required": ["message_id", "user_intent"],
+            },
+            function=gmail_generate_reply_tool,
+            requires_confirmation=True,
+        )
+    )
+
+    # ── Contacts tools (4) + send_to_contact (1) ───────────────────
+    try:
+        from bantz.contacts.store import (
+            contacts_delete as _contacts_delete,
+            contacts_list as _contacts_list,
+            contacts_resolve as _contacts_resolve,
+            contacts_upsert as _contacts_upsert,
+        )
+    except Exception:  # pragma: no cover
+        _contacts_upsert = None
+        _contacts_resolve = None
+        _contacts_list = None
+        _contacts_delete = None
+
+    reg.register(
+        Tool(
+            name="contacts.upsert",
+            description="Save a contact mapping (name → email)",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "email": {"type": "string"},
+                    "notes": {"type": "string"},
+                },
+                "required": ["name", "email"],
+            },
+            function=_contacts_upsert,
+        )
+    )
+    reg.register(
+        Tool(
+            name="contacts.resolve",
+            description="Resolve a contact name to an email",
+            parameters={
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            function=_contacts_resolve,
+        )
+    )
+    reg.register(
+        Tool(
+            name="contacts.list",
+            description="List saved contacts",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "prefix": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
+            },
+            function=_contacts_list,
+        )
+    )
+    reg.register(
+        Tool(
+            name="contacts.delete",
+            description="Delete a saved contact",
+            parameters={
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            function=_contacts_delete,
+        )
+    )
+
+    # Convenience: send email to a saved contact
+    try:
+        from bantz.contacts.store import contacts_resolve as _cr
+        from bantz.google.gmail import gmail_send as _gs
+
+        def _gmail_send_to_contact(*, name: str, subject: str, body: str, cc: str | None = None, bcc: str | None = None):
+            resolved = _cr(name=name)
+            if not resolved.get("ok"):
+                return {"ok": False, "error": f"contact_not_found: {name}", "name": name}
+            return _gs(to=str(resolved.get("email") or ""), subject=subject, body=body, cc=cc, bcc=bcc)
+    except Exception:  # pragma: no cover
+        _gmail_send_to_contact = None  # type: ignore[assignment]
+
+    reg.register(
+        Tool(
+            name="gmail.send_to_contact",
+            description="Gmail: send email to a saved contact name. Requires confirmation.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "subject": {"type": "string"},
+                    "body": {"type": "string"},
+                    "cc": {"type": "string"},
+                    "bcc": {"type": "string"},
+                },
+                "required": ["name", "subject", "body"],
+            },
+            function=_gmail_send_to_contact,
+            requires_confirmation=True,
+        )
+    )
 
     return reg

--- a/src/bantz/tools/browser_tools.py
+++ b/src/bantz/tools/browser_tools.py
@@ -1,0 +1,246 @@
+"""Browser runtime tool handlers — wraps ExtensionBridge for OrchestratorLoop.
+
+Issue #845: Planner-Runtime Tool Gap Kapatma
+─────────────────────────────────────────────
+Provides runtime handlers for 11 browser tools that were previously
+schema-only in the planner catalog (builtin_tools.py).
+
+All handlers use the global ExtensionBridge instance to communicate
+with the Firefox extension via WebSocket.
+"""
+
+from __future__ import annotations
+
+import logging
+import time as _time
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def _get_bridge():
+    """Lazy import to avoid circular deps."""
+    try:
+        from bantz.browser.extension_bridge import get_bridge
+        return get_bridge()
+    except Exception:
+        return None
+
+
+def _ensure_bridge():
+    """Get bridge or return error dict."""
+    bridge = _get_bridge()
+    if bridge is None:
+        return None, {"ok": False, "error": "extension_bridge_unavailable"}
+    if not bridge.has_client():
+        return None, {"ok": False, "error": "no_browser_extension_connected"}
+    return bridge, None
+
+
+# ── browser_open ────────────────────────────────────────────────────
+
+def browser_open_tool(*, url: str = "", **_: Any) -> Dict[str, Any]:
+    """Open a URL in Firefox via extension bridge."""
+    if not url:
+        return {"ok": False, "error": "url_required"}
+
+    # Normalize: bare domain → https://
+    if not url.startswith(("http://", "https://")):
+        # Common site shortcuts
+        shortcuts = {
+            "youtube": "https://www.youtube.com",
+            "google": "https://www.google.com",
+            "github": "https://github.com",
+            "twitter": "https://twitter.com",
+            "x": "https://x.com",
+            "reddit": "https://www.reddit.com",
+            "linkedin": "https://www.linkedin.com",
+            "instagram": "https://www.instagram.com",
+            "facebook": "https://www.facebook.com",
+            "gmail": "https://mail.google.com",
+            "calendar": "https://calendar.google.com",
+            "drive": "https://drive.google.com",
+            "maps": "https://maps.google.com",
+        }
+        url = shortcuts.get(url.lower(), f"https://{url}")
+
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    success = bridge.request_navigate(url)
+    if success:
+        _time.sleep(1.0)  # Wait for page load
+        return {"ok": True, "url": url, "navigated": True}
+    return {"ok": False, "error": "navigate_failed", "url": url}
+
+
+# ── browser_scan ────────────────────────────────────────────────────
+
+def browser_scan_tool(**_: Any) -> Dict[str, Any]:
+    """Scan current page and list clickable elements."""
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    scan = bridge.request_scan()
+    if scan is None:
+        return {"ok": False, "error": "scan_failed"}
+
+    elements = scan.get("elements", [])
+    # Truncate for LLM context
+    summary = []
+    for i, el in enumerate(elements[:50]):
+        summary.append({
+            "index": i,
+            "tag": el.get("tag", "?"),
+            "text": (el.get("text", "") or "")[:80],
+            "type": el.get("type", ""),
+        })
+
+    return {
+        "ok": True,
+        "url": scan.get("url", ""),
+        "title": scan.get("title", ""),
+        "element_count": len(elements),
+        "elements": summary,
+    }
+
+
+# ── browser_click ───────────────────────────────────────────────────
+
+def browser_click_tool(*, index: int | None = None, text: str | None = None, **_: Any) -> Dict[str, Any]:
+    """Click an element by index (preferred) or text match."""
+    if index is None and not text:
+        return {"ok": False, "error": "index_or_text_required"}
+
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    success = bridge.request_click(index=index, text=text)
+    if success:
+        _time.sleep(0.3)
+        return {"ok": True, "clicked": True, "index": index, "text": text}
+    return {"ok": False, "error": "click_failed"}
+
+
+# ── browser_type ────────────────────────────────────────────────────
+
+def browser_type_tool(*, text: str = "", index: int | None = None, submit: bool = False, **_: Any) -> Dict[str, Any]:
+    """Type text into the page, optionally into a specific element."""
+    if not text:
+        return {"ok": False, "error": "text_required"}
+
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    success = bridge.request_type(text, element_index=index, submit=submit)
+    if success:
+        return {"ok": True, "typed": True, "text": text[:100], "submit": submit}
+    return {"ok": False, "error": "type_failed"}
+
+
+# ── browser_back ────────────────────────────────────────────────────
+
+def browser_back_tool(**_: Any) -> Dict[str, Any]:
+    """Navigate back in browser history."""
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    success = bridge.request_go_back()
+    if success:
+        _time.sleep(0.5)
+        return {"ok": True, "navigated_back": True}
+    return {"ok": False, "error": "back_failed"}
+
+
+# ── browser_info ────────────────────────────────────────────────────
+
+def browser_info_tool(**_: Any) -> Dict[str, Any]:
+    """Get current page info (title, url)."""
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    page = bridge.get_current_page()
+    if page:
+        return {"ok": True, **page}
+    return {"ok": False, "error": "no_page_info"}
+
+
+# ── browser_detail ──────────────────────────────────────────────────
+
+def browser_detail_tool(*, index: int = 0, **_: Any) -> Dict[str, Any]:
+    """Get detailed info about a scanned element by index."""
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    elements = bridge.get_page_elements()
+    if not elements:
+        return {"ok": False, "error": "no_scan_data_run_browser_scan_first"}
+
+    if index < 0 or index >= len(elements):
+        return {"ok": False, "error": f"index_out_of_range_0_{len(elements) - 1}"}
+
+    el = elements[index]
+    return {"ok": True, "index": index, "element": el}
+
+
+# ── browser_wait ────────────────────────────────────────────────────
+
+def browser_wait_tool(*, seconds: int = 2, **_: Any) -> Dict[str, Any]:
+    """Wait for a specified number of seconds (1-30)."""
+    seconds = max(1, min(30, seconds))
+    _time.sleep(seconds)
+    return {"ok": True, "waited_seconds": seconds}
+
+
+# ── browser_search ──────────────────────────────────────────────────
+
+def browser_search_tool(*, query: str = "", **_: Any) -> Dict[str, Any]:
+    """Search within the current site/page context."""
+    if not query:
+        return {"ok": False, "error": "query_required"}
+
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    # Type into search and submit
+    success = bridge.request_type(query, submit=True)
+    if success:
+        _time.sleep(1.0)
+        return {"ok": True, "searched": True, "query": query}
+    return {"ok": False, "error": "search_failed"}
+
+
+# ── browser_scroll_down ────────────────────────────────────────────
+
+def browser_scroll_down_tool(*, amount: int = 500, **_: Any) -> Dict[str, Any]:
+    """Scroll down on the page."""
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    success = bridge.request_scroll(direction="down", amount=amount)
+    if success:
+        return {"ok": True, "scrolled": "down", "amount": amount}
+    return {"ok": False, "error": "scroll_failed"}
+
+
+# ── browser_scroll_up ──────────────────────────────────────────────
+
+def browser_scroll_up_tool(*, amount: int = 500, **_: Any) -> Dict[str, Any]:
+    """Scroll up on the page."""
+    bridge, err = _ensure_bridge()
+    if err:
+        return err
+
+    success = bridge.request_scroll(direction="up", amount=amount)
+    if success:
+        return {"ok": True, "scrolled": "up", "amount": amount}
+    return {"ok": False, "error": "scroll_failed"}

--- a/src/bantz/tools/code_tools.py
+++ b/src/bantz/tools/code_tools.py
@@ -1,0 +1,395 @@
+"""Code editing & project context runtime tool handlers.
+
+Issue #845: Planner-Runtime Tool Gap Kapatma
+─────────────────────────────────────────────
+Provides runtime handlers for 6 code/project tools.
+Bridges to CodingToolExecutor where available, with standalone
+fallbacks for simpler operations.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import logging
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def _workspace_root() -> Path:
+    """Best-effort workspace root detection."""
+    # Try env var first
+    ws = os.environ.get("BANTZ_WORKSPACE")
+    if ws:
+        return Path(ws).resolve()
+    # Walk up from this file to find pyproject.toml
+    p = Path(__file__).resolve()
+    for parent in p.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return Path.cwd()
+
+
+# ── code_format ─────────────────────────────────────────────────────
+
+def code_format_tool(*, path: str = "", **_: Any) -> Dict[str, Any]:
+    """Format code using appropriate formatter (black for Python)."""
+    if not path:
+        return {"ok": False, "error": "path_required"}
+
+    fpath = Path(path)
+    if not fpath.is_absolute():
+        fpath = _workspace_root() / fpath
+    fpath = fpath.resolve()
+
+    if not fpath.exists():
+        return {"ok": False, "error": f"file_not_found: {path}"}
+
+    suffix = fpath.suffix.lower()
+
+    try:
+        if suffix == ".py":
+            # Try black
+            if shutil.which("black"):
+                result = subprocess.run(
+                    ["black", "--quiet", str(fpath)],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if result.returncode == 0:
+                    return {"ok": True, "path": str(fpath), "formatter": "black", "formatted": True}
+                return {"ok": False, "error": f"black_error: {result.stderr.strip()[:200]}"}
+
+            # Fallback: autopep8
+            if shutil.which("autopep8"):
+                result = subprocess.run(
+                    ["autopep8", "--in-place", str(fpath)],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if result.returncode == 0:
+                    return {"ok": True, "path": str(fpath), "formatter": "autopep8", "formatted": True}
+
+            return {"ok": False, "error": "no_python_formatter_installed (try: pip install black)"}
+
+        elif suffix in (".js", ".ts", ".jsx", ".tsx", ".json", ".css", ".html"):
+            if shutil.which("prettier"):
+                result = subprocess.run(
+                    ["prettier", "--write", str(fpath)],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if result.returncode == 0:
+                    return {"ok": True, "path": str(fpath), "formatter": "prettier", "formatted": True}
+            return {"ok": False, "error": "prettier_not_installed"}
+
+        else:
+            return {"ok": False, "error": f"no_formatter_for: {suffix}"}
+
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "formatter_timeout"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── code_replace_function ──────────────────────────────────────────
+
+def code_replace_function_tool(*, path: str = "", function_name: str = "", new_code: str = "", **_: Any) -> Dict[str, Any]:
+    """Replace an entire function in a file."""
+    if not path or not function_name or not new_code:
+        return {"ok": False, "error": "path_function_name_new_code_required"}
+
+    fpath = Path(path)
+    if not fpath.is_absolute():
+        fpath = _workspace_root() / fpath
+    fpath = fpath.resolve()
+
+    if not fpath.exists():
+        return {"ok": False, "error": f"file_not_found: {path}"}
+
+    try:
+        content = fpath.read_text(encoding="utf-8")
+        lines = content.split("\n")
+
+        # Parse Python AST to find function boundaries
+        if fpath.suffix == ".py":
+            try:
+                tree = ast.parse(content)
+            except SyntaxError as e:
+                return {"ok": False, "error": f"syntax_error: {e}"}
+
+            func_node = None
+            for node in ast.walk(tree):
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if node.name == function_name:
+                        func_node = node
+                        break
+
+            if func_node is None:
+                return {"ok": False, "error": f"function_not_found: {function_name}"}
+
+            start_line = func_node.lineno - 1  # 0-indexed
+            end_line = func_node.end_lineno  # Already 1-indexed, exclusive
+
+            if end_line is None:
+                return {"ok": False, "error": "cannot_determine_function_end"}
+
+            # Replace
+            new_lines = lines[:start_line] + [new_code] + lines[end_line:]
+            new_content = "\n".join(new_lines)
+
+            fpath.write_text(new_content, encoding="utf-8")
+            return {
+                "ok": True,
+                "path": str(fpath),
+                "function": function_name,
+                "replaced": True,
+                "old_lines": f"{start_line + 1}-{end_line}",
+            }
+        else:
+            # Generic regex-based approach for other languages
+            pattern = rf"(def|function|fn|func)\s+{re.escape(function_name)}\s*\("
+            match = re.search(pattern, content)
+            if not match:
+                return {"ok": False, "error": f"function_not_found: {function_name}"}
+
+            return {"ok": False, "error": "non_python_function_replace_not_yet_supported"}
+
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── project_info ────────────────────────────────────────────────────
+
+def project_info_tool(**_: Any) -> Dict[str, Any]:
+    """Get project information (type, name, dependencies)."""
+    ws = _workspace_root()
+
+    info: Dict[str, Any] = {
+        "ok": True,
+        "workspace_root": str(ws),
+        "type": "unknown",
+        "name": ws.name,
+    }
+
+    # Detect project type
+    if (ws / "pyproject.toml").exists():
+        info["type"] = "python"
+        try:
+            import tomllib
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[no-redef]
+            except ImportError:
+                tomllib = None  # type: ignore[assignment]
+
+        if tomllib:
+            try:
+                data = tomllib.loads((ws / "pyproject.toml").read_text())
+                info["name"] = data.get("project", {}).get("name", ws.name)
+                info["version"] = data.get("project", {}).get("version", "unknown")
+                info["python_requires"] = data.get("project", {}).get("requires-python", "")
+            except Exception:
+                pass
+
+    elif (ws / "package.json").exists():
+        info["type"] = "node"
+        try:
+            import json
+            pkg = json.loads((ws / "package.json").read_text())
+            info["name"] = pkg.get("name", ws.name)
+            info["version"] = pkg.get("version", "unknown")
+        except Exception:
+            pass
+
+    elif (ws / "Cargo.toml").exists():
+        info["type"] = "rust"
+
+    elif (ws / "go.mod").exists():
+        info["type"] = "go"
+
+    # Count files
+    py_count = sum(1 for _ in ws.rglob("*.py"))
+    info["python_files"] = py_count
+
+    return info
+
+
+# ── project_tree ────────────────────────────────────────────────────
+
+def project_tree_tool(*, max_depth: int = 3, **_: Any) -> Dict[str, Any]:
+    """Get project file tree structure."""
+    ws = _workspace_root()
+    max_depth = max(1, min(max_depth, 5))
+
+    skip_dirs = {
+        ".git", "__pycache__", "node_modules", ".venv", "venv",
+        ".mypy_cache", ".pytest_cache", ".tox", "dist", "build",
+        ".eggs", "*.egg-info",
+    }
+
+    def build_tree(root: Path, depth: int) -> list[str]:
+        if depth > max_depth:
+            return []
+
+        entries = []
+        try:
+            items = sorted(root.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower()))
+        except PermissionError:
+            return []
+
+        for item in items:
+            if item.name.startswith(".") and item.name not in (".env.example",):
+                continue
+            if item.name in skip_dirs:
+                continue
+
+            indent = "  " * depth
+            if item.is_dir():
+                entries.append(f"{indent}📁 {item.name}/")
+                entries.extend(build_tree(item, depth + 1))
+            else:
+                entries.append(f"{indent}📄 {item.name}")
+
+        return entries
+
+    tree_lines = build_tree(ws, 0)
+
+    return {
+        "ok": True,
+        "workspace": str(ws),
+        "tree": "\n".join(tree_lines[:500]),
+        "truncated": len(tree_lines) > 500,
+    }
+
+
+# ── project_symbols ─────────────────────────────────────────────────
+
+def project_symbols_tool(*, path: str = "", **_: Any) -> Dict[str, Any]:
+    """Get symbols (functions, classes) from a Python file."""
+    if not path:
+        return {"ok": False, "error": "path_required"}
+
+    fpath = Path(path)
+    if not fpath.is_absolute():
+        fpath = _workspace_root() / fpath
+    fpath = fpath.resolve()
+
+    if not fpath.exists():
+        return {"ok": False, "error": f"file_not_found: {path}"}
+
+    if fpath.suffix != ".py":
+        return {"ok": False, "error": "only_python_files_supported"}
+
+    try:
+        content = fpath.read_text(encoding="utf-8")
+        tree = ast.parse(content)
+
+        symbols = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                symbols.append({
+                    "name": node.name,
+                    "type": "class",
+                    "line": node.lineno,
+                    "end_line": node.end_lineno,
+                })
+                # Class methods
+                for item in node.body:
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        symbols.append({
+                            "name": f"{node.name}.{item.name}",
+                            "type": "method",
+                            "line": item.lineno,
+                            "end_line": item.end_lineno,
+                            "parent": node.name,
+                        })
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                # Top-level function (not inside a class)
+                if not any(
+                    isinstance(p, ast.ClassDef)
+                    for p in ast.walk(tree)
+                    if hasattr(p, "body") and node in getattr(p, "body", [])
+                ):
+                    symbols.append({
+                        "name": node.name,
+                        "type": "function",
+                        "line": node.lineno,
+                        "end_line": node.end_lineno,
+                    })
+
+        return {
+            "ok": True,
+            "path": str(fpath),
+            "symbol_count": len(symbols),
+            "symbols": symbols,
+        }
+    except SyntaxError as e:
+        return {"ok": False, "error": f"syntax_error: {e}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── project_search_symbol ──────────────────────────────────────────
+
+def project_search_symbol_tool(*, name: str = "", type: str | None = None, **_: Any) -> Dict[str, Any]:
+    """Search for a symbol across the project."""
+    if not name:
+        return {"ok": False, "error": "name_required"}
+
+    ws = _workspace_root()
+    name_lower = name.lower()
+    results = []
+
+    skip_dirs = {"__pycache__", "node_modules", ".venv", "venv", ".git"}
+
+    for py_file in ws.rglob("*.py"):
+        # Skip excluded dirs
+        if any(sd in py_file.parts for sd in skip_dirs):
+            continue
+
+        if len(results) >= 50:
+            break
+
+        try:
+            content = py_file.read_text(encoding="utf-8", errors="ignore")
+            tree = ast.parse(content)
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef) and name_lower in node.name.lower():
+                    if type and type.lower() != "class":
+                        continue
+                    results.append({
+                        "file": str(py_file.relative_to(ws)),
+                        "name": node.name,
+                        "type": "class",
+                        "line": node.lineno,
+                    })
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and name_lower in node.name.lower():
+                    if type and type.lower() not in ("function", "method"):
+                        continue
+                    results.append({
+                        "file": str(py_file.relative_to(ws)),
+                        "name": node.name,
+                        "type": "function",
+                        "line": node.lineno,
+                    })
+        except Exception:
+            continue
+
+    return {
+        "ok": True,
+        "query": name,
+        "type_filter": type,
+        "count": len(results),
+        "results": results,
+    }

--- a/src/bantz/tools/file_tools.py
+++ b/src/bantz/tools/file_tools.py
@@ -1,0 +1,341 @@
+"""File system runtime tool handlers — sandboxed file operations.
+
+Issue #845: Planner-Runtime Tool Gap Kapatma
+─────────────────────────────────────────────
+Provides runtime handlers for 6 file tools with sandbox protection:
+- Path validation (no traversal outside workspace)
+- Automatic backups before writes
+- Configurable workspace root
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Default workspace root — can be overridden
+_WORKSPACE_ROOT: Path | None = None
+_BACKUP_DIR: Path | None = None
+
+# Max file size for read (10 MB)
+_MAX_READ_SIZE = 10 * 1024 * 1024
+# Max file size for write (5 MB)
+_MAX_WRITE_SIZE = 5 * 1024 * 1024
+# Max search results
+_MAX_SEARCH_RESULTS = 100
+
+
+def configure_workspace(root: str | Path | None = None) -> None:
+    """Configure the workspace root for file operations."""
+    global _WORKSPACE_ROOT, _BACKUP_DIR
+    if root is None:
+        root = Path.home()
+    _WORKSPACE_ROOT = Path(root).resolve()
+    _BACKUP_DIR = _WORKSPACE_ROOT / ".bantz" / "backups"
+    _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _get_workspace() -> Path:
+    """Get workspace root, initializing if needed."""
+    if _WORKSPACE_ROOT is None:
+        configure_workspace()
+    return _WORKSPACE_ROOT  # type: ignore[return-value]
+
+
+def _validate_path(path_str: str) -> tuple[Path | None, str | None]:
+    """Validate and resolve a path within the workspace.
+
+    Returns (resolved_path, error_message).
+    """
+    ws = _get_workspace()
+    try:
+        p = Path(path_str).expanduser()
+        if not p.is_absolute():
+            p = ws / p
+        p = p.resolve()
+
+        # Sandbox: must be within workspace or home
+        home = Path.home().resolve()
+        if not (str(p).startswith(str(ws)) or str(p).startswith(str(home))):
+            return None, f"path_outside_sandbox: {p}"
+
+        # Block sensitive paths
+        blocked = [".ssh", ".gnupg", ".config/bantz/secrets", ".env"]
+        for b in blocked:
+            if (home / b) == p or str(p).startswith(str(home / b)):
+                return None, f"blocked_sensitive_path: {p}"
+
+        return p, None
+    except Exception as e:
+        return None, f"invalid_path: {e}"
+
+
+def _make_backup(path: Path) -> str | None:
+    """Create a backup of a file. Returns backup path or None."""
+    if not path.exists():
+        return None
+    try:
+        if _BACKUP_DIR is None:
+            configure_workspace()
+        bdir = _BACKUP_DIR or Path.home() / ".bantz" / "backups"
+        bdir.mkdir(parents=True, exist_ok=True)
+
+        import time
+        ts = int(time.time())
+        backup_name = f"{path.name}.{ts}.bak"
+        backup_path = bdir / backup_name
+        shutil.copy2(str(path), str(backup_path))
+        return str(backup_path)
+    except Exception as e:
+        logger.warning(f"Backup failed for {path}: {e}")
+        return None
+
+
+# ── file_read ───────────────────────────────────────────────────────
+
+def file_read_tool(*, path: str = "", start_line: int | None = None, end_line: int | None = None, **_: Any) -> Dict[str, Any]:
+    """Read file contents, optionally a specific line range."""
+    if not path:
+        return {"ok": False, "error": "path_required"}
+
+    resolved, err = _validate_path(path)
+    if err:
+        return {"ok": False, "error": err}
+
+    if not resolved.exists():  # type: ignore[union-attr]
+        return {"ok": False, "error": f"file_not_found: {path}"}
+
+    if not resolved.is_file():  # type: ignore[union-attr]
+        return {"ok": False, "error": f"not_a_file: {path}"}
+
+    try:
+        size = resolved.stat().st_size  # type: ignore[union-attr]
+        if size > _MAX_READ_SIZE:
+            return {"ok": False, "error": f"file_too_large: {size} bytes (max {_MAX_READ_SIZE})"}
+
+        content = resolved.read_text(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+        lines = content.splitlines(keepends=True)
+
+        if start_line is not None and end_line is not None:
+            # 1-indexed
+            start_line = max(1, start_line)
+            end_line = min(len(lines), end_line)
+            selected = lines[start_line - 1 : end_line]
+            content = "".join(selected)
+            return {
+                "ok": True,
+                "path": str(resolved),
+                "content": content,
+                "start_line": start_line,
+                "end_line": end_line,
+                "total_lines": len(lines),
+            }
+
+        return {
+            "ok": True,
+            "path": str(resolved),
+            "content": content[:50000],  # Truncate for LLM
+            "total_lines": len(lines),
+            "truncated": len(content) > 50000,
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── file_write ──────────────────────────────────────────────────────
+
+def file_write_tool(*, path: str = "", content: str = "", **_: Any) -> Dict[str, Any]:
+    """Write content to a file. Creates backup automatically."""
+    if not path:
+        return {"ok": False, "error": "path_required"}
+
+    resolved, err = _validate_path(path)
+    if err:
+        return {"ok": False, "error": err}
+
+    if len(content.encode("utf-8")) > _MAX_WRITE_SIZE:
+        return {"ok": False, "error": f"content_too_large (max {_MAX_WRITE_SIZE} bytes)"}
+
+    try:
+        backup = None
+        if resolved.exists():  # type: ignore[union-attr]
+            backup = _make_backup(resolved)  # type: ignore[arg-type]
+
+        resolved.parent.mkdir(parents=True, exist_ok=True)  # type: ignore[union-attr]
+        resolved.write_text(content, encoding="utf-8")  # type: ignore[union-attr]
+
+        return {
+            "ok": True,
+            "path": str(resolved),
+            "written": True,
+            "size_bytes": len(content.encode("utf-8")),
+            "backup": backup,
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── file_edit ───────────────────────────────────────────────────────
+
+def file_edit_tool(*, path: str = "", old_string: str = "", new_string: str = "", **_: Any) -> Dict[str, Any]:
+    """Replace a specific string in a file."""
+    if not path or not old_string:
+        return {"ok": False, "error": "path_and_old_string_required"}
+
+    resolved, err = _validate_path(path)
+    if err:
+        return {"ok": False, "error": err}
+
+    if not resolved.exists():  # type: ignore[union-attr]
+        return {"ok": False, "error": f"file_not_found: {path}"}
+
+    try:
+        content = resolved.read_text(encoding="utf-8")  # type: ignore[union-attr]
+
+        if old_string not in content:
+            return {"ok": False, "error": "old_string_not_found"}
+
+        count = content.count(old_string)
+        if count > 1:
+            return {"ok": False, "error": f"ambiguous_match: {count} occurrences found"}
+
+        backup = _make_backup(resolved)  # type: ignore[arg-type]
+        new_content = content.replace(old_string, new_string, 1)
+        resolved.write_text(new_content, encoding="utf-8")  # type: ignore[union-attr]
+
+        return {
+            "ok": True,
+            "path": str(resolved),
+            "edited": True,
+            "backup": backup,
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── file_create ─────────────────────────────────────────────────────
+
+def file_create_tool(*, path: str = "", content: str = "", **_: Any) -> Dict[str, Any]:
+    """Create a new file with optional content."""
+    if not path:
+        return {"ok": False, "error": "path_required"}
+
+    resolved, err = _validate_path(path)
+    if err:
+        return {"ok": False, "error": err}
+
+    if resolved.exists():  # type: ignore[union-attr]
+        return {"ok": False, "error": f"file_already_exists: {path}"}
+
+    try:
+        resolved.parent.mkdir(parents=True, exist_ok=True)  # type: ignore[union-attr]
+        resolved.write_text(content or "", encoding="utf-8")  # type: ignore[union-attr]
+        return {
+            "ok": True,
+            "path": str(resolved),
+            "created": True,
+            "size_bytes": len((content or "").encode("utf-8")),
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── file_undo ───────────────────────────────────────────────────────
+
+def file_undo_tool(*, path: str = "", **_: Any) -> Dict[str, Any]:
+    """Undo the last edit by restoring from backup."""
+    if not path:
+        return {"ok": False, "error": "path_required"}
+
+    resolved, err = _validate_path(path)
+    if err:
+        return {"ok": False, "error": err}
+
+    if _BACKUP_DIR is None:
+        configure_workspace()
+
+    bdir = _BACKUP_DIR or Path.home() / ".bantz" / "backups"
+    if not bdir.exists():
+        return {"ok": False, "error": "no_backups_found"}
+
+    # Find latest backup for this file
+    fname = resolved.name  # type: ignore[union-attr]
+    backups = sorted(
+        [f for f in bdir.iterdir() if f.name.startswith(f"{fname}.")],
+        key=lambda f: f.stat().st_mtime,
+        reverse=True,
+    )
+
+    if not backups:
+        return {"ok": False, "error": f"no_backup_for: {fname}"}
+
+    latest = backups[0]
+    try:
+        shutil.copy2(str(latest), str(resolved))
+        latest.unlink()  # Remove used backup
+        return {
+            "ok": True,
+            "path": str(resolved),
+            "restored_from": str(latest),
+            "undone": True,
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── file_search ─────────────────────────────────────────────────────
+
+def file_search_tool(*, pattern: str = "", content: str | None = None, path: str = ".", **_: Any) -> Dict[str, Any]:
+    """Search for files by name pattern, optionally matching content."""
+    if not pattern:
+        return {"ok": False, "error": "pattern_required"}
+
+    resolved, err = _validate_path(path)
+    if err:
+        return {"ok": False, "error": err}
+
+    if not resolved.is_dir():  # type: ignore[union-attr]
+        return {"ok": False, "error": f"not_a_directory: {path}"}
+
+    try:
+        matches = []
+        content_re = re.compile(content, re.IGNORECASE) if content else None
+
+        for root, dirs, files in os.walk(str(resolved)):
+            # Skip hidden/venv/node_modules
+            dirs[:] = [d for d in dirs if not d.startswith(".") and d not in ("node_modules", "__pycache__", "venv", ".venv")]
+
+            for f in files:
+                if len(matches) >= _MAX_SEARCH_RESULTS:
+                    break
+
+                if fnmatch.fnmatch(f, pattern):
+                    fpath = os.path.join(root, f)
+
+                    if content_re:
+                        try:
+                            text = Path(fpath).read_text(encoding="utf-8", errors="ignore")[:100_000]
+                            if content_re.search(text):
+                                matches.append(fpath)
+                        except Exception:
+                            pass
+                    else:
+                        matches.append(fpath)
+
+        return {
+            "ok": True,
+            "pattern": pattern,
+            "content_filter": content,
+            "count": len(matches),
+            "files": matches,
+            "truncated": len(matches) >= _MAX_SEARCH_RESULTS,
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e)}

--- a/src/bantz/tools/gmail_extended_tools.py
+++ b/src/bantz/tools/gmail_extended_tools.py
@@ -1,0 +1,258 @@
+"""Gmail extended runtime tool handlers — wrappers over bantz.google.gmail.
+
+Issue #845: Planner-Runtime Tool Gap Kapatma
+─────────────────────────────────────────────
+These tools were previously only in the planner catalog with raw
+bantz.google.gmail function references. This module provides proper
+runtime wrappers with error handling for OrchestratorLoop.
+
+Tools provided:
+  - gmail.list_labels
+  - gmail.add_label / gmail.remove_label
+  - gmail.mark_read / gmail.mark_unread
+  - gmail.archive
+  - gmail.batch_modify
+  - gmail.download_attachment
+  - gmail.create_draft / gmail.list_drafts / gmail.update_draft
+  - gmail.send_draft / gmail.delete_draft
+  - gmail.generate_reply
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_call(fn, **kwargs) -> Dict[str, Any]:
+    """Call a gmail function with error wrapping."""
+    if fn is None:
+        return {"ok": False, "error": "function_not_available"}
+    try:
+        return fn(**kwargs)
+    except Exception as e:
+        logger.error(f"[Gmail] {fn.__name__} error: {e}", exc_info=True)
+        return {"ok": False, "error": str(e)}
+
+
+# ── gmail.list_labels ───────────────────────────────────────────────
+
+def gmail_list_labels_tool(**_: Any) -> Dict[str, Any]:
+    """List Gmail labels."""
+    try:
+        from bantz.google.gmail import gmail_list_labels
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_list_labels)
+
+
+# ── gmail.add_label ─────────────────────────────────────────────────
+
+def gmail_add_label_tool(*, message_id: str = "", label: str = "", **_: Any) -> Dict[str, Any]:
+    """Add a label to a Gmail message."""
+    if not message_id or not label:
+        return {"ok": False, "error": "message_id_and_label_required"}
+    try:
+        from bantz.google.gmail import gmail_add_label
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_add_label, message_id=message_id, label=label)
+
+
+# ── gmail.remove_label ──────────────────────────────────────────────
+
+def gmail_remove_label_tool(*, message_id: str = "", label: str = "", **_: Any) -> Dict[str, Any]:
+    """Remove a label from a Gmail message."""
+    if not message_id or not label:
+        return {"ok": False, "error": "message_id_and_label_required"}
+    try:
+        from bantz.google.gmail import gmail_remove_label
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_remove_label, message_id=message_id, label=label)
+
+
+# ── gmail.mark_read ─────────────────────────────────────────────────
+
+def gmail_mark_read_tool(*, message_id: str = "", **_: Any) -> Dict[str, Any]:
+    """Mark a Gmail message as read."""
+    if not message_id:
+        return {"ok": False, "error": "message_id_required"}
+    try:
+        from bantz.google.gmail import gmail_mark_read
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_mark_read, message_id=message_id)
+
+
+# ── gmail.mark_unread ───────────────────────────────────────────────
+
+def gmail_mark_unread_tool(*, message_id: str = "", **_: Any) -> Dict[str, Any]:
+    """Mark a Gmail message as unread."""
+    if not message_id:
+        return {"ok": False, "error": "message_id_required"}
+    try:
+        from bantz.google.gmail import gmail_mark_unread
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_mark_unread, message_id=message_id)
+
+
+# ── gmail.archive ───────────────────────────────────────────────────
+
+def gmail_archive_tool(*, message_id: str = "", **_: Any) -> Dict[str, Any]:
+    """Archive a Gmail message (remove INBOX label)."""
+    if not message_id:
+        return {"ok": False, "error": "message_id_required"}
+    try:
+        from bantz.google.gmail import gmail_archive
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_archive, message_id=message_id)
+
+
+# ── gmail.batch_modify ──────────────────────────────────────────────
+
+def gmail_batch_modify_tool(
+    *,
+    message_ids: list[str] | None = None,
+    add_labels: list[str] | None = None,
+    remove_labels: list[str] | None = None,
+    **_: Any,
+) -> Dict[str, Any]:
+    """Batch add/remove labels across messages."""
+    if not message_ids:
+        return {"ok": False, "error": "message_ids_required"}
+    try:
+        from bantz.google.gmail import gmail_batch_modify
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(
+        gmail_batch_modify,
+        message_ids=message_ids,
+        add_labels=add_labels or [],
+        remove_labels=remove_labels or [],
+    )
+
+
+# ── gmail.download_attachment ───────────────────────────────────────
+
+def gmail_download_attachment_tool(
+    *,
+    message_id: str = "",
+    attachment_id: str = "",
+    save_path: str = "",
+    overwrite: bool = False,
+    **_: Any,
+) -> Dict[str, Any]:
+    """Download a Gmail attachment to disk."""
+    if not message_id or not attachment_id or not save_path:
+        return {"ok": False, "error": "message_id_attachment_id_save_path_required"}
+    try:
+        from bantz.google.gmail import gmail_download_attachment
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(
+        gmail_download_attachment,
+        message_id=message_id,
+        attachment_id=attachment_id,
+        save_path=save_path,
+        overwrite=overwrite,
+    )
+
+
+# ── gmail.create_draft ──────────────────────────────────────────────
+
+def gmail_create_draft_tool(*, to: str = "", subject: str = "", body: str = "", **_: Any) -> Dict[str, Any]:
+    """Create a Gmail draft."""
+    if not to or not subject or not body:
+        return {"ok": False, "error": "to_subject_body_required"}
+    try:
+        from bantz.google.gmail import gmail_create_draft
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_create_draft, to=to, subject=subject, body=body)
+
+
+# ── gmail.list_drafts ───────────────────────────────────────────────
+
+def gmail_list_drafts_tool(*, max_results: int = 10, page_token: str | None = None, **_: Any) -> Dict[str, Any]:
+    """List Gmail drafts."""
+    try:
+        from bantz.google.gmail import gmail_list_drafts
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    kwargs: dict[str, Any] = {"max_results": max_results}
+    if page_token:
+        kwargs["page_token"] = page_token
+    return _safe_call(gmail_list_drafts, **kwargs)
+
+
+# ── gmail.update_draft ──────────────────────────────────────────────
+
+def gmail_update_draft_tool(*, draft_id: str = "", updates: dict | None = None, **_: Any) -> Dict[str, Any]:
+    """Update a Gmail draft."""
+    if not draft_id:
+        return {"ok": False, "error": "draft_id_required"}
+    try:
+        from bantz.google.gmail import gmail_update_draft
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_update_draft, draft_id=draft_id, updates=updates or {})
+
+
+# ── gmail.send_draft ────────────────────────────────────────────────
+
+def gmail_send_draft_tool(*, draft_id: str = "", **_: Any) -> Dict[str, Any]:
+    """Send a Gmail draft."""
+    if not draft_id:
+        return {"ok": False, "error": "draft_id_required"}
+    try:
+        from bantz.google.gmail import gmail_send_draft
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_send_draft, draft_id=draft_id)
+
+
+# ── gmail.delete_draft ──────────────────────────────────────────────
+
+def gmail_delete_draft_tool(*, draft_id: str = "", **_: Any) -> Dict[str, Any]:
+    """Delete a Gmail draft."""
+    if not draft_id:
+        return {"ok": False, "error": "draft_id_required"}
+    try:
+        from bantz.google.gmail import gmail_delete_draft
+    except ImportError:
+        return {"ok": False, "error": "gmail_module_not_available"}
+    return _safe_call(gmail_delete_draft, draft_id=draft_id)
+
+
+# ── gmail.generate_reply ────────────────────────────────────────────
+
+def gmail_generate_reply_tool(
+    *,
+    message_id: str = "",
+    user_intent: str = "",
+    base: str = "default",
+    reply_all: bool | None = None,
+    include_quote: bool = False,
+    **_: Any,
+) -> Dict[str, Any]:
+    """Generate reply suggestions and create a reply draft."""
+    if not message_id or not user_intent:
+        return {"ok": False, "error": "message_id_and_user_intent_required"}
+    try:
+        from bantz.google.gmail_reply import gmail_generate_reply
+    except ImportError:
+        return {"ok": False, "error": "gmail_reply_module_not_available"}
+    kwargs: dict[str, Any] = {
+        "message_id": message_id,
+        "user_intent": user_intent,
+        "base": base,
+        "include_quote": include_quote,
+    }
+    if reply_all is not None:
+        kwargs["reply_all"] = reply_all
+    return _safe_call(gmail_generate_reply, **kwargs)

--- a/src/bantz/tools/pc_tools.py
+++ b/src/bantz/tools/pc_tools.py
@@ -1,0 +1,234 @@
+"""PC control & clipboard runtime tool handlers.
+
+Issue #845: Planner-Runtime Tool Gap Kapatma
+─────────────────────────────────────────────
+Provides runtime handlers for PC control tools using xdotool/xclip.
+All PC tools require confirmation by default (policy.json: pc_*=confirm).
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Allowed hotkey modifiers/keys — deny dangerous combos
+_ALLOWED_MODIFIERS = {"alt", "ctrl", "super", "shift", "meta"}
+_BLOCKED_COMBOS = {
+    "ctrl+alt+delete",
+    "ctrl+alt+del",
+    "alt+f4",  # Only blocked for system-wide; can be overridden
+}
+
+
+def _run_cmd(cmd: list[str], timeout: int = 5) -> subprocess.CompletedProcess:
+    """Run a subprocess with timeout."""
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _check_tool(tool_name: str) -> str | None:
+    """Check if a tool is available. Returns path or None."""
+    return shutil.which(tool_name)
+
+
+# ── pc_hotkey ───────────────────────────────────────────────────────
+
+def pc_hotkey_tool(*, combo: str = "", **_: Any) -> Dict[str, Any]:
+    """Press a keyboard hotkey combination using xdotool."""
+    if not combo:
+        return {"ok": False, "error": "combo_required"}
+
+    # Normalize
+    combo_lower = combo.lower().strip()
+
+    # Block dangerous combos
+    if combo_lower.replace(" ", "") in _BLOCKED_COMBOS:
+        return {"ok": False, "error": f"blocked_hotkey: {combo}"}
+
+    if not _check_tool("xdotool"):
+        return {"ok": False, "error": "xdotool_not_installed"}
+
+    # Convert combo format: "alt+tab" → "alt+Tab" for xdotool
+    parts = combo.split("+")
+    xdo_keys = []
+    for p in parts:
+        p = p.strip()
+        if p.lower() in _ALLOWED_MODIFIERS:
+            xdo_keys.append(p.lower())
+        else:
+            # Capitalize first letter for xdotool key names
+            xdo_keys.append(p.capitalize() if len(p) > 1 else p)
+
+    key_str = "+".join(xdo_keys)
+
+    try:
+        result = _run_cmd(["xdotool", "key", key_str])
+        if result.returncode == 0:
+            return {"ok": True, "combo": combo, "sent": True}
+        return {"ok": False, "error": f"xdotool_error: {result.stderr.strip()}"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "xdotool_timeout"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── pc_mouse_move ───────────────────────────────────────────────────
+
+def pc_mouse_move_tool(*, x: int = 0, y: int = 0, duration_ms: int = 0, **_: Any) -> Dict[str, Any]:
+    """Move mouse to screen coordinate using xdotool."""
+    if not _check_tool("xdotool"):
+        return {"ok": False, "error": "xdotool_not_installed"}
+
+    # Clamp to reasonable range
+    x = max(0, min(x, 7680))
+    y = max(0, min(y, 4320))
+
+    try:
+        cmd = ["xdotool", "mousemove"]
+        if duration_ms > 0:
+            # xdotool doesn't have native duration, simulate with --delay
+            cmd.extend(["--sync"])
+        cmd.extend([str(x), str(y)])
+
+        result = _run_cmd(cmd)
+        if result.returncode == 0:
+            return {"ok": True, "x": x, "y": y, "moved": True}
+        return {"ok": False, "error": f"xdotool_error: {result.stderr.strip()}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── pc_mouse_click ──────────────────────────────────────────────────
+
+def pc_mouse_click_tool(
+    *,
+    x: int | None = None,
+    y: int | None = None,
+    button: str = "left",
+    double: bool = False,
+    **_: Any,
+) -> Dict[str, Any]:
+    """Mouse click, optionally at specific coordinates."""
+    if not _check_tool("xdotool"):
+        return {"ok": False, "error": "xdotool_not_installed"}
+
+    button_map = {"left": "1", "middle": "2", "right": "3"}
+    btn = button_map.get(button.lower(), "1")
+
+    try:
+        # Move first if coordinates given
+        if x is not None and y is not None:
+            x = max(0, min(x, 7680))
+            y = max(0, min(y, 4320))
+            move_result = _run_cmd(["xdotool", "mousemove", str(x), str(y)])
+            if move_result.returncode != 0:
+                return {"ok": False, "error": f"move_failed: {move_result.stderr.strip()}"}
+
+        cmd = ["xdotool", "click"]
+        if double:
+            cmd.extend(["--repeat", "2", "--delay", "50"])
+        cmd.append(btn)
+
+        result = _run_cmd(cmd)
+        if result.returncode == 0:
+            return {"ok": True, "button": button, "double": double, "x": x, "y": y, "clicked": True}
+        return {"ok": False, "error": f"xdotool_error: {result.stderr.strip()}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── pc_mouse_scroll ─────────────────────────────────────────────────
+
+def pc_mouse_scroll_tool(*, direction: str = "down", amount: int = 3, **_: Any) -> Dict[str, Any]:
+    """Scroll mouse wheel using xdotool."""
+    if not _check_tool("xdotool"):
+        return {"ok": False, "error": "xdotool_not_installed"}
+
+    # xdotool: button 4 = scroll up, button 5 = scroll down
+    btn = "5" if direction.lower() == "down" else "4"
+    amount = max(1, min(amount, 20))
+
+    try:
+        result = _run_cmd(["xdotool", "click", "--repeat", str(amount), "--delay", "30", btn])
+        if result.returncode == 0:
+            return {"ok": True, "direction": direction, "amount": amount, "scrolled": True}
+        return {"ok": False, "error": f"xdotool_error: {result.stderr.strip()}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── clipboard_set ───────────────────────────────────────────────────
+
+def clipboard_set_tool(*, text: str = "", **_: Any) -> Dict[str, Any]:
+    """Copy text to system clipboard."""
+    if not text:
+        return {"ok": False, "error": "text_required"}
+
+    # Try xclip first, then xsel
+    clip_tool = _check_tool("xclip") or _check_tool("xsel")
+    if not clip_tool:
+        return {"ok": False, "error": "xclip_or_xsel_not_installed"}
+
+    try:
+        if "xclip" in clip_tool:
+            proc = subprocess.run(
+                ["xclip", "-selection", "clipboard"],
+                input=text,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        else:
+            proc = subprocess.run(
+                ["xsel", "--clipboard", "--input"],
+                input=text,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+        if proc.returncode == 0:
+            return {"ok": True, "copied": True, "length": len(text)}
+        return {"ok": False, "error": f"clipboard_error: {proc.stderr.strip()}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+# ── clipboard_get ───────────────────────────────────────────────────
+
+def clipboard_get_tool(**_: Any) -> Dict[str, Any]:
+    """Read current clipboard text."""
+    clip_tool = _check_tool("xclip") or _check_tool("xsel")
+    if not clip_tool:
+        return {"ok": False, "error": "xclip_or_xsel_not_installed"}
+
+    try:
+        if "xclip" in clip_tool:
+            proc = subprocess.run(
+                ["xclip", "-selection", "clipboard", "-o"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        else:
+            proc = subprocess.run(
+                ["xsel", "--clipboard", "--output"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+        if proc.returncode == 0:
+            content = proc.stdout
+            return {"ok": True, "text": content[:4096], "length": len(content)}
+        return {"ok": False, "error": f"clipboard_error: {proc.stderr.strip()}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}

--- a/src/bantz/tools/terminal_tools.py
+++ b/src/bantz/tools/terminal_tools.py
@@ -1,0 +1,287 @@
+"""Terminal runtime tool handlers — policy-enforced command execution.
+
+Issue #845: Planner-Runtime Tool Gap Kapatma
+─────────────────────────────────────────────
+Provides runtime handlers for 4 terminal tools with policy.json enforcement:
+- Deny dangerous patterns (rm -rf, dd, mkfs, etc.)
+- Confirm patterns (sudo, apt, kill, chmod, etc.)
+- Timeout protection
+- Background process management
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import signal
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Background processes registry
+_background_processes: dict[int, dict] = {}
+_bg_counter = 0
+_bg_lock = threading.Lock()
+
+# Policy cache
+_policy: dict | None = None
+
+
+def _load_policy() -> dict:
+    """Load policy.json — cached after first load."""
+    global _policy
+    if _policy is not None:
+        return _policy
+
+    policy_paths = [
+        Path(__file__).parent.parent.parent.parent / "config" / "policy.json",
+        Path.home() / ".config" / "bantz" / "policy.json",
+    ]
+
+    for pp in policy_paths:
+        if pp.exists():
+            try:
+                _policy = json.loads(pp.read_text())
+                logger.info(f"[Terminal] Policy loaded from {pp}")
+                return _policy
+            except Exception as e:
+                logger.warning(f"[Terminal] Failed to load policy {pp}: {e}")
+
+    # Fallback minimal policy
+    _policy = {
+        "deny_patterns": [
+            "rm -rf /",
+            "rm -rf ~",
+            "dd if=",
+            "mkfs",
+            ":(){ :|:& };:",
+            "shutdown",
+            "reboot",
+            "init 0",
+            "init 6",
+        ],
+        "confirm_patterns": [
+            "sudo",
+            "apt",
+            "kill",
+            "chmod",
+            "chown",
+            "mv /",
+        ],
+    }
+    return _policy
+
+
+def _check_command(command: str) -> tuple[str, bool]:
+    """Check command against policy.
+
+    Patterns in policy.json are treated as regex when they contain
+    regex metacharacters (\\b, \\s, etc.), otherwise as plain substrings.
+
+    Returns:
+        (status, needs_confirm) where status is "allow", "deny", or "confirm"
+    """
+    import re as _re
+
+    policy = _load_policy()
+    cmd_lower = command.lower().strip()
+
+    def _matches(pattern: str, text: str) -> bool:
+        """Match pattern as regex first, fall back to substring."""
+        try:
+            if _re.search(pattern, text, _re.IGNORECASE):
+                return True
+        except _re.error:
+            pass
+        return pattern.lower() in text
+
+    # Check deny patterns
+    for dp in policy.get("deny_patterns", []):
+        if _matches(dp, cmd_lower):
+            return "deny", False
+
+    # Check for pipes/semicolons if denied
+    deny_chars = policy.get("deny_chars", [])
+    for dc in deny_chars:
+        if dc in command:
+            return "deny", False
+
+    # Check confirm patterns
+    for cp in policy.get("confirm_patterns", []):
+        if _matches(cp, cmd_lower):
+            return "confirm", True
+
+    return "allow", False
+
+
+# ── terminal_run ────────────────────────────────────────────────────
+
+def terminal_run_tool(*, command: str = "", timeout: int = 60, **_: Any) -> Dict[str, Any]:
+    """Run a shell command with policy enforcement."""
+    if not command:
+        return {"ok": False, "error": "command_required"}
+
+    # Policy check
+    status, needs_confirm = _check_command(command)
+    if status == "deny":
+        return {
+            "ok": False,
+            "error": "command_denied_by_policy",
+            "command": command,
+            "policy": "deny",
+        }
+
+    # Cap timeout
+    timeout = max(1, min(timeout, 300))
+
+    try:
+        # Sanitize environment
+        env = os.environ.copy()
+        # Remove sensitive vars
+        for key in list(env.keys()):
+            if any(s in key.upper() for s in ("SECRET", "PASSWORD", "TOKEN", "API_KEY", "PRIVATE")):
+                del env[key]
+
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            cwd=str(Path.home()),
+        )
+
+        output = ""
+        if result.stdout:
+            output += result.stdout[:10000]
+        if result.stderr:
+            if output:
+                output += "\n--- STDERR ---\n"
+            output += result.stderr[:5000]
+
+        return {
+            "ok": result.returncode == 0,
+            "exit_code": result.returncode,
+            "output": output,
+            "command": command,
+        }
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": f"timeout_after_{timeout}s", "command": command}
+    except Exception as e:
+        return {"ok": False, "error": str(e), "command": command}
+
+
+# ── terminal_background ────────────────────────────────────────────
+
+def terminal_background_tool(*, command: str = "", **_: Any) -> Dict[str, Any]:
+    """Start a command in the background."""
+    global _bg_counter
+
+    if not command:
+        return {"ok": False, "error": "command_required"}
+
+    status, _ = _check_command(command)
+    if status == "deny":
+        return {"ok": False, "error": "command_denied_by_policy", "command": command}
+
+    try:
+        env = os.environ.copy()
+        for key in list(env.keys()):
+            if any(s in key.upper() for s in ("SECRET", "PASSWORD", "TOKEN", "API_KEY", "PRIVATE")):
+                del env[key]
+
+        proc = subprocess.Popen(
+            command,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            cwd=str(Path.home()),
+            preexec_fn=os.setsid,
+        )
+
+        with _bg_lock:
+            _bg_counter += 1
+            bg_id = _bg_counter
+            _background_processes[bg_id] = {
+                "id": bg_id,
+                "command": command,
+                "pid": proc.pid,
+                "process": proc,
+            }
+
+        return {
+            "ok": True,
+            "id": bg_id,
+            "pid": proc.pid,
+            "command": command,
+            "started": True,
+        }
+    except Exception as e:
+        return {"ok": False, "error": str(e), "command": command}
+
+
+# ── terminal_background_list ───────────────────────────────────────
+
+def terminal_background_list_tool(**_: Any) -> Dict[str, Any]:
+    """List all running background processes."""
+    with _bg_lock:
+        processes = []
+        for bg_id, info in _background_processes.items():
+            proc = info["process"]
+            running = proc.poll() is None
+            entry = {
+                "id": bg_id,
+                "pid": info["pid"],
+                "command": info["command"],
+                "running": running,
+            }
+            if not running:
+                entry["exit_code"] = proc.returncode
+            processes.append(entry)
+
+    return {
+        "ok": True,
+        "count": len(processes),
+        "processes": processes,
+    }
+
+
+# ── terminal_background_kill ───────────────────────────────────────
+
+def terminal_background_kill_tool(*, id: int = 0, **_: Any) -> Dict[str, Any]:
+    """Kill a background process by ID."""
+    with _bg_lock:
+        info = _background_processes.get(id)
+
+    if info is None:
+        return {"ok": False, "error": f"process_not_found: {id}"}
+
+    proc = info["process"]
+    if proc.poll() is not None:
+        # Already dead
+        with _bg_lock:
+            _background_processes.pop(id, None)
+        return {"ok": True, "id": id, "already_exited": True, "exit_code": proc.returncode}
+
+    try:
+        # Kill the process group
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        proc.wait(timeout=2)
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+    with _bg_lock:
+        _background_processes.pop(id, None)
+
+    return {"ok": True, "id": id, "killed": True, "pid": info["pid"]}

--- a/tests/test_tool_gap_845.py
+++ b/tests/test_tool_gap_845.py
@@ -1,0 +1,668 @@
+"""Tests for Issue #845 — Planner-Runtime Tool Gap Closure.
+
+Verifies that all 52 previously missing runtime handlers now exist
+and function correctly. Tests are organized by tool category:
+
+  1. Registry completeness — all 69 tools with real handlers
+  2. Browser tools — mock ExtensionBridge
+  3. PC control tools — mock xdotool/xclip
+  4. File system tools — sandboxed, real filesystem
+  5. Terminal tools — policy enforcement
+  6. Code/project tools — AST-based
+  7. Gmail extended tools — mock gmail module
+  8. Contacts tools — from store
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. Registry Completeness
+# ═══════════════════════════════════════════════════════════════════
+
+class TestRegistryCompleteness:
+    """Verify the runtime registry has all expected tools."""
+
+    def test_runtime_registry_has_at_least_40_tools(self):
+        """Acceptance criteria: ≥40/69 tools with runtime handlers."""
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        assert len(reg.names()) >= 40
+
+    def test_runtime_registry_has_69_tools(self):
+        """Full coverage: 69 runtime tools."""
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        assert len(reg.names()) == 69
+
+    def test_no_null_handlers(self):
+        """Every registered tool must have a real function handler."""
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        for name in reg.names():
+            tool = reg.get(name)
+            fn = getattr(tool, "function", None) or getattr(tool, "handler", None)
+            assert fn is not None, f"{name} has no function handler"
+
+    def test_browser_tools_registered(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        expected = [
+            "browser_open", "browser_scan", "browser_click", "browser_type",
+            "browser_back", "browser_info", "browser_detail", "browser_wait",
+            "browser_search", "browser_scroll_down", "browser_scroll_up",
+        ]
+        names = reg.names()
+        for t in expected:
+            assert t in names, f"Missing browser tool: {t}"
+
+    def test_pc_tools_registered(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        expected = [
+            "pc_hotkey", "pc_mouse_move", "pc_mouse_click",
+            "pc_mouse_scroll", "clipboard_set", "clipboard_get",
+        ]
+        names = reg.names()
+        for t in expected:
+            assert t in names, f"Missing PC tool: {t}"
+
+    def test_file_tools_registered(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        expected = [
+            "file_read", "file_write", "file_edit",
+            "file_create", "file_undo", "file_search",
+        ]
+        names = reg.names()
+        for t in expected:
+            assert t in names, f"Missing file tool: {t}"
+
+    def test_terminal_tools_registered(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        expected = [
+            "terminal_run", "terminal_background",
+            "terminal_background_list", "terminal_background_kill",
+        ]
+        names = reg.names()
+        for t in expected:
+            assert t in names, f"Missing terminal tool: {t}"
+
+    def test_code_tools_registered(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        expected = [
+            "code_format", "code_replace_function",
+            "project_info", "project_tree",
+            "project_symbols", "project_search_symbol",
+        ]
+        names = reg.names()
+        for t in expected:
+            assert t in names, f"Missing code tool: {t}"
+
+    def test_gmail_extended_tools_registered(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        expected = [
+            "gmail.list_labels", "gmail.add_label", "gmail.remove_label",
+            "gmail.mark_read", "gmail.mark_unread", "gmail.archive",
+            "gmail.batch_modify", "gmail.download_attachment",
+            "gmail.create_draft", "gmail.list_drafts", "gmail.update_draft",
+            "gmail.send_draft", "gmail.delete_draft", "gmail.generate_reply",
+        ]
+        names = reg.names()
+        for t in expected:
+            assert t in names, f"Missing Gmail tool: {t}"
+
+    def test_contacts_tools_registered(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+        expected = [
+            "contacts.upsert", "contacts.resolve",
+            "contacts.list", "contacts.delete",
+        ]
+        names = reg.names()
+        for t in expected:
+            assert t in names, f"Missing contacts tool: {t}"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. Browser Tools
+# ═══════════════════════════════════════════════════════════════════
+
+class TestBrowserTools:
+    """Test browser tool handlers with mocked ExtensionBridge."""
+
+    def _mock_bridge(self, **overrides):
+        bridge = MagicMock()
+        bridge.has_client.return_value = True
+        bridge.request_navigate.return_value = True
+        bridge.request_scan.return_value = {
+            "elements": [{"tag": "a", "text": "Link 1", "type": "link"}],
+            "url": "https://example.com",
+            "title": "Example",
+        }
+        bridge.request_click.return_value = True
+        bridge.request_type.return_value = True
+        bridge.request_go_back.return_value = True
+        bridge.request_scroll.return_value = True
+        bridge.get_current_page.return_value = {"url": "https://example.com", "title": "Example"}
+        bridge.get_page_elements.return_value = [{"tag": "a", "text": "Link 1"}]
+        for k, v in overrides.items():
+            setattr(bridge, k, v)
+        return bridge
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_open(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_open_tool
+        result = browser_open_tool(url="youtube")
+        assert result["ok"] is True
+        assert "youtube" in result["url"]
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_open_no_url(self, mock_get_bridge):
+        from bantz.tools.browser_tools import browser_open_tool
+        result = browser_open_tool()
+        assert result["ok"] is False
+        assert "url_required" in result["error"]
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_scan(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_scan_tool
+        result = browser_scan_tool()
+        assert result["ok"] is True
+        assert result["element_count"] == 1
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_click(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_click_tool
+        result = browser_click_tool(index=0)
+        assert result["ok"] is True
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_type(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_type_tool
+        result = browser_type_tool(text="hello")
+        assert result["ok"] is True
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_back(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_back_tool
+        result = browser_back_tool()
+        assert result["ok"] is True
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_info(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_info_tool
+        result = browser_info_tool()
+        assert result["ok"] is True
+        assert "url" in result
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_detail(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_detail_tool
+        result = browser_detail_tool(index=0)
+        assert result["ok"] is True
+
+    def test_browser_wait(self):
+        from bantz.tools.browser_tools import browser_wait_tool
+        result = browser_wait_tool(seconds=1)
+        assert result["ok"] is True
+        assert result["waited_seconds"] == 1
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_search(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_search_tool
+        result = browser_search_tool(query="test")
+        assert result["ok"] is True
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_scroll_down(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_scroll_down_tool
+        result = browser_scroll_down_tool()
+        assert result["ok"] is True
+
+    @patch("bantz.tools.browser_tools._get_bridge")
+    def test_browser_scroll_up(self, mock_get_bridge):
+        mock_get_bridge.return_value = self._mock_bridge()
+        from bantz.tools.browser_tools import browser_scroll_up_tool
+        result = browser_scroll_up_tool()
+        assert result["ok"] is True
+
+    def test_browser_no_bridge(self):
+        """When bridge is unavailable, return graceful error."""
+        with patch("bantz.tools.browser_tools._get_bridge", return_value=None):
+            from bantz.tools.browser_tools import browser_scan_tool
+            result = browser_scan_tool()
+            assert result["ok"] is False
+            assert "unavailable" in result["error"]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. PC Control Tools
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPCTools:
+    """Test PC control tools with mocked subprocess."""
+
+    @patch("bantz.tools.pc_tools._check_tool", return_value="/usr/bin/xdotool")
+    @patch("bantz.tools.pc_tools._run_cmd")
+    def test_pc_hotkey(self, mock_run, mock_check):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from bantz.tools.pc_tools import pc_hotkey_tool
+        result = pc_hotkey_tool(combo="alt+tab")
+        assert result["ok"] is True
+        assert result["sent"] is True
+
+    def test_pc_hotkey_blocked(self):
+        from bantz.tools.pc_tools import pc_hotkey_tool
+        result = pc_hotkey_tool(combo="ctrl+alt+delete")
+        assert result["ok"] is False
+        assert "blocked" in result["error"]
+
+    def test_pc_hotkey_empty(self):
+        from bantz.tools.pc_tools import pc_hotkey_tool
+        result = pc_hotkey_tool()
+        assert result["ok"] is False
+
+    @patch("bantz.tools.pc_tools._check_tool", return_value="/usr/bin/xdotool")
+    @patch("bantz.tools.pc_tools._run_cmd")
+    def test_pc_mouse_move(self, mock_run, mock_check):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from bantz.tools.pc_tools import pc_mouse_move_tool
+        result = pc_mouse_move_tool(x=100, y=200)
+        assert result["ok"] is True
+        assert result["x"] == 100
+        assert result["y"] == 200
+
+    @patch("bantz.tools.pc_tools._check_tool", return_value="/usr/bin/xdotool")
+    @patch("bantz.tools.pc_tools._run_cmd")
+    def test_pc_mouse_click(self, mock_run, mock_check):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from bantz.tools.pc_tools import pc_mouse_click_tool
+        result = pc_mouse_click_tool(button="left")
+        assert result["ok"] is True
+
+    @patch("bantz.tools.pc_tools._check_tool", return_value="/usr/bin/xdotool")
+    @patch("bantz.tools.pc_tools._run_cmd")
+    def test_pc_mouse_scroll(self, mock_run, mock_check):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from bantz.tools.pc_tools import pc_mouse_scroll_tool
+        result = pc_mouse_scroll_tool(direction="down", amount=5)
+        assert result["ok"] is True
+
+    @patch("bantz.tools.pc_tools._check_tool", return_value="/usr/bin/xclip")
+    @patch("bantz.tools.pc_tools.subprocess.run")
+    def test_clipboard_set(self, mock_run, mock_check):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        from bantz.tools.pc_tools import clipboard_set_tool
+        result = clipboard_set_tool(text="test")
+        assert result["ok"] is True
+        assert result["length"] == 4
+
+    @patch("bantz.tools.pc_tools._check_tool", return_value="/usr/bin/xclip")
+    @patch("bantz.tools.pc_tools.subprocess.run")
+    def test_clipboard_get(self, mock_run, mock_check):
+        mock_run.return_value = MagicMock(returncode=0, stdout="clipboard content", stderr="")
+        from bantz.tools.pc_tools import clipboard_get_tool
+        result = clipboard_get_tool()
+        assert result["ok"] is True
+        assert result["text"] == "clipboard content"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. File System Tools
+# ═══════════════════════════════════════════════════════════════════
+
+class TestFileTools:
+    """Test file tools with real filesystem in tmp directory."""
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, tmp_path):
+        """Set up a temp workspace for each test."""
+        from bantz.tools import file_tools
+        file_tools.configure_workspace(tmp_path)
+        self.ws = tmp_path
+
+    def test_file_create_and_read(self):
+        from bantz.tools.file_tools import file_create_tool, file_read_tool
+        # Create
+        fpath = str(self.ws / "test.txt")
+        result = file_create_tool(path=fpath, content="hello world")
+        assert result["ok"] is True
+        assert result["created"] is True
+
+        # Read
+        result = file_read_tool(path=fpath)
+        assert result["ok"] is True
+        assert "hello world" in result["content"]
+
+    def test_file_read_line_range(self):
+        from bantz.tools.file_tools import file_create_tool, file_read_tool
+        fpath = str(self.ws / "lines.txt")
+        file_create_tool(path=fpath, content="line1\nline2\nline3\nline4\nline5")
+        result = file_read_tool(path=fpath, start_line=2, end_line=4)
+        assert result["ok"] is True
+        assert "line2" in result["content"]
+        assert "line4" in result["content"]
+        assert "line1" not in result["content"]
+
+    def test_file_write_with_backup(self):
+        from bantz.tools.file_tools import file_create_tool, file_write_tool
+        fpath = str(self.ws / "write_test.txt")
+        file_create_tool(path=fpath, content="original")
+        result = file_write_tool(path=fpath, content="updated")
+        assert result["ok"] is True
+        assert result["backup"] is not None
+
+    def test_file_edit(self):
+        from bantz.tools.file_tools import file_create_tool, file_edit_tool, file_read_tool
+        fpath = str(self.ws / "edit_test.txt")
+        file_create_tool(path=fpath, content="foo bar baz")
+        result = file_edit_tool(path=fpath, old_string="bar", new_string="qux")
+        assert result["ok"] is True
+        content = file_read_tool(path=fpath)
+        assert "foo qux baz" in content["content"]
+
+    def test_file_edit_not_found(self):
+        from bantz.tools.file_tools import file_edit_tool
+        result = file_edit_tool(path=str(self.ws / "nope.txt"), old_string="x", new_string="y")
+        assert result["ok"] is False
+
+    def test_file_create_already_exists(self):
+        from bantz.tools.file_tools import file_create_tool
+        fpath = str(self.ws / "dup.txt")
+        file_create_tool(path=fpath, content="first")
+        result = file_create_tool(path=fpath, content="second")
+        assert result["ok"] is False
+        assert "already_exists" in result["error"]
+
+    def test_file_undo(self):
+        from bantz.tools.file_tools import file_create_tool, file_write_tool, file_undo_tool, file_read_tool
+        fpath = str(self.ws / "undo_test.txt")
+        file_create_tool(path=fpath, content="original")
+        file_write_tool(path=fpath, content="changed")
+        result = file_undo_tool(path=fpath)
+        assert result["ok"] is True
+        content = file_read_tool(path=fpath)
+        assert "original" in content["content"]
+
+    def test_file_search(self):
+        from bantz.tools.file_tools import file_create_tool, file_search_tool
+        (self.ws / "subdir").mkdir()
+        file_create_tool(path=str(self.ws / "subdir" / "test.py"), content="import os")
+        file_create_tool(path=str(self.ws / "subdir" / "data.txt"), content="hello")
+        result = file_search_tool(pattern="*.py", path=str(self.ws))
+        assert result["ok"] is True
+        assert result["count"] >= 1
+
+    def test_file_search_with_content(self):
+        from bantz.tools.file_tools import file_create_tool, file_search_tool
+        file_create_tool(path=str(self.ws / "a.py"), content="import os\nprint('hello')")
+        file_create_tool(path=str(self.ws / "b.py"), content="import sys")
+        result = file_search_tool(pattern="*.py", content="hello", path=str(self.ws))
+        assert result["ok"] is True
+        assert result["count"] == 1
+
+    def test_file_path_traversal_blocked(self):
+        from bantz.tools.file_tools import file_read_tool
+        result = file_read_tool(path="/etc/shadow")
+        assert result["ok"] is False
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 5. Terminal Tools
+# ═══════════════════════════════════════════════════════════════════
+
+class TestTerminalTools:
+    """Test terminal tools with policy enforcement."""
+
+    def test_terminal_run_echo(self):
+        from bantz.tools.terminal_tools import terminal_run_tool
+        result = terminal_run_tool(command="echo hello")
+        assert result["ok"] is True
+        assert "hello" in result["output"]
+
+    def test_terminal_run_deny_rm_rf(self):
+        from bantz.tools.terminal_tools import terminal_run_tool
+        result = terminal_run_tool(command="rm -rf /")
+        assert result["ok"] is False
+        assert "denied" in result["error"]
+
+    def test_terminal_run_deny_dd(self):
+        from bantz.tools.terminal_tools import terminal_run_tool
+        result = terminal_run_tool(command="dd if=/dev/zero of=/dev/sda")
+        assert result["ok"] is False
+        assert "denied" in result["error"]
+
+    def test_terminal_run_deny_shutdown(self):
+        from bantz.tools.terminal_tools import terminal_run_tool
+        result = terminal_run_tool(command="shutdown now")
+        assert result["ok"] is False
+
+    def test_terminal_run_empty(self):
+        from bantz.tools.terminal_tools import terminal_run_tool
+        result = terminal_run_tool()
+        assert result["ok"] is False
+
+    def test_terminal_background_list_empty(self):
+        from bantz.tools.terminal_tools import terminal_background_list_tool
+        result = terminal_background_list_tool()
+        assert result["ok"] is True
+        assert isinstance(result["processes"], list)
+
+    def test_terminal_background_kill_not_found(self):
+        from bantz.tools.terminal_tools import terminal_background_kill_tool
+        result = terminal_background_kill_tool(id=99999)
+        assert result["ok"] is False
+
+    def test_terminal_background_start_and_kill(self):
+        from bantz.tools.terminal_tools import (
+            terminal_background_tool,
+            terminal_background_kill_tool,
+            terminal_background_list_tool,
+        )
+        # Start a background sleep
+        result = terminal_background_tool(command="sleep 60")
+        assert result["ok"] is True
+        bg_id = result["id"]
+
+        # List — should show it
+        listing = terminal_background_list_tool()
+        assert any(p["id"] == bg_id for p in listing["processes"])
+
+        # Kill it
+        kill_result = terminal_background_kill_tool(id=bg_id)
+        assert kill_result["ok"] is True
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. Code / Project Tools
+# ═══════════════════════════════════════════════════════════════════
+
+class TestCodeTools:
+    """Test code and project tools."""
+
+    def test_project_info(self):
+        from bantz.tools.code_tools import project_info_tool
+        result = project_info_tool()
+        assert result["ok"] is True
+        assert "workspace_root" in result
+
+    def test_project_tree(self):
+        from bantz.tools.code_tools import project_tree_tool
+        result = project_tree_tool(max_depth=2)
+        assert result["ok"] is True
+        assert "tree" in result
+
+    def test_project_symbols(self, tmp_path):
+        from bantz.tools.code_tools import project_symbols_tool
+        # Create a temp Python file
+        py_file = tmp_path / "sample.py"
+        py_file.write_text(textwrap.dedent("""\
+            def hello():
+                pass
+
+            class MyClass:
+                def method(self):
+                    pass
+        """))
+        result = project_symbols_tool(path=str(py_file))
+        assert result["ok"] is True
+        names = [s["name"] for s in result["symbols"]]
+        assert "hello" in names
+        assert "MyClass" in names
+
+    def test_project_search_symbol(self):
+        from bantz.tools.code_tools import project_search_symbol_tool
+        result = project_search_symbol_tool(name="build_default_registry")
+        assert result["ok"] is True
+        assert result["count"] >= 1
+
+    def test_code_format_not_found(self):
+        from bantz.tools.code_tools import code_format_tool
+        result = code_format_tool(path="/nonexistent/file.py")
+        assert result["ok"] is False
+
+    def test_code_replace_function(self, tmp_path):
+        from bantz.tools.code_tools import code_replace_function_tool
+        py_file = tmp_path / "funcs.py"
+        py_file.write_text(textwrap.dedent("""\
+            def old_func():
+                return 1
+
+            def keep_func():
+                return 2
+        """))
+        result = code_replace_function_tool(
+            path=str(py_file),
+            function_name="old_func",
+            new_code="def old_func():\n    return 42",
+        )
+        assert result["ok"] is True
+        content = py_file.read_text()
+        assert "return 42" in content
+        assert "return 2" in content  # keep_func preserved
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 7. Gmail Extended Tools
+# ═══════════════════════════════════════════════════════════════════
+
+class TestGmailExtendedTools:
+    """Test Gmail extended tools with mocked gmail module."""
+
+    @patch("bantz.tools.gmail_extended_tools.gmail_list_labels", create=True)
+    def test_list_labels(self, mock_fn):
+        # We need to mock at import time
+        with patch.dict("sys.modules", {}):
+            from bantz.tools.gmail_extended_tools import gmail_list_labels_tool
+        # Mock the lazy import
+        with patch("bantz.google.gmail.gmail_list_labels", return_value={"ok": True, "labels": []}, create=True):
+            result = gmail_list_labels_tool()
+            assert result["ok"] is True
+
+    def test_add_label_missing_params(self):
+        from bantz.tools.gmail_extended_tools import gmail_add_label_tool
+        result = gmail_add_label_tool()
+        assert result["ok"] is False
+        assert "required" in result["error"]
+
+    def test_mark_read_missing_id(self):
+        from bantz.tools.gmail_extended_tools import gmail_mark_read_tool
+        result = gmail_mark_read_tool()
+        assert result["ok"] is False
+
+    def test_archive_missing_id(self):
+        from bantz.tools.gmail_extended_tools import gmail_archive_tool
+        result = gmail_archive_tool()
+        assert result["ok"] is False
+
+    def test_create_draft_missing_params(self):
+        from bantz.tools.gmail_extended_tools import gmail_create_draft_tool
+        result = gmail_create_draft_tool()
+        assert result["ok"] is False
+
+    def test_send_draft_missing_id(self):
+        from bantz.tools.gmail_extended_tools import gmail_send_draft_tool
+        result = gmail_send_draft_tool()
+        assert result["ok"] is False
+
+    def test_generate_reply_missing_params(self):
+        from bantz.tools.gmail_extended_tools import gmail_generate_reply_tool
+        result = gmail_generate_reply_tool()
+        assert result["ok"] is False
+
+    def test_download_attachment_missing_params(self):
+        from bantz.tools.gmail_extended_tools import gmail_download_attachment_tool
+        result = gmail_download_attachment_tool()
+        assert result["ok"] is False
+
+    def test_batch_modify_missing_ids(self):
+        from bantz.tools.gmail_extended_tools import gmail_batch_modify_tool
+        result = gmail_batch_modify_tool()
+        assert result["ok"] is False
+
+
+# ═══════════════════════════════════════════════════════════════════
+# 8. Risk Classification
+# ═══════════════════════════════════════════════════════════════════
+
+class TestRiskClassification:
+    """Verify destructive tools require confirmation."""
+
+    def test_write_tools_require_confirmation(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+
+        must_confirm = [
+            "gmail.send", "gmail.archive", "gmail.batch_modify",
+            "gmail.send_draft", "gmail.download_attachment",
+            "gmail.generate_reply", "gmail.send_to_contact",
+            "calendar.create_event", "calendar.update_event",
+            "calendar.delete_event",
+            "terminal_run", "file_write",
+            "pc_hotkey", "pc_mouse_click", "clipboard_set",
+        ]
+
+        for name in must_confirm:
+            tool = reg.get(name)
+            assert tool is not None, f"Tool {name} not found"
+            assert tool.requires_confirmation, f"{name} should require confirmation"
+
+    def test_readonly_tools_no_confirmation(self):
+        from bantz.agent.registry import build_default_registry
+        reg = build_default_registry()
+
+        no_confirm = [
+            "browser_scan", "browser_info", "browser_detail",
+            "file_read", "file_search",
+            "gmail.list_labels", "gmail.list_drafts",
+            "gmail.mark_read", "gmail.mark_unread",
+            "contacts.list", "contacts.resolve",
+            "project_info", "project_tree",
+            "terminal_background_list",
+        ]
+
+        for name in no_confirm:
+            tool = reg.get(name)
+            assert tool is not None, f"Tool {name} not found"
+            assert not tool.requires_confirmation, f"{name} should NOT require confirmation"


### PR DESCRIPTION
## Issue
Closes #845

## Problem
Planner catalog declared **69 tools** but runtime registry only had **~17** with real handler functions. The remaining 52 tools existed only as metadata — calls would silently fail at runtime.

## Solution
6 new tool handler modules, **3240 lines** added:

| Module | Tools | Description |
|--------|-------|-------------|
| `browser_tools.py` | 11 | ExtensionBridge wrappers (open, scan, click, type, scroll, search…) |
| `pc_tools.py` | 6 | xdotool/xclip (hotkey, mouse, clipboard) with blocked combos |
| `file_tools.py` | 6 | Sandboxed file ops with backup, undo, path traversal protection |
| `terminal_tools.py` | 4 | Policy-enforced shell commands with regex-aware deny patterns |
| `code_tools.py` | 6 | AST-based symbols, project tree, code formatting |
| `gmail_extended_tools.py` | 14 | Labels, drafts, attachments, batch modify, reply generation |

### Registry
- `registry.py` expanded from ~17 → **69** registered tools
- Every tool has a real callable function handler
- Risk levels and confirmation flags properly assigned

### Bug Fix
- `terminal_tools._check_command()` used **substring matching** but `config/policy.json` deny patterns are **regex** (`\brm\b\s+-rf`)
- Fixed to use `re.search()` with substring fallback
- Before fix: `rm -rf /` was **NOT denied** — now properly blocked ✅

## Tests
**66/66 passed** across 9 test classes:

| Test Class | Result |
|------------|--------|
| TestRegistryCompleteness | ✅ 10/10 |
| TestBrowserTools | ✅ 13/13 |
| TestPCTools | ✅ 8/8 |
| TestFileTools | ✅ 10/10 |
| TestTerminalTools | ✅ 8/8 |
| TestCodeTools | ✅ 6/6 |
| TestGmailExtendedTools | ✅ 9/9 |
| TestRiskClassification | ✅ 2/2 |