### PR TITLE
fix(brain): add gmail_intent and gmail to planner_decision context

### DIFF
--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -1061,6 +1061,8 @@ def build_finalization_context(
     planner_decision = {
         "route": orchestrator_output.route,
         "calendar_intent": orchestrator_output.calendar_intent,
+        "gmail_intent": orchestrator_output.gmail_intent,
+        "gmail": orchestrator_output.gmail,
         "slots": orchestrator_output.slots,
         "tool_plan": orchestrator_output.tool_plan,
         "requires_confirmation": orchestrator_output.requires_confirmation,

--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -380,7 +380,7 @@ class FastFinalizer:
             "",
             "PLANNER_DECISION (JSON):",
             json.dumps(ctx.planner_decision, ensure_ascii=False),
-        ]
+        ])
 
         if ctx.tool_results:
             finalizer_results, was_truncated = _prepare_tool_results_for_finalizer(


### PR DESCRIPTION
## Summary
`build_finalization_context()` was missing `gmail_intent` and `gmail` fields from `OrchestratorOutput` when building the `planner_decision` dict. This caused the finalizer to lose Gmail routing context (send vs list vs search), leading to incorrect or generic email responses.

## Fix
Added `gmail_intent` and `gmail` to the planner_decision dict in `build_finalization_context()`.

**Depends on:** #1184 (cherry-picked #1169 fix since both touch finalization_pipeline.py)

Closes #1170