### PR TITLE
fix(tools): align gmail.search schema param to handler signature (#1082)

### DIFF
--- a/src/bantz/tools/register_all.py
+++ b/src/bantz/tools/register_all.py
@@ -334,7 +334,7 @@ def _register_gmail(registry: "ToolRegistry") -> int:
                    required=["to", "subject", "body"]),
               gmail_send_tool, risk="high", confirm=True)
     n += _reg(registry, "gmail.smart_search", "Smart Gmail search.",
-              _obj(("query", "string", "Search query"), required=["query"]),
+              _obj(("natural_query", "string", "Search query in natural language"), required=["natural_query"]),
               gmail_smart_search_tool)
     n += _reg(registry, "gmail.list_categories", "List Gmail categories with counts.",
               _obj(), gmail_list_categories_tool)


### PR DESCRIPTION
**Issue:** #1082

**Problem:** `gmail.search` schema declared `query` but handler expects `natural_query`. The mismatch causes `**_` to swallow the value → empty searches.

**Fix:** Changed schema param from `query` to `natural_query` in `register_all.py`.

**Severity:** P0 / CRITICAL