### PR TITLE
fix(brain): only override LLM time slot with NLU when LLM slot is empty (#1098)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -990,7 +990,9 @@ class OrchestratorLoop:
                     output.slots[_nk] = _nv
             if "time" in _nlu_merged:
                 # Time from NLU's Turkish parser is more reliable than LLM guess
-                output.slots["time"] = _nlu_merged["time"]
+                # Issue #1098: Only override if LLM didn't already extract a time
+                if not output.slots.get("time"):
+                    output.slots["time"] = _nlu_merged["time"]
 
         # Issue #607: Post-route correction for email sending.
         # The 3B router can misroute send-intents to smalltalk/unknown.


### PR DESCRIPTION
Closes #1098 — NLU time slot no longer unconditionally overwrites LLM's contextual time extraction