### PR TITLE
fix(tools): remove non-existent time_convert_tool import that breaks registration (#1087)

### DIFF
--- a/src/bantz/tools/register_all.py
+++ b/src/bantz/tools/register_all.py
@@ -515,10 +515,7 @@ def _register_system(registry: "ToolRegistry") -> int:
 
 def _register_time(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.time_tools import (
-            time_now_tool,
-            time_convert_tool,
-        )
+        from bantz.tools.time_tools import time_now_tool
     except ImportError:
         return 0
 
@@ -526,10 +523,4 @@ def _register_time(registry: "ToolRegistry") -> int:
     n += _reg(registry, "time.now", "Get current date and time.",
               _obj(("timezone", "string", "Timezone (default: local)")),
               time_now_tool)
-    n += _reg(registry, "time.convert", "Convert time between timezones.",
-              _obj(("time", "string", "Time to convert"),
-                   ("from_tz", "string", "Source timezone"),
-                   ("to_tz", "string", "Target timezone"),
-                   required=["time"]),
-              time_convert_tool)
     return n


### PR DESCRIPTION
**Issue:** #1087

**Problem:** `register_all.py` imported non-existent `time_convert_tool` from time tools module, causing ImportError that prevents `time_now_tool` from registering too.

**Fix:** Removed `time_convert_tool` import and `time.convert` registration. Kept `time_now_tool` standalone.

**Severity:** P0 / CRITICAL