### PR TITLE
fix(router): add generic intent property to OrchestratorOutput (#944)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -1853,11 +1853,20 @@ class OrchestratorLoop:
     # =========================================================================
     
     def _extract_user_intent(self, user_input: str, output: OrchestratorOutput) -> str:
-        """Extract concise user intent (1-3 words)."""
-        if output.route == "calendar":
-            return f"asked about {output.calendar_intent}"
-        elif output.route == "smalltalk":
-            # Check for common patterns
+        """Extract concise user intent (1-3 words).
+
+        Issue #944: Uses the generic `intent` property so all routes are covered.
+        """
+        route = (output.route or "").lower()
+        intent = output.intent  # generic accessor
+
+        if route == "calendar":
+            return f"asked about {intent}"
+        elif route == "gmail":
+            return f"email {intent}"
+        elif route == "system":
+            return f"system {intent}"
+        elif route == "smalltalk":
             if any(word in user_input.lower() for word in ["merhaba", "selam", "hey", "nasılsın"]):
                 return "greeted"
             elif any(word in user_input.lower() for word in ["kendini tanıt", "kimsin"]):
@@ -1865,7 +1874,7 @@ class OrchestratorLoop:
             else:
                 return "casual chat"
         else:
-            return "unclear request"
+            return f"request ({intent})"
     
     def _extract_action_taken(self, output: OrchestratorOutput) -> str:
         """Extract action taken (1-3 words)."""


### PR DESCRIPTION
## Summary
`calendar_intent` was misused as a generic intent field for all routes, causing bugs like gmail/system always returning 'unclear request' in memory summaries.

## Changes
- **llm_router.py**: New `@property intent` on `OrchestratorOutput`:
  - calendar → `calendar_intent`
  - gmail → `gmail_intent`
  - smalltalk → `'chat'`
  - unknown → `'unknown'`
  - system → `calendar_intent` (backward compat)
- **orchestrator_loop.py**: `_extract_user_intent()` now uses `output.intent` and covers gmail (`'email send'`), system (`'system time'`) properly
- `calendar_intent` field unchanged — full backward compatibility

Closes #944