### PR TITLE
fix(#888): Deduplicate _prepare_tool_results_for_finalizer — dead code removed

### DIFF
--- a/tests/test_unified_finalizer.py
+++ b/tests/test_unified_finalizer.py
@@ -55,13 +55,13 @@ def test_prepare_tool_results_empty():
 def test_prepare_tool_results_small():
     """Small tool results should pass through unchanged."""
     tool_results = [
-        {"tool": "get_weather", "success": True, "result": {"temp": 72}}
+        {"tool": "get_weather", "success": True, "raw_result": {"temp": 72}}
     ]
     results, truncated = _prepare_tool_results_for_finalizer(tool_results, max_tokens=1000)
     
     assert len(results) == 1
     assert results[0]["tool"] == "get_weather"
-    assert results[0]["status"] == "success"
+    assert results[0]["success"] is True
     assert results[0]["result"] == {"temp": 72}
     assert truncated is False
 
@@ -93,7 +93,8 @@ def test_prepare_tool_results_aggressive_truncation():
         {
             "tool": f"tool_{i}",
             "success": True,
-            "result": {"data": "x" * 1000}  # Large data
+            "raw_result": {"data": "x" * 1000},  # Large raw data
+            "result_summary": "y" * 500,          # Large summary too
         }
         for i in range(10)  # 10 tools
     ]
@@ -140,7 +141,7 @@ def test_build_prompt_with_draft():
 
 def test_build_prompt_with_tool_results():
     """Build prompt with tool results."""
-    tool_results = [{"tool": "get_weather", "status": "success", "result": {"temp": 72}}]
+    tool_results = [{"tool": "get_weather", "success": True, "result": {"temp": 72}}]
     
     prompt = _build_finalizer_prompt(
         user_input="Hava nasıl?",


### PR DESCRIPTION
## Summary
Removes the ~100-line duplicate `_prepare_tool_results_for_finalizer` from `finalizer.py` and replaces it with a thin delegation wrapper to the canonical implementation in `orchestrator_loop.py`.

## Problem
`finalizer.py` had its own copy of `_prepare_tool_results_for_finalizer` that diverged from the canonical version:
- Old: used `status` (string) key → `"success"` / `"error"`
- Canonical: uses `success` (boolean) + `raw_result` → `result` mapping

This created a maintenance trap where fixes to one copy wouldn't propagate to the other.

## Changes
- **`src/bantz/brain/finalizer.py`**: Replaced 100-line duplicate with 15-line wrapper that delegates to `orchestrator_loop._prepare_tool_results_for_finalizer`
- **`tests/test_unified_finalizer.py`**: Updated test inputs & assertions to match canonical schema (`raw_result` key, `success` boolean)
- Public exports (`_prepare_tool_results_for_finalizer`) preserved for backward compat

## Test Results
- 24/24 tests pass in `test_unified_finalizer.py`
- 7/7 smoke tests pass (import, delegation, schema, truncation, prompt builder)

Closes #888