### PR TITLE
fix(tools): create pc_type_tool, fix pc.type handler (#1052)

### DIFF
--- a/src/bantz/tools/pc_tools.py
+++ b/src/bantz/tools/pc_tools.py
@@ -80,6 +80,35 @@ def pc_hotkey_tool(*, combo: str = "", **_: Any) -> Dict[str, Any]:
         return {"ok": False, "error": str(e)}
 
 
+# ── pc_type (Issue #1052) ──────────────────────────────────────────
+
+def pc_type_tool(*, text: str = "", **_: Any) -> Dict[str, Any]:
+    """Type text on the keyboard using xdotool type.
+
+    Unlike pc_hotkey_tool (which sends key combos via 'xdotool key'),
+    this uses 'xdotool type' to simulate typing a string of characters.
+    """
+    if not text:
+        return {"ok": False, "error": "text_required"}
+
+    if not _check_tool("xdotool"):
+        return {"ok": False, "error": "xdotool_not_installed"}
+
+    # Safety: limit text length to prevent accidental massive input
+    if len(text) > 5000:
+        return {"ok": False, "error": "text_too_long (max 5000 chars)"}
+
+    try:
+        result = _run_cmd(["xdotool", "type", "--clearmodifiers", text], timeout=30)
+        if result.returncode == 0:
+            return {"ok": True, "typed": True, "length": len(text)}
+        return {"ok": False, "error": f"xdotool_error: {result.stderr.strip()}"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "xdotool_timeout"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
 # ── pc_mouse_move ───────────────────────────────────────────────────
 
 def pc_mouse_move_tool(*, x: int = 0, y: int = 0, duration_ms: int = 0, **_: Any) -> Dict[str, Any]:

--- a/src/bantz/tools/register_all.py
+++ b/src/bantz/tools/register_all.py
@@ -144,7 +144,7 @@ def _register_browser(registry: "ToolRegistry") -> int:
 def _register_pc(registry: "ToolRegistry") -> int:
     try:
         from bantz.tools.pc_tools import (
-            pc_hotkey_tool, pc_mouse_move_tool, pc_mouse_click_tool,
+            pc_hotkey_tool, pc_type_tool, pc_mouse_move_tool, pc_mouse_click_tool,
             pc_mouse_scroll_tool, clipboard_set_tool, clipboard_get_tool,
         )
     except ImportError as e:
@@ -168,7 +168,7 @@ def _register_pc(registry: "ToolRegistry") -> int:
               pc_mouse_scroll_tool, risk="low")
     n += _reg(registry, "pc.type", "Type text on keyboard.",
               _obj(("text", "string", "Text to type"), required=["text"]),
-              pc_hotkey_tool, risk="medium", confirm=True)  # xdotool type
+              pc_type_tool, risk="medium", confirm=True)  # xdotool type
     n += _reg(registry, "clipboard.set", "Set clipboard content.",
               _obj(("text", "string", "Text to copy"), required=["text"]),
               clipboard_set_tool, risk="low")


### PR DESCRIPTION
## Problem
`pc.type` tool was registered with `pc_hotkey_tool` as its handler. When the LLM selected pc.type to type text, it actually ran `xdotool key` (hotkey combo) instead of `xdotool type` (text input). Typing 'hello world' would try to press keys h+e+l+l+o as a combo instead of typing characters.

## Fix
1. Created `pc_type_tool` function in pc_tools.py using `xdotool type --clearmodifiers`
2. Updated register_all.py to import and use `pc_type_tool` for pc.type registration
3. Added safety limit (5000 chars) to prevent accidental massive input

## Files Changed
- `src/bantz/tools/pc_tools.py` — new `pc_type_tool` function
- `src/bantz/tools/register_all.py` — import + handler fix

Closes #1052