### PR TITLE
refactor(#1010): extract ContextBuilder from orchestrator_loop

### DIFF
--- a/src/bantz/brain/context_builder.py
+++ b/src/bantz/brain/context_builder.py
@@ -1,0 +1,358 @@
+"""Context builder for orchestrator LLM planning phase (Issue #1010).
+
+Extracted from orchestrator_loop.py._llm_planning_phase to reduce
+complexity.  Assembles the ``enhanced_summary`` from multiple sources:
+
+* Dialog summary (memory-lite)
+* PII redaction + token-budget trimming
+* User profile (persistent memory)
+* Personality block (Jarvis / Friday / Alfred)
+* Recent conversation history
+* Last tool results
+* Anaphora reference table
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ContextBuildResult:
+    """Value returned by :meth:`ContextBuilder.build`."""
+
+    enhanced_summary: str | None = None
+    dialog_summary: str | None = None   # For event-bus preview
+    turns_count: int = 0
+
+
+class ContextBuilder:
+    """Assembles enhanced context for the LLM router.
+
+    Replaces ~160 inline lines in ``_llm_planning_phase``.
+    Each source is optional — missing components are silently skipped.
+
+    Usage::
+
+        builder = ContextBuilder(
+            memory=self.memory,
+            user_memory=self.user_memory,
+            personality_injector=self.personality_injector,
+            pii_filter=self.config.memory_pii_filter,
+            memory_max_tokens=self.config.memory_max_tokens,
+        )
+        result = builder.build(
+            user_input=user_input,
+            conversation_history=conversation_history,
+            tool_results=tool_results,
+            state=state,
+            is_smalltalk=is_smalltalk,
+            memory_tracer=self._memory_tracer,
+        )
+        enhanced_summary = result.enhanced_summary
+    """
+
+    def __init__(
+        self,
+        *,
+        memory: Any,
+        user_memory: Any = None,
+        personality_injector: Any = None,
+        pii_filter: bool = False,
+        memory_max_tokens: int = 2048,
+    ):
+        self._memory = memory
+        self._user_memory = user_memory
+        self._personality_injector = personality_injector
+        self._pii_filter = pii_filter
+        self._memory_max_tokens = memory_max_tokens
+
+        # PII redaction cache (Issue #942)
+        self._cached_pii_summary: str | None = None
+        self._cached_pii_summary_key: int | None = None
+
+        # Personality cache (Issue #942)
+        self._cached_personality_block: str | None = None
+        self._personality_block_built: bool = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def build(
+        self,
+        *,
+        user_input: str,
+        conversation_history: list[dict[str, Any]],
+        tool_results: list[dict[str, Any]],
+        state: Any,
+        is_smalltalk: bool = False,
+        memory_tracer: Any = None,
+    ) -> ContextBuildResult:
+        """Build the enhanced summary string for the LLM router.
+
+        The caller is responsible for calling ``memory_tracer.end_turn()``
+        and publishing the resulting record on the event bus.
+        """
+        context_parts: list[str] = []
+        result = ContextBuildResult()
+
+        # 1. Dialog summary (memory-lite)
+        dialog_summary, turns_count = self._build_dialog_summary(memory_tracer)
+        result.dialog_summary = dialog_summary
+        result.turns_count = turns_count
+        if dialog_summary:
+            context_parts.append(dialog_summary)
+
+        # 2. User profile + long-term memory
+        um_facts = self._inject_user_profile(
+            user_input, context_parts, is_smalltalk,
+        )
+
+        # 3. Personality block
+        self._inject_personality(context_parts, um_facts)
+
+        # 4. Recent conversation (last 2 turns, PII-redacted)
+        self._inject_conversation_history(conversation_history, context_parts)
+
+        # 5. Recent tool results
+        self._inject_tool_results(tool_results, context_parts)
+
+        # 6. Anaphora reference table
+        self._inject_reference_table(tool_results, context_parts, state)
+
+        result.enhanced_summary = (
+            "\n\n".join(context_parts) if context_parts else None
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_dialog_summary(
+        self, memory_tracer: Any = None,
+    ) -> tuple[str | None, int]:
+        """Retrieve and process dialog summary from memory-lite.
+
+        Returns ``(dialog_summary, turns_count)``.
+        """
+        dialog_summary = self._memory.to_prompt_block()
+        turns_count = (
+            len(self._memory) if hasattr(self._memory, "__len__") else 0
+        )
+
+        if not dialog_summary:
+            return None, turns_count
+
+        if memory_tracer is not None:
+            try:
+                memory_tracer.begin_turn(
+                    int(getattr(self._memory, "turn_count", 0)) + 1
+                )
+            except Exception:
+                pass
+
+        # PII redaction with caching (Issue #942)
+        _raw_hash = hash(dialog_summary)
+
+        if self._pii_filter:
+            if (
+                _raw_hash == self._cached_pii_summary_key
+                and self._cached_pii_summary is not None
+            ):
+                dialog_summary = self._cached_pii_summary
+            else:
+                try:
+                    from bantz.privacy.redaction import redact_pii
+
+                    dialog_summary = redact_pii(dialog_summary)
+                    self._cached_pii_summary = dialog_summary
+                    self._cached_pii_summary_key = _raw_hash
+                except Exception:
+                    pass
+
+        # Token budget trimming  (Issue #599)
+        from bantz.llm.token_utils import estimate_tokens as _estimate_tokens
+
+        # Use tracer budget if available, else constructor default
+        try:
+            budget_tokens = int(memory_tracer.budget.max_tokens)  # type: ignore[union-attr]
+        except Exception:
+            budget_tokens = int(self._memory_max_tokens)
+        budget_tokens = max(1, budget_tokens)
+
+        original_tokens = _estimate_tokens(dialog_summary)
+
+        if original_tokens > budget_tokens:
+            budget_chars = budget_tokens * 4
+            trimmed = dialog_summary[-budget_chars:]
+            nl = trimmed.find("\n")
+            if 0 < nl < 80:
+                trimmed = trimmed[nl + 1:]
+            if memory_tracer is not None:
+                try:
+                    memory_tracer.record_trim(
+                        original_tokens,
+                        _estimate_tokens(trimmed),
+                        reason="token_budget",
+                    )
+                except Exception:
+                    pass
+            dialog_summary = trimmed
+
+        if memory_tracer is not None:
+            try:
+                memory_tracer.record_injection(
+                    dialog_summary,
+                    turns_count,
+                    token_estimator=_estimate_tokens,
+                )
+            except Exception:
+                pass
+
+        return dialog_summary, turns_count
+
+    def _inject_user_profile(
+        self,
+        user_input: str,
+        context_parts: list[str],
+        is_smalltalk: bool,
+    ) -> dict[str, str]:
+        """Inject user profile + long-term memory.  Returns facts dict."""
+        um_facts: dict[str, str] = {}
+
+        if self._user_memory is None or is_smalltalk:
+            return um_facts
+
+        try:
+            um_result = self._user_memory.on_turn_start(user_input)
+            profile_ctx = um_result.get("profile_context", "")
+            um_facts = um_result.get("facts", {})
+
+            if profile_ctx:
+                context_parts.append(f"USER_PROFILE:\n{profile_ctx}")
+
+            memory_snippets = um_result.get("memories", [])
+            if memory_snippets:
+                mem_block = "LONG_TERM_MEMORY:\n" + "\n".join(
+                    f"  - {s}" for s in memory_snippets[:5]
+                )
+                context_parts.append(mem_block)
+
+            # Update personality injector with user name
+            if self._personality_injector is not None:
+                pname = um_facts.get("name", "")
+                if pname:
+                    self._personality_injector.update_user_name(pname)
+
+        except Exception as exc:
+            logger.debug("[CONTEXT_BUILDER] user_memory failed: %s", exc)
+
+        return um_facts
+
+    def _inject_personality(
+        self,
+        context_parts: list[str],
+        um_facts: dict[str, str],
+    ) -> None:
+        """Inject personality block (cached per session)."""
+        if self._personality_injector is None:
+            return
+
+        try:
+            if not self._personality_block_built:
+                pi_block = self._personality_injector.build_router_block(
+                    facts=um_facts,
+                    preferences={},
+                )
+                self._cached_personality_block = pi_block
+                self._personality_block_built = True
+            else:
+                pi_block = self._cached_personality_block
+
+            if pi_block:
+                context_parts.append(f"PERSONALITY:\n{pi_block}")
+        except Exception as exc:
+            logger.debug("[CONTEXT_BUILDER] personality injection failed: %s", exc)
+
+    def _inject_conversation_history(
+        self,
+        conversation_history: list[dict[str, Any]],
+        context_parts: list[str],
+    ) -> None:
+        """Add last 2 turns of conversation history."""
+        if not conversation_history:
+            return
+
+        conv_lines = ["RECENT_CONVERSATION:"]
+        for turn in conversation_history[-2:]:
+            user_text = str(turn.get("user", ""))[:100]
+            asst_text = str(turn.get("assistant", ""))[:150]
+
+            if self._pii_filter:
+                try:
+                    from bantz.privacy.redaction import redact_pii
+
+                    user_text = redact_pii(user_text)
+                    asst_text = redact_pii(asst_text)
+                except Exception:
+                    pass
+
+            conv_lines.append(f"  U: {user_text}")
+            conv_lines.append(f"  A: {asst_text}")
+
+        context_parts.append("\n".join(conv_lines))
+
+    def _inject_tool_results(
+        self,
+        tool_results: list[dict[str, Any]],
+        context_parts: list[str],
+    ) -> None:
+        """Add last 2 tool results for context continuity."""
+        if not tool_results:
+            return
+
+        result_lines = ["LAST_TOOL_RESULTS:"]
+        for tr in tool_results[-2:]:
+            tool_name = str(tr.get("tool", ""))
+            result_str = str(tr.get("result_summary", ""))[:200]
+
+            if self._pii_filter:
+                try:
+                    from bantz.privacy.redaction import redact_pii
+
+                    result_str = redact_pii(result_str)
+                except Exception:
+                    pass
+
+            success = tr.get("success", True)
+            status = "ok" if success else "fail"
+            result_lines.append(f"  {tool_name} ({status}): {result_str}")
+
+        context_parts.append("\n".join(result_lines))
+
+    def _inject_reference_table(
+        self,
+        tool_results: list[dict[str, Any]],
+        context_parts: list[str],
+        state: Any,
+    ) -> None:
+        """Inject REFERENCE_TABLE for anaphora resolution (Issue #416)."""
+        if not tool_results:
+            return
+
+        try:
+            from bantz.brain.anaphora import ReferenceTable
+
+            ref_table = ReferenceTable.from_tool_results(tool_results)
+            ref_block = ref_table.to_prompt_block()
+            if ref_block:
+                context_parts.append(ref_block)
+                state.reference_table = ref_table
+        except Exception as exc:
+            logger.debug("[CONTEXT_BUILDER] reference table failed: %s", exc)

--- a/tests/test_issue_1010_context_builder.py
+++ b/tests/test_issue_1010_context_builder.py
@@ -1,0 +1,520 @@
+"""Tests for ContextBuilder (Issue #1010).
+
+Validates the extracted context-building logic behaves identically
+to the inline version that was in orchestrator_loop._llm_planning_phase.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.brain.context_builder import ContextBuilder, ContextBuildResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_memory(prompt_block: str | None = None, length: int = 0):
+    """Minimal DialogSummaryManager mock."""
+    mem = MagicMock()
+    mem.to_prompt_block.return_value = prompt_block
+    mem.__len__ = MagicMock(return_value=length)
+    mem.turn_count = length
+    return mem
+
+
+def _make_state():
+    """Minimal OrchestratorState mock with trace + reference_table."""
+    state = MagicMock()
+    state.trace = {}
+    state.reference_table = None
+    return state
+
+
+def _make_user_memory(facts=None, profile="", memories=None):
+    um = MagicMock()
+    um.on_turn_start.return_value = {
+        "profile_context": profile,
+        "facts": facts or {},
+        "memories": memories or [],
+    }
+    return um
+
+
+def _make_personality_injector(block="Jarvis personality block"):
+    pi = MagicMock()
+    pi.build_router_block.return_value = block
+    pi.update_user_name = MagicMock()
+    return pi
+
+
+# ---------------------------------------------------------------------------
+# Tests: Basic build
+# ---------------------------------------------------------------------------
+
+class TestContextBuilderBasic:
+    """Basic ContextBuilder.build() smoke tests."""
+
+    def test_empty_memory_returns_none(self):
+        builder = ContextBuilder(memory=_make_memory(None))
+        result = builder.build(
+            user_input="merhaba",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert isinstance(result, ContextBuildResult)
+        assert result.enhanced_summary is None
+        assert result.dialog_summary is None
+
+    def test_dialog_summary_included(self):
+        builder = ContextBuilder(memory=_make_memory("Turn 1 summary"))
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert result.dialog_summary == "Turn 1 summary"
+        assert "Turn 1 summary" in result.enhanced_summary
+
+    def test_conversation_history_injected(self):
+        builder = ContextBuilder(memory=_make_memory("mem"))
+        history = [
+            {"user": "merhaba", "assistant": "Merhaba!"},
+            {"user": "saat kaç", "assistant": "14:30"},
+        ]
+        result = builder.build(
+            user_input="test",
+            conversation_history=history,
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert "RECENT_CONVERSATION:" in result.enhanced_summary
+        assert "U: merhaba" in result.enhanced_summary
+        assert "A: 14:30" in result.enhanced_summary
+
+    def test_tool_results_injected(self):
+        builder = ContextBuilder(memory=_make_memory("mem"))
+        tools = [
+            {"tool": "calendar.list_events", "result_summary": "3 events found", "success": True},
+        ]
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=tools,
+            state=_make_state(),
+        )
+        assert "LAST_TOOL_RESULTS:" in result.enhanced_summary
+        assert "calendar.list_events (ok)" in result.enhanced_summary
+
+    def test_failed_tool_status(self):
+        builder = ContextBuilder(memory=_make_memory("mem"))
+        tools = [
+            {"tool": "gmail.send", "result_summary": "auth error", "success": False},
+        ]
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=tools,
+            state=_make_state(),
+        )
+        assert "gmail.send (fail)" in result.enhanced_summary
+
+    def test_returns_context_build_result_type(self):
+        builder = ContextBuilder(memory=_make_memory("mem"))
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert isinstance(result, ContextBuildResult)
+        assert result.enhanced_summary is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: User profile + personality
+# ---------------------------------------------------------------------------
+
+class TestContextBuilderProfile:
+    """User profile and personality injection."""
+
+    def test_user_profile_injected(self):
+        um = _make_user_memory(
+            profile="Name: Ali, Preference: formal",
+            facts={"name": "Ali"},
+        )
+        builder = ContextBuilder(
+            memory=_make_memory("mem"),
+            user_memory=um,
+        )
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert "USER_PROFILE:" in result.enhanced_summary
+        assert "Ali" in result.enhanced_summary
+
+    def test_user_profile_skipped_for_smalltalk(self):
+        um = _make_user_memory(profile="Name: Ali")
+        builder = ContextBuilder(
+            memory=_make_memory("mem"),
+            user_memory=um,
+        )
+        result = builder.build(
+            user_input="merhaba",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+            is_smalltalk=True,
+        )
+        um.on_turn_start.assert_not_called()
+        assert "USER_PROFILE:" not in (result.enhanced_summary or "")
+
+    def test_personality_block_injected(self):
+        pi = _make_personality_injector("I am Jarvis")
+        builder = ContextBuilder(
+            memory=_make_memory("mem"),
+            personality_injector=pi,
+        )
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert "PERSONALITY:" in result.enhanced_summary
+        assert "I am Jarvis" in result.enhanced_summary
+
+    def test_personality_block_cached(self):
+        pi = _make_personality_injector("Jarvis")
+        builder = ContextBuilder(
+            memory=_make_memory("mem"),
+            personality_injector=pi,
+        )
+        # First call builds
+        builder.build(
+            user_input="t1",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        # Second call uses cache
+        builder.build(
+            user_input="t2",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert pi.build_router_block.call_count == 1
+
+    def test_long_term_memory_snippets(self):
+        um = _make_user_memory(
+            memories=["Ali likes coffee", "Prefers morning meetings"],
+        )
+        builder = ContextBuilder(
+            memory=_make_memory("mem"),
+            user_memory=um,
+        )
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert "LONG_TERM_MEMORY:" in result.enhanced_summary
+        assert "Ali likes coffee" in result.enhanced_summary
+
+    def test_personality_injector_receives_user_name(self):
+        pi = _make_personality_injector("Block")
+        um = _make_user_memory(facts={"name": "Mehmet"})
+        builder = ContextBuilder(
+            memory=_make_memory("mem"),
+            user_memory=um,
+            personality_injector=pi,
+        )
+        builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        pi.update_user_name.assert_called_once_with("Mehmet")
+
+
+# ---------------------------------------------------------------------------
+# Tests: PII redaction
+# ---------------------------------------------------------------------------
+
+class TestContextBuilderPII:
+    """PII filtering and caching."""
+
+    @patch("bantz.brain.context_builder.logger")
+    def test_pii_filter_applied_to_dialog_summary(self, _mock_logger):
+        with patch(
+            "bantz.privacy.redaction.redact_pii",
+            side_effect=lambda s: s.replace("Ali", "[REDACTED]"),
+        ):
+            builder = ContextBuilder(
+                memory=_make_memory("Ali said hello"),
+                pii_filter=True,
+            )
+            result = builder.build(
+                user_input="test",
+                conversation_history=[],
+                tool_results=[],
+                state=_make_state(),
+            )
+            assert "[REDACTED]" in result.dialog_summary
+            assert "Ali" not in result.dialog_summary
+
+    @patch("bantz.brain.context_builder.logger")
+    def test_pii_cache_hit(self, _mock_logger):
+        with patch(
+            "bantz.privacy.redaction.redact_pii",
+            side_effect=lambda s: s.replace("Ali", "[R]"),
+        ) as mock_redact:
+            mem = _make_memory("Ali said hello")
+            builder = ContextBuilder(memory=mem, pii_filter=True)
+
+            # First build — redaction called
+            builder.build(
+                user_input="t1",
+                conversation_history=[],
+                tool_results=[],
+                state=_make_state(),
+            )
+            assert mock_redact.call_count >= 1
+            first_count = mock_redact.call_count
+
+            # Second build with same summary — cache hit, no extra call
+            builder.build(
+                user_input="t2",
+                conversation_history=[],
+                tool_results=[],
+                state=_make_state(),
+            )
+            # Only conversation_history / tool_results may call redact, not dialog_summary
+            # The dialog_summary redact should be cached
+            assert mock_redact.call_count == first_count
+
+    def test_pii_filter_applied_to_conversation_history(self):
+        with patch(
+            "bantz.privacy.redaction.redact_pii",
+            side_effect=lambda s: s.replace("secret", "[R]"),
+        ):
+            builder = ContextBuilder(
+                memory=_make_memory("mem"),
+                pii_filter=True,
+            )
+            result = builder.build(
+                user_input="test",
+                conversation_history=[
+                    {"user": "my secret number", "assistant": "ok secret"}
+                ],
+                tool_results=[],
+                state=_make_state(),
+            )
+            assert "secret" not in result.enhanced_summary
+            assert "[R]" in result.enhanced_summary
+
+
+# ---------------------------------------------------------------------------
+# Tests: Token budget trimming
+# ---------------------------------------------------------------------------
+
+class TestContextBuilderTokenBudget:
+    """Token budget enforcement for dialog summary."""
+
+    def test_long_summary_trimmed(self):
+        # Create a very long summary (>1000 tokens ≈ 4000 chars)
+        long_summary = "x" * 8000
+        builder = ContextBuilder(
+            memory=_make_memory(long_summary),
+            memory_max_tokens=500,
+        )
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        # Should be trimmed to ~500*4=2000 chars
+        assert len(result.dialog_summary) <= 2100
+
+    def test_short_summary_not_trimmed(self):
+        short_summary = "short dialog"
+        builder = ContextBuilder(
+            memory=_make_memory(short_summary),
+            memory_max_tokens=1000,
+        )
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+        )
+        assert result.dialog_summary == short_summary
+
+
+# ---------------------------------------------------------------------------
+# Tests: Memory tracer integration
+# ---------------------------------------------------------------------------
+
+class TestContextBuilderTracer:
+    """Memory tracer lifecycle (begin_turn, record_trim, record_injection)."""
+
+    def test_tracer_begin_turn_called(self):
+        tracer = MagicMock()
+        tracer.budget = MagicMock()
+        tracer.budget.max_tokens = 1000
+        mem = _make_memory("summary", length=3)
+        builder = ContextBuilder(memory=mem)
+        builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+            memory_tracer=tracer,
+        )
+        tracer.begin_turn.assert_called_once()
+
+    def test_tracer_record_injection_called(self):
+        tracer = MagicMock()
+        tracer.budget = MagicMock()
+        tracer.budget.max_tokens = 1000
+        builder = ContextBuilder(memory=_make_memory("summary"))
+        builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+            memory_tracer=tracer,
+        )
+        tracer.record_injection.assert_called_once()
+
+    def test_tracer_record_trim_called_on_overflow(self):
+        tracer = MagicMock()
+        tracer.budget = MagicMock()
+        tracer.budget.max_tokens = 10  # Very small budget
+        builder = ContextBuilder(
+            memory=_make_memory("x" * 1000),
+            memory_max_tokens=10,
+        )
+        builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=_make_state(),
+            memory_tracer=tracer,
+        )
+        tracer.record_trim.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Anaphora reference table
+# ---------------------------------------------------------------------------
+
+class TestContextBuilderAnaphora:
+    """REFERENCE_TABLE injection for anaphora resolution."""
+
+    def test_reference_table_injected(self):
+        mock_table = MagicMock()
+        mock_table.to_prompt_block.return_value = "REFERENCE_TABLE:\n#1: Event A"
+
+        with patch(
+            "bantz.brain.anaphora.ReferenceTable",
+        ) as MockRT:
+            MockRT.from_tool_results.return_value = mock_table
+
+            builder = ContextBuilder(memory=_make_memory("mem"))
+            state = _make_state()
+            result = builder.build(
+                user_input="test",
+                conversation_history=[],
+                tool_results=[{"tool": "cal", "result_summary": "ok"}],
+                state=state,
+            )
+            assert "REFERENCE_TABLE:" in result.enhanced_summary
+            assert state.reference_table is mock_table
+
+    def test_no_reference_table_without_tool_results(self):
+        builder = ContextBuilder(memory=_make_memory("mem"))
+        state = _make_state()
+        result = builder.build(
+            user_input="test",
+            conversation_history=[],
+            tool_results=[],
+            state=state,
+        )
+        assert state.reference_table is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Full integration (all sources combined)
+# ---------------------------------------------------------------------------
+
+class TestContextBuilderIntegration:
+    """Full build with all sources active."""
+
+    def test_all_sections_present(self):
+        mock_table = MagicMock()
+        mock_table.to_prompt_block.return_value = "REFERENCE_TABLE:\n#1: test"
+
+        with patch(
+            "bantz.brain.anaphora.ReferenceTable"
+        ) as MockRT:
+            MockRT.from_tool_results.return_value = mock_table
+
+            builder = ContextBuilder(
+                memory=_make_memory("Dialog block"),
+                user_memory=_make_user_memory(
+                    profile="Name: Ali",
+                    facts={"name": "Ali"},
+                    memories=["Likes tea"],
+                ),
+                personality_injector=_make_personality_injector("Jarvis style"),
+            )
+            result = builder.build(
+                user_input="saat kaç",
+                conversation_history=[
+                    {"user": "merhaba", "assistant": "Selam!"},
+                ],
+                tool_results=[
+                    {"tool": "time.now", "result_summary": "14:30", "success": True},
+                ],
+                state=_make_state(),
+            )
+
+            summary = result.enhanced_summary
+            assert "Dialog block" in summary
+            assert "USER_PROFILE:" in summary
+            assert "LONG_TERM_MEMORY:" in summary
+            assert "PERSONALITY:" in summary
+            assert "RECENT_CONVERSATION:" in summary
+            assert "LAST_TOOL_RESULTS:" in summary
+            assert "REFERENCE_TABLE:" in summary
+
+    def test_sections_separated_by_double_newline(self):
+        builder = ContextBuilder(
+            memory=_make_memory("Dialog block"),
+            personality_injector=_make_personality_injector("Jarvis"),
+        )
+        result = builder.build(
+            user_input="test",
+            conversation_history=[
+                {"user": "hi", "assistant": "hello"},
+            ],
+            tool_results=[],
+            state=_make_state(),
+        )
+        # Each section separated by \n\n
+        parts = result.enhanced_summary.split("\n\n")
+        assert len(parts) >= 3  # dialog + personality + conversation

--- a/tests/test_issue_873_persistent_user_memory.py
+++ b/tests/test_issue_873_persistent_user_memory.py
@@ -247,10 +247,14 @@ class TestOrchestratorWiring(unittest.TestCase):
         self.assertIn("UserMemoryBridge", source)
 
     def test_phase1_injects_profile_context(self):
-        """_llm_planning_phase should inject USER_PROFILE into context_parts."""
-        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
-        self.assertIn("USER_PROFILE:", source)
-        self.assertIn("on_turn_start", source)
+        """_llm_planning_phase should inject USER_PROFILE into context_parts.
+
+        Issue #1010: Context building extracted to ContextBuilder, so
+        the literal 'USER_PROFILE:' string now lives in context_builder.py.
+        """
+        cb_source = (_SRC / "brain" / "context_builder.py").read_text("utf-8")
+        self.assertIn("USER_PROFILE:", cb_source)
+        self.assertIn("on_turn_start", cb_source)
 
     def test_phase4_calls_on_turn_end(self):
         """_update_state_phase should call user_memory.on_turn_end."""
@@ -258,9 +262,12 @@ class TestOrchestratorWiring(unittest.TestCase):
         self.assertIn("on_turn_end", source)
 
     def test_phase1_injects_long_term_memory(self):
-        """_llm_planning_phase should inject LONG_TERM_MEMORY block."""
-        source = (_SRC / "brain" / "orchestrator_loop.py").read_text("utf-8")
-        self.assertIn("LONG_TERM_MEMORY:", source)
+        """_llm_planning_phase should inject LONG_TERM_MEMORY block.
+
+        Issue #1010: Context building extracted to ContextBuilder.
+        """
+        cb_source = (_SRC / "brain" / "context_builder.py").read_text("utf-8")
+        self.assertIn("LONG_TERM_MEMORY:", cb_source)
 
     def test_user_memory_init_is_best_effort(self):
         """user_memory init should be wrapped in try/except."""

--- a/tests/test_issue_874_personality_injection.py
+++ b/tests/test_issue_874_personality_injection.py
@@ -631,9 +631,13 @@ class TestOrchestratorWiring(unittest.TestCase):
         self.assertIn("PersonalityInjector", self._source)
 
     def test_personality_block_in_phase1(self):
-        """Phase 1 should inject PERSONALITY block."""
-        self.assertIn("PERSONALITY:", self._source)
-        self.assertIn("build_router_block", self._source)
+        """Phase 1 should inject PERSONALITY block.
+
+        Issue #1010: Context building extracted to ContextBuilder.
+        """
+        cb_source = (_SRC / "brain" / "context_builder.py").read_text("utf-8")
+        self.assertIn("PERSONALITY:", cb_source)
+        self.assertIn("build_router_block", cb_source)
 
     def test_personality_block_in_phase3(self):
         """Phase 3 should pass personality_block to build_finalization_context."""


### PR DESCRIPTION
## Issue #1010: Orchestrator Refactoring — ContextBuilder Extraction

### Changes
- Extract ~230-line context-building block from `_llm_planning_phase` into `bantz.brain.context_builder.ContextBuilder` class
- `ContextBuilder` owns: dialog summary, user profile injection, personality injection, PII filtering, conversation history, tool results, anaphora reference table
- Returns `ContextBuildResult` dataclass (`enhanced_summary`, `dialog_summary`, `turns_count`)
- Orchestrator `__init__` creates `self._context_builder`, `_llm_planning_phase` delegates to `self._context_builder.build()`
- File reduced from **1934 → 1795 lines** (139 lines removed)

### Tests
- 24 new tests in `test_issue_1010_context_builder.py` (all pass)
- Updated source-grep tests in `test_issue_873` and `test_issue_874` to check `context_builder.py`
- Full suite: 9189 passed (149 pre-existing failures unchanged)

Closes #1010