### PR TITLE
refactor(brain): fix circular imports in finalization_pipeline

### DIFF
--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -380,7 +380,7 @@ class FastFinalizer:
             "",
             "PLANNER_DECISION (JSON):",
             json.dumps(ctx.planner_decision, ensure_ascii=False),
-        ]
+        ])
 
         if ctx.tool_results:
             finalizer_results, was_truncated = _prepare_tool_results_for_finalizer(

--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -232,7 +232,7 @@ class QualityFinalizer:
 
     def _build_prompt(self, ctx: FinalizationContext) -> str:
         """Try ``PromptBuilder`` first, fall back to inline template."""
-        from bantz.brain.orchestrator_loop import _prepare_tool_results_for_finalizer
+        from bantz.brain.tool_result_summarizer import _prepare_tool_results_for_finalizer
 
         finalizer_results, was_truncated = _prepare_tool_results_for_finalizer(
             ctx.tool_results or [],
@@ -358,7 +358,7 @@ class FastFinalizer:
             return None
 
     def _build_prompt(self, ctx: FinalizationContext) -> str:
-        from bantz.brain.orchestrator_loop import _prepare_tool_results_for_finalizer
+        from bantz.brain.tool_result_summarizer import _prepare_tool_results_for_finalizer
 
         prompt_lines = [
             "Kimlik / Roller:",
@@ -810,7 +810,7 @@ class FinalizationPipeline:
             validated = _validate_reply_language(output.assistant_reply)
             return replace(output, assistant_reply=validated, finalizer_model="none(existing_reply)")
 
-        from bantz.brain.orchestrator_loop import _build_tool_success_summary
+        from bantz.brain.tool_result_summarizer import _build_tool_success_summary
 
         return replace(
             output,


### PR DESCRIPTION
## Summary
`finalization_pipeline.py` was importing `_prepare_tool_results_for_finalizer` and `_build_tool_success_summary` from `orchestrator_loop.py`, creating a circular dependency chain:

```
orchestrator_loop → finalization_pipeline → orchestrator_loop
```

These functions were already extracted to `tool_result_summarizer.py` (Issue #941) but the 3 deferred imports were never updated.

## Fix
Changed all 3 imports to point to `bantz.brain.tool_result_summarizer` directly, breaking the circular dependency.

**Depends on:** #1184 (cherry-picked #1169 fix)

Closes #1175