### PR TITLE
feat(#1242): Input Gate — translate TR user input to EN for router

### DIFF
--- a/src/bantz/brain/orchestrator_state.py
+++ b/src/bantz/brain/orchestrator_state.py
@@ -67,6 +67,10 @@ class OrchestratorState:
 
     # Issue #1218: Store last listed gmail message headers for entity resolution
     gmail_listed_messages: list[dict[str, str]] = field(default_factory=list)
+
+    # Issue #1242: Language Bridge — detected language and canonical EN input
+    detected_lang: str = ""
+    canonical_input: str = ""
     
     def add_tool_result(self, tool_name: str, result: Any, success: bool = True) -> None:
         """Add a tool result to state (FIFO queue).
@@ -240,3 +244,5 @@ class OrchestratorState:
         self.gmail_next_page_token = ""
         self.gmail_last_query = ""
         self.gmail_listed_messages = []
+        self.detected_lang = ""
+        self.canonical_input = ""


### PR DESCRIPTION
## Summary
Wires LanguageBridge into the orchestrator's input path. Router now receives English canonical text for better routing accuracy.

### Changes
- `orchestrator_loop.py`: Call `bridge.to_en()` before `_llm_planning_phase()`
- `orchestrator_state.py`: Add `detected_lang`, `canonical_input` fields
- Router gets EN text, finalization/state keep original TR
- Gated by `BANTZ_BRIDGE_INPUT_GATE` env var

### Flow
```
user_input (TR) → bridge.to_en() → canonical_en → router.route()
                                  ↘ state.current_user_input (TR preserved)
```

Closes #1242