### PR TITLE
feat(#873): Wire persistent user memory into orchestrator

### DIFF
--- a/src/bantz/brain/user_memory.py
+++ b/src/bantz/brain/user_memory.py
@@ -1,0 +1,423 @@
+"""
+Issue #873: Persistent User Memory — UserMemoryBridge.
+
+Façade that wraps ProfileManager + MemoryStore + LearningEngine + ContextBuilder
+into a single entry point for OrchestratorLoop.
+
+Two hooks:
+  1. on_turn_start(user_input) → dict with profile_context block for LLM prompt
+  2. on_turn_end(user_input, reply, route, tool_results) → learn + persist
+
+All operations are best-effort (never crashes the orchestrator).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class UserMemoryConfig:
+    """Configuration for UserMemoryBridge."""
+
+    profile_path: str = "~/.bantz/profile.json"
+    db_path: str = "~/.bantz/memory.db"
+
+    # How many memories to recall per turn
+    max_recall: int = 5
+    # Minimum importance for recalled memories
+    min_importance: float = 0.1
+    # Maximum chars for the profile context block injected into prompt
+    max_context_chars: int = 600
+
+    # Feature flags
+    learn_facts: bool = True
+    learn_preferences: bool = True
+    store_conversations: bool = True
+
+    # PII filtering (uses privacy.redaction if available)
+    pii_filter: bool = True
+
+    @classmethod
+    def from_env(cls) -> "UserMemoryConfig":
+        """Build config from environment variables (best-effort)."""
+        return cls(
+            profile_path=os.getenv("BANTZ_PROFILE_PATH", "~/.bantz/profile.json"),
+            db_path=os.getenv("BANTZ_MEMORY_DB", "~/.bantz/memory.db"),
+            max_recall=int(os.getenv("BANTZ_MEMORY_MAX_RECALL", "5")),
+            pii_filter=os.getenv("BANTZ_MEMORY_PII_FILTER", "1") == "1",
+        )
+
+
+# ---------------------------------------------------------------------------
+# UserMemoryBridge
+# ---------------------------------------------------------------------------
+
+class UserMemoryBridge:
+    """
+    Single entry point for persistent user memory in OrchestratorLoop.
+
+    Wraps:
+      - ProfileManager  (JSON — user facts, preferences, style)
+      - MemoryStore      (SQLite — long-term episodic memory)
+      - LearningEngine   (fact/preference extraction from text)
+
+    Thread-safety: delegates to underlying thread-safe managers.
+    """
+
+    def __init__(self, config: Optional[UserMemoryConfig] = None) -> None:
+        self.config = config or UserMemoryConfig.from_env()
+        self._ready = False
+
+        # Lazy-initialized references
+        self._profile_manager: Any = None
+        self._memory_store: Any = None
+        self._learning_engine: Any = None
+
+        self._init_components()
+
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
+    def _init_components(self) -> None:
+        """Initialize memory components (best-effort, non-fatal)."""
+        try:
+            from bantz.memory.profile import ProfileManager
+
+            self._profile_manager = ProfileManager(
+                profile_path=self.config.profile_path,
+                auto_save=True,
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning("[USER_MEMORY] ProfileManager init failed: %s", exc)
+            self._profile_manager = None
+
+        try:
+            from bantz.memory.store import MemoryStore
+
+            self._memory_store = MemoryStore(
+                db_path=self.config.db_path,
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning("[USER_MEMORY] MemoryStore init failed: %s", exc)
+            self._memory_store = None
+
+        try:
+            if self._memory_store is not None and self._profile_manager is not None:
+                from bantz.memory.learning import LearningEngine
+
+                self._learning_engine = LearningEngine(
+                    memory_store=self._memory_store,
+                    profile_manager=self._profile_manager,
+                )
+        except Exception as exc:  # pragma: no cover
+            logger.warning("[USER_MEMORY] LearningEngine init failed: %s", exc)
+            self._learning_engine = None
+
+        self._ready = (
+            self._profile_manager is not None
+            or self._memory_store is not None
+        )
+        if self._ready:
+            logger.info(
+                "[USER_MEMORY] Initialized (profile=%s, store=%s, learning=%s)",
+                self._profile_manager is not None,
+                self._memory_store is not None,
+                self._learning_engine is not None,
+            )
+        else:
+            logger.warning("[USER_MEMORY] No components initialized — memory disabled")
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def ready(self) -> bool:
+        """Whether at least one memory component is available."""
+        return self._ready
+
+    @property
+    def profile_manager(self) -> Any:
+        """Underlying ProfileManager (may be None)."""
+        return self._profile_manager
+
+    @property
+    def memory_store(self) -> Any:
+        """Underlying MemoryStore (may be None)."""
+        return self._memory_store
+
+    # ------------------------------------------------------------------
+    # Hook 1: Turn Start
+    # ------------------------------------------------------------------
+
+    def on_turn_start(self, user_input: str) -> Dict[str, Any]:
+        """
+        Called at the beginning of each turn.
+
+        Returns a dict with:
+          - "profile_context": str  — formatted block for LLM prompt injection
+          - "facts": dict           — known user facts
+          - "memories": list[str]   — recalled memory snippets relevant to input
+
+        Never raises — returns empty dict on error.
+        """
+        result: Dict[str, Any] = {
+            "profile_context": "",
+            "facts": {},
+            "memories": [],
+        }
+
+        if not self._ready:
+            return result
+
+        # 1. Load profile + build context block
+        try:
+            result.update(self._build_profile_context())
+        except Exception as exc:
+            logger.debug("[USER_MEMORY] profile context failed: %s", exc)
+
+        # 2. Recall relevant memories
+        try:
+            result["memories"] = self._recall_memories(user_input)
+        except Exception as exc:
+            logger.debug("[USER_MEMORY] memory recall failed: %s", exc)
+
+        # 3. PII filter on output
+        if self.config.pii_filter:
+            try:
+                result["profile_context"] = self._filter_pii(
+                    result.get("profile_context", "")
+                )
+            except Exception:
+                pass
+
+        return result
+
+    def _build_profile_context(self) -> Dict[str, Any]:
+        """Build profile context block for LLM prompt."""
+        if self._profile_manager is None:
+            return {"profile_context": "", "facts": {}}
+
+        profile = self._profile_manager.profile
+
+        parts: list[str] = []
+
+        # User facts
+        facts = dict(profile.facts) if profile.facts else {}
+        if facts:
+            fact_lines = [f"  • {k}: {v}" for k, v in facts.items()]
+            parts.append("KULLANICI BİLGİLERİ:\n" + "\n".join(fact_lines))
+
+        # Communication style
+        style_prompt = ""
+        if hasattr(profile, "get_communication_style_prompt"):
+            style_prompt = profile.get_communication_style_prompt()
+        elif hasattr(profile, "communication_style_prompt"):
+            style_prompt = profile.communication_style_prompt
+        if not style_prompt:
+            # Fallback: build from attributes
+            style_parts: list[str] = []
+            if profile.name:
+                style_parts.append(f"Kullanıcının adı: {profile.name}")
+            if getattr(profile, "preferred_language", None):
+                style_parts.append(
+                    f"Tercih edilen dil: {profile.preferred_language}"
+                )
+            vp = getattr(profile, "verbosity_preference", 0.5)
+            if vp < 0.3:
+                style_parts.append("Kısa ve öz cevaplar ver")
+            elif vp > 0.7:
+                style_parts.append("Detaylı açıklamalar yap")
+            tl = getattr(profile, "technical_level", 0.5)
+            if tl > 0.7:
+                style_parts.append("Teknik terimler kullanabilirsin")
+            elif tl < 0.3:
+                style_parts.append("Basit ve anlaşılır anlat")
+            style_prompt = ". ".join(style_parts)
+
+        if style_prompt:
+            parts.append(f"İLETİŞİM TARZI: {style_prompt}")
+
+        # Reliable preferences (confidence >= 0.5)
+        pref_lines: list[str] = []
+        prefs = getattr(profile, "preferences", {}) or {}
+        for key, pref in prefs.items():
+            if hasattr(pref, "is_reliable") and pref.is_reliable:
+                pref_lines.append(f"  • {key}: {pref.value}")
+            elif isinstance(pref, dict) and pref.get("confidence", 0) >= 0.5:
+                pref_lines.append(f"  • {key}: {pref.get('value', pref)}")
+        if pref_lines:
+            parts.append("TERCİHLER:\n" + "\n".join(pref_lines))
+
+        context_block = "\n".join(parts)
+
+        # Truncate to budget
+        if len(context_block) > self.config.max_context_chars:
+            context_block = context_block[: self.config.max_context_chars]
+            # Don't cut mid-line
+            nl = context_block.rfind("\n")
+            if nl > 0:
+                context_block = context_block[:nl]
+
+        return {"profile_context": context_block, "facts": facts}
+
+    def _recall_memories(self, user_input: str) -> List[str]:
+        """Recall relevant memories for user input."""
+        if self._memory_store is None or not user_input.strip():
+            return []
+
+        memories = self._memory_store.recall(
+            query=user_input,
+            limit=self.config.max_recall,
+            min_importance=self.config.min_importance,
+        )
+
+        snippets: list[str] = []
+        for mem in memories:
+            content = getattr(mem, "content", str(mem))
+            if content:
+                # Truncate individual snippets
+                if len(content) > 150:
+                    content = content[:147] + "..."
+                snippets.append(content)
+        return snippets
+
+    # ------------------------------------------------------------------
+    # Hook 2: Turn End
+    # ------------------------------------------------------------------
+
+    def on_turn_end(
+        self,
+        user_input: str,
+        assistant_reply: str,
+        route: str = "",
+        tool_results: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Called at the end of each turn to learn from interaction.
+
+        Returns a dict with:
+          - "facts": list[dict]        — newly extracted facts
+          - "preferences": list[dict]  — newly extracted preferences
+          - "memory_id": str | None    — conversation memory ID
+
+        Never raises — returns empty dict on error.
+        """
+        result: Dict[str, Any] = {
+            "facts": [],
+            "preferences": [],
+            "memory_id": None,
+        }
+
+        if not self._ready:
+            return result
+
+        # Use LearningEngine if available
+        if self._learning_engine is not None:
+            try:
+                from bantz.memory.learning import InteractionResult
+
+                task_result = None
+                if tool_results:
+                    # Build InteractionResult from tool_results
+                    success_count = sum(
+                        1 for r in tool_results if r.get("success", False)
+                    )
+                    task_result = InteractionResult(
+                        description=route or "unknown",
+                        success=success_count > 0,
+                        steps=[r.get("tool", "") for r in tool_results],
+                        apps_used=[],
+                    )
+
+                learned = self._learning_engine.process_interaction(
+                    user_input=user_input,
+                    assistant_response=assistant_reply,
+                    task_result=task_result,
+                )
+                result["facts"] = learned.get("facts", [])
+                result["preferences"] = learned.get("preferences", [])
+                result["memory_id"] = learned.get("memory_id")
+
+                if result["facts"] or result["preferences"]:
+                    logger.info(
+                        "[USER_MEMORY] Learned: %d facts, %d preferences",
+                        len(result["facts"]),
+                        len(result["preferences"]),
+                    )
+            except Exception as exc:
+                logger.debug("[USER_MEMORY] learning failed: %s", exc)
+        else:
+            # Fallback: at least try fact extraction from profile manager
+            try:
+                if self._profile_manager is not None:
+                    self._profile_manager.record_interaction()
+            except Exception:
+                pass
+
+        return result
+
+    # ------------------------------------------------------------------
+    # PII Filtering
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _filter_pii(text: str) -> str:
+        """Best-effort PII filtering."""
+        if not text:
+            return text
+        try:
+            from bantz.privacy.redaction import redact_pii
+
+            return redact_pii(text)
+        except ImportError:
+            pass
+        try:
+            from bantz.memory.safety import mask_pii
+
+            return mask_pii(text)
+        except ImportError:
+            pass
+        return text
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def get_profile_summary(self) -> str:
+        """Get a short summary of the user profile."""
+        if self._profile_manager is None:
+            return ""
+        try:
+            profile = self._profile_manager.profile
+            return profile.get_facts_summary()
+        except Exception:
+            return ""
+
+    def close(self) -> None:
+        """Clean up resources."""
+        if self._memory_store is not None:
+            try:
+                self._memory_store.close()
+            except Exception:
+                pass
+
+    def __repr__(self) -> str:
+        return (
+            f"UserMemoryBridge(ready={self._ready}, "
+            f"profile={self._profile_manager is not None}, "
+            f"store={self._memory_store is not None}, "
+            f"learning={self._learning_engine is not None})"
+        )

--- a/src/bantz/learning/__init__.py
+++ b/src/bantz/learning/__init__.py
@@ -6,7 +6,8 @@ deneyim sunan akıllı öğrenme sistemi.
 """
 
 from bantz.learning.profile import (
-    UserProfile,
+    BehavioralProfile,
+    UserProfile,  # backward-compat alias for BehavioralProfile
     ProfileManager,
     create_profile_manager,
 )
@@ -51,7 +52,8 @@ from bantz.learning.storage import (
 
 __all__ = [
     # Profile
-    "UserProfile",
+    "BehavioralProfile",
+    "UserProfile",  # backward-compat alias
     "ProfileManager",
     "create_profile_manager",
     # Behavioral

--- a/src/bantz/learning/adaptive.py
+++ b/src/bantz/learning/adaptive.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from bantz.learning.profile import UserProfile
+from bantz.learning.profile import BehavioralProfile as UserProfile
 
 
 class VerbosityLevel(Enum):

--- a/src/bantz/learning/behavioral.py
+++ b/src/bantz/learning/behavioral.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol
 
-from bantz.learning.profile import UserProfile
+from bantz.learning.profile import BehavioralProfile as UserProfile
 
 
 class EventBus(Protocol):

--- a/src/bantz/learning/preferences.py
+++ b/src/bantz/learning/preferences.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from bantz.learning.profile import UserProfile
+from bantz.learning.profile import BehavioralProfile as UserProfile
 
 
 class PreferenceType(Enum):

--- a/src/bantz/learning/profile.py
+++ b/src/bantz/learning/profile.py
@@ -1,7 +1,9 @@
 """
-User Profile module.
+Behavioral Profile module.
 
-Stores learned user preferences, behavior patterns, and personality traits.
+Stores learned user behavioral patterns, preferences, and personality traits.
+Renamed from UserProfile → BehavioralProfile in Issue #873 to disambiguate
+from memory.profile.UserProfile (fact-based, demographic profile).
 """
 
 import uuid
@@ -11,12 +13,15 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 @dataclass
-class UserProfile:
+class BehavioralProfile:
     """
-    Öğrenilen kullanıcı profili.
+    Öğrenilen davranışsal kullanıcı profili.
     
-    Kullanıcının tercihlerini, davranış kalıplarını ve
+    Kullanıcının davranış kalıplarını, tercihlerini ve
     kişilik özelliklerini saklar.
+    
+    Not: memory.profile.UserProfile ile karıştırılmamalı
+    (o modül demografik/fact bilgileri saklar).
     """
     
     id: str = ""
@@ -218,7 +223,7 @@ class UserProfile:
         }
     
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "UserProfile":
+    def from_dict(cls, data: Dict[str, Any]) -> "BehavioralProfile":
         """Create from dictionary."""
         profile = cls(
             id=data.get("id", ""),
@@ -282,15 +287,15 @@ class ProfileManager:
             storage: Optional ProfileStorage instance.
         """
         self._storage = storage
-        self._current_profile: Optional[UserProfile] = None
-        self._profiles: Dict[str, UserProfile] = {}
+        self._current_profile: Optional[BehavioralProfile] = None
+        self._profiles: Dict[str, BehavioralProfile] = {}
     
     @property
-    def current_profile(self) -> Optional[UserProfile]:
+    def current_profile(self) -> Optional[BehavioralProfile]:
         """Get current active profile."""
         return self._current_profile
     
-    def create_profile(self, profile_id: str = None) -> UserProfile:
+    def create_profile(self, profile_id: str = None) -> BehavioralProfile:
         """
         Create a new profile.
         
@@ -298,9 +303,9 @@ class ProfileManager:
             profile_id: Optional custom profile ID.
             
         Returns:
-            New UserProfile instance.
+            New BehavioralProfile instance.
         """
-        profile = UserProfile(id=profile_id or "")
+        profile = BehavioralProfile(id=profile_id or "")
         self._profiles[profile.id] = profile
         
         if self._current_profile is None:
@@ -308,7 +313,7 @@ class ProfileManager:
         
         return profile
     
-    def get_profile(self, profile_id: str) -> Optional[UserProfile]:
+    def get_profile(self, profile_id: str) -> Optional[BehavioralProfile]:
         """
         Get profile by ID.
         
@@ -429,7 +434,7 @@ class ProfileManager:
             return profile.to_dict()
         return None
     
-    def import_profile(self, data: Dict[str, Any]) -> UserProfile:
+    def import_profile(self, data: Dict[str, Any]) -> BehavioralProfile:
         """
         Import profile from dictionary.
         
@@ -437,9 +442,9 @@ class ProfileManager:
             data: Profile data dictionary.
             
         Returns:
-            Imported UserProfile instance.
+            Imported BehavioralProfile instance.
         """
-        profile = UserProfile.from_dict(data)
+        profile = BehavioralProfile.from_dict(data)
         self._profiles[profile.id] = profile
         return profile
 
@@ -455,3 +460,7 @@ def create_profile_manager(storage: Any = None) -> ProfileManager:
         Configured ProfileManager instance.
     """
     return ProfileManager(storage=storage)
+
+
+# Backward-compatibility alias (Issue #873)
+UserProfile = BehavioralProfile

--- a/src/bantz/learning/storage.py
+++ b/src/bantz/learning/storage.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from bantz.learning.profile import UserProfile
+from bantz.learning.profile import BehavioralProfile as UserProfile
 
 
 class ProfileStorage:

--- a/tests/test_issue_872_integration_audit.py
+++ b/tests/test_issue_872_integration_audit.py
@@ -97,7 +97,11 @@ class TestImportGraphIntegrity(unittest.TestCase):
     ]
 
     def test_no_memory_imports_in_production(self):
