### PR TITLE
fix(tools): align file.edit schema params to handler signature (#1084)

### DIFF
--- a/src/bantz/tools/register_all.py
+++ b/src/bantz/tools/register_all.py
@@ -218,8 +218,8 @@ def _register_file(registry: "ToolRegistry") -> int:
                    required=["path", "content"]),
               file_write_tool, risk="medium", confirm=True)
     n += _reg(registry, "file.edit", "Edit a specific part of a file.",
-              _obj(("path", "string", "File path"), ("old", "string", "Text to replace"),
-                   ("new", "string", "Replacement text"), required=["path", "old", "new"]),
+              _obj(("path", "string", "File path"), ("old_string", "string", "Text to replace"),
+                   ("new_string", "string", "Replacement text"), required=["path", "old_string", "new_string"]),
               file_edit_tool, risk="medium", confirm=True)
     n += _reg(registry, "file.create", "Create a new file.",
               _obj(("path", "string", "File path"), ("content", "string", "Initial content"),


### PR DESCRIPTION
**Issue:** #1084

**Problem:** `file.edit` schema declared `old`/`new` but handler expects `old_string`/`new_string`. Mismatch causes edits to silently fail.

**Fix:** Changed schema params from `old`/`new` to `old_string`/`new_string` in `register_all.py`.

**Severity:** P0 / CRITICAL