### PR TITLE
fix(preroute): extract date/time slots in calendar_list rule (#948)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -784,6 +784,10 @@ class OrchestratorLoop:
                 "preroute_confidence": round(preroute_match.confidence, 2),
                 "preroute_rule": preroute_match.rule_name,
             }
+            # Issue #948: Inject extracted slots from PreRouter into hint
+            # CalendarListRule extracts date/time/window_hint via nlu/slots.py
+            if preroute_match.extracted:
+                _preroute_hint["extracted"] = preroute_match.extracted
             self.event_bus.publish("preroute.hint", {
                 "intent": preroute_match.intent.value,
                 "confidence": preroute_match.confidence,


### PR DESCRIPTION
## Summary
PreRouter matched 'yarınki toplantılarım' as calendar_list but never extracted the date slot — LLM had to re-extract from scratch.

## Changes
- **preroute.py**: New `CalendarListRule(PatternRule)` with `match()` override that:
  - Extracts `window_hint` (today/tomorrow/week/morning/evening/afternoon) from Turkish
  - Runs `nlu/slots.extract_time()` to get concrete `date` and `time`
- **orchestrator_loop.py**: Preroute hint now includes `extracted` dict when present

## Impact
Calendar queries with temporal references now pass pre-extracted dates to the 3B model, e.g.:
```json
{"preroute_intent": "calendar_list", "extracted": {"window_hint": "tomorrow", "date": "2026-02-13"}}
```

Closes #948