### PR TITLE
fix(llm): add system_prompt param to complete_text (#1050)

### DIFF
--- a/src/bantz/llm/base.py
+++ b/src/bantz/llm/base.py
@@ -133,13 +133,14 @@ class LLMClient(ABC):
         pass
     
     @abstractmethod
-    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200) -> str:
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200, system_prompt: Optional[str] = None) -> str:
         """Simple text completion (used by Router).
         
         Args:
-            prompt: Single prompt string
+            prompt: Single prompt string (sent as user message)
             temperature: Sampling temperature
             max_tokens: Max tokens to generate
+            system_prompt: Optional system instructions (sent as system message)
             
         Returns:
             Generated text
@@ -180,7 +181,7 @@ class LLMClientProtocol(Protocol):
     ) -> str:
         ...
     
-    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200) -> str:
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200, system_prompt: Optional[str] = None) -> str:
         ...
     
     @property

--- a/src/bantz/llm/gemini_client.py
+++ b/src/bantz/llm/gemini_client.py
@@ -678,8 +678,11 @@ class GeminiClient(LLMClient):
                 ttft = chunk.ttft_ms
         return "".join(parts).strip(), ttft
 
-    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200) -> str:
-        messages = [LLMMessage(role="user", content=prompt)]
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200, system_prompt: Optional[str] = None) -> str:
+        messages: list[LLMMessage] = []
+        if system_prompt:
+            messages.append(LLMMessage(role="system", content=system_prompt))
+        messages.append(LLMMessage(role="user", content=prompt))
         return self.chat(messages, temperature=temperature, max_tokens=max_tokens)
 
 

--- a/src/bantz/llm/vllm_openai_client.py
+++ b/src/bantz/llm/vllm_openai_client.py
@@ -509,9 +509,16 @@ class VLLMOpenAIClient(LLMClient):
                     f"vLLM stream failed: {e}"
                 ) from e
     
-    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200, stop: Optional[List[str]] = None) -> str:
-        """Simple text completion (used by Router)."""
-        messages = [LLMMessage(role="user", content=prompt)]
+    def complete_text(self, *, prompt: str, temperature: float = 0.0, max_tokens: int = 200, stop: Optional[List[str]] = None, system_prompt: Optional[str] = None) -> str:
+        """Simple text completion (used by Router).
+
+        Issue #1050: When system_prompt is provided it is sent as a proper
+        system message instead of being crammed into the user message.
+        """
+        messages: List[LLMMessage] = []
+        if system_prompt:
+            messages.append(LLMMessage(role="system", content=system_prompt))
+        messages.append(LLMMessage(role="user", content=prompt))
         return self.chat(messages, temperature=temperature, max_tokens=max_tokens, stop=stop)
     
     @property


### PR DESCRIPTION
## Problem
`complete_text()` in all LLM clients sent the entire prompt (including system instructions) as `role='user'`. This degraded LLM output quality — 3B models handle system vs user separation much better for instruction following.

## Fix
Added optional `system_prompt: Optional[str] = None` kwarg to `complete_text()`. When provided, it is sent as a proper `role='system'` message separate from the user prompt.

Updated in:
- `src/bantz/llm/base.py` — ABC abstract method + Protocol
- `src/bantz/llm/vllm_openai_client.py` — vLLM implementation
- `src/bantz/llm/gemini_client.py` — Gemini implementation

Fully backward-compatible — existing callers work unchanged.

Closes #1050