### PR TITLE
fix(#1214): recover smalltalk misroutes via keyword detection

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1293,6 +1293,8 @@ U: test@gmail.com'a merhaba gönder → {"route":"gmail","gmail_intent":"send","
             "mail", "e-posta", "eposta", "mesaj", "gönder",
             "oku", "inbox", "gelen kutusu", "draft", "taslak",
             "yaz", "cevapla", "reply",
+            # Issue #1214: Additional gmail-context keywords
+            "güncelleme", "içerik", "bildirim", "notification",
         ],
         "system": [
             "saat kaç", "tarih", "gün ne", "pil", "batarya",


### PR DESCRIPTION
## Problem
'githubtaki güncelleminin içeriğini anlat' misrouted to smalltalk because 'güncelleme' and 'içerik' weren't in gmail keywords.

## Fix
1. Add missing gmail keywords: 'güncelleme', 'içerik', 'bildirim', 'notification'
2. After plan verification, when LLM routes to smalltalk/unknown with no tool_plan but keyword detection identifies a domain route → auto-recover by assigning the correct route + default tool

Closes #1214