### PR TITLE
fix(brain): invalidate personality cache when user name changes

### DIFF
--- a/src/bantz/brain/context_builder.py
+++ b/src/bantz/brain/context_builder.py
@@ -245,10 +245,17 @@ class ContextBuilder:
                 context_parts.append(mem_block)
 
             # Update personality injector with user name
+            # Issue #1178: Invalidate personality cache when name changes
             if self._personality_injector is not None:
                 pname = um_facts.get("name", "")
                 if pname:
+                    old_name = getattr(
+                        getattr(self._personality_injector, "config", None),
+                        "user_name", "",
+                    ) or ""
                     self._personality_injector.update_user_name(pname)
+                    if pname != old_name:
+                        self._personality_block_built = False
 
         except Exception as exc:
             logger.debug("[CONTEXT_BUILDER] user_memory failed: %s", exc)


### PR DESCRIPTION
## Summary
`_inject_personality` cached the personality block on first call (`_personality_block_built = True`) and never rebuilt it, even when `update_user_name()` changed the user name mid-session. This meant the personality block used stale name data for the entire session.

## Fix
Before each turn, compare the current user name from `um_facts` with the injector's stored `config.user_name`. When a change is detected, reset `_personality_block_built = False` so the block is rebuilt with the new name on the next call.

Closes #1178