### PR TITLE
fix(brain): add gmail aliases to GMAIL_VALID_PARAMS whitelist

### DIFF
--- a/src/bantz/brain/tool_param_builder.py
+++ b/src/bantz/brain/tool_param_builder.py
@@ -14,10 +14,16 @@ from bantz.brain.llm_router import OrchestratorOutput
 logger = logging.getLogger(__name__)
 
 # Valid gmail parameter names (Issue #365)
+# Issue #1171: Include known aliases so they survive early filtering
+# before remap. Aliases are remapped to canonical names below.
 GMAIL_VALID_PARAMS = frozenset({
     "to", "name", "subject", "body", "cc", "bcc",
     "label", "category", "query", "search_term", "natural_query",
     "message_id", "max_results", "unread_only", "prefer_unread",
+    # Aliases (remapped in build_tool_params)
+    "recipient", "email", "address", "emails", "to_address",
+    "message", "text", "content", "message_body",
+    "title",
 })
 
 


### PR DESCRIPTION
## Summary
LLM aliases like `recipient`, `message`, `title` were being dropped by the `GMAIL_VALID_PARAMS` filter before the alias remap logic could convert them to canonical names (`to`, `body`, `subject`).

**Example:** LLM returns `{"recipient": "ali@test.com"}` → filter drops it → remap never sees it → `to` is missing → gmail.send fails.

## Fix
Added all known aliases to `GMAIL_VALID_PARAMS` so they survive the early filtering and get properly remapped downstream.

Closes #1171