### PR TITLE
refactor(brain): extract 4 modules from orchestrator_loop.py God Object — closes #941

### DIFF
--- a/src/bantz/brain/post_route_corrections.py
+++ b/src/bantz/brain/post_route_corrections.py
@@ -1,0 +1,154 @@
+"""Post-route corrections (extracted from orchestrator_loop.py).
+
+Issue #941: Extracted to reduce orchestrator_loop.py from 2434 lines.
+Contains: email-send post-route correction and its helper methods.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import replace
+
+from bantz.brain.llm_router import OrchestratorOutput
+
+logger = logging.getLogger(__name__)
+
+
+def looks_like_email_send_intent(text: str) -> bool:
+    """Heuristic check for email-send intent in Turkish text."""
+    t = (text or "").strip().lower()
+    if not t:
+        return False
+    return bool(
+        re.search(r"\b(mail|e-?posta)\b\s*(gönder|at|yaz|yolla|ilet)\b", t)
+        or re.search(r"\b(mail|e-?posta)\b.*\b(gönder|at|yaz|yolla|ilet)\b", t)
+    )
+
+
+def extract_first_email(text: str) -> str | None:
+    """Extract the first email address from text."""
+    m = re.search(r"\b[^\s@]+@[^\s@]+\.[^\s@]+\b", text or "")
+    return str(m.group(0)).strip() if m else None
+
+
+def extract_recipient_name(text: str) -> str | None:
+    """Extract recipient name from Turkish email patterns (e.g. Ali'ye mail)."""
+    t = text or ""
+    m = re.search(
+        r"\b([A-Za-zÇĞİÖŞÜçğıöşü][\wÇĞİÖŞÜçğıöşü]+(?:\s+[A-Za-zÇĞİÖŞÜçğıöşü][\wÇĞİÖŞÜçğıöşü]+)*)\s*'?\s*(?:ye|ya)\s+(?:bir\s+)?(?:mail|e-?posta)\b",
+        t,
+        flags=re.IGNORECASE,
+    )
+    if not m:
+        return None
+    name = str(m.group(1) or "").strip()
+    return name or None
+
+
+def extract_message_body_hint(text: str) -> str | None:
+    """Extract potential message body from user input."""
+    t = (text or "").strip()
+    m = re.search(
+        r"\b(?:mail|e-?posta)\b\s*(?:gönder|at|yaz|yolla|ilet)\b\s*(.+)$",
+        t,
+        flags=re.IGNORECASE,
+    )
+    if not m:
+        return None
+    body = str(m.group(1) or "").strip()
+
+    email_in_body = re.search(r"\b[^\s@]+@[^\s@]+\.[^\s@]+\b", body)
+    if email_in_body and email_in_body.start() == 0:
+        body = body[email_in_body.end():].strip(" \t\n\r,;:-")
+
+    return body or None
+
+
+def post_route_correction_email_send(
+    user_input: str,
+    output: OrchestratorOutput,
+    *,
+    debug: bool = False,
+) -> OrchestratorOutput:
+    """Correct obvious email-send intents that the router misclassifies.
+
+    Issue #607 / #945: Post-route correction for email sending.
+    """
+    if not looks_like_email_send_intent(user_input):
+        return output
+
+    gmail_obj = dict(getattr(output, "gmail", None) or {})
+    slots = dict(getattr(output, "slots", None) or {})
+
+    gmail_obj.setdefault("subject", "")
+
+    if not gmail_obj.get("to"):
+        email = extract_first_email(user_input)
+        if email:
+            gmail_obj["to"] = email
+        else:
+            name = extract_recipient_name(user_input)
+            if name:
+                gmail_obj["to"] = name
+
+    if not gmail_obj.get("body"):
+        body_hint = extract_message_body_hint(user_input)
+        if body_hint:
+            gmail_obj["body"] = body_hint
+
+    to_val = str(gmail_obj.get("to") or "").strip()
+    body_val = str(gmail_obj.get("body") or "").strip()
+
+    ask_user = bool(getattr(output, "ask_user", False))
+    question = str(getattr(output, "question", "") or "")
+    tool_plan: list[str] = list(getattr(output, "tool_plan", None) or [])
+
+    if not to_val:
+        ask_user = True
+        question = "Kime göndermek istiyorsunuz efendim? (e-posta adresi veya kayıtlı kişi adı)"
+        tool_plan = []
+    elif not body_val:
+        ask_user = True
+        question = "Mailde ne yazmamı istersiniz efendim?"
+        tool_plan = []
+    else:
+        if "@" in to_val:
+            tool_plan = tool_plan or ["gmail.send"]
+        else:
+            gmail_obj.setdefault("name", to_val)
+            tool_plan = tool_plan or ["gmail.send_to_contact"]
+
+    if "to" not in slots and to_val:
+        slots["to"] = to_val
+    if "subject" not in slots and gmail_obj.get("subject") is not None:
+        slots["subject"] = str(gmail_obj.get("subject") or "")
+    if "name" not in slots and gmail_obj.get("name"):
+        slots["name"] = str(gmail_obj.get("name") or "")
+
+    corrected = replace(
+        output,
+        route="gmail",
+        calendar_intent="none",
+        gmail_intent="send",
+        gmail=gmail_obj,
+        slots=slots,
+        ask_user=ask_user,
+        question=question,
+        tool_plan=tool_plan,
+    )
+
+    if debug and (
+        corrected.route != output.route
+        or corrected.gmail_intent != getattr(output, "gmail_intent", "none")
+    ):
+        logger.debug(
+            "[POST_ROUTE_CORRECTION] email_send: route=%s->%s gmail_intent=%s tool_plan=%s ask_user=%s",
+            output.route,
+            corrected.route,
+            corrected.gmail_intent,
+            corrected.tool_plan,
+            corrected.ask_user,
+        )
+
+    return corrected

--- a/src/bantz/brain/tool_param_builder.py
+++ b/src/bantz/brain/tool_param_builder.py
@@ -1,0 +1,82 @@
+"""Tool parameter builder (extracted from orchestrator_loop.py).
+
+Issue #941: Extracted to reduce orchestrator_loop.py from 2434 lines.
+Contains: build_tool_params with field aliasing logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from bantz.brain.llm_router import OrchestratorOutput
+
+logger = logging.getLogger(__name__)
+
+# Valid gmail parameter names (Issue #365)
+GMAIL_VALID_PARAMS = frozenset({
+    "to", "name", "subject", "body", "cc", "bcc",
+    "label", "category", "query", "search_term", "natural_query",
+    "message_id", "max_results", "unread_only", "prefer_unread",
+})
+
+
+def build_tool_params(
+    tool_name: str,
+    slots: dict[str, Any],
+    output: Optional[OrchestratorOutput] = None,
+) -> dict[str, Any]:
+    """Build tool parameters from orchestrator slots.
+
+    Maps orchestrator slots to tool-specific parameters.
+    Handles nested objects like gmail: {to, subject, body}.
+
+    Issue #340: Applies field aliasing for common LLM variations.
+    """
+    params: dict[str, Any] = {}
+
+    if tool_name.startswith("gmail."):
+        # First check slots.gmail (legacy)
+        gmail_params = slots.get("gmail")
+        if isinstance(gmail_params, dict):
+            for key, val in gmail_params.items():
+                if key in GMAIL_VALID_PARAMS and val is not None:
+                    params[key] = val
+
+        # Issue #903: Check top-level slots for gmail params
+        for key, val in slots.items():
+            if key in GMAIL_VALID_PARAMS and val is not None and key not in params:
+                params[key] = val
+
+        # Then check output.gmail (Issue #317) — highest priority
+        if output is not None:
+            gmail_obj = getattr(output, "gmail", None) or {}
+            if isinstance(gmail_obj, dict):
+                for key, val in gmail_obj.items():
+                    if key in GMAIL_VALID_PARAMS and val is not None:
+                        params[key] = val
+
+        # Issue #340: Apply field aliasing for gmail.send
+        if tool_name == "gmail.send":
+            for alias in ["recipient", "email", "address", "emails", "to_address"]:
+                if alias in params and "to" not in params:
+                    params["to"] = params.pop(alias)
+                    break
+
+            for alias in ["message", "text", "content", "message_body"]:
+                if alias in params and "body" not in params:
+                    params["body"] = params.pop(alias)
+                    break
+
+            if "title" in params and "subject" not in params:
+                params["subject"] = params.pop("title")
+
+        # Minimal aliasing for gmail.send_to_contact
+        if tool_name == "gmail.send_to_contact":
+            if "name" not in params and "to" in params:
+                params["name"] = params.get("to")
+
+    else:
+        params = dict(slots)
+
+    return params

--- a/src/bantz/brain/tool_plan_sanitizer.py
+++ b/src/bantz/brain/tool_plan_sanitizer.py
@@ -1,0 +1,128 @@
+"""Tool plan sanitization and force-injection (extracted from orchestrator_loop.py).
+
+Issue #941: Extracted to reduce orchestrator_loop.py from 2434 lines.
+Contains: _TOOL_REMAP, _force_tool_plan, _sanitize_tool_plan.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from typing import Any
+
+from bantz.brain.llm_router import OrchestratorOutput
+
+logger = logging.getLogger(__name__)
+
+# Map of known LLM-hallucinated or mismatched tool names to correct tools.
+# Key: (tool_name, gmail_intent or "*") → replacement tool name.
+TOOL_REMAP: dict[tuple[str, str], str] = {
+    ("gmail.list_drafts", "list"): "gmail.list_messages",
+    ("gmail.list_all", "*"): "gmail.list_messages",
+    ("gmail.search_messages", "*"): "gmail.smart_search",
+    ("gmail.check_inbox", "*"): "gmail.list_messages",
+    ("gmail.get_unread", "*"): "gmail.unread_count",
+    ("gmail.inbox", "*"): "gmail.list_messages",
+    ("gmail.read_mail", "*"): "gmail.get_message",
+    ("calendar.get_events", "*"): "calendar.list_events",
+    ("calendar.add_event", "*"): "calendar.create_event",
+    ("calendar.remove_event", "*"): "calendar.delete_event",
+}
+
+
+def force_tool_plan(
+    output: OrchestratorOutput,
+    mandatory_tool_map: dict[tuple[str, str], list[str]],
+    gmail_intent_map: dict[str, list[str]],
+    *,
+    debug: bool = False,
+) -> OrchestratorOutput:
+    """Force mandatory tools based on route+intent (Issue #282).
+
+    Prevents LLM hallucination by ensuring queries always have tool_plan.
+    """
+    if output.ask_user:
+        return output
+
+    gmail_intent = (getattr(output, "gmail_intent", None) or "").strip().lower()
+    if output.confidence < 0.5 and not (
+        output.route == "gmail" and gmail_intent == "send"
+    ):
+        return output
+
+    if output.tool_plan:
+        return output
+
+    if output.route in ("smalltalk", "unknown"):
+        return output
+
+    if output.route == "gmail" and gmail_intent and gmail_intent != "none":
+        mandatory_tools = gmail_intent_map.get(gmail_intent)
+        if mandatory_tools:
+            if debug:
+                logger.debug("[FORCE_TOOL_PLAN] Gmail intent '%s', forcing: %s", gmail_intent, mandatory_tools)
+            return replace(output, tool_plan=mandatory_tools)
+
+    if output.calendar_intent in ("none", ""):
+        if output.route == "gmail":
+            mandatory_tools = ["gmail.list_messages"]
+            if debug:
+                logger.debug("[FORCE_TOOL_PLAN] Gmail fallback, forcing: %s", mandatory_tools)
+            return replace(output, tool_plan=mandatory_tools)
+        return output
+
+    if output.route == "gmail":
+        mandatory_tools = gmail_intent_map.get(gmail_intent)
+        if not mandatory_tools:
+            mandatory_tools = ["gmail.list_messages"]
+    else:
+        key = (output.route, output.calendar_intent)
+        mandatory_tools = mandatory_tool_map.get(key)
+
+    if not mandatory_tools:
+        if output.route == "system":
+            mandatory_tools = ["time.now"]
+        else:
+            return output
+
+    if debug:
+        logger.debug("[FORCE_TOOL_PLAN] Empty tool_plan, forcing: %s", mandatory_tools)
+
+    return replace(output, tool_plan=mandatory_tools)
+
+
+def sanitize_tool_plan(
+    output: OrchestratorOutput,
+    tool_remap: dict[tuple[str, str], str] | None = None,
+) -> OrchestratorOutput:
+    """Remap hallucinated or intent-mismatched tool names (Issue #870)."""
+    if not output.tool_plan:
+        return output
+
+    remap = tool_remap if tool_remap is not None else TOOL_REMAP
+
+    gmail_intent = (getattr(output, "gmail_intent", None) or "").strip().lower()
+    calendar_intent = (output.calendar_intent or "").strip().lower()
+    intent_key = gmail_intent or calendar_intent or "*"
+
+    changed = False
+    new_plan: list[str] = []
+    for tool_name in output.tool_plan:
+        replacement = remap.get((tool_name, intent_key))
+        if replacement is None:
+            replacement = remap.get((tool_name, "*"))
+
+        if replacement and replacement != tool_name:
+            logger.info(
+                "[SANITIZE] Remapping tool '%s' → '%s' (intent=%s)",
+                tool_name, replacement, intent_key,
+            )
+            new_plan.append(replacement)
+            changed = True
+        else:
+            new_plan.append(tool_name)
+
+    if not changed:
+        return output
+
+    return replace(output, tool_plan=new_plan)

--- a/src/bantz/brain/tool_result_summarizer.py
+++ b/src/bantz/brain/tool_result_summarizer.py
@@ -1,0 +1,259 @@
+"""Tool result summarization helpers (extracted from orchestrator_loop.py).
+
+Issue #941: Extracted to reduce orchestrator_loop.py from 2434 lines.
+Functions: _summarize_tool_result, _prepare_tool_results_for_finalizer,
+_build_tool_success_summary, _count_items, _extract_count, _extract_field.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _summarize_tool_result(result: Any, max_items: int = 5, max_chars: int = 500) -> str:
+    """Smart summarization of tool results that preserves structure.
+
+    Issue #353: Avoid naive string truncation that breaks JSON and loses
+    structured data. Instead, intelligently summarize based on type.
+    """
+    try:
+        if result is None:
+            return "None"
+
+        if isinstance(result, list):
+            total = len(result)
+            if total == 0:
+                return "[]"
+            preview = result[:max_items]
+            preview_json = json.dumps(preview, ensure_ascii=False)
+            if len(preview_json) > max_chars:
+                preview_json = preview_json[:max_chars] + "..."
+            if total > max_items:
+                return f"[{total} items, showing first {len(preview)}] {preview_json}"
+            return preview_json
+
+        if isinstance(result, dict):
+            if not result:
+                return "{}"
+            keys = list(result.keys())
+            result_json = json.dumps(result, ensure_ascii=False)
+            if len(result_json) > max_chars:
+                result_json = result_json[:max_chars] + "..."
+            return f"{{keys: {keys}}} {result_json}"
+
+        if isinstance(result, str):
+            if len(result) > max_chars:
+                return result[:max_chars] + f"... ({len(result)} chars total)"
+            return result
+
+        result_str = str(result)
+        if len(result_str) > max_chars:
+            return result_str[:max_chars] + "..."
+        return result_str
+
+    except Exception as e:
+        try:
+            s = str(result)
+            return s[:max_chars] if len(s) > max_chars else s
+        except Exception:
+            return f"<error serializing result: {e}>"
+
+
+def _prepare_tool_results_for_finalizer(
+    tool_results: list[dict[str, Any]],
+    max_tokens: int = 2000,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Prepare tool results for finalizer prompt with token budget control.
+
+    Issue #354: Finalizer prompts can overflow context when tool results are large.
+    """
+    if not tool_results:
+        return [], False
+
+    from bantz.llm.token_utils import estimate_tokens_json
+
+    finalizer_results = []
+    for r in tool_results:
+        finalizer_r = {
+            "tool": r.get("tool"),
+            "success": r.get("success"),
+            "result": r.get("raw_result"),
+            "error": r.get("error"),
+        }
+        finalizer_results.append(finalizer_r)
+
+    tokens = estimate_tokens_json(finalizer_results)
+    if tokens <= max_tokens:
+        return finalizer_results, False
+
+    logger.warning(
+        "[FINALIZER] Tool results (%d tokens) exceed budget (%d), using summaries",
+        tokens, max_tokens,
+    )
+
+    finalizer_results = []
+    for r in tool_results:
+        finalizer_r = {
+            "tool": r.get("tool"),
+            "success": r.get("success"),
+            "result": r.get("result_summary", ""),
+            "error": r.get("error"),
+        }
+        finalizer_results.append(finalizer_r)
+
+    tokens = estimate_tokens_json(finalizer_results)
+    if tokens <= max_tokens:
+        return finalizer_results, True
+
+    logger.warning(
+        "[FINALIZER] Tool result summaries (%d tokens) still exceed budget, truncating",
+        tokens,
+    )
+
+    truncated_results = []
+    for r in finalizer_results[:3]:
+        summary = str(r.get("result", ""))
+        if len(summary) > 200:
+            summary = summary[:200] + "..."
+        truncated_r = {
+            "tool": r.get("tool"),
+            "success": r.get("success"),
+            "result": summary,
+            "error": r.get("error"),
+        }
+        truncated_results.append(truncated_r)
+
+    return truncated_results, True
+
+
+def _count_items(raw: Any) -> int:
+    """Count items from a tool result."""
+    if isinstance(raw, list):
+        return len(raw)
+    if isinstance(raw, dict):
+        for key in ("events", "items", "messages", "results", "data", "contacts", "slots"):
+            val = raw.get(key)
+            if isinstance(val, list):
+                return len(val)
+        for key in ("count", "total", "total_count"):
+            val = raw.get(key)
+            if isinstance(val, (int, float)):
+                return int(val)
+    return 0
+
+
+def _extract_count(raw: Any) -> int | None:
+    """Extract a count value from a tool result."""
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    if isinstance(raw, dict):
+        for key in ("count", "total", "unread_count", "value"):
+            val = raw.get(key)
+            if isinstance(val, (int, float)):
+                return int(val)
+    return None
+
+
+def _extract_field(raw: Any, *field_names: str) -> str | None:
+    """Extract a string field from a tool result dict."""
+    if isinstance(raw, dict):
+        for name in field_names:
+            val = raw.get(name)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    return None
+
+
+def _build_tool_success_summary(tool_results: list[dict[str, Any]]) -> str:
+    """Build a tool-aware success summary instead of generic 'Tamamlandı efendim'.
+
+    Issue #370: When assistant_reply is empty after successful tool execution,
+    generate a meaningful summary from tool results.
+    """
+    if not tool_results:
+        return "Tamamlandı efendim."
+
+    parts: list[str] = []
+
+    for r in tool_results:
+        tool_name = str(r.get("tool") or "")
+        raw = r.get("raw_result")
+        success = r.get("success", False)
+
+        if not success:
+            continue
+
+        if tool_name in ("calendar.list_events", "calendar.find_free_slots"):
+            count = _count_items(raw)
+            if tool_name == "calendar.list_events":
+                if count == 0:
+                    parts.append("Takvimde etkinlik bulunamadı efendim.")
+                elif count == 1:
+                    parts.append("1 etkinlik bulundu efendim.")
+                else:
+                    parts.append(f"{count} etkinlik bulundu efendim.")
+            else:
+                if count == 0:
+                    parts.append("Uygun boş zaman dilimi bulunamadı efendim.")
+                else:
+                    parts.append(f"{count} uygun zaman dilimi bulundu efendim.")
+
+        elif tool_name == "calendar.create_event":
+            title = _extract_field(raw, "title", "summary")
+            if title:
+                parts.append(f"'{title}' etkinliği oluşturuldu efendim.")
+            else:
+                parts.append("Etkinlik oluşturuldu efendim.")
+
+        elif tool_name in ("gmail.list_messages", "gmail.smart_search"):
+            count = _count_items(raw)
+            if count == 0:
+                parts.append("Mesaj bulunamadı efendim.")
+            elif count == 1:
+                parts.append("1 mesaj bulundu efendim.")
+            else:
+                parts.append(f"{count} mesaj bulundu efendim.")
+
+        elif tool_name == "gmail.unread_count":
+            count = _extract_count(raw)
+            if count is not None:
+                if count == 0:
+                    parts.append("Okunmamış mesajınız yok efendim.")
+                else:
+                    parts.append(f"{count} okunmamış mesajınız var efendim.")
+            else:
+                parts.append("Okunmamış mesaj sayısı alındı efendim.")
+
+        elif tool_name in ("gmail.send", "gmail.send_to_contact", "gmail.send_draft"):
+            parts.append("Mail gönderildi efendim.")
+
+        elif tool_name == "gmail.get_message":
+            parts.append("Mesaj getirildi efendim.")
+
+        elif tool_name == "gmail.create_draft":
+            parts.append("Taslak oluşturuldu efendim.")
+
+        elif tool_name == "contacts.list":
+            count = _count_items(raw)
+            parts.append(f"{count} kişi listelendi efendim." if count > 0 else "Kayıtlı kişi bulunamadı efendim.")
+
+        elif tool_name == "contacts.resolve":
+            parts.append("Kişi bilgisi çözümlendi efendim.")
+
+        else:
+            tool_short = tool_name.split(".")[-1] if "." in tool_name else tool_name
+            parts.append(f"{tool_short} tamamlandı efendim.")
+
+    if not parts:
+        if len(tool_results) > 1:
+            return f"{len(tool_results)} işlem tamamlandı efendim."
+        return "Tamamlandı efendim."
+
+    if len(parts) == 1:
+        return parts[0]
+
+    return "\n".join(parts)


### PR DESCRIPTION
## Summary
Issue #941: orchestrator_loop.py was 2461 lines with 15+ responsibilities.

## Changes
Extracted ~626 lines into 4 focused modules:
- `tool_result_summarizer.py` — result summarization helpers
- `tool_plan_sanitizer.py` — TOOL_REMAP, force_tool_plan, sanitize_tool_plan
- `post_route_corrections.py` — email-send post-route correction + helpers
- `tool_param_builder.py` — build_tool_params with gmail field aliasing

orchestrator_loop.py retains thin wrappers and backward-compat re-exports.

## Files
- `src/bantz/brain/orchestrator_loop.py` (2461→1835 lines)
- `src/bantz/brain/tool_result_summarizer.py` (new)
- `src/bantz/brain/tool_plan_sanitizer.py` (new)
- `src/bantz/brain/post_route_corrections.py` (new)
- `src/bantz/brain/tool_param_builder.py` (new)

Closes #941