### PR TITLE
refactor: move dataclasses.replace to module-level imports (#912)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -21,7 +21,7 @@ import logging
 import os
 import re
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any, Optional, Protocol
 
 logger = logging.getLogger(__name__)
@@ -1786,8 +1786,6 @@ class HybridJarvisLLMOrchestrator:
         if planned.ask_user and planned.question:
             # Prefer explicit clarifying question.
             if not planned.assistant_reply:
-                from dataclasses import replace
-
                 return replace(planned, assistant_reply=planned.question)
             return planned
 
@@ -1857,8 +1855,6 @@ class HybridJarvisLLMOrchestrator:
                 reply = self._finalizer.complete_text(prompt=finalizer_prompt)
             reply = str(reply or "").strip()
             if reply:
-                from dataclasses import replace
-
                 return replace(planned, assistant_reply=reply)
         except Exception as exc:
             logger.warning("[HYBRID] Finalizer error (swallowed): %s", exc)

--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -15,7 +15,7 @@ import json
 import logging
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Optional
 
 from bantz.agent.tools import ToolRegistry
@@ -432,8 +432,7 @@ class OrchestratorLoop:
                             gen_result = mgr.generate_skill(gap)
                             if gen_result.success and gen_result.skill:
                                 skill = gen_result.skill
-                                from dataclasses import replace as _dc_replace
-                                orchestrator_output = _dc_replace(
+                                orchestrator_output = replace(
                                     orchestrator_output,
                                     assistant_reply=(
                                         f"Bu isteği karşılayacak bir yeteneğim yok, ama "


### PR DESCRIPTION
Issue #912: `from dataclasses import replace` was imported inside per-turn functions. Moved to module-level in orchestrator_loop.py and llm_router.py.

Closes #912