### PR TITLE
fix(brain): use correct attribute path for personality user_name (#1099)

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -1628,7 +1628,7 @@ class OrchestratorLoop:
                     except Exception:
                         pass
                 _personality_block = _pi.build_finalizer_block(
-                    user_name=getattr(_pi, "_config", None) and _pi._config.user_name or None,
+                    user_name=getattr(getattr(_pi, "config", None), "user_name", None),
                     facts=_fin_facts,
                     preferences=_fin_prefs,
                 )


### PR DESCRIPTION
Closes #1099 — Changed _config→config to match PersonalityInjector's actual attribute name