### PR TITLE
feat(misroute): integrate misroute dataset pipeline (#1012)

### DIFF
--- a/src/bantz/brain/misroute_integration.py
+++ b/src/bantz/brain/misroute_integration.py
@@ -1,0 +1,177 @@
+"""Misroute recording integration for orchestrator_loop (Issue #1012).
+
+Provides a lightweight hook that records potential misroutes after each turn.
+Controlled by BANTZ_MISROUTE_COLLECT=1 environment variable.
+
+Records are collected when:
+- Route is 'unknown' or 'fallback' (router couldn't decide)
+- Tool execution had failures (wrong tool selected)
+- Confidence is below threshold (uncertain routing)
+- Route changed during post-route correction (was misrouted initially)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Enable/disable via env var (off by default to avoid I/O overhead)
+MISROUTE_COLLECT_ENABLED = os.getenv("BANTZ_MISROUTE_COLLECT", "").strip() in ("1", "true", "yes")
+
+# Confidence threshold below which we record
+LOW_CONFIDENCE_THRESHOLD = float(os.getenv("BANTZ_MISROUTE_CONFIDENCE_THRESHOLD", "0.35"))
+
+# Lazy singleton — created on first use
+_dataset: Any = None
+
+
+def _get_dataset() -> Any:
+    """Lazy-init the MisrouteDataset singleton."""
+    global _dataset
+    if _dataset is None:
+        from bantz.router.misroute_collector import MisrouteDataset
+        _dataset = MisrouteDataset()
+    return _dataset
+
+
+def record_turn_misroute(
+    *,
+    user_input: str,
+    route: str,
+    intent: str,
+    confidence: float,
+    tool_plan: list,
+    tool_results: list[dict[str, Any]],
+    original_route: str | None = None,
+    session_id: str = "",
+    model_name: str = "",
+) -> None:
+    """Record a potential misroute if collection is enabled.
+
+    Called after each orchestrator turn. Only writes a record if at least
+    one misroute signal is detected:
+    - Unknown/fallback route
+    - Tool execution failure
+    - Low confidence
+    - Route corrected by post-route heuristics
+
+    Args:
+        user_input: The user's original message.
+        route: Final resolved route.
+        intent: Intent (calendar_intent or gmail_intent).
+        confidence: Router confidence score.
+        tool_plan: List of planned tool names.
+        tool_results: List of tool result dicts.
+        original_route: Route before post-route correction (if any).
+        session_id: Optional session identifier.
+        model_name: LLM model name used for routing.
+    """
+    if not MISROUTE_COLLECT_ENABLED:
+        return
+
+    reason = _classify_misroute(
+        route=route,
+        confidence=confidence,
+        tool_results=tool_results,
+        original_route=original_route,
+    )
+
+    if reason is None:
+        return  # Not a misroute — skip recording
+
+    try:
+        from bantz.router.misroute_collector import MisrouteRecord
+
+        record = MisrouteRecord(
+            user_text=user_input,
+            router_route=route,
+            router_intent=intent,
+            router_slots={},
+            router_confidence=confidence,
+            router_raw_output="",
+            expected_route=original_route if original_route and original_route != route else None,
+            reason=reason,
+            notes=_build_notes(tool_plan, tool_results, original_route, route),
+            session_id=session_id,
+            model_name=model_name,
+        )
+
+        _get_dataset().append(record)
+
+        logger.info(
+            "[MISROUTE] Recorded %s misroute: route=%s confidence=%.2f reason=%s",
+            "potential" if confidence > LOW_CONFIDENCE_THRESHOLD else "likely",
+            route, confidence, reason,
+        )
+
+    except Exception as exc:
+        logger.debug("[MISROUTE] Recording failed: %s", exc)
+
+
+def _classify_misroute(
+    *,
+    route: str,
+    confidence: float,
+    tool_results: list[dict[str, Any]],
+    original_route: str | None,
+) -> str | None:
+    """Classify the type of misroute, or None if no misroute detected."""
+
+    # 1. Fallback/unknown route
+    if route in ("unknown", "fallback", ""):
+        return "fallback"
+
+    # 2. Route was corrected by post-route heuristics
+    if original_route and original_route != route:
+        return "wrong_route"
+
+    # 3. Low confidence
+    if confidence < LOW_CONFIDENCE_THRESHOLD:
+        return "low_confidence"
+
+    # 4. Tool execution failures
+    failed_tools = [
+        tr for tr in tool_results
+        if isinstance(tr, dict) and tr.get("success") is False
+        or isinstance(tr, dict) and tr.get("status") in ("fail", "error")
+    ]
+    if failed_tools:
+        return "wrong_route"
+
+    return None
+
+
+def _build_notes(
+    tool_plan: list,
+    tool_results: list[dict[str, Any]],
+    original_route: str | None,
+    final_route: str,
+) -> str:
+    """Build human-readable notes for the misroute record."""
+    parts: list[str] = []
+
+    if original_route and original_route != final_route:
+        parts.append(f"route corrected: {original_route} → {final_route}")
+
+    if tool_plan:
+        names = [
+            (t.get("name") if isinstance(t, dict) else str(t))
+            for t in tool_plan
+        ]
+        parts.append(f"tools: {', '.join(names)}")
+
+    failed = [
+        str(tr.get("tool", "?"))
+        for tr in tool_results
+        if isinstance(tr, dict) and (
+            tr.get("success") is False
+            or tr.get("status") in ("fail", "error")
+        )
+    ]
+    if failed:
+        parts.append(f"failed: {', '.join(failed)}")
+
+    return "; ".join(parts) if parts else ""

--- a/tests/test_issue_1012_misroute_pipeline.py
+++ b/tests/test_issue_1012_misroute_pipeline.py
@@ -1,0 +1,150 @@
+"""Tests for Issue #1012: Misroute dataset pipeline integration.
+
+Tests the misroute_integration module (classification + recording logic)
+without requiring a running orchestrator or vLLM.
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+from bantz.brain.misroute_integration import (
+    _classify_misroute,
+    _build_notes,
+    record_turn_misroute,
+    LOW_CONFIDENCE_THRESHOLD,
+)
+
+
+class TestClassifyMisroute:
+    """Misroute classification logic."""
+
+    def test_unknown_route_is_fallback(self):
+        result = _classify_misroute(
+            route="unknown", confidence=0.5,
+            tool_results=[], original_route=None,
+        )
+        assert result == "fallback"
+
+    def test_empty_route_is_fallback(self):
+        result = _classify_misroute(
+            route="", confidence=0.5,
+            tool_results=[], original_route=None,
+        )
+        assert result == "fallback"
+
+    def test_route_corrected_is_wrong_route(self):
+        result = _classify_misroute(
+            route="gmail", confidence=0.8,
+            tool_results=[], original_route="calendar",
+        )
+        assert result == "wrong_route"
+
+    def test_low_confidence(self):
+        result = _classify_misroute(
+            route="calendar", confidence=0.1,
+            tool_results=[], original_route=None,
+        )
+        assert result == "low_confidence"
+
+    def test_tool_failure_is_wrong_route(self):
+        result = _classify_misroute(
+            route="calendar", confidence=0.9,
+            tool_results=[{"tool": "calendar.list_events", "success": False}],
+            original_route=None,
+        )
+        assert result == "wrong_route"
+
+    def test_no_misroute(self):
+        result = _classify_misroute(
+            route="calendar", confidence=0.9,
+            tool_results=[{"tool": "calendar.list_events", "success": True}],
+            original_route=None,
+        )
+        assert result is None
+
+    def test_same_original_route_not_wrong(self):
+        """If original_route == route, it's not a correction."""
+        result = _classify_misroute(
+            route="gmail", confidence=0.9,
+            tool_results=[], original_route="gmail",
+        )
+        assert result is None
+
+
+class TestBuildNotes:
+    """Notes builder for misroute records."""
+
+    def test_route_correction_noted(self):
+        notes = _build_notes([], [], "calendar", "gmail")
+        assert "calendar → gmail" in notes
+
+    def test_tool_names_listed(self):
+        notes = _build_notes(
+            [{"name": "calendar.list_events"}, "gmail.send"],
+            [], None, "calendar",
+        )
+        assert "calendar.list_events" in notes
+        assert "gmail.send" in notes
+
+    def test_failed_tools_noted(self):
+        notes = _build_notes(
+            [], [{"tool": "calendar.list_events", "success": False}],
+            None, "calendar",
+        )
+        assert "failed" in notes
+
+    def test_empty_notes(self):
+        notes = _build_notes([], [], None, "calendar")
+        assert notes == ""
+
+
+class TestRecordTurnMisroute:
+    """Integration test for record_turn_misroute."""
+
+    @patch("bantz.brain.misroute_integration.MISROUTE_COLLECT_ENABLED", False)
+    def test_disabled_does_nothing(self):
+        """When disabled, no recording happens."""
+        with patch("bantz.brain.misroute_integration._get_dataset") as mock_ds:
+            record_turn_misroute(
+                user_input="test",
+                route="unknown",
+                intent="none",
+                confidence=0.5,
+                tool_plan=[],
+                tool_results=[],
+            )
+            mock_ds.assert_not_called()
+
+    @patch("bantz.brain.misroute_integration.MISROUTE_COLLECT_ENABLED", True)
+    def test_enabled_records_fallback(self):
+        """When enabled, unknown route triggers recording."""
+        mock_dataset = MagicMock()
+        with patch("bantz.brain.misroute_integration._get_dataset", return_value=mock_dataset):
+            record_turn_misroute(
+                user_input="merhaba",
+                route="unknown",
+                intent="none",
+                confidence=0.3,
+                tool_plan=[],
+                tool_results=[],
+            )
+            mock_dataset.append.assert_called_once()
+            record = mock_dataset.append.call_args[0][0]
+            assert record.user_text == "merhaba"
+            assert record.reason == "fallback"
+
+    @patch("bantz.brain.misroute_integration.MISROUTE_COLLECT_ENABLED", True)
+    def test_no_misroute_skips_recording(self):
+        """Normal successful turns are not recorded."""
+        mock_dataset = MagicMock()
+        with patch("bantz.brain.misroute_integration._get_dataset", return_value=mock_dataset):
+            record_turn_misroute(
+                user_input="bugün ne var?",
+                route="calendar",
+                intent="query",
+                confidence=0.9,
+                tool_plan=["calendar.list_events"],
+                tool_results=[{"tool": "calendar.list_events", "success": True}],
+            )
+            mock_dataset.append.assert_not_called()


### PR DESCRIPTION
Closes #1012

## Changes
- **New `misroute_integration.py`**: Lightweight recording hook that classifies and records potential misroutes:
  - `fallback`: Unknown/empty route
  - `wrong_route`: Post-route correction or tool failure
  - `low_confidence`: Below configurable threshold (default 0.35)
- **Orchestrator hook**: Records after trace export in `process_turn()`
- **Env-controlled**: `BANTZ_MISROUTE_COLLECT=1` enables (off by default)
- **PII-safe**: Uses existing `MisrouteDataset` with PII redaction

## Tests
14 new tests — all passing.