### PR TITLE
feat: context-aware disambiguation dialog (#875)

### DIFF
--- a/src/bantz/brain/disambiguation.py
+++ b/src/bantz/brain/disambiguation.py
@@ -1,0 +1,254 @@
+"""Context-Aware Disambiguation Dialog (Issue #875).
+
+When tool results return multiple items (calendar events, emails,
+contacts, free slots, etc.), automatically builds a context-rich
+question asking the user which item they meant.
+
+Integrates with:
+- ``anaphora.ReferenceTable`` for item extraction and ``#N`` resolution
+- ``OrchestratorState.disambiguation_pending`` for state tracking
+- ``OrchestratorOutput.ask_user`` / ``.question`` for the response path
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from bantz.brain.anaphora import ReferenceItem, ReferenceTable, extract_references
+
+logger = logging.getLogger(__name__)
+
+# Minimum items required to trigger disambiguation
+MIN_ITEMS_FOR_DISAMBIGUATION = 2
+
+# Intents that operate on a single target (destructive / modify)
+DISAMBIGUATION_INTENTS = frozenset({
+    "calendar_delete_event",
+    "calendar_update_event",
+    "calendar_reschedule",
+    "gmail_delete",
+    "gmail_reply",
+    "gmail_forward",
+    "gmail_mark_read",
+    "contacts_delete",
+    "contacts_update",
+    "file_delete",
+    "file_open",
+    "generic_select",
+})
+
+# Turkish emoji + type labels
+TYPE_EMOJI: Dict[str, str] = {
+    "event": "📅",
+    "email": "📧",
+    "contact": "👤",
+    "slot": "🕐",
+    "generic": "📋",
+}
+
+TYPE_LABEL: Dict[str, str] = {
+    "event": "etkinlik",
+    "email": "e-posta",
+    "contact": "kişi",
+    "slot": "boş zaman",
+    "generic": "öğe",
+}
+
+
+@dataclass
+class DisambiguationRequest:
+    """Pending disambiguation request stored in OrchestratorState."""
+
+    reference_table: ReferenceTable
+    question_text: str
+    original_intent: str
+    source_tool: str
+    item_count: int = 0
+
+
+@dataclass
+class DisambiguationResult:
+    """Result of resolving a disambiguation response."""
+
+    resolved: bool = False
+    selected_item: Optional[ReferenceItem] = None
+    selected_index: Optional[int] = None
+    error: str = ""
+
+
+class DisambiguationDialog:
+    """Builds and resolves context-aware disambiguation dialogs.
+
+    Usage::
+
+        dialog = DisambiguationDialog()
+
+        # After tool execution, check if disambiguation is needed
+        request = dialog.check_tool_results(tool_results, intent="calendar_delete_event")
+
+        if request:
+            # Store in state, return ask_user=True + question
+            state.disambiguation_pending = request
+            output.ask_user = True
+            output.question = request.question_text
+            return
+
+        # On next turn, resolve user's answer
+        result = dialog.resolve_response(user_input, state.disambiguation_pending)
+        if result.resolved:
+            selected = result.selected_item
+            # Re-execute tool with specific item
+    """
+
+    def __init__(self, min_items: int = MIN_ITEMS_FOR_DISAMBIGUATION):
+        self._min_items = min_items
+
+    def check_tool_results(
+        self,
+        tool_results: List[Dict[str, Any]],
+        intent: str = "",
+    ) -> Optional[DisambiguationRequest]:
+        """Check if tool results need disambiguation.
+
+        Returns a ``DisambiguationRequest`` if:
+        1. There are ≥ ``min_items`` reference-able items
+        2. The intent is one that operates on a single target
+
+        Args:
+            tool_results: List of tool result dicts from execution phase.
+            intent: The detected intent (e.g. ``calendar_delete_event``).
+
+        Returns:
+            DisambiguationRequest if disambiguation is needed, else None.
+        """
+        if not tool_results:
+            return None
+
+        ref_table = extract_references(tool_results, max_items=10)
+
+        if len(ref_table) < self._min_items:
+            return None
+
+        # Only trigger for intents that target a single item
+        if intent and intent not in DISAMBIGUATION_INTENTS:
+            return None
+
+        question = self._build_question(ref_table, intent)
+
+        return DisambiguationRequest(
+            reference_table=ref_table,
+            question_text=question,
+            original_intent=intent,
+            source_tool=ref_table.source_tool,
+            item_count=len(ref_table),
+        )
+
+    def resolve_response(
+        self,
+        user_input: str,
+        pending: Optional[DisambiguationRequest],
+    ) -> DisambiguationResult:
+        """Resolve the user's response to a disambiguation question.
+
+        Uses ``ReferenceTable.resolve_reference()`` which handles:
+        - ``#1``, ``#2`` style references
+        - Turkish anaphora: ``ilkini``, ``ikincisini``, ``sonuncusu``
+        - Bare digits: ``1``, ``2``
+
+        Args:
+            user_input: The user's response text.
+            pending: The pending disambiguation request from state.
+
+        Returns:
+            DisambiguationResult with resolved item or error.
+        """
+        if not pending or not pending.reference_table:
+            return DisambiguationResult(error="Bekleyen seçim isteği yok.")
+
+        item = pending.reference_table.resolve_reference(user_input)
+
+        if item is None:
+            return DisambiguationResult(
+                error=f"Anlayamadım. Lütfen 1-{pending.item_count} arası bir numara girin.",
+            )
+
+        return DisambiguationResult(
+            resolved=True,
+            selected_item=item,
+            selected_index=item.index,
+        )
+
+    def _build_question(self, ref_table: ReferenceTable, intent: str) -> str:
+        """Build a context-rich Turkish disambiguation question.
+
+        Example output::
+
+            Takvimde 3 etkinlik buldum:
+              #1 📅 Pazartesi 14:00 — Proje görüşmesi
+              #2 📅 Salı 10:00 — 1-1 toplantı
+              #3 📅 Çarşamba 09:00 — Sprint planning
+            Hangisini silmemi istersin?
+        """
+        items = ref_table.items
+        if not items:
+            return "Seçenek bulunamadı."
+
+        # Detect item type from first item
+        item_type = items[0].item_type
+        emoji = TYPE_EMOJI.get(item_type, "📋")
+        type_label = TYPE_LABEL.get(item_type, "öğe")
+        count = len(items)
+
+        # Header
+        source_label = self._source_label(ref_table.source_tool)
+        header = f"{source_label}{count} {type_label} buldum:"
+
+        # Item lines
+        lines = [header]
+        for item in items:
+            lines.append(f"  #{item.index} {emoji} {item.label}")
+
+        # Action prompt based on intent
+        action = self._intent_action(intent)
+        lines.append(f"Hangisini {action}?")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _source_label(source_tool: str) -> str:
+        """Generate a Turkish source prefix."""
+        mapping = {
+            "calendar.list_events": "Takvimde ",
+            "calendar.free_slots": "Takvimde ",
+            "gmail.list_messages": "Gmail'de ",
+            "gmail.smart_search": "Gmail'de ",
+            "contacts.list": "Rehberde ",
+        }
+        return mapping.get(source_tool, "")
+
+    @staticmethod
+    def _intent_action(intent: str) -> str:
+        """Map intent to Turkish action verb."""
+        mapping = {
+            "calendar_delete_event": "silmemi istersin",
+            "calendar_update_event": "güncellememi istersin",
+            "calendar_reschedule": "ertelememi istersin",
+            "gmail_delete": "silmemi istersin",
+            "gmail_reply": "yanıtlamamı istersin",
+            "gmail_forward": "iletmemi istersin",
+            "gmail_mark_read": "okundu işaretlememi istersin",
+            "contacts_delete": "silmemi istersin",
+            "contacts_update": "güncellememi istersin",
+            "file_delete": "silmemi istersin",
+            "file_open": "açmamı istersin",
+        }
+        return mapping.get(intent, "seçmemi istersin")
+
+
+def create_disambiguation_dialog(
+    min_items: int = MIN_ITEMS_FOR_DISAMBIGUATION,
+) -> DisambiguationDialog:
+    """Factory for creating a DisambiguationDialog."""
+    return DisambiguationDialog(min_items=min_items)

--- a/src/bantz/brain/orchestrator_state.py
+++ b/src/bantz/brain/orchestrator_state.py
@@ -12,6 +12,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from bantz.brain.anaphora import ReferenceTable
+    from bantz.brain.disambiguation import DisambiguationRequest
 
 
 @dataclass
@@ -49,6 +50,9 @@ class OrchestratorState:
 
     # Issue #416: Last reference table for anaphora resolution
     reference_table: Optional[ReferenceTable] = field(default=None)
+
+    # Issue #875: Pending disambiguation request
+    disambiguation_pending: Optional[DisambiguationRequest] = field(default=None)
     
     def add_tool_result(self, tool_name: str, result: Any, success: bool = True) -> None:
         """Add a tool result to state (FIFO queue).
@@ -216,3 +220,4 @@ class OrchestratorState:
         self.turn_count = 0
         self.session_context = None
         self.reference_table = None
+        self.disambiguation_pending = None

--- a/tests/test_disambiguation.py
+++ b/tests/test_disambiguation.py
@@ -1,0 +1,205 @@
+"""Tests for DisambiguationDialog (Issue #875)."""
+from __future__ import annotations
+
+import pytest
+
+from bantz.brain.disambiguation import (
+    DisambiguationDialog,
+    DisambiguationRequest,
+    DisambiguationResult,
+    DISAMBIGUATION_INTENTS,
+    MIN_ITEMS_FOR_DISAMBIGUATION,
+    create_disambiguation_dialog,
+)
+from bantz.brain.anaphora import ReferenceItem, ReferenceTable
+from bantz.brain.orchestrator_state import OrchestratorState
+
+
+# ── helpers ──────────────────────────────────────────────────────
+
+def _calendar_tool_results(n: int = 3) -> list[dict]:
+    """Mock calendar.list_events tool results with n events."""
+    events = [
+        {"title": f"Toplantı {i}", "start": f"2025-07-{10+i}T{10+i}:00:00",
+         "event_id": f"evt_{i}"}
+        for i in range(1, n + 1)
+    ]
+    return [{"tool": "calendar.list_events", "success": True,
+             "raw_result": events, "result_summary": str(events)}]
+
+
+def _email_tool_results(n: int = 2) -> list[dict]:
+    """Mock gmail.list_messages tool results."""
+    msgs = [
+        {"from": f"user{i}@test.com", "subject": f"Konu {i}",
+         "message_id": f"msg_{i}"}
+        for i in range(1, n + 1)
+    ]
+    return [{"tool": "gmail.list_messages", "success": True,
+             "raw_result": msgs, "result_summary": str(msgs)}]
+
+
+# ── DisambiguationDialog.check_tool_results ──────────────────────
+
+class TestCheckToolResults:
+
+    def test_triggers_on_multiple_items(self):
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_delete_event"
+        )
+        assert req is not None
+        assert req.item_count >= 2
+        assert "hangisi" in req.question_text.lower() or "Hangisini" in req.question_text
+
+    def test_no_trigger_single_item(self):
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(1), intent="calendar_delete_event"
+        )
+        assert req is None
+
+    def test_no_trigger_non_disambiguation_intent(self):
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_list_events"
+        )
+        assert req is None
+
+    def test_no_trigger_empty_results(self):
+        d = DisambiguationDialog()
+        assert d.check_tool_results([], intent="calendar_delete_event") is None
+
+    def test_stores_reference_table(self):
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_update_event"
+        )
+        assert req is not None
+        assert isinstance(req.reference_table, ReferenceTable)
+        assert len(req.reference_table) >= 2
+
+
+# ── DisambiguationDialog._build_question ─────────────────────────
+
+class TestBuildQuestion:
+
+    def test_contains_item_labels(self):
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_delete_event"
+        )
+        assert req is not None
+        assert "#1" in req.question_text
+        assert "#2" in req.question_text
+
+    def test_contains_action_verb(self):
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(2), intent="gmail_reply"
+        )
+        # gmail_reply won't extract calendar events — use email results
+        req = d.check_tool_results(
+            _email_tool_results(2), intent="gmail_reply"
+        )
+        assert req is not None
+        assert "yanıtlamamı" in req.question_text
+
+    def test_source_label_calendar(self):
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_delete_event"
+        )
+        assert req is not None
+        assert "Takvimde" in req.question_text
+
+
+# ── DisambiguationDialog.resolve_response ────────────────────────
+
+class TestResolveResponse:
+
+    @pytest.fixture
+    def pending(self):
+        d = DisambiguationDialog()
+        return d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_delete_event"
+        )
+
+    def test_resolve_by_number(self, pending):
+        d = DisambiguationDialog()
+        result = d.resolve_response("#1", pending)
+        assert result.resolved is True
+        assert result.selected_index == 1
+
+    def test_resolve_by_bare_digit(self, pending):
+        d = DisambiguationDialog()
+        result = d.resolve_response("2", pending)
+        assert result.resolved is True
+        assert result.selected_index == 2
+
+    def test_resolve_invalid_number(self, pending):
+        d = DisambiguationDialog()
+        result = d.resolve_response("99", pending)
+        assert result.resolved is False
+        assert result.error
+
+    def test_resolve_no_pending(self):
+        d = DisambiguationDialog()
+        result = d.resolve_response("#1", None)
+        assert result.resolved is False
+        assert "yok" in result.error.lower()
+
+
+# ── OrchestratorState integration ───────────────────────────────
+
+class TestStateIntegration:
+
+    def test_disambiguation_pending_default_none(self):
+        state = OrchestratorState()
+        assert state.disambiguation_pending is None
+
+    def test_disambiguation_pending_survives_assignment(self):
+        state = OrchestratorState()
+        d = DisambiguationDialog()
+        req = d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_delete_event"
+        )
+        state.disambiguation_pending = req
+        assert state.disambiguation_pending is not None
+        assert state.disambiguation_pending.item_count >= 2
+
+    def test_disambiguation_cleared_on_reset(self):
+        state = OrchestratorState()
+        d = DisambiguationDialog()
+        state.disambiguation_pending = d.check_tool_results(
+            _calendar_tool_results(3), intent="calendar_delete_event"
+        )
+        state.reset()
+        assert state.disambiguation_pending is None
+
+
+# ── factory ──────────────────────────────────────────────────────
+
+class TestFactory:
+
+    def test_create_default(self):
+        d = create_disambiguation_dialog()
+        assert isinstance(d, DisambiguationDialog)
+
+    def test_create_custom_min_items(self):
+        d = create_disambiguation_dialog(min_items=5)
+        assert d._min_items == 5
+
+
+# ── disambiguation intents set ───────────────────────────────────
+
+class TestIntentsSet:
+
+    def test_contains_calendar_delete(self):
+        assert "calendar_delete_event" in DISAMBIGUATION_INTENTS
+
+    def test_contains_gmail_reply(self):
+        assert "gmail_reply" in DISAMBIGUATION_INTENTS
+
+    def test_not_contains_list(self):
+        assert "calendar_list_events" not in DISAMBIGUATION_INTENTS


### PR DESCRIPTION
## Summary
Tool sonucunda birden fazla item döndüğünde otomatik 'hangisi?' diyaloğu.

## Changes
- `src/bantz/brain/disambiguation.py`: DisambiguationDialog sınıfı
  - `check_tool_results()`: Çoklu sonuç tespiti + context-rich Türkçe soru
  - `resolve_response()`: Kullanıcı yanıtını ReferenceTable ile çöz (#N, ilkini, sonuncusu)
  - DISAMBIGUATION_INTENTS: Tek hedefli intent'ler (delete, update, reply...)
  - Emoji + detaylı liste formatı
- `src/bantz/brain/orchestrator_state.py`: `disambiguation_pending` field eklendi
- `tests/test_disambiguation.py`: 18 test

Closes #875