### PR TITLE
feat(#1244): Tool param bridge — restore TR content from original input

### DIFF
--- a/src/bantz/brain/orchestrator_loop.py
+++ b/src/bantz/brain/orchestrator_loop.py
@@ -1691,7 +1691,8 @@ class OrchestratorLoop:
                         merged_slots.update(args)
                     params = self._build_tool_params(
                         tool_name, merged_slots, output,
-                        user_input=state.current_user_input,
+                        user_input=state.canonical_input or state.current_user_input,
+                        original_user_input=state.current_user_input if state.canonical_input else None,
                     )
 
                 # Drop nulls (LLM JSON often includes explicit nulls for optional slots).
@@ -1849,8 +1850,13 @@ class OrchestratorLoop:
         output: Optional["OrchestratorOutput"] = None,
         *,
         user_input: Optional[str] = None,
+        original_user_input: Optional[str] = None,
     ) -> dict[str, Any]:
-        return build_tool_params(tool_name, slots, output, user_input=user_input)
+        return build_tool_params(
+            tool_name, slots, output,
+            user_input=user_input,
+            original_user_input=original_user_input,
+        )
     
     def _llm_finalization_phase(
         self,


### PR DESCRIPTION
## Summary
When LanguageBridge translates TR input to EN for routing, the LLM may produce English slot values (e.g. `title: 'breakfast'` instead of `kahvaltı`). This PR restores content params from the original Turkish text.

### Examples
| Scenario | Slot before | After restoration |
|---|---|---|
| `yarın kahvaltı ekle` → EN: `add breakfast tomorrow` | `title: 'breakfast'` | `title: 'kahvaltı'` |
| `yarın saat 15 toplantı ekle` → EN: `add meeting tomorrow at 3pm` | `title: 'meeting'` | `title: 'toplantı'` |

### Changes
- `tool_param_builder.py`: Add `original_user_input` param + TR content extraction
- `orchestrator_loop.py`: Pass `canonical_input` and `current_user_input` to builder

Closes #1244