### PR TITLE
fix(brain): recognize consonant-ending names without apostrophe as recipients

### DIFF
--- a/src/bantz/brain/post_route_corrections.py
+++ b/src/bantz/brain/post_route_corrections.py
@@ -66,6 +66,19 @@ def extract_recipient_name(text: str) -> str | None:
     if m:
         return m.group(1).strip() or None
 
+    # Pattern 2b: Name (consonant-ending, ≥3 chars) + bare dative (e/a) + mail
+    # Issue #1180: "Ahmete mail gönder", "Mehmete bir mail at"
+    # Consonant-ending names take bare -e/-a without buffer-y.
+    # Require ≥3 chars before the suffix to reduce false positives.
+    _CONSONANTS = "bcçdfgğhjklmnprsştvyzBCÇDFGĞHJKLMNPRSŞTVYZ"
+    m = re.search(
+        rf"\b([A-Za-zÇĞİÖŞÜçğıöşü][\wÇĞİÖŞÜçğıöşü]{{2,}}[{_CONSONANTS}])[eEaA]\s+{_MAIL}",
+        t,
+        flags=re.IGNORECASE,
+    )
+    if m:
+        return m.group(1).strip() or None
+
     # Pattern 3: mail keyword + name ("mail gönder Ahmet'e")
     m = re.search(
         rf"\b(?:mail|e-?posta)\b.*?\b({_NAME})\s*'?\s*[yY]?[eEaA]\b",


### PR DESCRIPTION
## Summary
`extract_recipient_name` only handled vowel-ending names without apostrophe (`Aliye mail gönder`). Consonant-ending names like `Ahmete mail gönder` were not recognized — Turkish dative suffix is just `-e/-a` without buffer-y for consonant-ending words.

~40% of Turkish names end in consonants and users rarely type apostrophes → unnecessary "Kime göndermek istiyorsunuz?" questions.

## Fix
Added Pattern 2b: consonant-ending name (≥3 chars) + bare dative (`e/a`) + mail keyword.

Verified: `Ahmete→Ahmet`, `Mehmete→Mehmet`, `Aliye→Ali` all work.

Closes #1180