### PR TITLE
fix: strengthen PreRouter rules — remove 'hi', raise system threshold (closes #1001)

### DIFF
--- a/src/bantz/routing/preroute.py
+++ b/src/bantz/routing/preroute.py
@@ -383,12 +383,16 @@ class CompositeRule(PreRouteRule):
 # =============================================================================
 
 def create_greeting_rule() -> PreRouteRule:
-    """Create greeting detection rule."""
+    """Create greeting detection rule.
+    
+    Issue #1001: Removed 'hi' — it matches Turkish words like 'hiç', 'hiçbir',
+    'hile', 'hikaye'. Use 'hello' for English greetings instead.
+    """
     return KeywordRule(
         name="greeting",
         intent=IntentCategory.GREETING,
         keywords=[
-            "merhaba", "selam", "selamlar", "hey", "hi", "hello",
+            "merhaba", "selam", "selamlar", "hey", "hello",
             "günaydın", "iyi günler", "iyi akşamlar",
             "hayırlı günler", "hayırlı sabahlar",
         ],
@@ -689,7 +693,11 @@ def create_gmail_keyword_rule() -> PreRouteRule:
 
 
 def create_system_keyword_rule() -> PreRouteRule:
-    """System status keyword rule (Issue #906)."""
+    """System status keyword rule (Issue #906, #1001).
+    
+    Issue #1001: Raised threshold from 1 to 2 to prevent single-keyword
+    false positives (e.g. 'disk' in 'diskoteka', 'ram' in 'ramazan').
+    """
     return ThresholdRule(
         name="system_keyword",
         intent=IntentCategory.SYSTEM_STATUS,
@@ -699,7 +707,7 @@ def create_system_keyword_rule() -> PreRouteRule:
             r"ne\s+kadar\s+(?:ram|disk|bellek|pil)",
             r"(?:cpu|ram|disk)\s+(?:kullanım|usage)",
         ],
-        threshold=1,
+        threshold=2,
         confidence=0.92,
     )
 

--- a/tests/test_routing_preroute.py
+++ b/tests/test_routing_preroute.py
@@ -397,7 +397,10 @@ class TestDefaultRuleFactories:
         assert rule.match("Merhaba!").matched is True
         assert rule.match("Selam").matched is True
         assert rule.match("Günaydın").matched is True
-        assert rule.match("Hi").matched is True
+        assert rule.match("Hello").matched is True
+        # Issue #1001: "hi" removed — matches Turkish "hiç", "hikaye" etc.
+        assert rule.match("Hi").matched is False
+        assert rule.match("hiç sorun yok").matched is False
     
     def test_farewell_rule(self) -> None:
         """Test farewell rule."""


### PR DESCRIPTION
Fixes #1001

**Problem:** 'hi' keyword matched Turkish words like 'hiç', 'hikaye'. System keyword threshold=1 caused false positives from standalone words like 'disk'.

**Fix:**
- Remove 'hi' from greeting keywords (use 'hello' for English)
- Raise system_keyword threshold from 1 to 2
- Tests updated: 91 passing