### PR TITLE
fix(brain): align confidence threshold to 0.5 — Closes #935

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -360,7 +360,7 @@ NOT: assistant_reply, memory_update, reasoning_summary alanları gerekli DEĞİL
 
 KURALLAR:
 1. Sadece tek JSON object; Markdown/açıklama YOK.
-2. confidence<0.7 → tool_plan=[], ask_user=true, question doldur.
+2. confidence<0.5 → tool_plan=[], ask_user=true, question doldur.
 3. Saat 1-6 belirsiz → PM varsay: "beş"→17:00, "üç"→15:00. "sabah" varsa AM.
 4. delete/modify/send → requires_confirmation=true.
 5. Belirsizlikte tool çağırma, ask_user=true.
@@ -462,7 +462,7 @@ USER: saat 8e toplantı ekle
         llm: Optional[LLMRouterProtocol] = None,
         llm_client: Optional[LLMRouterProtocol] = None,
         system_prompt: Optional[str] = None,
-        confidence_threshold: float = 0.7,
+        confidence_threshold: float = 0.5,
         max_attempts: int = 2,
     ):
         """Initialize router.
@@ -470,7 +470,7 @@ USER: saat 8e toplantı ekle
         Args:
             llm: LLM client implementing LLMRouterProtocol
             system_prompt: Override the default SYSTEM_PROMPT (useful for benchmarking)
-            confidence_threshold: Minimum confidence to execute tools (default 0.7)
+            confidence_threshold: Minimum confidence to execute tools (default 0.5)
             max_attempts: Max repair attempts for malformed JSON (default 2)
         """
         effective_llm = llm if llm is not None else llm_client

--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -536,14 +536,14 @@ class OrchestratorLoop:
             Updated output with forced tool_plan if needed
         """
         # Issue #347: Skip if confidence is too low - router wants clarification
-        # Issue #682: Lowered from 0.7 to 0.4 — 3B models typically produce
-        # 0.5-0.65 confidence for clear tool queries.  The old 0.7 gate
-        # blocked almost all forced tool injection.
+        # Issue #935: Aligned threshold to 0.5 — matches prompt rule and
+        # router confidence_threshold.  3B models give 0.5-0.65 for clear
+        # queries; 0.4 was too permissive, 0.7 was too strict.
         #
         # Issue #607: Gmail send intents should not get stuck tool-less just
         # because confidence is low.
         gmail_intent = (getattr(output, "gmail_intent", None) or "").strip().lower()
-        if output.confidence < 0.4 and not (
+        if output.confidence < 0.5 and not (
             output.route == "gmail" and gmail_intent == "send" and not output.ask_user
         ):
             return output
@@ -801,7 +801,7 @@ class OrchestratorLoop:
             if (
                 orchestrator_output.route == "unknown"
                 and not orchestrator_output.ask_user
-                and orchestrator_output.confidence < 0.4
+                and orchestrator_output.confidence < 0.5
             ):
                 try:
                     from bantz.skills.declarative.generator import get_self_evolving_manager


### PR DESCRIPTION
## Problem
The system prompt told the LLM `confidence < 0.7 → ask_user=true` while `_force_tool_plan` used 0.4 as the gate and the router `__init__` defaulted to 0.7.

This 3-way mismatch caused the 3B model (which typically returns 0.5–0.65 for clear queries) to oscillate between asking for clarification and forcing tools.

## Changes
| Location | Before | After |
|---|---|---|
| Prompt rule 2 | `confidence<0.7` | `confidence<0.5` |
| `JarvisLLMOrchestrator.__init__` | `confidence_threshold=0.7` | `confidence_threshold=0.5` |
| `_force_tool_plan` threshold | `0.4` | `0.5` |
| Self-evolving check | `0.4` | `0.5` |

## Impact
- 3B model's typical confidence range (0.5–0.65) now consistently clears the unified 0.5 gate
- Eliminates flip-flopping between `ask_user=true` and tool forcing
- The router's confidence boost mechanism still kicks in for valid routes below 0.5

Closes #935