### PR TITLE
fix(json_protocol): preserve JSON literals true/false/null during repair

### DIFF
--- a/src/bantz/brain/json_protocol.py
+++ b/src/bantz/brain/json_protocol.py
@@ -752,7 +752,14 @@ def repair_common_json_issues(text: str) -> str:
     
     # Fix unquoted string values (basic cases)
     # Pattern: : unquoted_value, or : unquoted_value}
-    text = re.sub(r':\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*([,}])', r': "\1"\2', text)
+    # IMPORTANT: Exclude JSON literals true, false, null — wrapping them in
+    # quotes corrupts semantics (e.g. true → "true" becomes a truthy string
+    # instead of a boolean).  See Issue #886.
+    text = re.sub(
+        r':\s*(?!(true|false|null)\s*[,}])([a-zA-Z_][a-zA-Z0-9_]*)\s*([,}])',
+        r': "\2"\3',
+        text,
+    )
     
     return text
 


### PR DESCRIPTION
## Summary
`repair_common_json_issues` içindeki unquoted-value regex, `true`, `false` ve `null` gibi geçerli JSON literallerini de string'e çeviriyordu. Bu, tool plan semantiğini bozuyordu:

- `{"ask_user": true}` → `{"ask_user": "true"}` — truthy string, boolean değil
- `{"confidence": null}` → `{"confidence": "null"}` — NoneType kontrolleri kırılıyor

## Changes
- `json_protocol.py`: Regex'e `(?!(true|false|null))` negative lookahead eklendi
- JSON literals artık korunuyor, diğer bare value'lar (route name, intent string) hala quote'lanıyor

## Testing
```python
# Before: {"ask_user": true, "route": calendar} → {"ask_user": "true", "route": "calendar"} ❌
# After:  {"ask_user": true, "route": calendar} → {"ask_user": true, "route": "calendar"} ✅
```

Closes #886