### PR TITLE
fix(brain): close extend() paren in FastFinalizer._build_prompt

### DIFF
--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -380,7 +380,7 @@ class FastFinalizer:
             "",
             "PLANNER_DECISION (JSON):",
             json.dumps(ctx.planner_decision, ensure_ascii=False),
-        ]
+        ])
 
         if ctx.tool_results:
             finalizer_results, was_truncated = _prepare_tool_results_for_finalizer(


### PR DESCRIPTION
## Summary
**CRITICAL** — SyntaxError prevented the entire finalization module from importing.

`prompt_lines.extend([...])` in `FastFinalizer._build_prompt` was missing its closing `)`, causing:
```
SyntaxError: '(' was never closed (line 375)
```

Every turn reaching Phase 3 (finalization) would crash silently and return a generic error message.

## Fix
Added the missing `)` after the closing `]` on line 383.

Closes #1169