### PR TITLE
fix(preroute): skip AFFIRMATIVE/NEGATIVE matching during pending confirmations — closes #940

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -679,7 +679,10 @@ class OrchestratorLoop:
         _preroute_hint = None
 
         if self.config.enable_preroute:
-            preroute_match = self.prerouter.route(user_input)
+            preroute_match = self.prerouter.route(
+                user_input,
+                has_pending_confirmation=state.has_pending_confirmation(),
+            )
         else:
             from bantz.routing.preroute import PreRouteMatch
             preroute_match = PreRouteMatch.no_match()

--- a/src/bantz/routing/preroute.py
+++ b/src/bantz/routing/preroute.py
@@ -667,11 +667,15 @@ class PreRouter:
                 return True
         return False
     
-    def route(self, text: str) -> PreRouteMatch:
+    def route(self, text: str, *, has_pending_confirmation: bool = False) -> PreRouteMatch:
         """Try to pre-route the text.
         
         Args:
             text: User input text.
+            has_pending_confirmation: If True, skip AFFIRMATIVE/NEGATIVE
+                matching so the orchestrator's confirmation flow handles
+                'evet'/'hayır' instead of returning a local smalltalk
+                response.  (Issue #940)
         
         Returns:
             Match result with intent if detected.
@@ -680,6 +684,11 @@ class PreRouter:
         
         text = text.strip()
         if not text:
+            return PreRouteMatch.no_match()
+
+        # Issue #940: When a destructive-action confirmation is pending,
+        # let the orchestrator handle affirmative/negative tokens.
+        if has_pending_confirmation:
             return PreRouteMatch.no_match()
         
         # Try each rule


### PR DESCRIPTION
## Summary
Issue #940: PreRouter intercepted 'evet' as AFFIRMATIVE/smalltalk, returning 'Tamam efendim' instead of executing the confirmed destructive tool.

## Changes
- Add `has_pending_confirmation` kwarg to `PreRouter.route()`
- Return `no_match()` immediately when a confirmation is pending
- Pass `state.has_pending_confirmation()` from orchestrator

## Files
- `src/bantz/routing/preroute.py`
- `src/bantz/brain/orchestrator_loop.py`

Closes #940