### PR TITLE
fix(#1218): resolve specific mail by keyword from listed messages

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1377,6 +1377,7 @@ U: test@gmail.com'a merhaba gönder → {"route":"gmail","gmail_intent":"send","
         ("gmail", "list"): "gmail.list_messages",
         ("gmail", "send"): "gmail.send",
         ("gmail", "read"): "gmail.list_messages",
+        ("gmail", "detail"): "gmail.get_message",  # Issue #1218
         ("gmail", "draft"): "gmail.create_draft",
         ("gmail", "reply"): "gmail.generate_reply",
         ("gmail", "forward"): "gmail.send",

--- a/src/bantz/brain/orchestrator_state.py
+++ b/src/bantz/brain/orchestrator_state.py
@@ -64,6 +64,9 @@ class OrchestratorState:
     # Issue #1217: Gmail pagination — store next_page_token for continuation
     gmail_next_page_token: str = ""
     gmail_last_query: str = ""
+
+    # Issue #1218: Store last listed gmail message headers for entity resolution
+    gmail_listed_messages: list[dict[str, str]] = field(default_factory=list)
     
     def add_tool_result(self, tool_name: str, result: Any, success: bool = True) -> None:
         """Add a tool result to state (FIFO queue).
@@ -236,3 +239,4 @@ class OrchestratorState:
         self.last_tool_route = ""
         self.gmail_next_page_token = ""
         self.gmail_last_query = ""
+        self.gmail_listed_messages = []


### PR DESCRIPTION
## Problem
'github mailinin içeriğini özetle' after listing mails re-lists ALL mails instead of fetching the specific GitHub mail content.

## Fix
- Store `gmail_listed_messages` (id/from/subject) from previous list results
- Add `_match_mail_by_keyword()` for entity resolution against stored headers
- When user mentions a mail by keyword ('github maili') and we have listed messages, resolve message_id and switch to `gmail.get_message`
- Added `('gmail', 'detail') → 'gmail.get_message'` to tool lookup

Closes #1218