### PR TITLE
fix(tools): unify dual risk taxonomy between metadata.py and register_all.py (#1079)

### DIFF
--- a/src/bantz/tools/metadata.py
+++ b/src/bantz/tools/metadata.py
@@ -138,6 +138,30 @@ _FALLBACK_ALWAYS_CONFIRM: set[str] = {
 
 _RISK_NAME_MAP = {"safe": ToolRisk.SAFE, "moderate": ToolRisk.MODERATE, "destructive": ToolRisk.DESTRUCTIVE}
 
+# Issue #1079: Bridge between ToolRisk (safe/moderate/destructive) and
+# RiskLevel (LOW/MED/HIGH) used in agent/tools.py & register_all.py.
+_TOOL_RISK_TO_RISK_LEVEL: dict[ToolRisk, str] = {
+    ToolRisk.SAFE: "LOW",
+    ToolRisk.MODERATE: "MED",
+    ToolRisk.DESTRUCTIVE: "HIGH",
+}
+
+_RISK_LEVEL_TO_TOOL_RISK: dict[str, ToolRisk] = {
+    "LOW": ToolRisk.SAFE,
+    "MED": ToolRisk.MODERATE,
+    "HIGH": ToolRisk.DESTRUCTIVE,
+}
+
+
+def tool_risk_to_risk_level(risk: ToolRisk) -> str:
+    """Convert ToolRisk enum to RiskLevel literal (LOW/MED/HIGH)."""
+    return _TOOL_RISK_TO_RISK_LEVEL.get(risk, "LOW")
+
+
+def risk_level_to_tool_risk(level: str) -> ToolRisk:
+    """Convert RiskLevel literal to ToolRisk enum."""
+    return _RISK_LEVEL_TO_TOOL_RISK.get(level.upper(), ToolRisk.SAFE)
+
 # Default policy.json path (relative to project root)
 _DEFAULT_POLICY_PATH = Path(__file__).resolve().parents[3] / "config" / "policy.json"
 

--- a/src/bantz/tools/register_all.py
+++ b/src/bantz/tools/register_all.py
@@ -47,17 +47,31 @@ def register_all_tools(registry: "ToolRegistry") -> int:
 
 # ── helpers ──────────────────────────────────────────────────────────
 
+# Issue #1079: Canonical risk mapping — single vocabulary for both
+# register_all and metadata.py ToolRisk.
+_RISK_NORMALIZE: dict[str, str] = {
+    "low": "LOW",
+    "safe": "LOW",
+    "medium": "MED",
+    "moderate": "MED",
+    "med": "MED",
+    "high": "HIGH",
+    "destructive": "HIGH",
+}
+
+
 def _reg(registry: "ToolRegistry", name: str, desc: str, params: dict,
          fn, *, risk: str = "low", confirm: bool = False) -> bool:
     """Register a single tool, returning True on success."""
     from bantz.agent.tools import Tool
+    canonical_risk = _RISK_NORMALIZE.get(risk.lower().strip(), "LOW")
     try:
         registry.register(Tool(
             name=name,
             description=desc,
             parameters=params,
             function=fn,
-            risk_level=risk,
+            risk_level=canonical_risk,
             requires_confirmation=confirm,
         ))
         return True


### PR DESCRIPTION
Added canonical risk mapping in register_all.py (low→LOW, medium→MED, etc.) and bridge functions in metadata.py to convert between ToolRisk and RiskLevel. Closes #1079