### PR TITLE
fix: remove ML deps from base requirements.txt (#909)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-autoawq>=0.2.6
+# Core runtime dependencies (lightweight).
+# For ML/LLM deps (torch, vllm, autoawq) see requirements-llm.txt
+# or install via:  pip install -e ".[llm]"
 openai>=1.40.0
 requests>=2.31.0
-torch>=2.4.0
-transformers>=4.45.0
-vllm>=0.6.0
 websockets>=11.0.0


### PR DESCRIPTION
Closes #909

Removes autoawq, torch, transformers, vllm from `requirements.txt`. Keeps only core lightweight deps (openai, requests, websockets).

ML deps remain available via:
- `requirements-llm.txt`
- `pip install -e '.[llm]'`