### PR TITLE
fix(brain): remove incorrect gmail.list_drafts→gmail.list_messages remap (#1081)

### DIFF
--- a/src/bantz/brain/tool_plan_sanitizer.py
+++ b/src/bantz/brain/tool_plan_sanitizer.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 # Map of known LLM-hallucinated or mismatched tool names to correct tools.
 # Key: (tool_name, gmail_intent or "*") → replacement tool name.
 TOOL_REMAP: dict[tuple[str, str], str] = {
-    ("gmail.list_drafts", "list"): "gmail.list_messages",
     ("gmail.list_all", "*"): "gmail.list_messages",
     ("gmail.search_messages", "*"): "gmail.smart_search",
     ("gmail.check_inbox", "*"): "gmail.list_messages",


### PR DESCRIPTION
gmail.list_drafts is a legitimate tool. The remap caused draft-listing requests to return inbox messages instead. Closes #1081