### PR TITLE
harden: review fixes for #898, #889, #893

### DIFF
--- a/config/model-settings.yaml
+++ b/config/model-settings.yaml
@@ -65,6 +65,7 @@ router:
   temperature: 0.0  # Deterministic routing
   max_tokens: 256   # Issue #418: increased from 128 to avoid JSON truncation with slim schema
   top_p: 1.0
+  boost_floor: 0.3  # Issue #889: min confidence to allow auto-boost (env: BANTZ_ROUTER_BOOST_FLOOR)
   stop_sequences:
     # IMPORTANT: Never use "}" alone as a stop sequence — it truncates JSON
     # at the first nested closing brace instead of the root object's.

--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1086,33 +1086,44 @@ USER: saat 8e toplantı ekle
         # ── Issue #898: brace-balancing guard for truncated LLM output ──
         # When max_tokens cuts the JSON mid-stream the output has unclosed
         # braces/brackets.  Append the minimal closing chars and retry.
-        try:
-            balanced = balance_truncated_json(text)
-            if balanced != text:
-                parsed = extract_first_json_object(balanced, strict=False)
-                is_valid, errors = validate_orchestrator_output(parsed, strict=False)
-                if errors:
-                    logger.debug("[router_json] balanced_validation_issues: %s", errors)
-                self._publish_json_event("json_balanced", {
-                    "phase": "balance_parse",
-                    "chars_appended": len(balanced) - len(text),
-                })
-                try:
-                    repaired_schema, report = repair_router_output(parsed)
-                    if report.needed_repair:
-                        self._publish_json_event("schema_repaired", {
-                            "phase": "balance_parse",
-                            "fields_missing": report.fields_missing,
-                            "fields_invalid": report.fields_invalid,
-                            "fields_repaired": report.fields_repaired,
-                            "valid_after": report.is_valid_after,
-                        })
-                    parsed = repaired_schema
-                except Exception as exc:
-                    logger.debug("[router_json] schema_repair_failed (balanced): %s", str(exc)[:120])
-                return parsed, True
-        except Exception as e:
-            logger.debug("[router_json] balance_parse_failed: %s", str(e)[:100])
+        # Guard: only attempt if text actually looks like JSON (contains '{').
+        if "{" in text:
+            try:
+                balanced = balance_truncated_json(text)
+                if balanced != text:
+                    parsed = extract_first_json_object(balanced, strict=False)
+                    is_valid, errors = validate_orchestrator_output(parsed, strict=False)
+                    if errors:
+                        logger.debug("[router_json] balanced_validation_issues: %s", errors)
+                    self._publish_json_event("json_balanced", {
+                        "phase": "balance_parse",
+                        "chars_appended": len(balanced) - len(text),
+                    })
+                    # Validation MUST pass after balance — otherwise the
+                    # balanced JSON is syntactically valid but semantically
+                    # garbage (e.g. truncated route string).
+                    try:
+                        repaired_schema, report = repair_router_output(parsed)
+                        if report.needed_repair:
+                            self._publish_json_event("schema_repaired", {
+                                "phase": "balance_parse",
+                                "fields_missing": report.fields_missing,
+                                "fields_invalid": report.fields_invalid,
+                                "fields_repaired": report.fields_repaired,
+                                "valid_after": report.is_valid_after,
+                            })
+                        if not report.is_valid_after:
+                            logger.info(
+                                "[router_json] balanced JSON failed schema validation — falling through to repair",
+                            )
+                            raise ValueError("balanced_schema_invalid")
+                        parsed = repaired_schema
+                    except Exception as exc:
+                        logger.debug("[router_json] schema_repair_failed (balanced): %s", str(exc)[:120])
+                        raise  # fall through to repair_common_json_issues
+                    return parsed, True
+            except Exception as e:
+                logger.debug("[router_json] balance_parse_failed: %s", str(e)[:100])
 
         # Second attempt: repair common issues and retry
         try:
@@ -1528,7 +1539,7 @@ USER: saat 8e toplantı ekle
         # Issue #889: Guard-rail — only boost when original confidence is above
         # a minimum floor.  Very low values (< 0.3) indicate the model is
         # genuinely confused and we should ask the user to clarify.
-        _BOOST_FLOOR = 0.3  # below this, never auto-boost
+        _BOOST_FLOOR = float(os.getenv("BANTZ_ROUTER_BOOST_FLOOR", "0.3"))
         if confidence < self._confidence_threshold:
             # Check if route+intent are actually valid and meaningful
             _route_valid = route in ("calendar", "gmail", "system")


### PR DESCRIPTION
## Review hardening for previous sprint fixes

Addresses feedback on the 3 fixes from sprint 2:

### #898 balance guard
- Only attempt brace-balancing if text contains `{` (skip plain smalltalk)
- Balanced JSON **must** pass schema validation (`repair_router_output`); if `is_valid_after=False`, falls through to `repair_common_json_issues` instead of returning semantically broken JSON

### #889 boost floor
- `_BOOST_FLOOR` now reads from `BANTZ_ROUTER_BOOST_FLOOR` env var (default 0.3)
- Added `boost_floor` key to `model-settings.yaml` for documentation
- Allows tuning per model without code changes

### #893 tool results
- `result_raw` capped: lists >50 items truncated to first 50
- `get_context_for_llm()` **excludes** `result_raw` — only sends lightweight `result_summary` to LLM
- Prevents payload bloat in logs/API debug dumps