### PR TITLE
fix: replace bare except: with except Exception: (#848)

### DIFF
--- a/src/bantz/browser/firefox.py
+++ b/src/bantz/browser/firefox.py
@@ -324,7 +324,7 @@ def _get_running_profile() -> Optional[str]:
                     # If lock was modified in last 60 seconds, likely active
                     if now - mtime < 60:
                         return item.name
-                except:
+                except Exception:
                     pass
     
     # If Firefox is running but we can't determine profile, assume it's fine

--- a/src/bantz/cli.py
+++ b/src/bantz/cli.py
@@ -51,7 +51,7 @@ def get_terminal_size() -> tuple[int, int]:
     try:
         size = shutil.get_terminal_size()
         return size.columns, size.lines
-    except:
+    except Exception:
         return 80, 24
 
 

--- a/src/bantz/server.py
+++ b/src/bantz/server.py
@@ -925,14 +925,14 @@ class BantzServer:
         try:
             reminder_manager = get_reminder_manager()
             reminder_manager.stop_scheduler()
-        except:
+        except Exception:
             pass
 
         # Close browser
         from bantz.browser.controller import get_controller
         try:
             get_controller().close()
-        except:
+        except Exception:
             pass
 
         print("\n👋 Bantz Server kapatıldı.")
@@ -996,7 +996,7 @@ class BantzServer:
             error_response = {"ok": False, "text": f"Server hatası: {e}"}
             try:
                 self._send_framed(conn, json.dumps(error_response).encode("utf-8"))
-            except:
+            except Exception:
                 pass
         finally:
             conn.close()
@@ -1059,7 +1059,7 @@ def is_server_running(session_name: str = DEFAULT_SESSION) -> bool:
     try:
         response = send_to_server("__status__", session_name, timeout=2.0)
         return response.get("ok", False)
-    except:
+    except Exception:
         return False
 
 

--- a/src/bantz/ui/jarvis_panel.py
+++ b/src/bantz/ui/jarvis_panel.py
@@ -875,7 +875,7 @@ class JarvisPanel(QWidget):
         self.hide()
         try:
             self.fade_animation.finished.disconnect(self._on_fade_out_done)
-        except:
+        except Exception:
             pass
     
     def _do_show(self):

--- a/src/bantz/ui/streaming/manager.py
+++ b/src/bantz/ui/streaming/manager.py
@@ -371,7 +371,7 @@ class StreamingManager:
         """
         try:
             self._event_queue.put_nowait(event)
-        except:
+        except Exception:
             pass  # Queue full, drop event
     
     def on_event(self, event_type: EventType, callback: Callable[[ActionEvent], None]):


### PR DESCRIPTION
Closes #848

## Changes
All 8 bare `except:` clauses replaced with `except Exception:` across 5 files:

| File | Context |
|------|---------|
| `cli.py` | `get_terminal_size` fallback |
| `server.py` | shutdown handler (scheduler stop) |
| `server.py` | shutdown handler (browser close) |
| `server.py` | error response send |
| `server.py` | `is_server_running` |
| `browser/firefox.py` | lock file stat |
| `ui/jarvis_panel.py` | disconnect signal |
| `ui/streaming/manager.py` | event queue put |

This prevents `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` from being silently swallowed, enabling clean `Ctrl+C` shutdown.