### PR TITLE
feat: LLM-based research summarizer with citation preservation (#861)

### DIFF
--- a/src/bantz/research/orchestrator.py
+++ b/src/bantz/research/orchestrator.py
@@ -269,7 +269,8 @@ class ResearchOrchestrator:
 # Factory function for creating orchestrator with defaults
 def create_research_orchestrator(
     event_bus: Optional[EventBus] = None,
-    search_tool=None
+    search_tool=None,
+    summarizer=None,
 ) -> ResearchOrchestrator:
     """
     Create a ResearchOrchestrator with default components.
@@ -277,14 +278,23 @@ def create_research_orchestrator(
     Args:
         event_bus: Optional event bus for events
         search_tool: Optional search tool for source collection
+        summarizer: Optional summarizer. If None, uses ResearchSummarizer.
     
     Returns:
         Configured ResearchOrchestrator
     """
+    if summarizer is None:
+        try:
+            from bantz.research.summarizer import create_research_summarizer
+            summarizer = create_research_summarizer()
+        except Exception:
+            pass  # Will use fallback snippet concatenation
+
     return ResearchOrchestrator(
         collector=SourceCollector(search_tool=search_tool),
         ranker=SourceRanker(),
         contradiction_detector=ContradictionDetector(),
         confidence_scorer=ConfidenceScorer(),
-        event_bus=event_bus
+        event_bus=event_bus,
+        summarizer=summarizer,
     )

--- a/src/bantz/research/summarizer.py
+++ b/src/bantz/research/summarizer.py
@@ -1,0 +1,279 @@
+"""LLM-based research summarizer.
+
+Replaces the fallback concatenation in ResearchOrchestrator with a real
+multi-source synthesis pipeline:
+
+- Accepts ranked sources + contradiction data
+- Builds a structured prompt for quality-tier LLM (Gemini)
+- Preserves source citations ([1], [2], …)
+- Detects and flags conflicting claims
+- Falls back to snippet concatenation when LLM is unavailable
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from bantz.research.source_collector import Source
+from bantz.research.contradiction import ContradictionResult
+
+logger = logging.getLogger(__name__)
+
+# Max source text per source to avoid token overflow
+MAX_SOURCE_CHARS = 1500
+# Max total chars from all sources combined
+MAX_TOTAL_SOURCE_CHARS = 8000
+
+
+@dataclass
+class SummaryRequest:
+    """Input to the summarizer."""
+
+    query: str
+    sources: List[Source]
+    contradiction: Optional[ContradictionResult] = None
+    language: str = "tr"  # Turkish by default
+    max_words: int = 300
+
+
+@dataclass
+class SummaryResult:
+    """Output from the summarizer."""
+
+    text: str
+    citations: List[Dict[str, str]] = field(default_factory=list)
+    method: str = "llm"  # "llm" | "fallback"
+    source_count: int = 0
+    has_contradictions: bool = False
+
+
+class ResearchSummarizer:
+    """LLM-powered research summarizer with citation preservation.
+
+    Example::
+
+        summarizer = ResearchSummarizer()
+        result = await summarizer.summarize(
+            query="Python 3.13 yenilikleri",
+            sources=ranked_sources,
+            contradiction=contradiction_result,
+        )
+        print(result.text)
+    """
+
+    # System prompt template
+    SYSTEM_PROMPT = textwrap.dedent("""\
+        Sen bir araştırma asistanısın. Verilen kaynaklardan kapsamlı bir özet çıkar.
+
+        Kurallar:
+        1. Her bilginin kaynağını [1], [2] gibi numaralarla belirt.
+        2. Kaynaklar arasında çelişki varsa açıkça belirt.
+        3. En güvenilir kaynaklara öncelik ver.
+        4. Özet {language} dilinde olsun.
+        5. Maksimum {max_words} kelime.
+        6. Nesnel ve bilgilendirici ol, yorum katma.
+    """)
+
+    def __init__(
+        self,
+        llm_client: Optional[Any] = None,
+        model: Optional[str] = None,
+        language: str = "tr",
+    ):
+        """
+        Args:
+            llm_client: LLM client for summarization. If None, uses Gemini via env.
+            model: Model name override.
+            language: Output language (default: Turkish).
+        """
+        self._llm_client = llm_client
+        self._model = model or os.getenv("BANTZ_GEMINI_MODEL", "gemini-2.0-flash")
+        self._language = language
+
+    async def summarize(
+        self,
+        query: str,
+        sources: List[Source],
+        contradiction: Optional[ContradictionResult] = None,
+        max_words: int = 300,
+    ) -> SummaryResult:
+        """Generate a multi-source summary with citations.
+
+        Args:
+            query: Original research query.
+            sources: Ranked sources to summarize.
+            contradiction: Contradiction detection result.
+            max_words: Maximum output words.
+
+        Returns:
+            SummaryResult with text and citation metadata.
+        """
+        if not sources:
+            return SummaryResult(
+                text=f"'{query}' için güvenilir kaynak bulunamadı.",
+                method="fallback",
+            )
+
+        # Build citation index
+        citations = self._build_citations(sources)
+
+        # Try LLM summarization
+        try:
+            text = await self._llm_summarize(
+                query=query,
+                sources=sources,
+                contradiction=contradiction,
+                citations=citations,
+                max_words=max_words,
+            )
+            return SummaryResult(
+                text=text,
+                citations=citations,
+                method="llm",
+                source_count=len(sources),
+                has_contradictions=bool(
+                    contradiction and contradiction.has_contradiction
+                ),
+            )
+        except Exception as exc:
+            logger.warning("LLM summarization failed, using fallback: %s", exc)
+
+        # Fallback: structured snippet concatenation
+        text = self._fallback_summarize(query, sources, contradiction, citations)
+        return SummaryResult(
+            text=text,
+            citations=citations,
+            method="fallback",
+            source_count=len(sources),
+            has_contradictions=bool(
+                contradiction and contradiction.has_contradiction
+            ),
+        )
+
+    async def _llm_summarize(
+        self,
+        query: str,
+        sources: List[Source],
+        contradiction: Optional[ContradictionResult],
+        citations: List[Dict[str, str]],
+        max_words: int,
+    ) -> str:
+        """Call the LLM to generate a summary."""
+        system = self.SYSTEM_PROMPT.format(
+            language="Türkçe" if self._language == "tr" else "English",
+            max_words=max_words,
+        )
+
+        # Build source context
+        source_parts: List[str] = []
+        total_chars = 0
+        for i, src in enumerate(sources, 1):
+            snippet = (src.snippet or "")[:MAX_SOURCE_CHARS]
+            if total_chars + len(snippet) > MAX_TOTAL_SOURCE_CHARS:
+                break
+            total_chars += len(snippet)
+            source_parts.append(
+                f"[{i}] {src.title or src.url}\n"
+                f"   Kaynak: {src.domain or src.url}\n"
+                f"   İçerik: {snippet}"
+            )
+
+        # Add contradiction info if present
+        contradiction_note = ""
+        if contradiction and contradiction.has_contradiction:
+            claims = contradiction.conflicting_claims[:3]
+            contradiction_note = (
+                "\n\n⚠️ Çelişkili bilgiler tespit edildi:\n"
+                + "\n".join(f"- {c}" for c in claims)
+            )
+
+        user_prompt = (
+            f"Araştırma sorusu: {query}\n\n"
+            f"Kaynaklar:\n{''.join(source_parts)}"
+            f"{contradiction_note}\n\n"
+            f"Yukarıdaki kaynaklara dayanarak kapsamlı bir özet yaz."
+        )
+
+        # Call LLM
+        client = self._get_llm_client()
+        response = await client.generate(
+            prompt=user_prompt,
+            system=system,
+            model=self._model,
+        )
+
+        return response.strip()
+
+    def _get_llm_client(self):
+        """Get or create an LLM client."""
+        if self._llm_client is not None:
+            return self._llm_client
+
+        # Try to get Gemini client from Bantz infra
+        try:
+            from bantz.brain.gemini_client import get_gemini_client
+
+            self._llm_client = get_gemini_client()
+            return self._llm_client
+        except ImportError:
+            pass
+
+        raise RuntimeError(
+            "No LLM client available. Set GEMINI_API_KEY or provide llm_client."
+        )
+
+    def _fallback_summarize(
+        self,
+        query: str,
+        sources: List[Source],
+        contradiction: Optional[ContradictionResult],
+        citations: List[Dict[str, str]],
+    ) -> str:
+        """Structured fallback when LLM is unavailable."""
+        parts = [f"Araştırma: {query}\n"]
+
+        # Key findings with citations
+        parts.append("Bulgular:")
+        for i, src in enumerate(sources[:5], 1):
+            if src.snippet:
+                parts.append(f"  [{i}] {src.snippet}")
+
+        # Contradiction warning
+        if contradiction and contradiction.has_contradiction:
+            parts.append(
+                f"\n⚠️ {len(contradiction.conflicting_claims)} çelişkili bilgi tespit edildi."
+            )
+
+        # Source list
+        parts.append("\nKaynaklar:")
+        for i, c in enumerate(citations[:5], 1):
+            parts.append(f"  [{i}] {c['title']} — {c['domain']}")
+
+        return "\n".join(parts)
+
+    @staticmethod
+    def _build_citations(sources: List[Source]) -> List[Dict[str, str]]:
+        """Build citation metadata from sources."""
+        citations = []
+        for src in sources:
+            citations.append(
+                {
+                    "url": src.url,
+                    "title": src.title or src.url,
+                    "domain": src.domain or "",
+                    "date": str(src.date) if src.date else "",
+                }
+            )
+        return citations
+
+
+def create_research_summarizer(
+    llm_client: Optional[Any] = None,
+    language: str = "tr",
+) -> ResearchSummarizer:
+    """Factory for creating a ResearchSummarizer."""
+    return ResearchSummarizer(llm_client=llm_client, language=language)

--- a/tests/test_research_summarizer.py
+++ b/tests/test_research_summarizer.py
@@ -1,0 +1,172 @@
+"""Tests for ResearchSummarizer (Issue #861)."""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bantz.research.summarizer import (
+    ResearchSummarizer,
+    SummaryRequest,
+    SummaryResult,
+    create_research_summarizer,
+    MAX_SOURCE_CHARS,
+)
+from bantz.research.source_collector import Source
+from bantz.research.contradiction import ContradictionResult
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+def _source(title="T", snippet="S", url="https://x.com", domain="x.com", date=None):
+    return Source(
+        url=url, title=title, snippet=snippet, domain=domain,
+        date=date, reliability_score=0.8, content_type="news",
+    )
+
+
+def _contradiction(has_contradiction=False, descriptions=None):
+    claims = []
+    for desc in (descriptions or []):
+        s1 = _source(title="Src1")
+        s2 = _source(title="Src2")
+        claims.append((s1, s2, desc))
+    return ContradictionResult(
+        has_contradiction=has_contradiction,
+        conflicting_claims=claims,
+        agreement_score=0.9 if not has_contradiction else 0.4,
+    )
+
+
+# ── SummaryResult ────────────────────────────────────────────────
+
+class TestSummaryResult:
+
+    def test_defaults(self):
+        r = SummaryResult(text="test")
+        assert r.method == "llm"
+        assert r.citations == []
+
+
+# ── ResearchSummarizer ──────────────────────────────────────────
+
+class TestResearchSummarizer:
+
+    @pytest.mark.asyncio
+    async def test_empty_sources(self):
+        s = ResearchSummarizer()
+        result = await s.summarize(query="test", sources=[])
+        assert "bulunamadı" in result.text
+        assert result.method == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_llm_success(self):
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = "LLM özet metni."
+
+        s = ResearchSummarizer(llm_client=mock_client)
+        result = await s.summarize(
+            query="Python 3.13",
+            sources=[_source(title="Py News", snippet="Python 3.13 released")],
+        )
+        assert result.text == "LLM özet metni."
+        assert result.method == "llm"
+        assert result.source_count == 1
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_falls_back(self):
+        mock_client = AsyncMock()
+        mock_client.generate.side_effect = RuntimeError("API down")
+
+        s = ResearchSummarizer(llm_client=mock_client)
+        result = await s.summarize(
+            query="test",
+            sources=[_source(snippet="data here")],
+        )
+        assert result.method == "fallback"
+        assert "data here" in result.text
+
+    @pytest.mark.asyncio
+    async def test_citations_built(self):
+        s = ResearchSummarizer(llm_client=AsyncMock(generate=AsyncMock(return_value="ok")))
+        result = await s.summarize(
+            query="q",
+            sources=[
+                _source(title="A", url="https://a.com", domain="a.com"),
+                _source(title="B", url="https://b.com", domain="b.com"),
+            ],
+        )
+        assert len(result.citations) == 2
+        assert result.citations[0]["title"] == "A"
+        assert result.citations[1]["domain"] == "b.com"
+
+    @pytest.mark.asyncio
+    async def test_contradiction_flag(self):
+        mock_client = AsyncMock()
+        mock_client.generate.return_value = "Çelişkili."
+
+        s = ResearchSummarizer(llm_client=mock_client)
+        result = await s.summarize(
+            query="q",
+            sources=[_source()],
+            contradiction=_contradiction(has_contradiction=True, descriptions=["A vs B"]),
+        )
+        assert result.has_contradictions is True
+
+    @pytest.mark.asyncio
+    async def test_fallback_includes_sources(self):
+        s = ResearchSummarizer()
+        # No LLM → fallback
+        with patch.object(s, "_get_llm_client", side_effect=RuntimeError):
+            result = await s.summarize(
+                query="q",
+                sources=[_source(title="NewsX", snippet="content here", domain="news.com")],
+            )
+        assert result.method == "fallback"
+        assert "NewsX" in result.text
+        assert "news.com" in result.text
+
+    @pytest.mark.asyncio
+    async def test_fallback_contradiction_warning(self):
+        s = ResearchSummarizer()
+        with patch.object(s, "_get_llm_client", side_effect=RuntimeError):
+            result = await s.summarize(
+                query="q",
+                sources=[_source()],
+                contradiction=_contradiction(has_contradiction=True, descriptions=["X vs Y"]),
+            )
+        assert "çelişkili" in result.text.lower()
+
+
+# ── build_citations ─────────────────────────────────────────────
+
+class TestBuildCitations:
+
+    def test_ordered(self):
+        sources = [
+            _source(title="First", url="https://1.com", domain="1.com"),
+            _source(title="Second", url="https://2.com", domain="2.com"),
+        ]
+        cits = ResearchSummarizer._build_citations(sources)
+        assert cits[0]["title"] == "First"
+        assert cits[1]["title"] == "Second"
+
+    def test_with_date(self):
+        dt = datetime(2025, 6, 15)
+        cits = ResearchSummarizer._build_citations([_source(date=dt)])
+        assert "2025" in cits[0]["date"]
+
+
+# ── factory ──────────────────────────────────────────────────────
+
+class TestFactory:
+
+    def test_create_default(self):
+        s = create_research_summarizer()
+        assert isinstance(s, ResearchSummarizer)
+        assert s._language == "tr"
+
+    def test_create_english(self):
+        s = create_research_summarizer(language="en")
+        assert s._language == "en"


### PR DESCRIPTION
## Summary
LLM tabanlı araştırma özetleyici. Kaynak birleştirme yerine Gemini ile kaliteli özet üretir.

## Changes
- `src/bantz/research/summarizer.py`: ResearchSummarizer class with LLM-based multi-source summarization
  - Citation references (\[1\], \[2\], …) preserved in output
  - Contradiction flagging when sources conflict
  - Structured fallback when LLM unavailable
  - SummaryRequest / SummaryResult dataclasses
  - create_research_summarizer() factory
- `src/bantz/research/orchestrator.py`: Updated factory to auto-wire ResearchSummarizer
- `tests/test_research_summarizer.py`: 10 tests (LLM path, fallback, citations, contradictions, factory)

Closes #861