### PR TITLE
fix(tools): fix system tools import error (#1051)

### DIFF
--- a/src/bantz/tools/register_all.py
+++ b/src/bantz/tools/register_all.py
@@ -472,7 +472,7 @@ def _register_calendar(registry: "ToolRegistry") -> int:
 def _register_system(registry: "ToolRegistry") -> int:
     try:
         from bantz.tools.system_tools import (
-            system_info_tool,
+            system_status,
             system_notify_tool,
             system_screenshot_tool,
         )
@@ -481,7 +481,7 @@ def _register_system(registry: "ToolRegistry") -> int:
 
     n = 0
     n += _reg(registry, "system.info", "Get system information (CPU, RAM, disk).",
-              _obj(), system_info_tool)
+              _obj(), system_status)
     n += _reg(registry, "system.notify", "Show desktop notification.",
               _obj(("message", "string", "Notification message"), required=["message"]),
               system_notify_tool)

--- a/src/bantz/tools/system_tools.py
+++ b/src/bantz/tools/system_tools.py
@@ -116,6 +116,38 @@ def system_status(*, include_env: bool = False, **_: Any) -> dict[str, Any]:
     return out
 
 
+# ── system_notify (Issue #1051) ─────────────────────────────────────
+
+def system_notify_tool(*, message: str = "", title: str = "Bantz", **_: Any) -> dict[str, Any]:
+    """Show a desktop notification using notify-send (Linux).
+
+    Falls back gracefully when notify-send is not available.
+    """
+    import shutil
+    import subprocess
+
+    if not message:
+        return {"ok": False, "error": "message_required"}
+
+    if not shutil.which("notify-send"):
+        return {"ok": False, "error": "notify-send not installed"}
+
+    try:
+        result = subprocess.run(
+            ["notify-send", "--app-name=Bantz", title, message],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return {"ok": True, "sent": True}
+        return {"ok": False, "error": f"notify-send error: {result.stderr.strip()}"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "notify-send timeout"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
 def system_screenshot_tool(*, monitor: int = 0, **_: Any) -> dict[str, Any]:
     """Capture a screenshot and return base64-encoded image data.
 


### PR DESCRIPTION
## Problem
`_register_system()` in register_all.py imported `system_info_tool` and `system_notify_tool` from system_tools.py — but neither existed. The actual function was `system_status` and `system_notify_tool` was never implemented. This caused an ImportError that silently returned 0, meaning ALL system tools (including screenshot) failed to register.

## Fix
1. Changed import: `system_info_tool` → `system_status` (the actual function name)
2. Implemented `system_notify_tool` using `notify-send` (Linux desktop notifications)
3. All 3 system tools now register correctly

## Files Changed
- `src/bantz/tools/system_tools.py` — added `system_notify_tool`
- `src/bantz/tools/register_all.py` — fixed import name

Closes #1051