### PR TITLE
fix: vLLM health check uses correct /v1/models URL (#996)

### DIFF
--- a/src/bantz/llm/vllm_openai_client.py
+++ b/src/bantz/llm/vllm_openai_client.py
@@ -176,8 +176,13 @@ class VLLMOpenAIClient(LLMClient):
             return False
         
         try:
-            # base_url already includes /v1, so just append /models
-            health_url = f"{self.base_url.rstrip('/')}/models"
+            # Issue #996: self.base_url is the raw URL (e.g. http://localhost:8001).
+            # vLLM serves /v1/models, not /models.  Must mirror _get_client()'s
+            # /v1 suffix logic.
+            _api_base = self.base_url.rstrip("/")
+            if not _api_base.endswith("/v1"):
+                _api_base = f"{_api_base}/v1"
+            health_url = f"{_api_base}/models"
             r = requests.get(
                 health_url,
                 timeout=float(timeout_seconds),

--- a/tests/test_issue_996_vllm_health.py
+++ b/tests/test_issue_996_vllm_health.py
@@ -1,0 +1,57 @@
+"""Tests for Issue #996: vLLM Health Check URL fix.
+
+is_available() was using self.base_url/models instead of self.base_url/v1/models.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestIsAvailableURL:
+    """is_available() should hit /v1/models, not /models."""
+
+    def _make_client(self, base_url="http://localhost:8001"):
+        from bantz.llm.vllm_openai_client import VLLMOpenAIClient
+        return VLLMOpenAIClient(base_url=base_url, model="test-model")
+
+    @patch("requests.get")
+    def test_url_includes_v1(self, mock_get):
+        """Health check should use /v1/models endpoint."""
+        mock_get.return_value = MagicMock(status_code=200)
+        client = self._make_client("http://localhost:8001")
+        result = client.is_available()
+        assert result is True
+        called_url = mock_get.call_args[0][0]
+        assert called_url == "http://localhost:8001/v1/models"
+
+    @patch("requests.get")
+    def test_url_already_has_v1(self, mock_get):
+        """If base_url already ends with /v1, don't double it."""
+        mock_get.return_value = MagicMock(status_code=200)
+        client = self._make_client("http://localhost:8001/v1")
+        result = client.is_available()
+        assert result is True
+        called_url = mock_get.call_args[0][0]
+        assert called_url == "http://localhost:8001/v1/models"
+
+    @patch("requests.get")
+    def test_trailing_slash_stripped(self, mock_get):
+        """Trailing slash should be stripped before appending."""
+        mock_get.return_value = MagicMock(status_code=200)
+        client = self._make_client("http://localhost:8001/")
+        result = client.is_available()
+        assert result is True
+        called_url = mock_get.call_args[0][0]
+        assert called_url == "http://localhost:8001/v1/models"
+
+    @patch("requests.get")
+    def test_server_down_returns_false(self, mock_get):
+        mock_get.side_effect = ConnectionError("refused")
+        client = self._make_client()
+        assert client.is_available() is False
+
+    @patch("requests.get")
+    def test_404_returns_false(self, mock_get):
+        mock_get.return_value = MagicMock(status_code=404)
+        client = self._make_client()
+        assert client.is_available() is False


### PR DESCRIPTION
Closes #996

is_available() was hitting /models instead of /v1/models, causing health checks to always return false (404). Now mirrors _get_client() /v1 suffix logic. 5 tests.