### PR TITLE
fix(#1219): dynamic token budget for mail content requests

### DIFF
--- a/src/bantz/brain/finalization_pipeline.py
+++ b/src/bantz/brain/finalization_pipeline.py
@@ -259,8 +259,17 @@ class QualityFinalizer:
             else "default"
         )
 
+        # Issue #1219: Increase token budget for detail-content tools
+        _DETAIL_TOOLS = {"gmail.get_message", "gmail.get_thread"}
+        _has_detail = any(
+            r.get("tool") in _DETAIL_TOOLS
+            for r in (ctx.tool_results or [])
+            if r.get("success", False)
+        )
+        _prompt_budget = 5000 if _has_detail else 3500
+
         builder = PromptBuilder(
-            token_budget=3500,
+            token_budget=_prompt_budget,
             experiment="issue191_orchestrator_finalizer",
         )
         built = builder.build_finalizer_prompt(


### PR DESCRIPTION
## Problem
Finalizer token budget (2000 tokens) truncates mail body content, losing important details when user asks to summarize/read a specific mail.

## Fix
- Auto-increase tool result token budget from 2000 → 4000 when `gmail.get_message` (detail content) is present
- Increase overall prompt token budget from 3500 → 5000 for detail tools
- Budget remains at original levels for list/search results

Closes #1219