### PR TITLE
fix: correct Gmail install hint to .[google] extra (#910)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ calendar = [
 	"google-auth-oauthlib>=1.0.0",
 	"google-api-python-client>=2.0.0",
 ]
+google = [
+	"google-auth>=2.0.0",
+	"google-auth-oauthlib>=1.0.0",
+	"google-api-python-client>=2.0.0",
+]
 voice = [
 	"requests>=2.31.0",
 	"numpy>=1.24.0",

--- a/src/bantz/tools/gmail_tools.py
+++ b/src/bantz/tools/gmail_tools.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 # ── Issue #870: Türkçe hata mesajı çevirici ─────────────────────────
 _GMAIL_ERROR_TR_MAP: list[tuple[str, str]] = [
     ("Google client secret not found", "Google hesap bilgileri bulunamadı. Lütfen BANTZ_GOOGLE_CLIENT_SECRET ayarını yapın."),
-    ("Gmail dependencies are not installed", "Gmail bağımlılıkları yüklü değil. pip install -e '.[calendar]' ile yükleyin."),
+    ("Gmail dependencies are not installed", "Gmail bağımlılıkları yüklü değil. pip install -e '.[google]' ile yükleyin."),
     ("HttpError 401", "Gmail yetkilendirmesi başarısız. Lütfen tekrar giriş yapın."),
     ("HttpError 403", "Gmail erişim izni yok. Lütfen izinleri kontrol edin."),
     ("HttpError 404", "Belirtilen e-posta bulunamadı."),


### PR DESCRIPTION
Closes #910

- Changes error hint in `gmail_tools.py` from `.[calendar]` to `.[google]`
- Adds new `google` optional-dependency extra in `pyproject.toml` with the same Google API deps (google-auth, google-auth-oauthlib, google-api-python-client)