### PR TITLE
fix(router): add GMAIL and SYSTEM to RouteType enum (Closes #1108)

### DIFF
--- a/src/bantz/router/schemas.py
+++ b/src/bantz/router/schemas.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel, Field, field_validator, ConfigDict
 class RouteType(str, Enum):
     """Valid route types for router output."""
     CALENDAR = "calendar"
+    GMAIL = "gmail"
+    SYSTEM = "system"
     SMALLTALK = "smalltalk"
     UNKNOWN = "unknown"
 


### PR DESCRIPTION
## Summary
Added missing `GMAIL = "gmail"` and `SYSTEM = "system"` members to the `RouteType` enum so router can properly type these routes.

Closes #1108