### PR TITLE
feat(#874): Personality Injection — 3-layer kişilik enjeksiyonu LLM promptlarına

### DIFF
--- a/src/bantz/brain/personality_injector.py
+++ b/src/bantz/brain/personality_injector.py
@@ -1,0 +1,340 @@
+"""
+Issue #874: Personality Injection — 3-Layer Personality → LLM Prompt.
+
+Builds compact, injection-ready prompt blocks from:
+  Layer 1: Persona (Personality preset — Jarvis/Friday/Alfred)
+  Layer 2: User Preferences (UserProfile facts + style)
+  Layer 3: Behavior Rules (confirmation, verbosity, routing)
+
+Token budget: persona(200) + prefs(150) + rules(100) = max ~450 tokens.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Token budget constants
+# ---------------------------------------------------------------------------
+
+_PERSONA_MAX_CHARS = 800    # ~200 tokens
+_PREFS_MAX_CHARS = 600      # ~150 tokens
+_RULES_MAX_CHARS = 400      # ~100 tokens
+_TOTAL_MAX_CHARS = 1800     # ~450 tokens
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PersonalityConfig:
+    """Configuration for personality injection."""
+
+    # Which preset to use (jarvis, friday, alfred, cortana, hal)
+    preset_name: str = "jarvis"
+
+    # User name override (if known from profile)
+    user_name: str = ""
+
+    # Behavior rules
+    confirmation_mode: str = "dangerous"   # always | dangerous | never
+    verbosity: str = "short"               # short | normal | detailed
+    response_language: str = "tr"          # tr | en | auto
+
+    # Token budgets
+    persona_max_chars: int = _PERSONA_MAX_CHARS
+    prefs_max_chars: int = _PREFS_MAX_CHARS
+    rules_max_chars: int = _RULES_MAX_CHARS
+
+    @classmethod
+    def from_env(cls) -> "PersonalityConfig":
+        """Build config from environment variables."""
+        return cls(
+            preset_name=os.getenv("BANTZ_PERSONALITY", "jarvis").lower(),
+            user_name=os.getenv("BANTZ_USER_NAME", ""),
+            confirmation_mode=os.getenv("BANTZ_CONFIRMATION_MODE", "dangerous"),
+            verbosity=os.getenv("BANTZ_VERBOSITY", "short"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# PersonalityInjector
+# ---------------------------------------------------------------------------
+
+class PersonalityInjector:
+    """
+    Builds injection-ready personality blocks for LLM prompts.
+
+    Usage in orchestrator:
+        injector = PersonalityInjector()
+        block = injector.build_router_block()       # for Phase 1
+        block = injector.build_finalizer_block()     # for Phase 3
+        identity = injector.build_identity_lines()   # replaces hardcoded BANTZ identity
+    """
+
+    def __init__(self, config: Optional[PersonalityConfig] = None) -> None:
+        self.config = config or PersonalityConfig.from_env()
+        self._personality: Any = None
+        self._init_personality()
+
+    def _init_personality(self) -> None:
+        """Load personality preset (best-effort)."""
+        try:
+            from bantz.memory.personality import get_personality
+
+            self._personality = get_personality(self.config.preset_name)
+        except Exception as exc:
+            logger.warning("[PERSONALITY] Failed to load preset '%s': %s",
+                           self.config.preset_name, exc)
+            self._personality = None
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def personality(self) -> Any:
+        """Underlying Personality instance (may be None)."""
+        return self._personality
+
+    @property
+    def name(self) -> str:
+        """Active personality name."""
+        if self._personality is not None:
+            return self._personality.name
+        return "Bantz"
+
+    @property
+    def uses_honorifics(self) -> bool:
+        """Whether the active personality uses honorifics."""
+        if self._personality is not None:
+            return self._personality.use_honorifics
+        return True  # default Jarvis behavior
+
+    # ------------------------------------------------------------------
+    # Layer 1: Persona Block
+    # ------------------------------------------------------------------
+
+    def _build_persona_block(self, user_name: str = "") -> str:
+        """Build Layer 1: Persona identity block."""
+        name = user_name or self.config.user_name or "kullanıcı"
+        p = self._personality
+
+        if p is None:
+            return f"Sen Bantz'sın, {name}'nın kişisel asistanısın."
+
+        parts: list[str] = [
+            f"Sen {p.name}'sin, {name}'nın kişisel asistanısın.",
+        ]
+
+        # Speaking style
+        style_desc = getattr(p.speaking_style, "description_tr", "Samimi iletişim")
+        parts.append(f"İletişim tarzın: {style_desc}.")
+
+        # Honorifics
+        if p.use_honorifics:
+            parts.append("'Efendim' hitabını kullan (yanıt başına en fazla 1 kez).")
+        else:
+            parts.append("Samimi bir dil kullan, resmi hitaplardan kaçın.")
+
+        # Humor
+        if p.witty_remarks and p.sarcasm_level > 0:
+            level = "hafif" if p.sarcasm_level < 0.3 else "orta"
+            parts.append(f"Zaman zaman {level} espri yapabilirsin.")
+
+        # Verbosity from config
+        if self.config.verbosity == "short":
+            parts.append("Kısa ve öz yanıtlar ver (1-3 cümle).")
+        elif self.config.verbosity == "detailed":
+            parts.append("Detaylı açıklamalar yap, adım adım anlat.")
+        else:
+            parts.append("Normal uzunlukta yanıtlar ver.")
+
+        block = "\n".join(parts)
+        return block[:self.config.persona_max_chars]
+
+    # ------------------------------------------------------------------
+    # Layer 2: User Preferences Block (from profile data)
+    # ------------------------------------------------------------------
+
+    def _build_prefs_block(
+        self,
+        facts: Optional[Dict[str, str]] = None,
+        preferences: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Build Layer 2: User preferences block."""
+        parts: list[str] = []
+
+        if facts:
+            fact_lines = [f"- {k}: {v}" for k, v in list(facts.items())[:8]]
+            if fact_lines:
+                parts.append("Kullanıcı hakkında bildiklerin:")
+                parts.extend(fact_lines)
+
+        if preferences:
+            pref_lines: list[str] = []
+            for key, pref in list(preferences.items())[:6]:
+                if hasattr(pref, "is_reliable") and pref.is_reliable:
+                    pref_lines.append(f"- {key}: {pref.value}")
+                elif isinstance(pref, dict) and pref.get("confidence", 0) >= 0.5:
+                    pref_lines.append(f"- {key}: {pref.get('value', pref)}")
+            if pref_lines:
+                if parts:
+                    parts.append("")
+                parts.append("Tercihleri:")
+                parts.extend(pref_lines)
+
+        block = "\n".join(parts)
+        return block[:self.config.prefs_max_chars]
+
+    # ------------------------------------------------------------------
+    # Layer 3: Behavior Rules Block
+    # ------------------------------------------------------------------
+
+    def _build_rules_block(self) -> str:
+        """Build Layer 3: Behavior rules block."""
+        rules: list[str] = ["Davranış kuralları:"]
+
+        # Confirmation mode
+        mode = self.config.confirmation_mode
+        if mode == "always":
+            rules.append("- Tüm işlemlerde onay iste.")
+        elif mode == "never":
+            rules.append("- Onay istemeden doğrudan yap.")
+        else:  # dangerous
+            rules.append("- Riskli işlemlerde (silme, güncelleme) onay iste.")
+
+        # Language
+        rules.append("- SADECE TÜRKÇE konuş. Çince, Korece, İngilizce YASAK.")
+
+        # Output format
+        rules.append("- Sadece kullanıcıya söyleyeceğin düz metin üret. JSON/Markdown yok.")
+
+        # Honesty
+        rules.append("- Bilmediğin konularda dürüst ol.")
+
+        block = "\n".join(rules)
+        return block[:self.config.rules_max_chars]
+
+    # ------------------------------------------------------------------
+    # Combined Blocks (for Router & Finalizer)
+    # ------------------------------------------------------------------
+
+    def build_router_block(
+        self,
+        user_name: str = "",
+        facts: Optional[Dict[str, str]] = None,
+        preferences: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """
+        Build full personality block for Phase 1 (router/planner) injection.
+
+        Returns a multi-line string suitable for appending to context_parts.
+        """
+        sections: list[str] = []
+
+        persona = self._build_persona_block(user_name)
+        if persona:
+            sections.append(persona)
+
+        prefs = self._build_prefs_block(facts, preferences)
+        if prefs:
+            sections.append(prefs)
+
+        combined = "\n\n".join(sections)
+
+        # Enforce total budget
+        if len(combined) > _TOTAL_MAX_CHARS:
+            combined = combined[:_TOTAL_MAX_CHARS]
+            nl = combined.rfind("\n")
+            if nl > 0:
+                combined = combined[:nl]
+
+        return combined
+
+    def build_finalizer_block(
+        self,
+        user_name: str = "",
+        facts: Optional[Dict[str, str]] = None,
+        preferences: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """
+        Build full personality block for Phase 3 (finalizer) injection.
+
+        Includes all 3 layers: persona + prefs + rules.
+        """
+        sections: list[str] = []
+
+        persona = self._build_persona_block(user_name)
+        if persona:
+            sections.append(persona)
+
+        prefs = self._build_prefs_block(facts, preferences)
+        if prefs:
+            sections.append(prefs)
+
+        rules = self._build_rules_block()
+        if rules:
+            sections.append(rules)
+
+        combined = "\n\n".join(sections)
+
+        # Enforce total budget
+        if len(combined) > _TOTAL_MAX_CHARS:
+            combined = combined[:_TOTAL_MAX_CHARS]
+            nl = combined.rfind("\n")
+            if nl > 0:
+                combined = combined[:nl]
+
+        return combined
+
+    def build_identity_lines(self, user_name: str = "") -> str:
+        """
+        Build identity lines to replace hardcoded 'BANTZ' in _build_system_prompt.
+
+        Returns compact identity string for PromptBuilder injection.
+        """
+        name = user_name or self.config.user_name or "USER"
+        p = self._personality
+
+        persona_name = p.name if p is not None else "Bantz"
+
+        lines = [
+            f"- Sen {persona_name}'sin. Kullanıcı {name}'dır.",
+            "- SADECE TÜRKÇE konuş. Asla Çince, Korece, İngilizce veya başka dil kullanma!",
+        ]
+
+        if self.uses_honorifics:
+            lines.append("- 'Efendim' hitabını kullan.")
+        else:
+            lines.append("- Samimi bir dil kullan.")
+
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def switch_preset(self, preset_name: str) -> None:
+        """Switch to a different personality preset."""
+        self.config.preset_name = preset_name.lower()
+        self._init_personality()
+        logger.info("[PERSONALITY] Switched to preset: %s", self.name)
+
+    def update_user_name(self, name: str) -> None:
+        """Update the user name from profile."""
+        self.config.user_name = name
+
+    def __repr__(self) -> str:
+        return (
+            f"PersonalityInjector(preset={self.config.preset_name!r}, "
+            f"name={self.name!r}, "
+            f"honorifics={self.uses_honorifics})"
+        )

--- a/tests/test_issue_874_personality_injection.py
+++ b/tests/test_issue_874_personality_injection.py
@@ -1,0 +1,661 @@
+"""Tests for Issue #874: Personality Injection — Kişilik ve Tercihler LLM Prompt'a Enjekte.
+
+Validates:
+1. PersonalityInjector creation & config
+2. Layer 1: Persona block (identity, style, honorifics)
+3. Layer 2: User prefs block (facts, preferences)
+4. Layer 3: Behavior rules block (confirmation, language)
+5. Combined blocks (router & finalizer)
+6. Token budget enforcement (~450 tokens max)
+7. Preset switching (jarvis → friday → alfred)
+8. PromptBuilder personality_block integration
+9. FinalizationContext personality_block field
+10. Fallback prompt personality awareness
+
+Run one class at a time:
+    python3 -m pytest tests/test_issue_874_personality_injection.py::TestPersonalityConfig -x -v --tb=short --no-header -p no:cacheprovider -p no:randomly
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "bantz"
+
+
+# =========================================================================
+# Class 1: PersonalityConfig Tests
+# =========================================================================
+
+
+class TestPersonalityConfig(unittest.TestCase):
+    """Test PersonalityConfig creation and env loading."""
+
+    def test_import(self):
+        from bantz.brain.personality_injector import PersonalityConfig
+        self.assertTrue(callable(PersonalityConfig))
+
+    def test_defaults(self):
+        from bantz.brain.personality_injector import PersonalityConfig
+        cfg = PersonalityConfig()
+        self.assertEqual(cfg.preset_name, "jarvis")
+        self.assertEqual(cfg.user_name, "")
+        self.assertEqual(cfg.confirmation_mode, "dangerous")
+        self.assertEqual(cfg.verbosity, "short")
+        self.assertEqual(cfg.response_language, "tr")
+
+    def test_from_env(self):
+        from bantz.brain.personality_injector import PersonalityConfig
+        env = {
+            "BANTZ_PERSONALITY": "friday",
+            "BANTZ_USER_NAME": "İclal",
+            "BANTZ_CONFIRMATION_MODE": "always",
+            "BANTZ_VERBOSITY": "detailed",
+        }
+        with patch.dict(os.environ, env):
+            cfg = PersonalityConfig.from_env()
+            self.assertEqual(cfg.preset_name, "friday")
+            self.assertEqual(cfg.user_name, "İclal")
+            self.assertEqual(cfg.confirmation_mode, "always")
+            self.assertEqual(cfg.verbosity, "detailed")
+
+    def test_from_env_defaults(self):
+        from bantz.brain.personality_injector import PersonalityConfig
+        # Clear env vars
+        env = {k: "" for k in [
+            "BANTZ_PERSONALITY", "BANTZ_USER_NAME",
+            "BANTZ_CONFIRMATION_MODE", "BANTZ_VERBOSITY",
+        ]}
+        with patch.dict(os.environ, env, clear=False):
+            cfg = PersonalityConfig.from_env()
+            # Should not crash
+            self.assertIsNotNone(cfg.preset_name)
+
+    def test_token_budgets(self):
+        from bantz.brain.personality_injector import (
+            PersonalityConfig, _PERSONA_MAX_CHARS,
+            _PREFS_MAX_CHARS, _RULES_MAX_CHARS,
+        )
+        cfg = PersonalityConfig()
+        self.assertEqual(cfg.persona_max_chars, _PERSONA_MAX_CHARS)
+        self.assertEqual(cfg.prefs_max_chars, _PREFS_MAX_CHARS)
+        self.assertEqual(cfg.rules_max_chars, _RULES_MAX_CHARS)
+
+
+# =========================================================================
+# Class 2: PersonalityInjector Unit Tests
+# =========================================================================
+
+
+class TestPersonalityInjector(unittest.TestCase):
+    """Test PersonalityInjector core functionality."""
+
+    def test_import(self):
+        from bantz.brain.personality_injector import PersonalityInjector
+        self.assertTrue(callable(PersonalityInjector))
+
+    def test_init_default(self):
+        from bantz.brain.personality_injector import PersonalityInjector
+        inj = PersonalityInjector()
+        self.assertIsNotNone(inj)
+        self.assertEqual(inj.config.preset_name, "jarvis")
+
+    def test_name_property(self):
+        from bantz.brain.personality_injector import PersonalityInjector
+        inj = PersonalityInjector()
+        name = inj.name
+        self.assertIsInstance(name, str)
+        self.assertTrue(len(name) > 0)
+
+    def test_uses_honorifics_jarvis(self):
+        from bantz.brain.personality_injector import PersonalityInjector, PersonalityConfig
+        cfg = PersonalityConfig(preset_name="jarvis")
+        inj = PersonalityInjector(config=cfg)
+        self.assertTrue(inj.uses_honorifics)
+
+    def test_uses_honorifics_friday(self):
+        from bantz.brain.personality_injector import PersonalityInjector, PersonalityConfig
+        cfg = PersonalityConfig(preset_name="friday")
+        inj = PersonalityInjector(config=cfg)
+        self.assertFalse(inj.uses_honorifics)
+
+    def test_personality_loaded(self):
+        from bantz.brain.personality_injector import PersonalityInjector
+        inj = PersonalityInjector()
+        # Should have loaded the personality preset
+        self.assertIsNotNone(inj.personality)
+
+    def test_repr(self):
+        from bantz.brain.personality_injector import PersonalityInjector
+        inj = PersonalityInjector()
+        r = repr(inj)
+        self.assertIn("PersonalityInjector", r)
+        self.assertIn("jarvis", r)
+
+
+# =========================================================================
+# Class 3: Layer Building Tests
+# =========================================================================
+
+
+class TestLayerBuilding(unittest.TestCase):
+    """Test individual layer blocks."""
+
+    def _make_injector(self, preset="jarvis", verbosity="short"):
+        from bantz.brain.personality_injector import PersonalityInjector, PersonalityConfig
+        cfg = PersonalityConfig(preset_name=preset, verbosity=verbosity)
+        return PersonalityInjector(config=cfg)
+
+    # -- Layer 1: Persona --
+
+    def test_persona_block_not_empty(self):
+        inj = self._make_injector()
+        block = inj._build_persona_block("İclal")
+        self.assertTrue(len(block) > 0)
+        self.assertIn("İclal", block)
+
+    def test_persona_block_contains_name(self):
+        inj = self._make_injector()
+        block = inj._build_persona_block("TestUser")
+        self.assertIn("TestUser", block)
+
+    def test_persona_block_jarvis_honorifics(self):
+        inj = self._make_injector("jarvis")
+        block = inj._build_persona_block()
+        self.assertIn("Efendim", block)
+
+    def test_persona_block_friday_no_honorifics(self):
+        inj = self._make_injector("friday")
+        block = inj._build_persona_block()
+        self.assertIn("Samimi", block)
+        self.assertNotIn("Efendim", block)
+
+    def test_persona_block_short_verbosity(self):
+        inj = self._make_injector(verbosity="short")
+        block = inj._build_persona_block()
+        self.assertIn("Kısa", block)
+
+    def test_persona_block_detailed_verbosity(self):
+        inj = self._make_injector(verbosity="detailed")
+        block = inj._build_persona_block()
+        self.assertIn("Detaylı", block)
+
+    def test_persona_block_budget(self):
+        from bantz.brain.personality_injector import _PERSONA_MAX_CHARS
+        inj = self._make_injector()
+        block = inj._build_persona_block()
+        self.assertLessEqual(len(block), _PERSONA_MAX_CHARS)
+
+    # -- Layer 2: Prefs --
+
+    def test_prefs_block_empty_if_no_data(self):
+        inj = self._make_injector()
+        block = inj._build_prefs_block()
+        self.assertEqual(block, "")
+
+    def test_prefs_block_with_facts(self):
+        inj = self._make_injector()
+        facts = {"name": "İclal", "occupation": "mühendis"}
+        block = inj._build_prefs_block(facts=facts)
+        self.assertIn("İclal", block)
+        self.assertIn("mühendis", block)
+        self.assertIn("Kullanıcı hakkında", block)
+
+    def test_prefs_block_budget(self):
+        from bantz.brain.personality_injector import _PREFS_MAX_CHARS
+        inj = self._make_injector()
+        # Many facts
+        facts = {f"fact_{i}": f"value_{i}" * 20 for i in range(20)}
+        block = inj._build_prefs_block(facts=facts)
+        self.assertLessEqual(len(block), _PREFS_MAX_CHARS)
+
+    def test_prefs_block_limits_facts(self):
+        inj = self._make_injector()
+        # More than 8 facts should be truncated
+        facts = {f"fact_{i}": f"val_{i}" for i in range(15)}
+        block = inj._build_prefs_block(facts=facts)
+        # Should have at most 8 fact lines
+        fact_lines = [l for l in block.split("\n") if l.startswith("- fact_")]
+        self.assertLessEqual(len(fact_lines), 8)
+
+    # -- Layer 3: Rules --
+
+    def test_rules_block_not_empty(self):
+        inj = self._make_injector()
+        block = inj._build_rules_block()
+        self.assertTrue(len(block) > 0)
+        self.assertIn("Davranış kuralları", block)
+
+    def test_rules_block_dangerous_mode(self):
+        from bantz.brain.personality_injector import PersonalityConfig, PersonalityInjector
+        cfg = PersonalityConfig(confirmation_mode="dangerous")
+        inj = PersonalityInjector(config=cfg)
+        block = inj._build_rules_block()
+        self.assertIn("Riskli", block)
+
+    def test_rules_block_always_mode(self):
+        from bantz.brain.personality_injector import PersonalityConfig, PersonalityInjector
+        cfg = PersonalityConfig(confirmation_mode="always")
+        inj = PersonalityInjector(config=cfg)
+        block = inj._build_rules_block()
+        self.assertIn("Tüm", block)
+
+    def test_rules_block_never_mode(self):
+        from bantz.brain.personality_injector import PersonalityConfig, PersonalityInjector
+        cfg = PersonalityConfig(confirmation_mode="never")
+        inj = PersonalityInjector(config=cfg)
+        block = inj._build_rules_block()
+        self.assertIn("Onay istemeden", block)
+
+    def test_rules_language_rule(self):
+        inj = self._make_injector()
+        block = inj._build_rules_block()
+        self.assertIn("TÜRKÇE", block)
+
+    def test_rules_budget(self):
+        from bantz.brain.personality_injector import _RULES_MAX_CHARS
+        inj = self._make_injector()
+        block = inj._build_rules_block()
+        self.assertLessEqual(len(block), _RULES_MAX_CHARS)
+
+
+# =========================================================================
+# Class 4: Combined Blocks & Token Budget Tests
+# =========================================================================
+
+
+class TestCombinedBlocks(unittest.TestCase):
+    """Test router_block, finalizer_block, identity_lines, and token budget."""
+
+    def _make_injector(self, preset="jarvis"):
+        from bantz.brain.personality_injector import PersonalityInjector, PersonalityConfig
+        cfg = PersonalityConfig(preset_name=preset, user_name="İclal")
+        return PersonalityInjector(config=cfg)
+
+    def test_router_block_has_persona(self):
+        inj = self._make_injector()
+        block = inj.build_router_block(user_name="İclal")
+        self.assertIn("İclal", block)
+        self.assertTrue(len(block) > 10)
+
+    def test_router_block_has_facts(self):
+        inj = self._make_injector()
+        facts = {"hobby": "coding"}
+        block = inj.build_router_block(facts=facts)
+        self.assertIn("coding", block)
+
+    def test_router_block_no_rules(self):
+        """Router block should NOT include Layer 3 (rules)."""
+        inj = self._make_injector()
+        block = inj.build_router_block()
+        self.assertNotIn("Davranış kuralları", block)
+
+    def test_finalizer_block_has_rules(self):
+        """Finalizer block SHOULD include Layer 3 (rules)."""
+        inj = self._make_injector()
+        block = inj.build_finalizer_block()
+        self.assertIn("Davranış kuralları", block)
+
+    def test_finalizer_block_all_layers(self):
+        inj = self._make_injector()
+        facts = {"name": "İclal"}
+        block = inj.build_finalizer_block(user_name="İclal", facts=facts)
+        # Layer 1: persona
+        self.assertIn("İclal", block)
+        # Layer 2: facts
+        self.assertIn("Kullanıcı hakkında", block)
+        # Layer 3: rules
+        self.assertIn("Davranış kuralları", block)
+
+    def test_total_budget(self):
+        from bantz.brain.personality_injector import _TOTAL_MAX_CHARS
+        inj = self._make_injector()
+        # Big facts to push budget
+        facts = {f"f{i}": f"val_{i}" * 10 for i in range(15)}
+        prefs = {f"p{i}": {"value": f"x_{i}", "confidence": 0.9} for i in range(10)}
+        block = inj.build_finalizer_block(facts=facts, preferences=prefs)
+        self.assertLessEqual(len(block), _TOTAL_MAX_CHARS)
+
+    def test_identity_lines_jarvis(self):
+        inj = self._make_injector("jarvis")
+        lines = inj.build_identity_lines("İclal")
+        self.assertIn("Jarvis", lines)
+        self.assertIn("İclal", lines)
+        self.assertIn("Efendim", lines)
+
+    def test_identity_lines_friday(self):
+        inj = self._make_injector("friday")
+        lines = inj.build_identity_lines("İclal")
+        self.assertIn("Friday", lines)
+        self.assertIn("Samimi", lines)
+        self.assertNotIn("Efendim", lines)
+
+    def test_switch_preset(self):
+        inj = self._make_injector("jarvis")
+        self.assertEqual(inj.name.lower(), "jarvis")
+        inj.switch_preset("friday")
+        self.assertEqual(inj.name.lower(), "friday")
+        self.assertFalse(inj.uses_honorifics)
+
+    def test_update_user_name(self):
+        inj = self._make_injector("jarvis")
+        inj.update_user_name("TestUser")
+        self.assertEqual(inj.config.user_name, "TestUser")
+        block = inj.build_router_block()
+        self.assertIn("TestUser", block)
+
+
+# =========================================================================
+# Class 5: PromptBuilder Integration Tests
+# =========================================================================
+
+
+class TestPromptBuilderIntegration(unittest.TestCase):
+    """Test PromptBuilder personality_block parameter threading."""
+
+    def test_build_finalizer_prompt_accepts_personality(self):
+        """build_finalizer_prompt should accept personality_block kwarg."""
+        from bantz.brain.prompt_engineering import PromptBuilder
+
+        builder = PromptBuilder(token_budget=4000)
+        result = builder.build_finalizer_prompt(
+            route="chat",
+            user_input="merhaba",
+            planner_decision={"route": "chat"},
+            personality_block="- Sen Jarvis'sin, İclal'ın asistanısın.",
+        )
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result.prompt)
+
+    def test_personality_block_in_prompt(self):
+        """Personality block content should appear in generated prompt."""
+        from bantz.brain.prompt_engineering import PromptBuilder
+
+        marker = "UNIQUE_PERSONALITY_MARKER_XYZ"
+        builder = PromptBuilder(token_budget=5000)
+        result = builder.build_finalizer_prompt(
+            route="chat",
+            user_input="merhaba",
+            planner_decision={"route": "chat"},
+            personality_block=f"- {marker}",
+        )
+        self.assertIn(marker, result.prompt)
+
+    def test_system_prompt_uses_personality(self):
+        """When personality_block given, system prompt should use it."""
+        from bantz.brain.prompt_engineering import PromptBuilder
+
+        builder = PromptBuilder(token_budget=5000)
+        result = builder.build_finalizer_prompt(
+            route="calendar",
+            user_input="bugün takvimde ne var",
+            planner_decision={"route": "calendar"},
+            personality_block="- Sen Alfred'sin.",
+        )
+        # System prompt should include personality block
+        self.assertIn("Alfred", result.prompt)
+
+    def test_no_personality_falls_back(self):
+        """Without personality_block, should use default BANTZ identity."""
+        from bantz.brain.prompt_engineering import PromptBuilder
+
+        builder = PromptBuilder(token_budget=5000)
+        result = builder.build_finalizer_prompt(
+            route="chat",
+            user_input="merhaba",
+            planner_decision={"route": "chat"},
+        )
+        self.assertIn("BANTZ", result.prompt)
+
+    def test_personality_block_none_falls_back(self):
+        """personality_block=None should use default BANTZ identity."""
+        from bantz.brain.prompt_engineering import PromptBuilder
+
+        builder = PromptBuilder(token_budget=5000)
+        result = builder.build_finalizer_prompt(
+            route="chat",
+            user_input="merhaba",
+            planner_decision={"route": "chat"},
+            personality_block=None,
+        )
+        self.assertIn("BANTZ", result.prompt)
+
+    def test_language_rule_always_present(self):
+        """TÜRKÇE language rule must be present regardless of personality."""
+        from bantz.brain.prompt_engineering import PromptBuilder
+
+        builder = PromptBuilder(token_budget=5000)
+
+        # With personality
+        r1 = builder.build_finalizer_prompt(
+            route="chat",
+            user_input="hi",
+            planner_decision={"route": "chat"},
+            personality_block="- Sen Friday'sin.",
+        )
+        self.assertIn("TÜRKÇE", r1.prompt)
+
+        # Without personality
+        r2 = builder.build_finalizer_prompt(
+            route="chat",
+            user_input="hi",
+            planner_decision={"route": "chat"},
+        )
+        self.assertIn("TÜRKÇE", r2.prompt)
+
+
+# =========================================================================
+# Class 6: FinalizationContext & Pipeline Integration Tests
+# =========================================================================
+
+
+class TestFinalizationContextIntegration(unittest.TestCase):
+    """Test FinalizationContext personality_block field and threading."""
+
+    def test_finalization_context_has_personality_field(self):
+        """FinalizationContext should accept personality_block."""
+        from bantz.brain.finalization_pipeline import FinalizationContext
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        oo = MagicMock()
+        oo.route = "chat"
+
+        ctx = FinalizationContext(
+            user_input="merhaba",
+            orchestrator_output=oo,
+            tool_results=[],
+            state=MagicMock(spec=OrchestratorState),
+            planner_decision={"route": "chat"},
+            personality_block="- Sen Jarvis'sin.",
+        )
+        self.assertEqual(ctx.personality_block, "- Sen Jarvis'sin.")
+
+    def test_finalization_context_personality_default_none(self):
+        """personality_block should default to None."""
+        from bantz.brain.finalization_pipeline import FinalizationContext
+
+        ctx = FinalizationContext(
+            user_input="test",
+            orchestrator_output=MagicMock(),
+            tool_results=[],
+            state=MagicMock(),
+            planner_decision={},
+        )
+        self.assertIsNone(ctx.personality_block)
+
+    def test_build_finalization_context_accepts_personality(self):
+        """build_finalization_context should accept personality_block."""
+        from bantz.brain.finalization_pipeline import build_finalization_context
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        oo = MagicMock()
+        oo.route = "chat"
+        oo.calendar_intent = None
+        oo.slots = {}
+        oo.tool_plan = []
+        oo.requires_confirmation = False
+        oo.confirmation_prompt = ""
+        oo.ask_user = False
+        oo.question = ""
+
+        state = MagicMock(spec=OrchestratorState)
+        state.get_context_for_llm.return_value = {}
+        state.session_context = None
+
+        memory = MagicMock()
+        memory.to_prompt_block.return_value = ""
+
+        ctx = build_finalization_context(
+            user_input="test",
+            orchestrator_output=oo,
+            tool_results=[],
+            state=state,
+            memory=memory,
+            finalizer_llm=None,
+            personality_block="- Sen Alfred'sin.",
+        )
+        self.assertEqual(ctx.personality_block, "- Sen Alfred'sin.")
+
+    def test_build_finalization_context_personality_default(self):
+        """Without personality_block arg, should default to None."""
+        from bantz.brain.finalization_pipeline import build_finalization_context
+        from bantz.brain.orchestrator_state import OrchestratorState
+
+        oo = MagicMock()
+        oo.route = "chat"
+        oo.calendar_intent = None
+        oo.slots = {}
+        oo.tool_plan = []
+        oo.requires_confirmation = False
+        oo.confirmation_prompt = ""
+        oo.ask_user = False
+        oo.question = ""
+
+        state = MagicMock(spec=OrchestratorState)
+        state.get_context_for_llm.return_value = {}
+        state.session_context = None
+
+        memory = MagicMock()
+        memory.to_prompt_block.return_value = ""
+
+        ctx = build_finalization_context(
+            user_input="test",
+            orchestrator_output=oo,
+            tool_results=[],
+            state=state,
+            memory=memory,
+            finalizer_llm=None,
+        )
+        self.assertIsNone(ctx.personality_block)
+
+
+# =========================================================================
+# Class 7: Fallback Prompt Personality Tests
+# =========================================================================
+
+
+class TestFallbackPromptPersonality(unittest.TestCase):
+    """Test fallback prompt uses personality when available."""
+
+    def _make_ctx(self, personality_block=None):
+        from bantz.brain.finalization_pipeline import FinalizationContext
+
+        oo = MagicMock()
+        oo.route = "chat"
+
+        return FinalizationContext(
+            user_input="merhaba",
+            orchestrator_output=oo,
+            tool_results=[],
+            state=MagicMock(),
+            planner_decision={"route": "chat"},
+            personality_block=personality_block,
+        )
+
+    def test_fallback_with_personality(self):
+        """Fallback prompt should use personality block when present."""
+        from bantz.brain.finalization_pipeline import QualityFinalizer
+
+        ctx = self._make_ctx(personality_block="- Sen Alfred'sin, İclal'ın sadık asistanısın.")
+        prompt = QualityFinalizer._build_fallback_prompt(ctx, [])
+        self.assertIn("Alfred", prompt)
+        self.assertIn("İclal", prompt)
+
+    def test_fallback_without_personality(self):
+        """Fallback prompt should use default BANTZ when no personality."""
+        from bantz.brain.finalization_pipeline import QualityFinalizer
+
+        ctx = self._make_ctx(personality_block=None)
+        prompt = QualityFinalizer._build_fallback_prompt(ctx, [])
+        self.assertIn("BANTZ", prompt)
+        self.assertIn("Efendim", prompt)
+
+    def test_fallback_format_rules_always_present(self):
+        """FORMAT KURALLARI should always be present in fallback."""
+        from bantz.brain.finalization_pipeline import QualityFinalizer
+
+        ctx = self._make_ctx(personality_block="- Sen Friday'sin.")
+        prompt = QualityFinalizer._build_fallback_prompt(ctx, [])
+        self.assertIn("FORMAT KURALLARI", prompt)
+
+    def test_fallback_dogruluk_rules_always_present(self):
+        """DOĞRULUK KURALLARI should always be present in fallback."""
+        from bantz.brain.finalization_pipeline import QualityFinalizer
+
+        ctx = self._make_ctx(personality_block="- Sen Friday'sin.")
+        prompt = QualityFinalizer._build_fallback_prompt(ctx, [])
+        self.assertIn("DOĞRULUK KURALLARI", prompt)
+
+
+# =========================================================================
+# Class 8: Orchestrator Wiring (AST-based, no heavy imports)
+# =========================================================================
+
+
+class TestOrchestratorWiring(unittest.TestCase):
+    """Verify orchestrator has personality_injector wired in (AST analysis)."""
+
+    @classmethod
+    def setUpClass(cls):
+        path = _SRC / "brain" / "orchestrator_loop.py"
+        cls._source = path.read_text(encoding="utf-8")
+        cls._tree = ast.parse(cls._source)
+
+    def test_personality_injector_in_init(self):
+        """__init__ should create self.personality_injector."""
+        self.assertIn("personality_injector", self._source)
+        self.assertIn("PersonalityInjector", self._source)
+
+    def test_personality_block_in_phase1(self):
+        """Phase 1 should inject PERSONALITY block."""
+        self.assertIn("PERSONALITY:", self._source)
+        self.assertIn("build_router_block", self._source)
+
+    def test_personality_block_in_phase3(self):
+        """Phase 3 should pass personality_block to build_finalization_context."""
+        self.assertIn("build_finalizer_block", self._source)
+        self.assertIn("personality_block=_personality_block", self._source)
+
+    def test_personality_injector_import(self):
+        """PersonalityInjector should be imported in orchestrator."""
+        self.assertIn("from bantz.brain.personality_injector", self._source)
+
+    def test_finalization_pipeline_personality_field(self):
+        """finalization_pipeline should have personality_block field."""
+        fp_path = _SRC / "brain" / "finalization_pipeline.py"
+        source = fp_path.read_text(encoding="utf-8")
+        self.assertIn("personality_block", source)
+
+    def test_prompt_engineering_personality_param(self):
+        """PromptBuilder should accept personality_block."""
+        pe_path = _SRC / "brain" / "prompt_engineering.py"
+        source = pe_path.read_text(encoding="utf-8")
+        self.assertIn("personality_block", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue #874: [Core] Personality Injection — Kişilik ve Tercihler LLM Prompt'a Enjekte

### Yeni modül
- **brain/personality_injector.py**: `PersonalityInjector` + `PersonalityConfig`
  - **Layer 1**: Persona (Jarvis/Friday/Alfred preset — identity, style, honorifics)
  - **Layer 2**: User Preferences (profil facts + tercihler)
  - **Layer 3**: Behavior Rules (onay modu, dil, format, dürüstlük)
  - Token budget: ~450 token max (800+600+400 char)
  - `BANTZ_PERSONALITY` env var ile preset seçimi

### Wiring
- **orchestrator_loop.py `__init__`**: PersonalityInjector oluşturma (best-effort try/except)
- **Phase 1 (router)**: `PERSONALITY:` bloğu (Layer 1+2) context_parts'a enjekte
- **Phase 3 (finalizer)**: personality_block threading:
  - `FinalizationContext.personality_block` alanı
  - `build_finalization_context()` personality_block parametresi
  - `QualityFinalizer` → `PromptBuilder` personality_block geçirme
  - Fallback prompt personality-aware

### PromptBuilder
- `build_finalizer_prompt()` personality_block parametresi
- `_build_system_prompt()` personality ile dinamik kimlik enjeksiyonu
- `PERSONALITY:` content bloğu ekleme
- Hardcoded BANTZ kimliği → personality-aware (fallback korunuyor)

### Stats
- **+1099 / -4** across 5 files
- **59/59 tests passed** (8 classes)
- Regresyon: #872 22/22 ✅, #873 32/32 ✅

Closes #874