### PR TITLE
fix(nlu): require action verb in browser_open regex (#1058)

### DIFF
--- a/src/bantz/router/nlu.py
+++ b/src/bantz/router/nlu.py
@@ -653,7 +653,9 @@ def parse_intent(text: str) -> Parsed:
             return Parsed(intent="browser_search", slots={"query": query})
 
     # browser_open: "instagram'ı aç", "twitter aç", "github.com aç", "wikipedia aç", "duck aç"
-    m = re.search(r"\b(instagram|twitter|facebook|youtube|github|linkedin|reddit|twitch|spotify|netflix|whatsapp|telegram|discord|wikipedia|vikipedi|amazon|ebay|stackoverflow|stack\s*overflow|duck|duckduckgo|chatgpt|claude|gemini|perplexity)\b['\s]*(ı|i|'?y[ıi])?\s*(aç|başlat)?", t)
+    # Issue #1058: action verb (aç|başlat) is now REQUIRED — just mentioning
+    # a site name (e.g. "instagram güzel") must NOT trigger browser_open.
+    m = re.search(r"\b(instagram|twitter|facebook|youtube|github|linkedin|reddit|twitch|spotify|netflix|whatsapp|telegram|discord|wikipedia|vikipedi|amazon|ebay|stackoverflow|stack\s*overflow|duck|duckduckgo|chatgpt|claude|gemini|perplexity)\b['\s]*(ı|i|'?y[ıi])?\s*(aç|başlat)", t)
     if m:
         site = m.group(1).lower().replace(" ", "")
         urls = {


### PR DESCRIPTION
## Problem
The browser_open regex in nlu.py had `(aç|başlat)?` with the action verb optional. This meant any mention of a site name (e.g. 'instagram güzel', 'youtube videosu') would trigger browser_open intent even when the user didn't ask to open a site.

## Fix
Made the action verb required by removing the `?` quantifier. Now only explicit commands like 'instagram aç' or 'twitter başlat' trigger browser_open.

## Files Changed
- `src/bantz/router/nlu.py` — line 656 regex fix

Closes #1058