### PR TITLE
fix(#898): brace-balancing guard for truncated LLM JSON output

### DIFF
--- a/config/model-settings.yaml
+++ b/config/model-settings.yaml
@@ -66,8 +66,13 @@ router:
   max_tokens: 256   # Issue #418: increased from 128 to avoid JSON truncation with slim schema
   top_p: 1.0
   stop_sequences:
-    - "}"
-    - "\n\n"
+    # IMPORTANT: Never use "}" alone as a stop sequence — it truncates JSON
+    # at the first nested closing brace instead of the root object's.
+    # The actual stop tokens are hardcoded in llm_router.py for safety.
+    # These are kept here for documentation only.
+    - "\nUSER:"
+    - "\n\nUSER:"
+    - "\n---"
   
   # Prompt budget
   max_system_prompt_tokens: 500


### PR DESCRIPTION
## Problem
When the 3B router model hits `max_tokens` mid-JSON, the output is truncated with unclosed braces/brackets. This causes parse failures that trigger expensive repair prompts or complete fallback to defaults.

The `model-settings.yaml` also had dangerous `stop_sequences: ["}", "\n\n"]` that would cut JSON at the first `}` — though this config is currently documentation-only (not read by Python code), it could cause silent breakage if any future code consumes it.

## Solution
1. **`balance_truncated_json()`** in `json_protocol.py`: scans for unmatched braces/brackets/strings and appends the minimal closing characters (`"`, `]`, `}`)
2. **Wired into `_parse_json` pipeline** as a new step between first-parse failure and `repair_common_json_issues` — catches truncation without a full LLM re-prompt
3. **Fixed `model-settings.yaml`**: replaced dangerous stop_sequences with safe documentation-only values

## Testing
All smoke tests pass:
- Already balanced JSON → unchanged
- Missing closing brace → fixed
- Missing bracket + brace → fixed
- Truncated mid-string → fixed
- Integration with `extract_first_json_object` → works

Closes #898