### PR TITLE
fix(#1212): follow-up context tracking for anaphoric references

### DIFF
--- a/src/bantz/brain/orchestrator_state.py
+++ b/src/bantz/brain/orchestrator_state.py
@@ -56,6 +56,10 @@ class OrchestratorState:
 
     # Issue #875: Pending disambiguation request
     disambiguation_pending: Optional[DisambiguationRequest] = field(default=None)
+
+    # Issue #1212: Follow-up context — track last successful tool for anaphora
+    last_tool_called: str = ""
+    last_tool_route: str = ""
     
     def add_tool_result(self, tool_name: str, result: Any, success: bool = True) -> None:
         """Add a tool result to state (FIFO queue).
@@ -224,3 +228,5 @@ class OrchestratorState:
         self.session_context = None
         self.reference_table = None
         self.disambiguation_pending = None
+        self.last_tool_called = ""
+        self.last_tool_route = ""


### PR DESCRIPTION
## Summary
- Add `last_tool_called` and `last_tool_route` fields to OrchestratorState
- Track last successful tool name and route in `_update_state_phase`
- Add `_is_anaphoric_followup()` detector for Turkish pronouns/continuations
- In `_llm_planning_phase`: when input is anaphoric + last_tool exists, carry forward previous route and tool plan

## Problem
User says 'nelermiş onlar' or 'bunları özetle' after a tool call — the 3B router couldn't detect the domain from the anaphoric input and misrouted to smalltalk.

## Fix
Track the last successful tool call and route. When the next input is a short anaphoric follow-up (Turkish pronouns like 'onlar', 'bunlar', 'özetle'), automatically carry forward the previous route and tool plan.

Closes #1212