### PR TITLE
fix(verify): retryable tool whitelist, valid empty results, robust safety check — closes #939

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -1104,18 +1104,8 @@ class OrchestratorLoop:
             return tool_results
 
         def _retry_fn(tool_name: str, original: dict[str, Any]) -> dict[str, Any]:
+            """Retry callback — safety/whitelist checks in verify_results."""
             try:
-                from bantz.tools.metadata import is_destructive, get_tool_risk
-
-                if is_destructive(tool_name):
-                    return original
-
-                # Safety-rejected results should never be retried: the args
-                # failed validation and retrying with empty/same params would
-                # bypass the safety guard.
-                if original.get("safety_rejected"):
-                    return original
-
                 tool = self.tools.get(tool_name)
                 if tool is None or tool.function is None:
                     return original


### PR DESCRIPTION
## Summary
Issue #939: verify_results_phase could double-execute destructive tools, treated valid empty query results as failures, and had fragile safety_rejected detection.

## Changes
1. **Retryable tool whitelist** — only idempotent read-only tools can be retried (replaces destructive blacklist)
2. **Valid empty tools** — `calendar.list_events` returning `[]` is not a failure; added `valid_empty_tools` to VerifyConfig
3. **Robust safety check** — `_is_safety_rejected()` checks multiple key patterns
4. **Cleaned orchestrator retry_fn** — destructive/safety logic centralized in verify_results.py

## Files
- `src/bantz/brain/verify_results.py`
- `src/bantz/brain/orchestrator_loop.py`

Closes #939