### PR TITLE
fix(brain): stop post_route_correction from hijacking calendar/system (#1057)

### DIFF
--- a/src/bantz/brain/post_route_corrections.py
+++ b/src/bantz/brain/post_route_corrections.py
@@ -149,8 +149,10 @@ def post_route_correction_email_send(
                 "[POST_ROUTE_CORRECTION] email_send: LLM already route=gmail/send, skipping override"
             )
         return output
-    if _route not in ("unknown", "smalltalk", "calendar", "system", ""):
-        # Issue #1006: Also catch calendar/system misroutes for email-send
+    if _route not in ("unknown", "smalltalk", ""):
+        # Issue #1057: Only override unknown/smalltalk misroutes.
+        # Calendar/system routes must NOT be hijacked even if the user
+        # text contains email-like keywords (e.g. "mail gönder konulu toplantı").
         return output
 
     gmail_obj = dict(getattr(output, "gmail", None) or {})


### PR DESCRIPTION
## Problem
`post_route_correction_email_send` guard included `calendar` and `system` in the override-eligible routes. When a user said something like 'mail gönder konulu toplantı oluştur' (create meeting with subject 'send email'), the correct calendar route was hijacked to gmail because 'mail gönder' matched the email regex.

## Fix
Changed the guard from `not in ('unknown', 'smalltalk', 'calendar', 'system', '')` to `not in ('unknown', 'smalltalk', '')`. Calendar and system routes are now trusted and won't be overridden.

Closes #1057