### PR TITLE
fix: add gmail_intent and gmail to ORCHESTRATOR_FALLBACK_DEFAULTS (#911)

### DIFF
--- a/src/bantz/brain/json_protocol.py
+++ b/src/bantz/brain/json_protocol.py
@@ -689,7 +689,9 @@ ORCHESTRATOR_OUTPUT_SCHEMA: dict[str, Any] = {
 ORCHESTRATOR_FALLBACK_DEFAULTS: dict[str, Any] = {
     "route": "smalltalk",
     "calendar_intent": "none",
+    "gmail_intent": "none",
     "slots": {},
+    "gmail": {},
     "confidence": 0.0,
     "tool_plan": [],
     "assistant_reply": "",


### PR DESCRIPTION
Closes #911

Adds missing `gmail_intent` and `gmail` keys to `ORCHESTRATOR_FALLBACK_DEFAULTS` in `json_protocol.py`.

Without these keys, any fallback recovery for Gmail routes would produce an `OrchestratorOutput` missing the gmail fields, causing downstream KeyError or silent data loss.