### PR TITLE
fix(router): remove 'saat' from calendar route keywords (Closes #1106)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1278,7 +1278,7 @@ U: test@gmail.com'a merhaba gönder → {"route":"gmail","gmail_intent":"send","
     _ROUTE_KEYWORDS: dict[str, list[str]] = {
         "calendar": [
             "etkinlik", "takvim", "randevu", "toplantı",
-            "saat", "yarın", "bugün", "akşam", "sabah", "öğle",
+            "yarın", "bugün", "akşam", "sabah", "öğle",
             "ekle", "oluştur", "planla", "ne yapıyoruz",
             "programım", "programda", "gündem",
             # Issue #1071: Replaced generic "plan" and "iptal" with


### PR DESCRIPTION
## Summary
Removed 'saat' from `_ROUTE_KEYWORDS["calendar"]` to prevent 'saat kaç' (what time is it) from misrouting to the calendar handler instead of system.

Closes #1106