### PR TITLE
fix: add missing deps — vosk, pydantic, aiohttp (#859)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 	"requests>=2.31.0",
 	"openai>=1.40.0",
 	"pydantic>=2.0.0",
+	"aiohttp>=3.9.0",
 ]
 
 [project.optional-dependencies]
@@ -50,6 +51,7 @@ voice = [
 	"pynput>=1.7.6",
 	"rapidfuzz>=3.6.0",
 	"openwakeword>=0.6.0",
+	"vosk>=0.3.45",
 ]
 system = [
 	"dbus-next>=0.2.3",
@@ -105,6 +107,7 @@ all = [
 	"pynput>=1.7.6",
 	"rapidfuzz>=3.6.0",
 	"openwakeword>=0.6.0",
+	"vosk>=0.3.45",
 	# system/ui/vision/security
 	"dbus-next>=0.2.3",
 	"PyQt5>=5.15.0",
@@ -115,6 +118,8 @@ all = [
 	"pytesseract>=0.3.10",
 	"google-auth>=2.0.0",
 	"cryptography>=42.0.0",
+	# async http
+	"aiohttp>=3.9.0",
 ]
 
 [project.scripts]

--- a/requirements-voice.txt
+++ b/requirements-voice.txt
@@ -1,6 +1,7 @@
 faster-whisper>=1.0.0
 numpy>=1.24.0
 openwakeword>=0.6.0
+vosk>=0.3.45
 pynput>=1.7.6
 rapidfuzz>=3.6.0
 requests>=2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 # Core runtime dependencies (lightweight).
 # For ML/LLM deps (torch, vllm, autoawq) see requirements-llm.txt
 # or install via:  pip install -e ".[llm]"
+aiohttp>=3.9.0
 openai>=1.40.0
+pydantic>=2.0.0
 requests>=2.31.0
 websockets>=11.0.0


### PR DESCRIPTION
Closes #859

- `pydantic>=2.0.0` added to `requirements.txt` (already in pyproject.toml core deps)
- `aiohttp>=3.9.0` added to `requirements.txt` + pyproject.toml core deps + `[all]` extra
- `vosk>=0.3.45` added to `requirements-voice.txt` + pyproject.toml `[voice]` extra + `[all]` extra