### PR TITLE
fix(brain): compress system prompt ~60% & align context to 4096 — Closes #937

### DIFF
--- a/config/model-settings.yaml
+++ b/config/model-settings.yaml
@@ -17,11 +17,11 @@ models:
   router:
     name: "Qwen/Qwen2.5-3B-Instruct-AWQ"
     provider: "vllm"
-    context_window: 2048
+    context_window: 4096
     endpoint: "http://localhost:8001/v1"
     port: 8001
     quantization: "awq_marlin"
-    max_model_len: 2048
+    max_model_len: 4096
     gpu_memory_utilization: 0.70
     vram_usage_gb: 3.0
     ttft_ms: 41  # Validated (vllm_validation_report.md)
@@ -33,7 +33,7 @@ models:
     provider: "vllm"
     endpoint: "http://localhost:8001/v1"  # Same as router (single 3B server)
     port: 8001
-    context_window: 2048
+    context_window: 4096
     quantization: "awq_marlin"
     
   chat:
@@ -41,9 +41,9 @@ models:
     provider: "vllm"
     endpoint: "http://localhost:8001/v1"
     port: 8001
-    context_window: 2048
+    context_window: 4096
     quantization: "awq_marlin"
-    max_model_len: 2048
+    max_model_len: 4096
     gpu_memory_utilization: 0.70
     vram_usage_gb: 3.0
     ttft_ms: 41  # Same server as router
@@ -55,7 +55,7 @@ single_model:
   name: "Qwen/Qwen2.5-3B-Instruct-AWQ"
   provider: "vllm"
   endpoint: "http://localhost:8001/v1"
-  context_window: 2048
+  context_window: 4096
   quantization: "awq_marlin"
 
 # =============================================================================


### PR DESCRIPTION
## Problem
The router system prompt was **~1650 tokens** — on a 2048-context model with 512 completion reserve, the entire prompt budget was consumed by the system instructions alone, leaving **~0 tokens** for user input + dialog context.

This is the **#1 root cause** of the agent feeling "dumb": the 3B model was seeing a truncated, incoherent prompt.

## Changes

### System Prompt Compression (~57% reduction)
| Tier | Before | After |
|---|---|---|
| CORE | ~700 tokens | ~400 tokens |
| DETAIL | ~400 tokens | ~120 tokens |
| EXAMPLES | ~550 tokens | ~200 tokens |
| **Total** | **~1650 tokens** | **~720 tokens** |

Key compression strategies:
- Merged redundant rules (12 → 10, removed overlaps like rule 7 "calendar+tool → reply can be empty")
- Condensed DETAIL block into 3 compact lines (gmail query syntax, smart_search keywords, system routing, time examples)
- Reduced EXAMPLES from 12 verbose examples to 6 essential ones covering all routes
- Tighter Turkish wording throughout

### Context Length Alignment
| Config | Before | After |
|---|---|---|
| `PromptBudgetConfig.context_length` | 1024 | 4096 |
| `PromptBudgetConfig.completion_reserve` | 256 | 768 |
| `model-settings.yaml` context_window | 2048 | 4096 |
| `model-settings.yaml` max_model_len | 2048 | 4096 |

Aligned to `start_3b.sh` default (`--max-model-len 4096`).

## Token Budget (after fix)
```
4096 ctx - 768 completion - 32 safety = 3296 available
~720 system prompt → 2576 tokens for user input + context
```

vs. before:
```
2048 ctx - 512 completion - 32 safety = 1504 available
```

Closes #937