### PR TITLE
fix(bridge): anaphoric follow-up uses original TR text, not EN translation (#1254)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1345,11 +1345,15 @@ U: test@gmail.com'a merhaba gönder → {"route":"gmail","gmail_intent":"send","
         return "unknown"
 
     # Issue #1212: Anaphoric follow-up detection for Turkish
+    # Issue #1254: Added "başka", "içeriğinde", "ne var", "daha" etc.
     _ANAPHORA_TOKENS: frozenset[str] = frozenset({
         "onlar", "bunlar", "şunlar", "bunları", "onları", "şunları",
         "nelermiş", "neymiş", "neydi", "hangisi", "hangileri",
         "özetle", "detay", "ayrıntı", "devam", "devamı",
         "tekrarla", "göster", "oku", "anlat",
+        # Issue #1254: Common follow-up words missing from original set
+        "başka", "içeriğinde", "içeriği", "içindeki", "daha",
+        "neler", "neymiş", "bana", "söyle", "açıkla",
     })
 
     def _is_anaphoric_followup(self, user_input: str) -> bool:


### PR DESCRIPTION
## Issue #1254 — Anaphoric Follow-up Broken After Bridge (P1)

### Problem
User says `içeriğinde başka ne var` (follow-up to gmail.get_message).
Bridge translates to `What else is in it?`.
`_is_anaphoric_followup()` checks Turkish tokens (`bunları`, `özetle`...)
on the English text → no match → recovery skipped → routed to smalltalk.

### Fix
1. **Use original TR text**: Anaphoric check and pagination detection now
   use `state.current_user_input` (original TR) instead of the bridge-translated
   `user_input` parameter in `_llm_planning_phase()`.

2. **Expanded anaphora tokens**: Added `başka`, `içeriğinde`, `içeriği`,
   `içindeki`, `daha`, `neler`, `bana`, `söyle`, `açıkla`.

### Tests
8 new tests in `TestAnaphoricBridgeInteraction`:
- Token set verification (`başka`, `içeriğinde`, `daha`)
- TR follow-up detection (`içeriğinde başka ne var` → True)
- EN translation rejection (`What else is in it?` → False)
- Classic patterns (`bunları özetle`, `devamı var mı`)
- Long input rejection (>6 tokens)

Closes #1254