### PR TITLE
config(#1246): add LanguageBridge feature flag env vars

### DIFF
--- a/config/bantz-env.example
+++ b/config/bantz-env.example
@@ -227,6 +227,16 @@ BANTZ_BRIEFING_HOUR=08
 # BANTZ_IDEMPOTENCY_STORE=                 # Calendar idempotency store path
 
 
+# ─── Language Bridge (TR↔EN translation layer) ──────────────────
+# Brain works in English for better routing accuracy, UI stays Turkish.
+# BANTZ_BRIDGE_ENABLED=0                   # Master switch (1=on, 0=off)
+# BANTZ_BRIDGE_INPUT_GATE=1                # TR→EN input translation for router
+# BANTZ_BRIDGE_OUTPUT_GATE=0               # EN→TR output translation (finalizer)
+# BANTZ_BRIDGE_ENGINE=marianmt             # Translation engine: marianmt | nllb
+# BANTZ_BRIDGE_CACHE_TTL=300               # Translation cache TTL (seconds)
+# BANTZ_BRIDGE_LOG=0                       # Log every translation (debug)
+
+
 # ─── Debug ───────────────────────────────────────────────────────
 # BANTZ_DEBUG=0                            # Enable debug mode (1=on)
 # BANTZ_DEBUG_TIERS=0                      # Tier-specific debug logging


### PR DESCRIPTION
Add BANTZ_BRIDGE_* env vars to bantz-env.example for the upcoming TR↔EN translation layer. All disabled by default for safe rollout.

Closes #1246