-        """Production brain/ files must not import from bantz.memory."""
+        """Production brain/ files must not import from bantz.memory directly.
+        
+        Note: Issue #873 wires memory via bantz.brain.user_memory (a façade),
+        which is allowed — we only block direct bantz.memory imports.
+        """
         violations = []
         for relpath in self.PRODUCTION_FILES:
             fpath = _SRC / relpath

--- a/tests/test_issue_873_persistent_user_memory.py
+++ b/tests/test_issue_873_persistent_user_memory.py
@@ -1,0 +1,533 @@
+"""Tests for Issue #873: Persistent User Memory — Kullanıcı Hafızasını Orchestrator'a Bağla.
+
+Validates:
+1. UserMemoryBridge creation and lifecycle
+2. on_turn_start returns profile context
+3. on_turn_end learns facts/preferences
+4. Orchestrator wiring (init, Phase 1, Phase 4)
+5. BehavioralProfile rename + backward-compat alias
+6. PII filtering in bridge
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "bantz"
+
+
+# =========================================================================
+# Class 1: UserMemoryBridge Unit Tests
+# =========================================================================
+
+
+class TestUserMemoryBridge(unittest.TestCase):
+    """Test UserMemoryBridge core lifecycle."""
+
+    def test_import(self):
+        """UserMemoryBridge should be importable."""
+        from bantz.brain.user_memory import UserMemoryBridge
+
+        self.assertTrue(callable(UserMemoryBridge))
+
+    def test_config_defaults(self):
+        """UserMemoryConfig should have sane defaults."""
+        from bantz.brain.user_memory import UserMemoryConfig
+
+        cfg = UserMemoryConfig()
+        self.assertEqual(cfg.max_recall, 5)
+        self.assertTrue(cfg.learn_facts)
+        self.assertTrue(cfg.pii_filter)
+        self.assertIn("profile.json", cfg.profile_path)
+        self.assertIn("memory.db", cfg.db_path)
+
+    def test_config_from_env(self):
+        """UserMemoryConfig.from_env reads BANTZ_MEMORY_MAX_RECALL."""
+        from bantz.brain.user_memory import UserMemoryConfig
+
+        with patch.dict(os.environ, {"BANTZ_MEMORY_MAX_RECALL": "10"}):
+            cfg = UserMemoryConfig.from_env()
+            self.assertEqual(cfg.max_recall, 10)
+
+    def test_init_with_tmp_paths(self):
+        """Bridge should init with temp paths without error."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            self.assertTrue(bridge.ready)
+            self.assertIsNotNone(bridge.profile_manager)
+            self.assertIsNotNone(bridge.memory_store)
+            bridge.close()
+
+    def test_on_turn_start_empty_profile(self):
+        """on_turn_start should return empty context for fresh profile."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            result = bridge.on_turn_start("merhaba")
+
+            self.assertIsInstance(result, dict)
+            self.assertIn("profile_context", result)
+            self.assertIn("facts", result)
+            self.assertIn("memories", result)
+            bridge.close()
+
+    def test_on_turn_start_with_profile(self):
+        """on_turn_start should return facts when profile has data."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Pre-create profile with facts
+            profile_path = os.path.join(tmp, "profile.json")
+            profile_data = {
+                "version": 1,
+                "name": "İclal",
+                "preferred_language": "tr",
+                "timezone": "Europe/Istanbul",
+                "formality_level": 0.5,
+                "verbosity_preference": 0.5,
+                "humor_appreciation": 0.5,
+                "technical_level": 0.5,
+                "preferred_styles": [],
+                "work_pattern": {},
+                "common_tasks": [],
+                "favorite_apps": [],
+                "app_positions": {},
+                "facts": {"name": "İclal", "job": "yazılımcı"},
+                "preferences": {},
+                "total_interactions": 5,
+                "first_interaction": None,
+                "last_interaction": None,
+                "session_count": 1,
+            }
+            with open(profile_path, "w", encoding="utf-8") as f:
+                json.dump(profile_data, f)
+
+            cfg = UserMemoryConfig(
+                profile_path=profile_path,
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            result = bridge.on_turn_start("merhaba")
+
+            self.assertIn("İclal", result.get("profile_context", ""))
+            self.assertEqual(result["facts"].get("name"), "İclal")
+            bridge.close()
+
+    def test_on_turn_end_returns_dict(self):
+        """on_turn_end should return dict with facts/preferences/memory_id."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            result = bridge.on_turn_end(
+                user_input="benim adım Ali",
+                assistant_reply="Merhaba Ali!",
+                route="smalltalk",
+            )
+
+            self.assertIsInstance(result, dict)
+            self.assertIn("facts", result)
+            self.assertIn("preferences", result)
+            self.assertIn("memory_id", result)
+            bridge.close()
+
+    def test_on_turn_end_learns_name(self):
+        """on_turn_end should extract name fact from Turkish input."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            result = bridge.on_turn_end(
+                user_input="benim adım Ahmet",
+                assistant_reply="Merhaba Ahmet!",
+            )
+
+            # LearningEngine's FactExtractor should pick up the name
+            facts = result.get("facts", [])
+            if facts:
+                # At least one fact about name
+                name_facts = [f for f in facts if f.get("category") == "name"]
+                self.assertTrue(len(name_facts) > 0, f"Expected name fact, got {facts}")
+            bridge.close()
+
+    def test_get_profile_summary(self):
+        """get_profile_summary should work even for empty profile."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            summary = bridge.get_profile_summary()
+            self.assertIsInstance(summary, str)
+            bridge.close()
+
+    def test_repr(self):
+        """repr should contain state info."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            r = repr(bridge)
+            self.assertIn("UserMemoryBridge", r)
+            self.assertIn("ready=True", r)
+            bridge.close()
+
+    def test_not_ready_when_components_fail(self):
+        """Bridge should be not ready when both components fail."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        cfg = UserMemoryConfig(
+            profile_path="/nonexistent/dir/that/wont/exist/profile.json",
+            db_path="/nonexistent/dir/that/wont/exist/memory.db",
+            pii_filter=False,
+        )
+        # This may or may not raise — depends on directory creation
+        # At minimum, test that it doesn't crash the process
+        try:
+            bridge = UserMemoryBridge(config=cfg)
+            # Even if not ready, on_turn_start should return empty
+            result = bridge.on_turn_start("hello")
+            self.assertIsInstance(result, dict)
+        except Exception:
+            pass  # OS permission errors are acceptable
+
+
+# =========================================================================
+# Class 2: Orchestrator Wiring Tests
+# =========================================================================
+
+
+class TestOrchestratorWiring(unittest.TestCase):
+    """Test that orchestrator_loop.py has the user_memory hooks."""
+
+    def test_init_has_user_memory_attribute(self):
+        """orchestrator_loop.py __init__ should set self.user_memory."""
+        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
+        self.assertIn("self.user_memory", source)
+        self.assertIn("UserMemoryBridge", source)
+
+    def test_phase1_injects_profile_context(self):
+        """_llm_planning_phase should inject USER_PROFILE into context_parts."""
+        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
+        self.assertIn("USER_PROFILE:", source)
+        self.assertIn("on_turn_start", source)
+
+    def test_phase4_calls_on_turn_end(self):
+        """_update_state_phase should call user_memory.on_turn_end."""
+        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
+        self.assertIn("on_turn_end", source)
+
+    def test_phase1_injects_long_term_memory(self):
+        """_llm_planning_phase should inject LONG_TERM_MEMORY block."""
+        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
+        self.assertIn("LONG_TERM_MEMORY:", source)
+
+    def test_user_memory_init_is_best_effort(self):
+        """user_memory init should be wrapped in try/except."""
+        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
+        # Find the user_memory block
+        idx = source.find("Issue #873")
+        self.assertGreater(idx, -1)
+        # There should be a try block nearby
+        block = source[idx:idx + 300]
+        self.assertIn("try:", block)
+        self.assertIn("except", block)
+
+    def test_phase4_on_turn_end_is_best_effort(self):
+        """on_turn_end call should be wrapped in try/except."""
+        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
+        # Find on_turn_end in _update_state_phase
+        idx = source.find("on_turn_end")
+        self.assertGreater(idx, -1)
+        # Look backwards for try
+        block = source[max(0, idx - 200):idx + 100]
+        self.assertIn("try:", block)
+
+
+# =========================================================================
+# Class 3: BehavioralProfile Rename Tests
+# =========================================================================
+
+
+class TestBehavioralProfileRename(unittest.TestCase):
+    """Test that learning/profile.py uses BehavioralProfile with alias."""
+
+    def test_behavioral_profile_class_exists(self):
+        """BehavioralProfile class should exist in learning.profile."""
+        from bantz.learning.profile import BehavioralProfile
+
+        p = BehavioralProfile()
+        self.assertTrue(hasattr(p, "preferred_apps"))
+        self.assertTrue(hasattr(p, "command_sequences"))
+
+    def test_user_profile_alias_works(self):
+        """UserProfile should still be importable as backward-compat alias."""
+        from bantz.learning.profile import UserProfile, BehavioralProfile
+
+        self.assertIs(UserProfile, BehavioralProfile)
+
+    def test_user_profile_from_init(self):
+        """UserProfile should be importable from bantz.learning."""
+        from bantz.learning import UserProfile, BehavioralProfile
+
+        self.assertIs(UserProfile, BehavioralProfile)
+
+    def test_behavioral_profile_in_all(self):
+        """BehavioralProfile should be in __all__."""
+        from bantz.learning import __all__ as exports
+
+        self.assertIn("BehavioralProfile", exports)
+        self.assertIn("UserProfile", exports)
+
+    def test_profile_creation(self):
+        """BehavioralProfile should be instantiable."""
+        from bantz.learning.profile import BehavioralProfile
+
+        p = BehavioralProfile()
+        self.assertIsNotNone(p.id)
+        self.assertEqual(p.total_interactions, 0)
+        self.assertIsInstance(p.preferred_apps, dict)
+
+    def test_profile_round_trip(self):
+        """BehavioralProfile to_dict/from_dict round trip."""
+        from bantz.learning.profile import BehavioralProfile
+
+        p = BehavioralProfile()
+        p.preferred_apps["discord"] = 0.9
+        p.record_interaction(success=True)
+
+        data = p.to_dict()
+        p2 = BehavioralProfile.from_dict(data)
+
+        self.assertEqual(p2.preferred_apps.get("discord"), 0.9)
+        self.assertEqual(p2.total_interactions, 1)
+
+    def test_learning_modules_import_behavioral(self):
+        """Internal learning/ modules should import BehavioralProfile."""
+        for mod_name in ["behavioral", "preferences", "adaptive", "storage"]:
+            mod_path = _SRC / "learning" / f"{mod_name}.py"
+            if not mod_path.exists():
+                continue
+            source = mod_path.read_text("utf-8")
+            self.assertIn(
+                "BehavioralProfile",
+                source,
+                f"learning/{mod_name}.py should reference BehavioralProfile",
+            )
+
+    def test_no_name_collision_with_memory_profile(self):
+        """memory.profile.UserProfile and learning.profile.BehavioralProfile are different."""
+        from bantz.memory.profile import UserProfile as MemoryProfile
+        from bantz.learning.profile import BehavioralProfile
+
+        # They should be different classes
+        self.assertIsNot(MemoryProfile, BehavioralProfile)
+
+        # Memory profile has 'facts' dict
+        mp = MemoryProfile()
+        self.assertTrue(hasattr(mp, "facts"))
+
+        # Behavioral profile has 'command_sequences'
+        bp = BehavioralProfile()
+        self.assertTrue(hasattr(bp, "command_sequences"))
+        self.assertFalse(hasattr(bp, "facts"))
+
+
+# =========================================================================
+# Class 4: PII Filtering Tests
+# =========================================================================
+
+
+class TestPIIFiltering(unittest.TestCase):
+    """Test PII filtering in UserMemoryBridge."""
+
+    def test_filter_pii_static_method(self):
+        """_filter_pii should exist as static method."""
+        from bantz.brain.user_memory import UserMemoryBridge
+
+        self.assertTrue(hasattr(UserMemoryBridge, "_filter_pii"))
+        # Should not crash on empty
+        result = UserMemoryBridge._filter_pii("")
+        self.assertEqual(result, "")
+
+    def test_filter_pii_passthrough(self):
+        """_filter_pii should pass through non-PII text."""
+        from bantz.brain.user_memory import UserMemoryBridge
+
+        text = "merhaba dünya"
+        result = UserMemoryBridge._filter_pii(text)
+        self.assertIsInstance(result, str)
+        # At minimum, should not be empty (PII filter may not strip this)
+        self.assertTrue(len(result) > 0)
+
+    def test_pii_filter_in_on_turn_start(self):
+        """When pii_filter=True, on_turn_start should apply filtering."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=True,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+            # Should not crash even with PII filter on
+            result = bridge.on_turn_start("merhaba")
+            self.assertIsInstance(result, dict)
+            bridge.close()
+
+
+# =========================================================================
+# Class 5: Integration Smoke Tests
+# =========================================================================
+
+
+class TestIntegrationSmoke(unittest.TestCase):
+    """End-to-end smoke tests for the full memory pipeline."""
+
+    def test_full_turn_lifecycle(self):
+        """Full turn: start → end → start again should work."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+
+            # Turn 1
+            ctx1 = bridge.on_turn_start("merhaba")
+            self.assertIsInstance(ctx1, dict)
+
+            bridge.on_turn_end(
+                user_input="benim adım Test",
+                assistant_reply="Merhaba Test!",
+                route="smalltalk",
+            )
+
+            # Turn 2 — profile should now have the name
+            ctx2 = bridge.on_turn_start("nasılsın")
+            self.assertIsInstance(ctx2, dict)
+
+            bridge.close()
+
+    def test_tool_results_passed_to_learning(self):
+        """Tool results should be forwarded to LearningEngine."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg = UserMemoryConfig(
+                profile_path=os.path.join(tmp, "profile.json"),
+                db_path=os.path.join(tmp, "memory.db"),
+                pii_filter=False,
+            )
+            bridge = UserMemoryBridge(config=cfg)
+
+            tool_results = [
+                {"tool": "calendar.list_events", "success": True, "result": "ok"},
+                {"tool": "gmail.list_messages", "success": False, "result": "error"},
+            ]
+            result = bridge.on_turn_end(
+                user_input="takvimimi göster",
+                assistant_reply="Bugün 2 toplantın var",
+                route="calendar",
+                tool_results=tool_results,
+            )
+
+            self.assertIsInstance(result, dict)
+            bridge.close()
+
+    def test_user_memory_bridge_module_exists(self):
+        """brain/user_memory.py should exist."""
+        path = _SRC / "brain" / "user_memory.py"
+        self.assertTrue(path.exists(), f"Missing {path}")
+
+    def test_profile_persists_across_bridges(self):
+        """Profile data should persist on disk between bridge instances."""
+        from bantz.brain.user_memory import UserMemoryBridge, UserMemoryConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            profile_path = os.path.join(tmp, "profile.json")
+            db_path = os.path.join(tmp, "memory.db")
+
+            # Bridge 1: learn a name
+            cfg1 = UserMemoryConfig(
+                profile_path=profile_path,
+                db_path=db_path,
+                pii_filter=False,
+            )
+            b1 = UserMemoryBridge(config=cfg1)
+            b1.on_turn_end(
+                user_input="benim adım Zeynep",
+                assistant_reply="Merhaba Zeynep!",
+            )
+            b1.close()
+
+            # Profile JSON should exist
+            self.assertTrue(
+                os.path.exists(profile_path),
+                "profile.json should be written to disk"
+            )
+
+            # Bridge 2: should see the name
+            cfg2 = UserMemoryConfig(
+                profile_path=profile_path,
+                db_path=db_path,
+                pii_filter=False,
+            )
+            b2 = UserMemoryBridge(config=cfg2)
+            ctx = b2.on_turn_start("merhaba")
+
+            # The name should appear in facts or profile_context
+            has_name = (
+                "Zeynep" in ctx.get("profile_context", "")
+                or ctx.get("facts", {}).get("name") == "Zeynep"
+            )
+            self.assertTrue(has_name, f"Expected Zeynep in context, got {ctx}")
+            b2.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue #873: [Core] Persistent User Memory — Kullanıcı Hafızasını Orchestrator'a Bağla

