### PR TITLE
fix(agent): prevent validate_call from mutating caller params

### DIFF
--- a/src/bantz/agent/tools.py
+++ b/src/bantz/agent/tools.py
@@ -165,6 +165,10 @@ class ToolRegistry:
         if not tool:
             return False, f"unknown_tool:{name}"
 
+        # Issue #1174: Work on a shallow copy so empty-string → None
+        # coercion doesn't mutate the caller's original dict.
+        params = dict(params)
+
         schema = tool.parameters or {}
         required = schema.get("required") or []
         for key in required:


### PR DESCRIPTION
## Summary
`validate_call()` coerces empty strings to `None` (Issue #663), but it was doing so directly on the caller's dict reference. This caused surprising side effects where the original params dict was silently modified before being passed to the actual tool executor.

## Fix
Added `params = dict(params)` shallow copy at the start of `validate_call` so coercion only affects the validation-local copy.

Closes #1174