### PR TITLE
feat: real Git-based plugin registry (#852)

### DIFF
--- a/src/bantz/plugins/registry.py
+++ b/src/bantz/plugins/registry.py
@@ -1,22 +1,30 @@
 """
 Skill Registry.
 
-Online registry interface for discovering and installing plugins:
-- Search for plugins
-- Install from registry
-- Update installed plugins
+Real registry interface for discovering and installing plugins:
+- Install from Git URL (clone)
+- Update installed plugins (git pull / checkout tag)
+- Version control via git tags
+- Local manifest (skill.yaml) based discovery
 """
 
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+import json
 import logging
+import os
+import shutil
+import subprocess
 from datetime import datetime
 from enum import Enum, auto
 
 from bantz.plugins.base import PluginMetadata, PluginPermission
 
 logger = logging.getLogger(__name__)
+
+# Manifest filename expected inside each skill repository
+SKILL_MANIFEST = "skill.yaml"
 
 
 class RegistrySource(Enum):
@@ -161,155 +169,300 @@ class RegistrySearchResult:
 
 class SkillRegistry:
     """
-    Online registry of available plugins.
-    
-    Provides:
-    - Search for plugins
-    - Install from registry
-    - Update installed plugins
-    - Check for updates
-    
-    Example:
+    Git-based skill registry.
+
+    Provides real plugin installation via ``git clone``, version pinning
+    through git tags, and update via ``git pull`` / ``git checkout``.
+
+    Example::
+
         registry = SkillRegistry()
-        
-        # Search for plugins
-        results = registry.search("music")
-        
-        # Install a plugin
-        registry.install("spotify")
-        
-        # Update a plugin
-        registry.update("spotify")
-    
-    Note: Currently uses mock data. In production, this would
-    connect to an actual registry server.
+
+        # Install from Git URL
+        registry.install_from_git(
+            "https://github.com/bantz/plugin-spotify",
+            version="v1.0.0",
+        )
+
+        # Update to latest
+        registry.update("plugin-spotify")
+
+        # List installed
+        print(registry.get_installed())
     """
-    
-    # Future: Real registry URL
+
+    # Future: Real registry URL for online catalogue
     REGISTRY_URL = "https://registry.bantz.dev/api/v1"
-    
+
+    # Index file that caches installed-plugin metadata locally
+    _INDEX_FILE = "installed.json"
+
     def __init__(
         self,
         install_dir: Optional[Path] = None,
         cache_dir: Optional[Path] = None,
     ):
+        config_home = os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config"))
+        cache_home = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
+
+        self.install_dir = Path(install_dir) if install_dir else Path(config_home) / "bantz" / "plugins"
+        self.cache_dir = Path(cache_dir) if cache_dir else Path(cache_home) / "bantz" / "registry"
+
+        self._index: Dict[str, Dict[str, Any]] = {}
+        self._load_index()
+
+    # ── index persistence ────────────────────────────────────────
+
+    def _index_path(self) -> Path:
+        return self.install_dir / self._INDEX_FILE
+
+    def _load_index(self) -> None:
+        path = self._index_path()
+        if path.exists():
+            try:
+                self._index = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                self._index = {}
+
+    def _save_index(self) -> None:
+        self.install_dir.mkdir(parents=True, exist_ok=True)
+        self._index_path().write_text(json.dumps(self._index, indent=2, default=str))
+
+    # ── git helpers ──────────────────────────────────────────────
+
+    @staticmethod
+    def _run_git(args: List[str], cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
+        """Run a git command and return the result."""
+        cmd = ["git"] + args
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    @staticmethod
+    def _repo_name_from_url(url: str) -> str:
+        """Extract repository name from a Git URL."""
+        name = url.rstrip("/").rsplit("/", 1)[-1]
+        if name.endswith(".git"):
+            name = name[:-4]
+        return name
+
+    def _resolve_version(self, plugin_dir: Path, version: Optional[str]) -> Optional[str]:
+        """Checkout a specific tag/version if requested."""
+        if not version:
+            return None
+        result = self._run_git(["checkout", version], cwd=plugin_dir)
+        if result.returncode != 0:
+            logger.warning("Could not checkout version %s: %s", version, result.stderr.strip())
+            return None
+        return version
+
+    # ── public API ───────────────────────────────────────────────
+
+    def install_from_git(
+        self,
+        url: str,
+        version: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> bool:
         """
-        Initialize skill registry.
-        
+        Install a skill by cloning its Git repository.
+
         Args:
-            install_dir: Directory to install plugins
-            cache_dir: Directory to cache registry data
+            url: Git remote URL (https or ssh).
+            version: Git tag / branch to pin (e.g. ``"v1.0.0"``).
+            name: Override directory name (default: derived from URL).
+
+        Returns:
+            ``True`` on success.
         """
-        import os
-        
-        if install_dir is None:
-            config_home = os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
-            install_dir = Path(config_home) / "bantz" / "plugins"
-        
-        if cache_dir is None:
-            cache_home = os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")
-            cache_dir = Path(cache_home) / "bantz" / "registry"
-        
-        self.install_dir = Path(install_dir)
-        self.cache_dir = Path(cache_dir)
-        
-        self._mock_entries = self._create_mock_entries()
-    
-    def _create_mock_entries(self) -> List[RegistryEntry]:
-        """Create mock registry entries for development."""
-        return [
-            RegistryEntry(
-                name="spotify",
-                version="1.0.0",
-                author="Bantz",
-                description="Spotify müzik kontrolü - oynat, duraklat, sonraki/önceki şarkı",
-                source=RegistrySource.OFFICIAL,
-                repository="https://github.com/bantz/plugin-spotify",
-                downloads=1523,
-                rating=4.5,
-                ratings_count=42,
-                tags=["music", "spotify", "media"],
-                permissions=[PluginPermission.NETWORK],
-                icon="🎵",
-                verified=True,
-            ),
-            RegistryEntry(
-                name="notion",
-                version="1.2.0",
-                author="Bantz",
-                description="Notion entegrasyonu - not oluştur, düzenle, ara",
-                source=RegistrySource.OFFICIAL,
-                repository="https://github.com/bantz/plugin-notion",
-                downloads=892,
-                rating=4.3,
-                ratings_count=28,
-                tags=["notes", "notion", "productivity"],
-                permissions=[PluginPermission.NETWORK],
-                icon="📝",
-                verified=True,
-            ),
-            RegistryEntry(
-                name="home-assistant",
-                version="2.0.0",
-                author="Community",
-                description="Home Assistant akıllı ev kontrolü",
-                source=RegistrySource.COMMUNITY,
-                repository="https://github.com/community/bantz-ha",
-                downloads=567,
-                rating=4.7,
-                ratings_count=19,
-                tags=["smart-home", "iot", "automation"],
-                permissions=[PluginPermission.NETWORK],
-                icon="🏠",
-                verified=False,
-            ),
-            RegistryEntry(
-                name="calendar",
-                version="1.1.0",
-                author="Bantz",
-                description="Takvim yönetimi - etkinlik oluştur, hatırlat",
-                source=RegistrySource.OFFICIAL,
-                repository="https://github.com/bantz/plugin-calendar",
-                downloads=1245,
-                rating=4.6,
-                ratings_count=35,
-                tags=["calendar", "events", "productivity"],
-                permissions=[PluginPermission.CALENDAR],
-                icon="📅",
-                verified=True,
-            ),
-            RegistryEntry(
-                name="todoist",
-                version="1.0.0",
-                author="Community",
-                description="Todoist görev yönetimi",
-                source=RegistrySource.COMMUNITY,
-                repository="https://github.com/user/bantz-todoist",
-                downloads=234,
-                rating=4.1,
-                ratings_count=8,
-                tags=["tasks", "todoist", "productivity"],
-                permissions=[PluginPermission.NETWORK],
-                icon="✅",
-                verified=False,
-            ),
-            RegistryEntry(
-                name="weather",
-                version="1.0.0",
-                author="Bantz",
-                description="Hava durumu sorgulama",
-                source=RegistrySource.OFFICIAL,
-                repository="https://github.com/bantz/plugin-weather",
-                downloads=2156,
-                rating=4.8,
-                ratings_count=67,
-                tags=["weather", "forecast"],
-                permissions=[PluginPermission.NETWORK, PluginPermission.LOCATION],
-                icon="🌤️",
-                verified=True,
-            ),
-        ]
-    
+        repo_name = name or self._repo_name_from_url(url)
+        plugin_dir = self.install_dir / repo_name
+
+        if plugin_dir.exists():
+            logger.warning("Plugin already installed at %s — use update() instead", plugin_dir)
+            return False
+
+        self.install_dir.mkdir(parents=True, exist_ok=True)
+
+        result = self._run_git(["clone", url, str(plugin_dir)])
+        if result.returncode != 0:
+            logger.error("git clone failed: %s", result.stderr.strip())
+            return False
+
+        resolved = self._resolve_version(plugin_dir, version)
+
+        # Read manifest if available
+        metadata = self._read_manifest(plugin_dir)
+
+        self._index[repo_name] = {
+            "url": url,
+            "version": resolved or "latest",
+            "installed_at": datetime.utcnow().isoformat(),
+            "source": RegistrySource.GIT.name,
+            "metadata": metadata,
+        }
+        self._save_index()
+
+        logger.info("Installed %s from %s (version=%s)", repo_name, url, resolved or "latest")
+        return True
+
+    def install(self, name: str, version: Optional[str] = None) -> bool:
+        """
+        Install a plugin by name.
+
+        Looks up the name in the local index or known entries.
+        Falls back to ``install_from_git`` if a repository URL is found.
+        """
+        entry = self.get(name)
+        if entry and entry.repository:
+            return self.install_from_git(entry.repository, version=version, name=name)
+
+        logger.error("No repository URL found for plugin: %s", name)
+        return False
+
+    def uninstall(self, name: str) -> bool:
+        """Remove an installed plugin."""
+        plugin_dir = self.install_dir / name
+        if not plugin_dir.exists():
+            logger.warning("Plugin not installed: %s", name)
+            return False
+
+        shutil.rmtree(plugin_dir)
+        self._index.pop(name, None)
+        self._save_index()
+
+        logger.info("Uninstalled plugin: %s", name)
+        return True
+
+    def update(self, name: str, version: Optional[str] = None) -> bool:
+        """
+        Update an installed plugin via ``git pull`` or tag checkout.
+
+        Args:
+            name: Plugin directory name.
+            version: Pin a specific tag, or ``None`` to pull latest.
+        """
+        plugin_dir = self.install_dir / name
+        if not plugin_dir.exists():
+            logger.error("Plugin not installed: %s", name)
+            return False
+
+        if version:
+            result = self._run_git(["fetch", "--tags"], cwd=plugin_dir)
+            if result.returncode != 0:
+                logger.error("git fetch failed: %s", result.stderr.strip())
+                return False
+            result = self._run_git(["checkout", version], cwd=plugin_dir)
+        else:
+            result = self._run_git(["pull", "--ff-only"], cwd=plugin_dir)
+
+        if result.returncode != 0:
+            logger.error("git update failed for %s: %s", name, result.stderr.strip())
+            return False
+
+        # Refresh metadata
+        metadata = self._read_manifest(plugin_dir)
+        if name in self._index:
+            self._index[name]["version"] = version or "latest"
+            self._index[name]["metadata"] = metadata
+            self._save_index()
+
+        logger.info("Updated %s to %s", name, version or "latest")
+        return True
+
+    def check_updates(self) -> List[str]:
+        """
+        Return names of installed plugins that have upstream changes.
+
+        Performs ``git fetch`` + ``git rev-list`` comparison.
+        """
+        outdated: List[str] = []
+
+        if not self.install_dir.exists():
+            return outdated
+
+        for name in list(self._index):
+            plugin_dir = self.install_dir / name
+            if not plugin_dir.exists():
+                continue
+
+            fetch = self._run_git(["fetch"], cwd=plugin_dir)
+            if fetch.returncode != 0:
+                continue
+
+            diff = self._run_git(
+                ["rev-list", "HEAD..@{u}", "--count"],
+                cwd=plugin_dir,
+            )
+            if diff.returncode == 0 and diff.stdout.strip() not in ("0", ""):
+                outdated.append(name)
+
+        return outdated
+
+    def get_installed(self) -> List[str]:
+        """Get list of installed plugin names."""
+        installed = []
+        if self.install_dir.exists():
+            for item in self.install_dir.iterdir():
+                if item.is_dir() and (item / "plugin.py").exists():
+                    installed.append(item.name)
+        return installed
+
+    def is_installed(self, name: str) -> bool:
+        """Check if a plugin is installed."""
+        return (self.install_dir / name / "plugin.py").exists()
+
+    def get_installed_version(self, name: str) -> Optional[str]:
+        """Return the pinned version of an installed plugin, or None."""
+        info = self._index.get(name)
+        return info["version"] if info else None
+
+    def list_versions(self, name: str) -> List[str]:
+        """
+        List available git tags for an installed plugin.
+
+        Returns:
+            Sorted list of tag names (newest first).
+        """
+        plugin_dir = self.install_dir / name
+        if not plugin_dir.exists():
+            return []
+
+        self._run_git(["fetch", "--tags"], cwd=plugin_dir)
+        result = self._run_git(
+            ["tag", "--sort=-creatordate"],
+            cwd=plugin_dir,
+        )
+        if result.returncode != 0:
+            return []
+
+        return [t.strip() for t in result.stdout.splitlines() if t.strip()]
+
+    # ── manifest / metadata ──────────────────────────────────────
+
+    @staticmethod
+    def _read_manifest(plugin_dir: Path) -> Optional[Dict[str, Any]]:
+        """Read skill.yaml from a plugin directory if present."""
+        manifest = plugin_dir / SKILL_MANIFEST
+        if not manifest.exists():
+            return None
+
+        try:
+            import yaml  # optional dep
+            return yaml.safe_load(manifest.read_text())
+        except ImportError:
+            logger.debug("PyYAML not installed — skipping manifest parsing")
+            return None
+        except Exception as exc:
+            logger.warning("Failed to read manifest %s: %s", manifest, exc)
+            return None
+
+    # ── catalogue / search (uses local index + cached entries) ───
+
     def search(
         self,
         query: str = "",
@@ -319,234 +472,106 @@ class SkillRegistry:
         per_page: int = 20,
     ) -> RegistrySearchResult:
         """
-        Search for plugins in the registry.
-        
-        Args:
-            query: Search query
-            tags: Filter by tags
-            verified_only: Only show verified plugins
-            page: Page number
-            per_page: Results per page
-            
-        Returns:
-            Search results
+        Search installed & cached catalogue entries.
+
+        Currently operates on installed plugins only.
+        When ``registry.bantz.dev`` is live, this will also query the API.
         """
-        results = self._mock_entries.copy()
-        
-        # Filter by query
+        entries = self._build_entries_from_index()
+
         if query:
-            query_lower = query.lower()
-            results = [
-                e for e in results
-                if query_lower in e.name.lower() or
-                   query_lower in e.description.lower() or
-                   any(query_lower in tag.lower() for tag in e.tags)
+            q = query.lower()
+            entries = [
+                e for e in entries
+                if q in e.name.lower() or q in e.description.lower()
+                or any(q in t.lower() for t in e.tags)
             ]
-        
-        # Filter by tags
         if tags:
-            tags_lower = [t.lower() for t in tags]
-            results = [
-                e for e in results
-                if any(t.lower() in tags_lower for t in e.tags)
-            ]
-        
-        # Filter verified
+            tl = [t.lower() for t in tags]
+            entries = [e for e in entries if any(t.lower() in tl for t in e.tags)]
         if verified_only:
-            results = [e for e in results if e.verified]
-        
-        # Sort by downloads
-        results.sort(key=lambda e: e.downloads, reverse=True)
-        
-        # Paginate
-        total = len(results)
+            entries = [e for e in entries if e.verified]
+
+        total = len(entries)
         start = (page - 1) * per_page
-        end = start + per_page
-        results = results[start:end]
-        
+        entries = entries[start:start + per_page]
+
         return RegistrySearchResult(
-            entries=results,
-            total=total,
-            page=page,
-            per_page=per_page,
-            query=query,
+            entries=entries, total=total, page=page, per_page=per_page, query=query,
         )
-    
+
     def get(self, name: str) -> Optional[RegistryEntry]:
-        """
-        Get a specific plugin from the registry.
-        
-        Args:
-            name: Plugin name
-            
-        Returns:
-            Registry entry or None
-        """
-        for entry in self._mock_entries:
-            if entry.name == name:
-                return entry
-        return None
-    
-    def install(self, name: str, version: Optional[str] = None) -> bool:
-        """
-        Install a plugin from the registry.
-        
-        Args:
-            name: Plugin name
-            version: Specific version (or latest)
-            
-        Returns:
-            True if installed successfully
-        """
-        entry = self.get(name)
-        if not entry:
-            logger.error(f"Plugin not found: {name}")
-            return False
-        
-        # In production, this would:
-        # 1. Download plugin from repository/URL
-        # 2. Verify signatures
-        # 3. Extract to install_dir
-        # 4. Run post-install hooks
-        
-        logger.info(f"Would install {name} v{entry.version} to {self.install_dir}")
-        
-        # Mock: Create plugin directory
-        plugin_dir = self.install_dir / name
-        plugin_dir.mkdir(parents=True, exist_ok=True)
-        
-        return True
-    
-    def uninstall(self, name: str) -> bool:
-        """
-        Uninstall a plugin.
-        
-        Args:
-            name: Plugin name
-            
-        Returns:
-            True if uninstalled successfully
-        """
-        plugin_dir = self.install_dir / name
-        
-        if not plugin_dir.exists():
-            logger.warning(f"Plugin not installed: {name}")
-            return False
-        
-        # In production, this would:
-        # 1. Run pre-uninstall hooks
-        # 2. Remove plugin directory
-        # 3. Clean up config
-        
-        import shutil
-        shutil.rmtree(plugin_dir)
-        
-        logger.info(f"Uninstalled plugin: {name}")
-        return True
-    
-    def update(self, name: str) -> bool:
-        """
-        Update an installed plugin.
-        
-        Args:
-            name: Plugin name
-            
-        Returns:
-            True if updated successfully
-        """
-        entry = self.get(name)
-        if not entry:
-            logger.error(f"Plugin not found: {name}")
-            return False
-        
-        # Check if installed
-        plugin_dir = self.install_dir / name
-        if not plugin_dir.exists():
-            logger.error(f"Plugin not installed: {name}")
-            return False
-        
-        # In production, this would:
-        # 1. Check for newer version
-        # 2. Download new version
-        # 3. Backup current version
-        # 4. Install new version
-        # 5. Run migration hooks
-        
-        logger.info(f"Would update {name} to v{entry.version}")
-        return True
-    
-    def check_updates(self) -> List[RegistryEntry]:
-        """
-        Check for available updates.
-        
-        Returns:
-            List of plugins with available updates
-        """
-        updates = []
-        
-        # Check each installed plugin
-        if self.install_dir.exists():
-            for plugin_dir in self.install_dir.iterdir():
-                if not plugin_dir.is_dir():
-                    continue
-                
-                name = plugin_dir.name
-                entry = self.get(name)
-                
-                if entry:
-                    # In production, compare versions
-                    # For now, just return all as having updates
-                    updates.append(entry)
-        
-        return updates
-    
-    def get_installed(self) -> List[str]:
-        """Get list of installed plugin names."""
-        installed = []
-        
-        if self.install_dir.exists():
-            for item in self.install_dir.iterdir():
-                if item.is_dir() and (item / "plugin.py").exists():
-                    installed.append(item.name)
-        
-        return installed
-    
-    def is_installed(self, name: str) -> bool:
-        """Check if a plugin is installed."""
-        return (self.install_dir / name / "plugin.py").exists()
-    
-    def get_popular(self, limit: int = 10) -> List[RegistryEntry]:
-        """Get most popular plugins."""
-        entries = self._mock_entries.copy()
-        entries.sort(key=lambda e: e.downloads, reverse=True)
-        return entries[:limit]
-    
-    def get_recent(self, limit: int = 10) -> List[RegistryEntry]:
-        """Get recently updated plugins."""
-        entries = [e for e in self._mock_entries if e.updated_at]
-        entries.sort(key=lambda e: e.updated_at, reverse=True)
-        return entries[:limit]
-    
-    def get_by_tag(self, tag: str) -> List[RegistryEntry]:
-        """Get plugins by tag."""
-        return [
-            e for e in self._mock_entries
-            if tag.lower() in [t.lower() for t in e.tags]
-        ]
+        """Look up a specific entry from the local index."""
+        info = self._index.get(name)
+        if not info:
+            return None
+
+        meta = info.get("metadata") or {}
+        return RegistryEntry(
+            name=name,
+            version=info.get("version", "0.0.0"),
+            author=meta.get("author", "unknown"),
+            description=meta.get("description", ""),
+            source=RegistrySource.GIT,
+            repository=info.get("url", ""),
+            tags=meta.get("tags", []),
+        )
+
+    def _build_entries_from_index(self) -> List[RegistryEntry]:
+        entries = []
+        for name, info in self._index.items():
+            meta = info.get("metadata") or {}
+            entries.append(RegistryEntry(
+                name=name,
+                version=info.get("version", "0.0.0"),
+                author=meta.get("author", "unknown"),
+                description=meta.get("description", ""),
+                source=RegistrySource.GIT,
+                repository=info.get("url", ""),
+                tags=meta.get("tags", []),
+            ))
+        return entries
 
 
 class MockSkillRegistry(SkillRegistry):
-    """Mock registry for testing."""
-    
-    def __init__(self, entries: Optional[List[RegistryEntry]] = None):
-        super().__init__()
-        if entries is not None:
-            self._mock_entries = entries
-    
+    """Mock registry for testing — pre-seeds an in-memory index."""
+
+    def __init__(
+        self,
+        entries: Optional[List[RegistryEntry]] = None,
+        install_dir: Optional[Path] = None,
+    ):
+        import tempfile
+
+        _dir = install_dir or Path(tempfile.mkdtemp(prefix="bantz_mock_reg_"))
+        super().__init__(install_dir=_dir, cache_dir=_dir / ".cache")
+
+        if entries:
+            for e in entries:
+                self._index[e.name] = {
+                    "url": e.repository,
+                    "version": e.version,
+                    "installed_at": datetime.utcnow().isoformat(),
+                    "source": e.source.name,
+                    "metadata": {
+                        "author": e.author,
+                        "description": e.description,
+                        "tags": e.tags,
+                    },
+                }
+
     def add_entry(self, entry: RegistryEntry) -> None:
-        """Add an entry to the mock registry."""
-        self._mock_entries.append(entry)
-    
+        self._index[entry.name] = {
+            "url": entry.repository,
+            "version": entry.version,
+            "installed_at": datetime.utcnow().isoformat(),
+            "source": entry.source.name,
+            "metadata": {
+                "author": entry.author,
+                "description": entry.description,
+                "tags": entry.tags,
+            },
+        }
+
     def clear(self) -> None:
-        """Clear all entries."""
-        self._mock_entries.clear()
+        self._index.clear()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -846,43 +846,26 @@ class TestSkillRegistry:
     
     def test_registry_creation(self):
         """Test registry creation."""
-        registry = SkillRegistry()
-        assert registry is not None
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            registry = SkillRegistry(install_dir=Path(td) / "p", cache_dir=Path(td) / "c")
+            assert registry is not None
     
     def test_registry_search(self):
         """Test searching the registry."""
-        registry = SkillRegistry()
-        results = registry.search("spotify")
-        
-        assert isinstance(results, RegistrySearchResult)
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            registry = SkillRegistry(install_dir=Path(td) / "p", cache_dir=Path(td) / "c")
+            results = registry.search("anything")
+            assert isinstance(results, RegistrySearchResult)
     
-    def test_registry_get(self):
-        """Test getting a specific plugin."""
-        registry = SkillRegistry()
-        entry = registry.get("spotify")
-        
-        # Mock registry should have spotify
-        if entry:
-            assert entry.name == "spotify"
-    
-    def test_registry_get_popular(self):
-        """Test getting popular plugins."""
-        registry = SkillRegistry()
-        popular = registry.get_popular(limit=5)
-        
-        assert isinstance(popular, list)
-        assert len(popular) <= 5
-    
-    def test_registry_get_by_category(self):
-        """Test getting plugins by category."""
-        registry = SkillRegistry()
-        # Call with any category - just verify it doesn't error
-        try:
-            result = registry.get_by_category("music")
-            assert isinstance(result, list)
-        except (AttributeError, NotImplementedError):
-            # Method may not exist in all implementations
-            pass
+    def test_registry_get_unknown(self):
+        """Test getting a non-existent plugin."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            registry = SkillRegistry(install_dir=Path(td) / "p", cache_dir=Path(td) / "c")
+            entry = registry.get("nonexistent")
+            assert entry is None
 
 
 class TestMockSkillRegistry:
@@ -890,9 +873,12 @@ class TestMockSkillRegistry:
     
     def test_mock_registry(self):
         """Test mock registry."""
-        registry = MockSkillRegistry()
+        entries = [
+            RegistryEntry(name="spotify", version="1.0", author="T", description="Music"),
+        ]
+        registry = MockSkillRegistry(entries=entries)
         
-        results = registry.search("music")
+        results = registry.search("spotify")
         assert isinstance(results, RegistrySearchResult)
         
         entry = registry.get("spotify")

--- a/tests/test_registry_git.py
+++ b/tests/test_registry_git.py
@@ -1,0 +1,388 @@
+"""Tests for Git-based SkillRegistry (Issue #852).
+
+Covers:
+- install_from_git (clone, version pin, manifest)
+- update (pull, tag checkout)
+- uninstall (rmtree + index cleanup)
+- check_updates (fetch + rev-list)
+- list_versions (tags)
+- search / get from local index
+- index persistence (load/save JSON)
+- _repo_name_from_url edge cases
+- MockSkillRegistry helper
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.plugins.registry import (
+    MockSkillRegistry,
+    RegistryEntry,
+    RegistrySearchResult,
+    RegistrySource,
+    SkillRegistry,
+    SKILL_MANIFEST,
+)
+
+
+# ── fixtures ─────────────────────────────────────────────────────
+
+@pytest.fixture
+def tmp_install(tmp_path):
+    """Temporary install directory."""
+    return tmp_path / "plugins"
+
+
+@pytest.fixture
+def registry(tmp_install, tmp_path):
+    """SkillRegistry with temp dirs."""
+    return SkillRegistry(install_dir=tmp_install, cache_dir=tmp_path / "cache")
+
+
+def _ok(stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess([], 0, stdout=stdout, stderr=stderr)
+
+
+def _fail(stderr: str = "error") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess([], 1, stdout="", stderr=stderr)
+
+
+# ─────────────────────────────────────────────────────────────────
+# _repo_name_from_url
+# ─────────────────────────────────────────────────────────────────
+
+class TestRepoNameFromUrl:
+
+    def test_https_url(self):
+        assert SkillRegistry._repo_name_from_url("https://github.com/org/plugin-x") == "plugin-x"
+
+    def test_dot_git_suffix(self):
+        assert SkillRegistry._repo_name_from_url("git@github.com:org/foo.git") == "foo"
+
+    def test_trailing_slash(self):
+        assert SkillRegistry._repo_name_from_url("https://host/bar/") == "bar"
+
+
+# ─────────────────────────────────────────────────────────────────
+# install_from_git
+# ─────────────────────────────────────────────────────────────────
+
+class TestInstallFromGit:
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_ok())
+    def test_success(self, mock_git, registry, tmp_install):
+        assert registry.install_from_git("https://github.com/org/my-skill") is True
+        assert "my-skill" in registry._index
+        assert registry._index["my-skill"]["url"] == "https://github.com/org/my-skill"
+        assert (tmp_install / "installed.json").exists()
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_ok())
+    def test_custom_name(self, mock_git, registry):
+        registry.install_from_git("https://github.com/org/repo", name="custom")
+        assert "custom" in registry._index
+
+    @patch.object(SkillRegistry, "_run_git")
+    def test_with_version(self, mock_git, registry):
+        mock_git.return_value = _ok()
+        registry.install_from_git("https://github.com/org/r", version="v2.0.0")
+        assert registry._index["r"]["version"] == "v2.0.0"
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_fail("clone error"))
+    def test_clone_failure(self, mock_git, registry):
+        assert registry.install_from_git("https://bad/repo") is False
+        assert registry._index == {}
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_ok())
+    def test_already_installed(self, mock_git, registry, tmp_install):
+        (tmp_install / "dup").mkdir(parents=True)
+        assert registry.install_from_git("https://g.c/o/dup") is False
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_ok())
+    def test_reads_manifest(self, mock_git, registry, tmp_install):
+        # Simulate git clone creating dir
+        pdir = tmp_install / "myplugin"
+        pdir.mkdir(parents=True)
+        manifest = pdir / SKILL_MANIFEST
+        manifest.write_text("name: myplugin\nauthor: test\ntags: [a, b]\n")
+
+        # Because the dir already exists, install_from_git will see "already installed"
+        # So we test _read_manifest directly
+        meta = SkillRegistry._read_manifest(pdir)
+        if meta is not None:  # yaml may not be installed
+            assert meta["name"] == "myplugin"
+
+
+# ─────────────────────────────────────────────────────────────────
+# install (by name via index)
+# ─────────────────────────────────────────────────────────────────
+
+class TestInstallByName:
+
+    @patch.object(SkillRegistry, "install_from_git", return_value=True)
+    def test_with_entry(self, mock_ifg, registry):
+        registry._index["myp"] = {
+            "url": "https://github.com/org/myp",
+            "version": "1.0",
+            "source": "GIT",
+            "metadata": None,
+        }
+        assert registry.install("myp") is True
+
+    def test_unknown_name(self, registry):
+        assert registry.install("nonexistent") is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# uninstall
+# ─────────────────────────────────────────────────────────────────
+
+class TestUninstall:
+
+    def test_success(self, registry, tmp_install):
+        pdir = tmp_install / "rm-me"
+        pdir.mkdir(parents=True)
+        (pdir / "plugin.py").write_text("")
+        registry._index["rm-me"] = {"url": "", "version": "1.0"}
+        registry._save_index()
+
+        assert registry.uninstall("rm-me") is True
+        assert not pdir.exists()
+        assert "rm-me" not in registry._index
+
+    def test_not_installed(self, registry):
+        assert registry.uninstall("ghost") is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# update
+# ─────────────────────────────────────────────────────────────────
+
+class TestUpdate:
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_ok())
+    def test_pull_latest(self, mock_git, registry, tmp_install):
+        pdir = tmp_install / "upd"
+        pdir.mkdir(parents=True)
+        registry._index["upd"] = {"url": "u", "version": "1.0", "metadata": None}
+
+        assert registry.update("upd") is True
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_ok())
+    def test_pin_version(self, mock_git, registry, tmp_install):
+        pdir = tmp_install / "upd2"
+        pdir.mkdir(parents=True)
+        registry._index["upd2"] = {"url": "u", "version": "1.0", "metadata": None}
+
+        assert registry.update("upd2", version="v3.0") is True
+        assert registry._index["upd2"]["version"] == "v3.0"
+
+    def test_not_installed(self, registry):
+        assert registry.update("nope") is False
+
+    @patch.object(SkillRegistry, "_run_git", return_value=_fail())
+    def test_pull_fail(self, mock_git, registry, tmp_install):
+        (tmp_install / "failpull").mkdir(parents=True)
+        registry._index["failpull"] = {"url": "u", "version": "1.0", "metadata": None}
+        assert registry.update("failpull") is False
+
+
+# ─────────────────────────────────────────────────────────────────
+# check_updates
+# ─────────────────────────────────────────────────────────────────
+
+class TestCheckUpdates:
+
+    @patch.object(SkillRegistry, "_run_git")
+    def test_outdated(self, mock_git, registry, tmp_install):
+        pdir = tmp_install / "outdated"
+        pdir.mkdir(parents=True)
+        registry._index["outdated"] = {"url": "u", "version": "1.0"}
+        registry._save_index()
+
+        mock_git.side_effect = [_ok(), _ok(stdout="3\n")]
+        result = registry.check_updates()
+        assert "outdated" in result
+
+    @patch.object(SkillRegistry, "_run_git")
+    def test_up_to_date(self, mock_git, registry, tmp_install):
+        pdir = tmp_install / "fresh"
+        pdir.mkdir(parents=True)
+        registry._index["fresh"] = {"url": "u", "version": "1.0"}
+        registry._save_index()
+
+        mock_git.side_effect = [_ok(), _ok(stdout="0\n")]
+        result = registry.check_updates()
+        assert result == []
+
+
+# ─────────────────────────────────────────────────────────────────
+# list_versions
+# ─────────────────────────────────────────────────────────────────
+
+class TestListVersions:
+
+    @patch.object(SkillRegistry, "_run_git")
+    def test_returns_tags(self, mock_git, registry, tmp_install):
+        pdir = tmp_install / "tagged"
+        pdir.mkdir(parents=True)
+        mock_git.side_effect = [_ok(), _ok(stdout="v2.0.0\nv1.0.0\n")]
+        tags = registry.list_versions("tagged")
+        assert tags == ["v2.0.0", "v1.0.0"]
+
+    def test_not_installed(self, registry):
+        assert registry.list_versions("nope") == []
+
+
+# ─────────────────────────────────────────────────────────────────
+# get_installed / is_installed
+# ─────────────────────────────────────────────────────────────────
+
+class TestGetInstalled:
+
+    def test_with_plugin_py(self, registry, tmp_install):
+        pdir = tmp_install / "real"
+        pdir.mkdir(parents=True)
+        (pdir / "plugin.py").write_text("")
+        assert "real" in registry.get_installed()
+        assert registry.is_installed("real")
+
+    def test_without_plugin_py(self, registry, tmp_install):
+        (tmp_install / "empty").mkdir(parents=True)
+        assert "empty" not in registry.get_installed()
+        assert not registry.is_installed("empty")
+
+    def test_no_dir(self, registry):
+        assert registry.get_installed() == []
+
+
+# ─────────────────────────────────────────────────────────────────
+# get_installed_version
+# ─────────────────────────────────────────────────────────────────
+
+class TestGetInstalledVersion:
+
+    def test_known(self, registry):
+        registry._index["x"] = {"version": "v1.2.3"}
+        assert registry.get_installed_version("x") == "v1.2.3"
+
+    def test_unknown(self, registry):
+        assert registry.get_installed_version("y") is None
+
+
+# ─────────────────────────────────────────────────────────────────
+# index persistence
+# ─────────────────────────────────────────────────────────────────
+
+class TestIndexPersistence:
+
+    def test_save_and_load(self, tmp_install, tmp_path):
+        r1 = SkillRegistry(install_dir=tmp_install, cache_dir=tmp_path / "c")
+        r1._index["a"] = {"url": "https://x", "version": "1"}
+        r1._save_index()
+
+        r2 = SkillRegistry(install_dir=tmp_install, cache_dir=tmp_path / "c")
+        assert "a" in r2._index
+
+    def test_corrupt_json(self, tmp_install, tmp_path):
+        tmp_install.mkdir(parents=True)
+        (tmp_install / "installed.json").write_text("{bad json")
+        r = SkillRegistry(install_dir=tmp_install, cache_dir=tmp_path / "c")
+        assert r._index == {}
+
+
+# ─────────────────────────────────────────────────────────────────
+# search / get
+# ─────────────────────────────────────────────────────────────────
+
+class TestSearchAndGet:
+
+    def _seeded(self, registry):
+        registry._index["alpha"] = {
+            "url": "https://g.c/alpha",
+            "version": "1.0",
+            "metadata": {"author": "A", "description": "Alpha plugin", "tags": ["ai"]},
+        }
+        registry._index["beta"] = {
+            "url": "https://g.c/beta",
+            "version": "2.0",
+            "metadata": {"author": "B", "description": "Beta thing", "tags": ["web"]},
+        }
+        return registry
+
+    def test_search_all(self, registry):
+        r = self._seeded(registry)
+        result = r.search()
+        assert result.total == 2
+
+    def test_search_query(self, registry):
+        r = self._seeded(registry)
+        result = r.search(query="alpha")
+        assert result.total == 1
+        assert result.entries[0].name == "alpha"
+
+    def test_search_by_tag(self, registry):
+        r = self._seeded(registry)
+        result = r.search(tags=["web"])
+        assert result.total == 1
+
+    def test_get_existing(self, registry):
+        r = self._seeded(registry)
+        e = r.get("alpha")
+        assert e is not None
+        assert e.name == "alpha"
+
+    def test_get_missing(self, registry):
+        assert registry.get("nope") is None
+
+
+# ─────────────────────────────────────────────────────────────────
+# RegistryEntry (kept from original)
+# ─────────────────────────────────────────────────────────────────
+
+class TestRegistryEntry:
+
+    def test_to_dict(self):
+        e = RegistryEntry(name="x", version="1", author="A", description="D")
+        d = e.to_dict()
+        assert d["name"] == "x"
+        assert d["source"] == "COMMUNITY"
+
+    def test_from_dict_roundtrip(self):
+        orig = RegistryEntry(name="y", version="2", author="B", description="E", tags=["t"])
+        d = orig.to_dict()
+        restored = RegistryEntry.from_dict(d)
+        assert restored.name == "y"
+        assert restored.tags == ["t"]
+
+
+# ─────────────────────────────────────────────────────────────────
+# MockSkillRegistry
+# ─────────────────────────────────────────────────────────────────
+
+class TestMockSkillRegistry:
+
+    def test_with_entries(self):
+        entries = [
+            RegistryEntry(name="a", version="1", author="X", description="A", repository="https://r"),
+        ]
+        m = MockSkillRegistry(entries=entries)
+        assert "a" in m._index
+
+    def test_add_entry(self):
+        m = MockSkillRegistry()
+        m.add_entry(RegistryEntry(name="b", version="1", author="Y", description="B"))
+        assert "b" in m._index
+
+    def test_clear(self):
+        m = MockSkillRegistry(entries=[
+            RegistryEntry(name="c", version="1", author="Z", description="C"),
+        ])
+        m.clear()
+        assert m._index == {}


### PR DESCRIPTION
## Summary
Mock plugin registry'yi gerçek Git-based implementasyona çevirdik.

### Değişiklikler
- **install_from_git()**: `git clone` ile repo klonlama, tag ile versiyon pinleme
- **update()**: `git pull --ff-only` veya `git checkout <tag>`
- **uninstall()**: Dizin silme + index temizleme
- **check_updates()**: `git fetch` + `rev-list` karşılaştırması
- **list_versions()**: Git tag listesi
- **Local index**: `installed.json` ile persistence
- **skill.yaml**: Manifest desteği (opsiyonel PyYAML)
- 6 hardcoded mock entry kaldırıldı
- `test_registry_git.py` ile ~40 yeni test

### Kabul Kriterleri
- [x] Git URL'den skill indirme çalışıyor
- [x] Versiyon kontrolü çalışıyor
- [x] Mock veri kaldırıldı
- [x] Test yazıldı

Closes #852