### Summary
Wires the disconnected memory subsystem (ProfileManager, MemoryStore, LearningEngine) into the orchestrator via a new `UserMemoryBridge` façade. Also renames learning's `UserProfile` → `BehavioralProfile` to resolve the duplicate naming issue.

### Changes

#### New: `brain/user_memory.py` (UserMemoryBridge)
- Façade wrapping ProfileManager + MemoryStore + LearningEngine
- `on_turn_start(user_input)` → profile context + recalled memories for LLM prompt
- `on_turn_end(user_input, reply, route, tool_results)` → fact/preference extraction + persistence
- All operations best-effort (try/except) — never crashes orchestrator
- PII filtering via privacy.redaction or memory.safety
- Config from env vars (BANTZ_PROFILE_PATH, BANTZ_MEMORY_DB, etc.)

#### Orchestrator Wiring (`orchestrator_loop.py`)
- **`__init__`**: Creates UserMemoryBridge alongside memory-lite (best-effort)
- **Phase 1** (`_llm_planning_phase`): Injects `USER_PROFILE` + `LONG_TERM_MEMORY` into context_parts for LLM routing
- **Phase 4** (`_update_state_phase`): Calls `on_turn_end()` to learn from each interaction

#### BehavioralProfile Rename (`learning/profile.py`)
- `UserProfile` → `BehavioralProfile` (disambiguates from memory.profile.UserProfile)
- Backward-compat alias: `UserProfile = BehavioralProfile`
- Updated all learning/ internal imports + `__init__.py` exports
- All 115 existing learning tests pass unchanged

### Tests: 32/32 passed (5 classes)
| Class | Tests | Status |
|-------|-------|--------|
| TestUserMemoryBridge | 11 | ✅ |
| TestOrchestratorWiring | 6 | ✅ |
| TestBehavioralProfileRename | 8 | ✅ |
| TestPIIFiltering | 3 | ✅ |
| TestIntegrationSmoke | 4 | ✅ |

### Diff Stats
```
10 files changed, +1031, -23
```

Closes #873