### PR TITLE
fix(#869): Gmail/Calendar tools — Web Dashboard confirmation flow

### DIFF
--- a/src/bantz/api/static/index.html
+++ b/src/bantz/api/static/index.html
@@ -142,6 +142,23 @@ input,textarea{font-family:var(--font);outline:none}
 .qr-container img{max-width:200px;border-radius:var(--radius);border:2px solid var(--bg3)}
 .qr-url{font-family:var(--mono);font-size:.85rem;color:var(--accent2);margin-top:12px;word-break:break-all}
 
+/* ── Confirmation Modal (Issue #869) ───────────────── */
+.confirm-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);z-index:300;justify-content:center;align-items:center;animation:fadeIn .2s ease}
+.confirm-overlay.active{display:flex}
+.confirm-modal{background:var(--bg2);border:1px solid var(--bg3);border-radius:var(--radius);padding:24px;max-width:420px;width:90%;box-shadow:0 8px 32px rgba(0,0,0,.5);animation:modalIn .25s ease}
+@keyframes fadeIn{from{opacity:0}to{opacity:1}}
+@keyframes modalIn{from{opacity:0;transform:scale(.95) translateY(10px)}to{opacity:1;transform:none}}
+.confirm-modal .confirm-icon{font-size:2rem;text-align:center;margin-bottom:12px}
+.confirm-modal .confirm-title{font-size:1.1rem;font-weight:600;text-align:center;margin-bottom:8px}
+.confirm-modal .confirm-tool{font-size:.75rem;color:var(--fg3);text-align:center;margin-bottom:16px;font-family:var(--mono)}
+.confirm-modal .confirm-text{font-size:.95rem;line-height:1.6;color:var(--fg);text-align:center;padding:16px;background:var(--bg);border-radius:var(--radius-sm);margin-bottom:20px}
+.confirm-modal .confirm-actions{display:flex;gap:12px;justify-content:center}
+.confirm-modal .confirm-actions button{padding:10px 28px;border-radius:var(--radius-sm);font-size:.95rem;font-weight:600;transition:all .15s}
+.confirm-modal .btn-confirm{background:var(--green);color:#fff}
+.confirm-modal .btn-confirm:hover{opacity:.85;transform:translateY(-1px)}
+.confirm-modal .btn-reject{background:var(--bg3);color:var(--fg2)}
+.confirm-modal .btn-reject:hover{background:var(--red);color:#fff;transform:translateY(-1px)}
+
 /* ── Toast ────────────────────────────────────────── */
 .toast{position:fixed;bottom:24px;right:24px;background:var(--bg2);border:1px solid var(--bg3);border-radius:var(--radius);padding:14px 20px;color:var(--fg);font-size:.9rem;box-shadow:var(--shadow);z-index:200;animation:toastIn .3s ease;max-width:360px}
 .toast.success{border-left:3px solid var(--green)}
@@ -307,6 +324,20 @@ input,textarea{font-family:var(--font);outline:none}
   </div>
 </div>
 
+<!-- Confirmation Modal (Issue #869) -->
+<div class="confirm-overlay" id="confirmOverlay">
+  <div class="confirm-modal">
+    <div class="confirm-icon">⚠️</div>
+    <div class="confirm-title">İşlem Onayı</div>
+    <div class="confirm-tool" id="confirmTool"></div>
+    <div class="confirm-text" id="confirmText"></div>
+    <div class="confirm-actions">
+      <button class="btn-confirm" onclick="confirmAction('yes')">✅ Evet, Devam Et</button>
+      <button class="btn-reject" onclick="confirmAction('no')">❌ İptal</button>
+    </div>
+  </div>
+</div>
+
 <script>
 /* ── State ────────────────────────────────────────── */
 let ws = null;
@@ -349,6 +380,12 @@ function connectWS(){
         hideTyping();
         addMessage('assistant', msg.data.response||'(boş yanıt)', msg.data.route);
         document.getElementById('lastRoute').textContent = msg.data.route||'unknown';
+      } else if(msg.type==='confirm_request'){
+        // Issue #869: Show confirmation dialog
+        hideTyping();
+        addMessage('assistant', msg.data.response||'İşlem onayı bekleniyor...', msg.data.route);
+        document.getElementById('lastRoute').textContent = msg.data.route||'confirmation';
+        showConfirmDialog(msg.data.tool||'', msg.data.prompt||msg.data.response||'');
       } else if(msg.type==='event'){
         // Orchestrator trace events — could show in future
       } else if(msg.type==='error'){
@@ -368,6 +405,35 @@ function setWSStatus(status, label){
   lbl.textContent = label;
 }
 
+/* ── Confirmation Dialog (Issue #869) ──────────────── */
+function showConfirmDialog(tool, prompt){
+  document.getElementById('confirmTool').textContent = tool||'';
+  document.getElementById('confirmText').textContent = prompt||'Bu işlemi onaylıyor musunuz?';
+  document.getElementById('confirmOverlay').classList.add('active');
+}
+function hideConfirmDialog(){
+  document.getElementById('confirmOverlay').classList.remove('active');
+}
+function confirmAction(action){
+  hideConfirmDialog();
+  if(action==='yes'){
+    addMessage('user','✅ Evet, onaylıyorum');
+  } else {
+    addMessage('user','❌ İptal');
+  }
+  showTyping();
+  if(ws && ws.readyState===WebSocket.OPEN){
+    ws.send(JSON.stringify({type:'confirm',action:action}));
+  } else {
+    // REST fallback — send Turkish confirmation token
+    const msg = action==='yes'?'evet':'hayır';
+    fetch(API+'/api/v1/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:msg})})
+      .then(r=>r.json())
+      .then(d=>{hideTyping();addMessage('assistant',d.response||d.text||'(boş)',d.route);})
+      .catch(e=>{hideTyping();addMessage('system','⚠️ Bağlantı hatası: '+e.message)});
+  }
+}
+
 /* ── Chat ─────────────────────────────────────────── */
 function sendMessage(){
   const input = document.getElementById('chatInput');
@@ -383,7 +449,15 @@ function sendMessage(){
     // Fallback to REST
     fetch(API+'/api/v1/chat',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({message:text})})
       .then(r=>r.json())
-      .then(d=>{hideTyping();addMessage('assistant',d.response||d.text||'(boş)',d.route);document.getElementById('lastRoute').textContent=d.route||'unknown'})
+      .then(d=>{
+        hideTyping();
+        addMessage('assistant',d.response||d.text||'(boş)',d.route);
+        document.getElementById('lastRoute').textContent=d.route||'unknown';
+        // Issue #869: Handle confirmation in REST response
+        if(d.requires_confirmation && d.confirmation_prompt){
+          showConfirmDialog(d.confirmation_tool||'', d.confirmation_prompt);
+        }
+      })
       .catch(e=>{hideTyping();addMessage('system','⚠️ Bağlantı hatası: '+e.message)});
   }
 }

--- a/tests/test_issue_869_gmail_calendar_web.py
+++ b/tests/test_issue_869_gmail_calendar_web.py
@@ -1,0 +1,482 @@
+"""Tests for Issue #869 — Gmail & Calendar tools on Web Dashboard.
+
+Covers:
+  1. handle_command() brain path — confirmation fields pass through
+  2. handle_command() — pending confirmation yes/no handling
+  3. WebSocket handler — confirm_request message type
+  4. WebSocket handler — confirm message type (yes/no)
+  5. REST chat endpoint — requires_confirmation field in response
+  6. Frontend confirmation dialog (existence check in HTML)
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────
+# Fake server with confirmation support
+# ─────────────────────────────────────────────────────────────
+
+
+class FakeOrchestratorOutput:
+    """Fake orchestrator output."""
+
+    def __init__(
+        self,
+        assistant_reply: str = "Test yanıtı efendim.",
+        route: str = "smalltalk",
+        ask_user: bool = False,
+        question: str = "",
+        requires_confirmation: bool = False,
+        confirmation_prompt: str = "",
+    ):
+        self.assistant_reply = assistant_reply
+        self.route = route
+        self.ask_user = ask_user
+        self.question = question
+        self.requires_confirmation = requires_confirmation
+        self.confirmation_prompt = confirmation_prompt
+
+
+class FakeOrchestratorState:
+    """Minimal fake OrchestratorState with confirmation support."""
+
+    def __init__(self):
+        self.pending_confirmations: list[dict] = []
+        self.confirmed_tool: Optional[str] = None
+
+    def has_pending_confirmation(self) -> bool:
+        return bool(self.pending_confirmations)
+
+    def peek_pending_confirmation(self) -> Optional[dict]:
+        if not self.pending_confirmations:
+            return None
+        return self.pending_confirmations[0]
+
+    def pop_pending_confirmation(self) -> Optional[dict]:
+        if not self.pending_confirmations:
+            return None
+        return self.pending_confirmations.pop(0)
+
+    def clear_pending_confirmation(self) -> None:
+        self.pending_confirmations.clear()
+        self.confirmed_tool = None
+
+    def add_pending_confirmation(self, action: dict) -> None:
+        self.pending_confirmations.append(action)
+
+
+class FakeInboxStore:
+    def snapshot(self):
+        return {"items": [], "unread": 0}
+
+    def mark_read(self, target_id):
+        return False
+
+    def clear(self):
+        pass
+
+
+# ─────────────────────────────────────────────────────────────
+# Test: server.py handle_command confirmation flow
+# ─────────────────────────────────────────────────────────────
+
+
+class TestHandleCommandConfirmation:
+    """Test that handle_command correctly handles confirmation flow."""
+
+    def _make_server(self, *, pending_tool=None, pending_prompt=None):
+        """Create a minimal real BantzServer mock with brain + state."""
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        server = MagicMock()
+        server._brain = MagicMock()
+        server._brain_state = OrchestratorState()
+        server._inbox = FakeInboxStore()
+        server._running = True
+        server.session_name = "test"
+        server.ctx = MagicMock()
+        server.ctx.mode = "normal"
+        server.ctx.queue_active = lambda: False
+        server.ctx.pending = None
+
+        if pending_tool:
+            server._brain_state.add_pending_confirmation({
+                "tool": pending_tool,
+                "prompt": pending_prompt or f"{pending_tool} onay bekleniyor",
+                "slots": {},
+                "risk_level": "med",
+            })
+
+        return server
+
+    def test_brain_path_returns_confirmation_fields(self):
+        """When brain output creates a pending confirmation, handle_command
+        should return needs_confirmation=True + prompt."""
+        from bantz.server import BantzServer
+
+        server = self._make_server()
+        state = server._brain_state
+
+        # After process_turn, simulate the state having a pending confirmation
+        def fake_process_turn(command, brain_state):
+            brain_state.add_pending_confirmation({
+                "tool": "calendar.create_event",
+                "prompt": "'Toplantı' yarın 14:00'de eklensin mi?",
+                "slots": {},
+                "risk_level": "med",
+            })
+            return FakeOrchestratorOutput(
+                assistant_reply="",
+                route="calendar",
+            ), brain_state
+
+        server._brain.process_turn = fake_process_turn
+
+        # Call handle_command via the real method with mocked internals
+        # We need to call the actual handle_command, not the mock
+        result = BantzServer.handle_command(server, "yarın 2ye toplantı koy")
+
+        assert result["needs_confirmation"] is True
+        assert result["confirmation_prompt"] is not None
+        assert "Toplantı" in result["confirmation_prompt"] or "calendar" in str(result.get("confirmation_tool", ""))
+
+    def test_confirmation_yes_clears_pending(self):
+        """When user says 'evet' with pending confirmation, it should
+        set confirmed_tool and re-run process_turn."""
+        from bantz.server import BantzServer
+
+        server = self._make_server(
+            pending_tool="calendar.create_event",
+            pending_prompt="'Toplantı' yarın 14:00'de eklensin mi?",
+        )
+
+        def fake_process_turn(command, brain_state):
+            # When called after confirmation, return success
+            return FakeOrchestratorOutput(
+                assistant_reply="Tamamdır efendim, toplantı eklendi.",
+                route="calendar",
+            ), brain_state
+
+        server._brain.process_turn = fake_process_turn
+
+        result = BantzServer.handle_command(server, "evet")
+
+        assert result["ok"] is True
+        assert "Tamamdır" in result["text"] or "toplantı" in result["text"].lower()
+        assert result["brain"] is True
+
+    def test_confirmation_no_cancels(self):
+        """When user says 'hayır' with pending confirmation, it should
+        cancel and clear pending."""
+        from bantz.server import BantzServer
+
+        server = self._make_server(
+            pending_tool="calendar.create_event",
+            pending_prompt="'Toplantı' yarın 14:00'de eklensin mi?",
+        )
+
+        result = BantzServer.handle_command(server, "hayır")
+
+        assert result["ok"] is True
+        assert "iptal" in result["text"].lower()
+        assert result["route"] == "cancelled"
+        # Pending should be cleared
+        assert not server._brain_state.has_pending_confirmation()
+
+    def test_confirmation_unknown_reprompts(self):
+        """When user says something unrelated with pending confirmation,
+        re-show the confirmation prompt."""
+        from bantz.server import BantzServer
+
+        server = self._make_server(
+            pending_tool="calendar.create_event",
+            pending_prompt="'Toplantı' yarın 14:00'de eklensin mi?",
+        )
+
+        result = BantzServer.handle_command(server, "hava nasıl?")
+
+        assert result["needs_confirmation"] is True
+        assert "confirmation_prompt" in result
+
+    def test_yes_variations_accepted(self):
+        """Various Turkish confirmation words should be accepted."""
+        from bantz.server import BantzServer
+
+        yes_words = ["evet", "tamam", "ok", "olur", "ekle", "e", "kabul"]
+        for word in yes_words:
+            server = self._make_server(
+                pending_tool="calendar.create_event",
+                pending_prompt="Onay bekleniyor",
+            )
+            server._brain.process_turn = lambda cmd, st: (
+                FakeOrchestratorOutput(assistant_reply="OK", route="calendar"), st
+            )
+            result = BantzServer.handle_command(server, word)
+            assert result["ok"] is True, f"'{word}' should be accepted as confirmation"
+            assert result.get("needs_confirmation") is not True, f"'{word}' should clear confirmation"
+
+    def test_no_variations_accepted(self):
+        """Various Turkish rejection words should be accepted."""
+        from bantz.server import BantzServer
+
+        no_words = ["hayır", "iptal", "vazgeç", "hayir", "reddet", "yok"]
+        for word in no_words:
+            server = self._make_server(
+                pending_tool="calendar.create_event",
+                pending_prompt="Onay bekleniyor",
+            )
+            result = BantzServer.handle_command(server, word)
+            assert result["ok"] is True, f"'{word}' should be accepted as rejection"
+            assert "iptal" in result["text"].lower(), f"'{word}' should cancel"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test: WebSocket handler
+# ─────────────────────────────────────────────────────────────
+
+
+class TestWebSocketConfirmation:
+    """Test WebSocket chat endpoint confirmation support."""
+
+    @pytest.fixture()
+    def _app(self):
+        from bantz.api.server import create_app
+        from bantz.core.events import EventBus
+
+        server = MagicMock()
+        server.handle_command = MagicMock()
+        event_bus = EventBus(history_size=10)
+
+        os.environ.pop("BANTZ_API_TOKEN", None)
+        app = create_app(bantz_server=server, event_bus=event_bus)
+        return app, server
+
+    def test_ws_chat_normal_response(self, _app):
+        """Normal chat response should be type='chat'."""
+        from fastapi.testclient import TestClient
+
+        app, server = _app
+        server.handle_command.return_value = {
+            "ok": True,
+            "text": "Merhaba efendim!",
+            "brain": True,
+            "route": "smalltalk",
+        }
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat") as websocket:
+            websocket.send_json({"type": "chat", "message": "merhaba"})
+            response = websocket.receive_json()
+
+        assert response["type"] == "chat"
+        assert response["data"]["response"] == "Merhaba efendim!"
+
+    def test_ws_chat_confirmation_response(self, _app):
+        """When response has needs_confirmation, type should be 'confirm_request'."""
+        from fastapi.testclient import TestClient
+
+        app, server = _app
+        server.handle_command.return_value = {
+            "ok": True,
+            "text": "'Toplantı' yarın 14:00'de eklensin mi?",
+            "brain": True,
+            "route": "calendar",
+            "needs_confirmation": True,
+            "confirmation_prompt": "'Toplantı' yarın 14:00'de eklensin mi?",
+            "confirmation_tool": "calendar.create_event",
+        }
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat") as websocket:
+            websocket.send_json({"type": "chat", "message": "yarın 2ye toplantı koy"})
+            response = websocket.receive_json()
+
+        assert response["type"] == "confirm_request"
+        assert response["data"]["tool"] == "calendar.create_event"
+        assert "Toplantı" in response["data"]["prompt"]
+
+    def test_ws_confirm_yes(self, _app):
+        """Sending confirm action=yes should call handle_command with 'evet'."""
+        from fastapi.testclient import TestClient
+
+        app, server = _app
+        server.handle_command.return_value = {
+            "ok": True,
+            "text": "Tamamdır, toplantı eklendi.",
+            "brain": True,
+            "route": "calendar",
+        }
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat") as websocket:
+            websocket.send_json({"type": "confirm", "action": "yes"})
+            response = websocket.receive_json()
+
+        server.handle_command.assert_called_once_with("evet")
+        assert response["type"] == "chat"
+        assert "toplantı" in response["data"]["response"].lower() or response["data"]["ok"]
+
+    def test_ws_confirm_no(self, _app):
+        """Sending confirm action=no should call handle_command with 'hayır'."""
+        from fastapi.testclient import TestClient
+
+        app, server = _app
+        server.handle_command.return_value = {
+            "ok": True,
+            "text": "Anlaşıldı efendim, iptal ettim.",
+            "brain": True,
+            "route": "cancelled",
+        }
+
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat") as websocket:
+            websocket.send_json({"type": "confirm", "action": "no"})
+            response = websocket.receive_json()
+
+        server.handle_command.assert_called_once_with("hayır")
+        assert response["type"] == "chat"
+
+    def test_ws_confirm_invalid_action(self, _app):
+        """Invalid confirm action should return error."""
+        from fastapi.testclient import TestClient
+
+        app, server = _app
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat") as websocket:
+            websocket.send_json({"type": "confirm", "action": "maybe"})
+            response = websocket.receive_json()
+
+        assert response["type"] == "error"
+        assert "invalid_confirm" in response["data"]["code"]
+
+    def test_ws_ping_still_works(self, _app):
+        """Ping/pong should still work."""
+        from fastapi.testclient import TestClient
+
+        app, server = _app
+        client = TestClient(app)
+        with client.websocket_connect("/ws/chat") as websocket:
+            websocket.send_json({"type": "ping"})
+            response = websocket.receive_json()
+
+        assert response["type"] == "pong"
+
+
+# ─────────────────────────────────────────────────────────────
+# Test: REST /api/v1/chat confirmation
+# ─────────────────────────────────────────────────────────────
+
+
+class TestRESTChatConfirmation:
+    """Test REST chat endpoint includes confirmation fields."""
+
+    @pytest.fixture()
+    def client(self):
+        from bantz.api.server import create_app
+        from bantz.core.events import EventBus
+        from fastapi.testclient import TestClient
+
+        server = MagicMock()
+        server.handle_command = MagicMock()
+        event_bus = EventBus(history_size=10)
+
+        os.environ.pop("BANTZ_API_TOKEN", None)
+        app = create_app(bantz_server=server, event_bus=event_bus)
+        with TestClient(app) as tc:
+            yield tc, server
+
+    def test_rest_chat_confirmation_fields(self, client):
+        """REST chat response should include requires_confirmation."""
+        tc, server = client
+        server.handle_command.return_value = {
+            "ok": True,
+            "text": "'Toplantı' eklensin mi?",
+            "brain": True,
+            "route": "calendar",
+            "needs_confirmation": True,
+            "confirmation_prompt": "'Toplantı' eklensin mi?",
+        }
+
+        response = tc.post("/api/v1/chat", json={"message": "toplantı ekle"})
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["requires_confirmation"] is True
+        assert data["confirmation_prompt"] == "'Toplantı' eklensin mi?"
+
+    def test_rest_chat_no_confirmation(self, client):
+        """Normal responses should have requires_confirmation=False."""
+        tc, server = client
+        server.handle_command.return_value = {
+            "ok": True,
+            "text": "Merhaba!",
+            "brain": True,
+            "route": "smalltalk",
+        }
+
+        response = tc.post("/api/v1/chat", json={"message": "merhaba"})
+        data = response.json()
+
+        assert response.status_code == 200
+        assert data["requires_confirmation"] is False
+
+
+# ─────────────────────────────────────────────────────────────
+# Test: Frontend HTML confirmation dialog
+# ─────────────────────────────────────────────────────────────
+
+
+class TestFrontendConfirmation:
+    """Test that the frontend HTML includes confirmation UI."""
+
+    @pytest.fixture()
+    def html_content(self):
+        from pathlib import Path
+        html_path = Path(__file__).parent.parent / "src" / "bantz" / "api" / "static" / "index.html"
+        return html_path.read_text(encoding="utf-8")
+
+    def test_confirm_overlay_exists(self, html_content):
+        """Confirmation overlay div should exist."""
+        assert 'id="confirmOverlay"' in html_content
+
+    def test_confirm_text_element_exists(self, html_content):
+        """Confirmation text element should exist."""
+        assert 'id="confirmText"' in html_content
+
+    def test_confirm_tool_element_exists(self, html_content):
+        """Confirmation tool element should exist."""
+        assert 'id="confirmTool"' in html_content
+
+    def test_confirm_buttons_exist(self, html_content):
+        """Confirm/reject buttons should exist."""
+        assert "confirmAction('yes')" in html_content
+        assert "confirmAction('no')" in html_content
+
+    def test_showConfirmDialog_function(self, html_content):
+        """showConfirmDialog JS function should exist."""
+        assert "function showConfirmDialog" in html_content
+
+    def test_confirmAction_function(self, html_content):
+        """confirmAction JS function should exist."""
+        assert "function confirmAction" in html_content
+
+    def test_confirm_request_handler(self, html_content):
+        """WS onmessage should handle confirm_request type."""
+        assert "confirm_request" in html_content
+
+    def test_ws_sends_confirm_message(self, html_content):
+        """confirmAction should send {type:'confirm'} via WS."""
+        assert "type:'confirm'" in html_content
+
+    def test_confirm_modal_css(self, html_content):
+        """Confirmation modal CSS should exist."""
+        assert ".confirm-overlay" in html_content
+        assert ".confirm-modal" in html_content


### PR DESCRIPTION
## Issue
Closes #869

## Problem
Gmail ve Calendar tool'ları Web Dashboard (`bantz --serve --http`) üzerinden düzgün çalışmıyordu:

1. **`calendar.create_event` firewall block** — Confirmation pending ama web UI'da onay mekanizması yok
2. **Brain path confirmation fields eksik** — `handle_command()` brain path'i `needs_confirmation`, `confirmation_prompt` dönmüyordu
3. **WebSocket stripped confirmation** — WS handler sadece `{ok, response, route, brain}` gönderiyordu

## Root Causes & Fixes

### 1. Brain Path (server.py)
- `handle_command()` brain path yalnızca `{ok, text, brain, route}` döndürüyordu
- **Fix**: OrchestratorState'ten pending confirmation kontrol edilip tüm confirmation field'ları response'a eklendi
- Evet/hayır (15+ Türkçe varyant) ile confirmation handling eklendi

### 2. WebSocket Handler (ws.py)
- WS handler confirmation field'larını tamamen kırpıyordu
- **Fix**: `confirm_request` message type eklendi (tool name + prompt ile)
- `confirm` message type eklendi (client → server: `{type:'confirm', action:'yes/no'}`)

### 3. Frontend (index.html)
- Hiçbir confirmation dialog/modal yoktu
- **Fix**: Tam confirmation modal eklendi:
  - ⚠️ icon + tool adı + onay metni
  - ✅ 'Evet, Devam Et' / ❌ 'İptal' butonları
  - Animated overlay
  - WS + REST fallback desteği

## Confirmation Flow (Yeni)
```
User: 'saat 3'e toplantı ekle'
  → Brain: calendar.create_event → firewall → pending_confirmation
  → WS: {type: 'confirm_request', data: {tool: '...', prompt: '...'}}
  → Frontend: Modal göster
User: ✅ Evet
  → WS: {type: 'confirm', action: 'yes'}
  → Server: handle_command('evet') → confirmed_tool set → re-run
  → WS: {type: 'chat', data: {response: 'Toplantı eklendi!'}}
```

## Tests
**23/23 passed** across 4 test classes:

| Test Class | Result |
|------------|--------|
| TestHandleCommandConfirmation | ✅ 6/6 |
| TestWebSocketConfirmation | ✅ 6/6 |
| TestRESTChatConfirmation | ✅ 2/2 |
| TestFrontendConfirmation | ✅ 9/9 |