### PR TITLE
fix: policy deny_patterns — remove pipe/semicolon, add dangerous combos (#855)

### DIFF
--- a/config/policy.json
+++ b/config/policy.json
@@ -6,9 +6,10 @@
     "\\bshutdown\\b",
     "\\breboot\\b",
     "\\bpoweroff\\b",
-    "curl\\s+.*\\|\\s*sh",
-    "\\|",
-    ";"
+    "curl\\s+.*\\|\\s*(?:ba)?sh",
+    "wget\\s+.*\\|\\s*(?:ba)?sh",
+    "curl\\s+.*\\|\\s*python",
+    "wget\\s+.*\\|\\s*python"
   ],
   "confirm_patterns": [
     "\\bsudo\\b",
@@ -24,7 +25,11 @@
     "&"
   ],
   "deny_even_if_confirmed_patterns": [
-    "\\bsudo\\b"
+    "\\bsudo\\b",
+    "\\bsu\\b",
+    "\\bdoas\\b",
+    "\\bpkexec\\b",
+    "\\bnsenter\\b"
   ],
   "intent_levels": {
     "open_browser": "allow",


### PR DESCRIPTION
Closes #855

**Problem:** Blanket `\|` and `;` in `deny_patterns` blocked legitimate commands like `ls | grep foo` and `echo hello; echo world`.

**Changes:**
- **Removed** `\|` (pipe) and `;` (semicolon) from `deny_patterns`
- **Added** targeted dangerous pipe patterns: `curl|sh`, `curl|bash`, `wget|sh`, `wget|bash`, `curl|python`, `wget|python`
- **Expanded** `deny_even_if_confirmed_patterns` with `su`, `doas`, `pkexec`, `nsenter` (privilege escalation commands alongside sudo)