### PR TITLE
feat(data): Ingest Store — TTL Cache + Fingerprint Dedup (#1288)

### DIFF
--- a/src/bantz/data/__init__.py
+++ b/src/bantz/data/__init__.py
@@ -1,0 +1,11 @@
+"""
+bantz.data — Data persistence layer.
+
+Provides:
+- IngestStore: TTL-cached tool result store with fingerprint dedup
+- DataClass: EPHEMERAL / SESSION / PERSISTENT lifecycle classification
+"""
+
+from bantz.data.ingest_store import IngestStore, DataClass, IngestRecord
+
+__all__ = ["IngestStore", "DataClass", "IngestRecord"]

--- a/src/bantz/data/ingest_bridge.py
+++ b/src/bantz/data/ingest_bridge.py
@@ -1,0 +1,222 @@
+"""
+Ingest Store integration bridge for the orchestrator loop.
+
+Provides a lightweight helper that subscribes to tool result events
+and automatically ingests them into the IngestStore.  This module
+keeps the orchestrator loop clean by encapsulating all ingest logic.
+
+Usage in OrchestratorLoop.__init__::
+
+    from bantz.data.ingest_bridge import IngestBridge
+    self._ingest_bridge = IngestBridge.create_default()
+
+After tool execution::
+
+    self._ingest_bridge.on_tool_result(tool_name, params, result, elapsed_ms)
+
+Query cached results::
+
+    cached = self._ingest_bridge.get_cached(tool_name, params)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from bantz.data.ingest_store import (
+    IngestStore,
+    DataClass,
+    IngestRecord,
+    classify_tool_result,
+    fingerprint,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class IngestBridge:
+    """Bridge between orchestrator tool results and the Ingest Store.
+
+    Responsibility:
+    - Classify and ingest tool results automatically
+    - Provide cache-hit lookup before tool execution
+    - Track ingest statistics per turn
+    """
+
+    def __init__(self, store: IngestStore) -> None:
+        self._store = store
+        self._turn_ingested: int = 0
+        self._turn_cache_hits: int = 0
+
+    @classmethod
+    def create_default(cls, db_path: str = "~/.bantz/data/ingest.db") -> "IngestBridge":
+        """Create with default settings — safe to call even if DB dir doesn't exist."""
+        try:
+            store = IngestStore(db_path=db_path)
+            return cls(store)
+        except Exception as e:
+            logger.warning("[IngestBridge] Failed to init store: %s — using in-memory fallback", e)
+            store = IngestStore(db_path=":memory:")
+            return cls(store)
+
+    # ── public API ────────────────────────────────────────────
+
+    def on_tool_result(
+        self,
+        tool_name: str,
+        params: Dict[str, Any],
+        result: Any,
+        *,
+        elapsed_ms: int = 0,
+        success: bool = True,
+        summary: Optional[str] = None,
+    ) -> Optional[str]:
+        """Ingest a successful tool result.  Returns record id or None on failure.
+
+        Failed tool results (success=False) are deliberately NOT ingested —
+        we don't want to cache error responses.
+        """
+        if not success:
+            return None
+
+        # Don't ingest trivially empty or very small results
+        if result is None:
+            return None
+        if isinstance(result, (dict, list)) and not result:
+            return None
+
+        data_class = classify_tool_result(tool_name)
+
+        # Build ingestable content
+        content = self._build_content(tool_name, params, result)
+
+        # Build a cache key based solely on tool+params (no result)
+        # so we can look up cached results before executing a tool.
+        cache_key = fingerprint(
+            self._build_content(tool_name, params, placeholder=True),
+            tool_name,
+        )
+
+        meta = {
+            "tool_name": tool_name,
+            "params": params,
+            "elapsed_ms": elapsed_ms,
+            "cache_key": cache_key,
+        }
+
+        try:
+            record_id = self._store.ingest(
+                content=content,
+                source=tool_name,
+                data_class=data_class,
+                summary=summary,
+                meta=meta,
+            )
+            self._turn_ingested += 1
+            return record_id
+        except Exception as e:
+            logger.warning("[IngestBridge] Failed to ingest %s result: %s", tool_name, e)
+            return None
+
+    def get_cached(
+        self,
+        tool_name: str,
+        params: Dict[str, Any],
+        *,
+        max_age: Optional[float] = None,
+    ) -> Optional[IngestRecord]:
+        """Look up a cached tool result by (tool_name, params) cache key.
+
+        Parameters
+        ----------
+        tool_name : str
+            The tool that produced the result.
+        params : dict
+            The params that were passed to the tool.
+        max_age : float, optional
+            Maximum age in seconds.  If the cached record is older it's
+            treated as a miss.  *None* accepts any non-expired record.
+
+        Returns
+        -------
+        IngestRecord or None
+        """
+        cache_key = fingerprint(
+            self._build_content(tool_name, params, placeholder=True),
+            tool_name,
+        )
+
+        try:
+            # Search for the cache_key in the meta field
+            records = self._store.search(cache_key, source=tool_name, limit=1)
+        except Exception:
+            return None
+
+        if not records:
+            return None
+
+        record = records[0]
+
+        if max_age is not None:
+            import time
+            age = time.time() - record.created_at
+            if age > max_age:
+                return None
+
+        self._turn_cache_hits += 1
+        return record
+
+    def reset_turn_stats(self) -> Dict[str, int]:
+        """Return and reset per-turn counters."""
+        stats = {
+            "ingested": self._turn_ingested,
+            "cache_hits": self._turn_cache_hits,
+        }
+        self._turn_ingested = 0
+        self._turn_cache_hits = 0
+        return stats
+
+    @property
+    def store(self) -> IngestStore:
+        """Direct access to the underlying store (for queries, stats)."""
+        return self._store
+
+    def close(self) -> None:
+        self._store.close()
+
+    # ── private helpers ───────────────────────────────────────
+
+    @staticmethod
+    def _build_content(
+        tool_name: str,
+        params: Dict[str, Any],
+        result: Any = None,
+        *,
+        placeholder: bool = False,
+    ) -> Dict[str, Any]:
+        """Build canonical content dict for fingerprinting and storage.
+
+        When *placeholder* is True, result is excluded — used for
+        cache lookups where we only know the tool+params, not the result.
+        """
+        if placeholder:
+            return {"tool": tool_name, "params": _stable_params(params)}
+        return {
+            "tool": tool_name,
+            "params": _stable_params(params),
+            "result": result,
+        }
+
+
+def _stable_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of params with unstable keys removed.
+
+    Some params vary between calls but produce identical results
+    (e.g. ``page_token``, ``_request_id``).  We strip those so the
+    fingerprint is content-stable.
+    """
+    if not isinstance(params, dict):
+        return params
+    skip = {"page_token", "_request_id", "_trace_id", "timestamp"}
+    return {k: v for k, v in sorted(params.items()) if k not in skip}

--- a/src/bantz/data/ingest_store.py
+++ b/src/bantz/data/ingest_store.py
@@ -1,0 +1,614 @@
+"""
+Ingest Store — TTL-cached, fingerprint-deduped data layer for Bantz.
+
+Every tool result, API response, and structured data payload flows through
+the Ingest Store.  Items are classified into one of three data classes:
+
+    EPHEMERAL   24 h   mail listings, search results, API responses
+    SESSION      7 d   in-session decisions, active context fragments
+    PERSISTENT   ∞     contacts, user preferences, learned knowledge
+
+Duplicate detection is SHA-256 fingerprint based: if the same canonical
+content from the same source arrives twice, only ``accessed_at`` is bumped.
+
+Usage::
+
+    store = IngestStore()                       # ~/.bantz/data/ingest.db
+    rid = store.ingest({"subject": "hi"},
+                       source="gmail",
+                       data_class=DataClass.EPHEMERAL)
+    record = store.get(rid)
+    store.close()
+
+The TTL sweeper can be run as a one-shot or as an asyncio background task
+(see :func:`ttl_sweep_once` and :func:`start_ttl_sweeper`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import sqlite3
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# ── Data-class / lifecycle enum ──────────────────────────────────
+
+class DataClass(str, Enum):
+    """Lifecycle category for ingested data."""
+    EPHEMERAL  = "EPHEMERAL"    # TTL 24 h — mail listings, search results
+    SESSION    = "SESSION"      # TTL 7 d  — session decisions, active context
+    PERSISTENT = "PERSISTENT"   # TTL ∞    — contacts, preferences, learned facts
+
+# Default TTL values in seconds
+_TTL_MAP: Dict[DataClass, Optional[float]] = {
+    DataClass.EPHEMERAL:  24 * 3600,        # 24 hours
+    DataClass.SESSION:    7 * 24 * 3600,    # 7 days
+    DataClass.PERSISTENT: None,              # never expires
+}
+
+
+# ── IngestRecord data-class ──────────────────────────────────────
+
+@dataclass
+class IngestRecord:
+    """A single record stored in the Ingest Store."""
+    id: str
+    fingerprint: str
+    data_class: DataClass
+    source: str
+    content: Dict[str, Any]
+    summary: Optional[str] = None
+    created_at: float = 0.0
+    expires_at: Optional[float] = None
+    accessed_at: float = 0.0
+    access_count: int = 0
+    meta: Optional[Dict[str, Any]] = None
+
+    # ── helpers ───────────────────────────────────────────────
+    @property
+    def is_expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return time.time() > self.expires_at
+
+    @property
+    def age_seconds(self) -> float:
+        return time.time() - self.created_at
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "fingerprint": self.fingerprint,
+            "data_class": self.data_class.value,
+            "source": self.source,
+            "content": self.content,
+            "summary": self.summary,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "accessed_at": self.accessed_at,
+            "access_count": self.access_count,
+            "meta": self.meta,
+        }
+
+
+# ── Fingerprinting ───────────────────────────────────────────────
+
+def fingerprint(content: Any, source: str) -> str:
+    """Deterministic SHA-256 fingerprint of canonical (source, content).
+
+    Same content from the same source always produces the same hash.
+    """
+    if isinstance(content, (dict, list)):
+        canonical = json.dumps(content, sort_keys=True, ensure_ascii=False)
+    else:
+        canonical = str(content)
+    raw = f"{source}:{canonical}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+# ── SQLite schema ────────────────────────────────────────────────
+
+_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS ingest_store (
+    id              TEXT PRIMARY KEY,
+    fingerprint     TEXT NOT NULL UNIQUE,
+    data_class      TEXT NOT NULL DEFAULT 'EPHEMERAL',
+    source          TEXT NOT NULL,
+    content         TEXT NOT NULL,
+    summary         TEXT,
+    created_at      REAL NOT NULL,
+    expires_at      REAL,
+    accessed_at     REAL,
+    access_count    INTEGER NOT NULL DEFAULT 0,
+    meta            TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_class   ON ingest_store(data_class);
+CREATE INDEX IF NOT EXISTS idx_ingest_source  ON ingest_store(source);
+CREATE INDEX IF NOT EXISTS idx_ingest_expires ON ingest_store(expires_at);
+CREATE INDEX IF NOT EXISTS idx_ingest_fp      ON ingest_store(fingerprint);
+"""
+
+
+# ── IngestStore ──────────────────────────────────────────────────
+
+class IngestStore:
+    """SQLite-backed, thread-safe ingestion cache.
+
+    Parameters
+    ----------
+    db_path : str | Path
+        Path to the SQLite file.  ``":memory:"`` for in-memory store.
+    auto_sweep : bool
+        If *True*, expired rows are deleted on each :meth:`ingest` call
+        when more than ``sweep_interval`` seconds have passed since the
+        last sweep.  Set *False* for manual control.
+    sweep_interval : int
+        Minimum seconds between auto-sweeps (default 3 600 = 1 h).
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path = "~/.bantz/data/ingest.db",
+        *,
+        auto_sweep: bool = True,
+        sweep_interval: int = 3600,
+    ) -> None:
+        if str(db_path) == ":memory:":
+            self._db_path = ":memory:"
+        else:
+            resolved = Path(str(db_path)).expanduser()
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+            self._db_path = str(resolved)
+
+        self._auto_sweep = auto_sweep
+        self._sweep_interval = sweep_interval
+        self._last_sweep: float = 0.0
+        self._lock = threading.Lock()
+
+        self._conn = self._connect()
+        self._ensure_schema()
+
+    # ── connection helpers ────────────────────────────────────
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._lock:
+            self._conn.executescript(_SCHEMA_SQL)
+            self._conn.commit()
+
+    @contextmanager
+    def _cursor(self):
+        with self._lock:
+            cur = self._conn.cursor()
+            try:
+                yield cur
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            finally:
+                cur.close()
+
+    # ── core API ──────────────────────────────────────────────
+
+    def ingest(
+        self,
+        content: Any,
+        source: str,
+        data_class: DataClass = DataClass.EPHEMERAL,
+        *,
+        summary: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+        custom_ttl: Optional[float] = None,
+    ) -> str:
+        """Store a data payload.  Returns the record id.
+
+        If an identical fingerprint already exists the existing record is
+        *touched* (``accessed_at`` bumped, ``access_count`` incremented)
+        and its id is returned — no duplicate row is created.
+
+        Parameters
+        ----------
+        content : dict | list | str | Any
+            The data payload (serialised to JSON internally).
+        source : str
+            Origin identifier, e.g. ``"gmail"``, ``"calendar"``.
+        data_class : DataClass
+            Lifecycle class — determines default TTL.
+        summary : str, optional
+            Human-readable summary (for compaction / display).
+        meta : dict, optional
+            Arbitrary metadata blob.
+        custom_ttl : float, optional
+            Override the default TTL for this record (seconds).
+        """
+        # Auto-sweep stale records
+        if self._auto_sweep:
+            self._maybe_sweep()
+
+        fp = fingerprint(content, source)
+
+        # Check for duplicate
+        existing = self._get_by_fingerprint(fp)
+        if existing is not None:
+            self._touch(existing.id)
+            logger.debug("Ingest dedup hit: fp=%s → id=%s", fp[:12], existing.id)
+            return existing.id
+
+        now = time.time()
+        ttl = custom_ttl if custom_ttl is not None else _TTL_MAP.get(data_class)
+        expires_at = (now + ttl) if ttl is not None else None
+
+        record_id = uuid.uuid4().hex
+
+        content_json = json.dumps(content, ensure_ascii=False, default=str)
+        meta_json = json.dumps(meta, ensure_ascii=False) if meta else None
+
+        with self._cursor() as cur:
+            cur.execute(
+                """INSERT INTO ingest_store
+                   (id, fingerprint, data_class, source, content,
+                    summary, created_at, expires_at, accessed_at,
+                    access_count, meta)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)""",
+                (
+                    record_id,
+                    fp,
+                    data_class.value,
+                    source,
+                    content_json,
+                    summary,
+                    now,
+                    expires_at,
+                    now,
+                    meta_json,
+                ),
+            )
+
+        logger.debug(
+            "Ingested id=%s src=%s class=%s ttl=%s",
+            record_id[:12], source, data_class.value,
+            f"{ttl}s" if ttl else "∞",
+        )
+        return record_id
+
+    def get(self, record_id: str) -> Optional[IngestRecord]:
+        """Retrieve a record by id.  Returns *None* if not found or expired."""
+        with self._cursor() as cur:
+            cur.execute("SELECT * FROM ingest_store WHERE id = ?", (record_id,))
+            row = cur.fetchone()
+        if row is None:
+            return None
+        record = self._row_to_record(row)
+        if record.is_expired:
+            self._delete_ids([record_id])
+            return None
+        self._touch(record_id)
+        return record
+
+    def get_by_fingerprint(self, fp: str) -> Optional[IngestRecord]:
+        """Look up by fingerprint hash.  Expired rows are pruned."""
+        record = self._get_by_fingerprint(fp)
+        if record is None:
+            return None
+        if record.is_expired:
+            self._delete_ids([record.id])
+            return None
+        self._touch(record.id)
+        return record
+
+    def query(
+        self,
+        *,
+        source: Optional[str] = None,
+        data_class: Optional[DataClass] = None,
+        limit: int = 50,
+        include_expired: bool = False,
+    ) -> List[IngestRecord]:
+        """Query records with optional filters.
+
+        Results are ordered by ``accessed_at`` descending (most-recently-used
+        first).
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+        if data_class is not None:
+            clauses.append("data_class = ?")
+            params.append(data_class.value)
+        if not include_expired:
+            clauses.append("(expires_at IS NULL OR expires_at > ?)")
+            params.append(time.time())
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        sql = f"SELECT * FROM ingest_store{where} ORDER BY accessed_at DESC LIMIT ?"
+        params.append(limit)
+
+        with self._cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [self._row_to_record(r) for r in rows]
+
+    def search(
+        self,
+        keyword: str,
+        *,
+        source: Optional[str] = None,
+        limit: int = 20,
+    ) -> List[IngestRecord]:
+        """Simple keyword search across content, summary and meta fields."""
+        clauses = [
+            "(content LIKE ? OR summary LIKE ? OR meta LIKE ?)",
+            "(expires_at IS NULL OR expires_at > ?)",
+        ]
+        pattern = f"%{keyword}%"
+        params: list[Any] = [pattern, pattern, pattern, time.time()]
+
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+
+        where = " WHERE " + " AND ".join(clauses)
+        sql = f"SELECT * FROM ingest_store{where} ORDER BY accessed_at DESC LIMIT ?"
+        params.append(limit)
+
+        with self._cursor() as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [self._row_to_record(r) for r in rows]
+
+    def update_summary(self, record_id: str, summary: str) -> bool:
+        """Set or overwrite the summary for a record."""
+        with self._cursor() as cur:
+            cur.execute(
+                "UPDATE ingest_store SET summary = ? WHERE id = ?",
+                (summary, record_id),
+            )
+            return cur.rowcount > 0
+
+    def update_meta(self, record_id: str, meta: Dict[str, Any]) -> bool:
+        """Merge new metadata into an existing record."""
+        existing = self.get(record_id)
+        if existing is None:
+            return False
+        merged = {**(existing.meta or {}), **meta}
+        meta_json = json.dumps(merged, ensure_ascii=False)
+        with self._cursor() as cur:
+            cur.execute(
+                "UPDATE ingest_store SET meta = ? WHERE id = ?",
+                (meta_json, record_id),
+            )
+            return cur.rowcount > 0
+
+    def promote(self, record_id: str, new_class: DataClass) -> bool:
+        """Change the data-class of a record (e.g. SESSION → PERSISTENT).
+
+        TTL is recalculated based on the new class.
+        """
+        record = self.get(record_id)
+        if record is None:
+            return False
+        now = time.time()
+        ttl = _TTL_MAP.get(new_class)
+        new_expires = (now + ttl) if ttl is not None else None
+        with self._cursor() as cur:
+            cur.execute(
+                "UPDATE ingest_store SET data_class = ?, expires_at = ? WHERE id = ?",
+                (new_class.value, new_expires, record_id),
+            )
+            return cur.rowcount > 0
+
+    def delete(self, record_id: str) -> bool:
+        """Delete a single record."""
+        with self._cursor() as cur:
+            cur.execute("DELETE FROM ingest_store WHERE id = ?", (record_id,))
+            return cur.rowcount > 0
+
+    # ── TTL sweeping ──────────────────────────────────────────
+
+    def sweep_expired(self) -> int:
+        """Delete all records whose ``expires_at`` has passed.
+
+        Returns the number of rows deleted.
+        """
+        now = time.time()
+        with self._cursor() as cur:
+            cur.execute(
+                "DELETE FROM ingest_store WHERE expires_at IS NOT NULL AND expires_at <= ?",
+                (now,),
+            )
+            count = cur.rowcount
+        self._last_sweep = now
+        if count:
+            logger.info("TTL sweep: %d expired records deleted", count)
+        return count
+
+    # ── statistics ────────────────────────────────────────────
+
+    def stats(self) -> Dict[str, Any]:
+        """Return basic store statistics."""
+        with self._cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM ingest_store")
+            total = cur.fetchone()[0]
+
+            cur.execute(
+                "SELECT data_class, COUNT(*) FROM ingest_store GROUP BY data_class"
+            )
+            by_class = {row[0]: row[1] for row in cur.fetchall()}
+
+            cur.execute(
+                "SELECT source, COUNT(*) FROM ingest_store GROUP BY source"
+            )
+            by_source = {row[0]: row[1] for row in cur.fetchall()}
+
+            cur.execute(
+                "SELECT COUNT(*) FROM ingest_store WHERE expires_at IS NOT NULL AND expires_at <= ?",
+                (time.time(),),
+            )
+            expired = cur.fetchone()[0]
+
+        return {
+            "total": total,
+            "by_class": by_class,
+            "by_source": by_source,
+            "expired_pending_sweep": expired,
+            "db_path": self._db_path,
+        }
+
+    # ── lifecycle ─────────────────────────────────────────────
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    # ── private helpers ───────────────────────────────────────
+
+    def _get_by_fingerprint(self, fp: str) -> Optional[IngestRecord]:
+        with self._cursor() as cur:
+            cur.execute(
+                "SELECT * FROM ingest_store WHERE fingerprint = ?", (fp,)
+            )
+            row = cur.fetchone()
+        return self._row_to_record(row) if row else None
+
+    def _touch(self, record_id: str) -> None:
+        with self._cursor() as cur:
+            cur.execute(
+                "UPDATE ingest_store SET accessed_at = ?, access_count = access_count + 1 WHERE id = ?",
+                (time.time(), record_id),
+            )
+
+    def _delete_ids(self, ids: Sequence[str]) -> int:
+        if not ids:
+            return 0
+        placeholders = ",".join("?" for _ in ids)
+        with self._cursor() as cur:
+            cur.execute(
+                f"DELETE FROM ingest_store WHERE id IN ({placeholders})",
+                list(ids),
+            )
+            return cur.rowcount
+
+    def _maybe_sweep(self) -> None:
+        now = time.time()
+        if now - self._last_sweep >= self._sweep_interval:
+            try:
+                self.sweep_expired()
+            except Exception as e:
+                logger.warning("Auto-sweep failed: %s", e)
+
+    @staticmethod
+    def _row_to_record(row: sqlite3.Row) -> IngestRecord:
+        content_raw = row["content"]
+        try:
+            content = json.loads(content_raw)
+        except (json.JSONDecodeError, TypeError):
+            content = {"_raw": content_raw}
+
+        meta_raw = row["meta"]
+        try:
+            meta = json.loads(meta_raw) if meta_raw else None
+        except (json.JSONDecodeError, TypeError):
+            meta = None
+
+        return IngestRecord(
+            id=row["id"],
+            fingerprint=row["fingerprint"],
+            data_class=DataClass(row["data_class"]),
+            source=row["source"],
+            content=content,
+            summary=row["summary"],
+            created_at=row["created_at"],
+            expires_at=row["expires_at"],
+            accessed_at=row["accessed_at"],
+            access_count=row["access_count"],
+            meta=meta,
+        )
+
+
+# ── Async TTL sweeper (for daemon usage) ─────────────────────────
+
+def ttl_sweep_once(store: IngestStore) -> int:
+    """Run a single sweep pass (synchronous).  Returns rows deleted."""
+    return store.sweep_expired()
+
+
+async def start_ttl_sweeper(
+    store: IngestStore,
+    interval: int = 3600,
+) -> None:
+    """Run the TTL sweeper as an asyncio background task.
+
+    Call with ``asyncio.create_task(start_ttl_sweeper(store))`` from
+    the main event loop.  Runs every *interval* seconds (default 1 h).
+    """
+    logger.info("TTL sweeper started (interval=%ds)", interval)
+    while True:
+        try:
+            deleted = store.sweep_expired()
+            if deleted:
+                logger.info("TTL sweep pass: %d records removed", deleted)
+        except Exception as e:
+            logger.error("TTL sweeper error: %s", e)
+        await asyncio.sleep(interval)
+
+
+# ── Convenience: classify tool results ────────────────────────────
+
+# Tool source → default data-class mapping
+_TOOL_DATA_CLASS: Dict[str, DataClass] = {
+    # Read-only / listing tools → ephemeral
+    "gmail.search_email":       DataClass.EPHEMERAL,
+    "gmail.list_email":         DataClass.EPHEMERAL,
+    "gmail.get_message":        DataClass.EPHEMERAL,
+    "calendar.list_events":     DataClass.EPHEMERAL,
+    "web.search":               DataClass.EPHEMERAL,
+    "web.scrape":               DataClass.EPHEMERAL,
+    # Write/action tools → session
+    "gmail.send_email":         DataClass.SESSION,
+    "gmail.reply_email":        DataClass.SESSION,
+    "calendar.create_event":    DataClass.SESSION,
+    "calendar.update_event":    DataClass.SESSION,
+    "calendar.delete_event":    DataClass.SESSION,
+    # Persistent knowledge
+    "contacts.search":          DataClass.PERSISTENT,
+    "contacts.get":             DataClass.PERSISTENT,
+}
+
+
+def classify_tool_result(tool_name: str) -> DataClass:
+    """Return the default DataClass for a given tool's output.
+
+    Falls back to EPHEMERAL for unknown tools.
+    """
+    return _TOOL_DATA_CLASS.get(tool_name, DataClass.EPHEMERAL)

--- a/tests/test_ingest_bridge.py
+++ b/tests/test_ingest_bridge.py
@@ -1,0 +1,249 @@
+"""
+Tests for bantz.data.ingest_bridge — IngestBridge orchestrator integration.
+
+Issue #1288: Ingest Store bridge for tool result caching.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bantz.data.ingest_store import IngestStore, DataClass, IngestRecord
+from bantz.data.ingest_bridge import IngestBridge, _stable_params
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+@pytest.fixture
+def store():
+    return IngestStore(db_path=":memory:", auto_sweep=False)
+
+
+@pytest.fixture
+def bridge(store):
+    return IngestBridge(store)
+
+
+# ── IngestBridge: Basic ───────────────────────────────────────────
+
+class TestIngestBridgeBasic:
+    def test_on_tool_result_returns_id(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="gmail.search_email",
+            params={"query": "from:ali"},
+            result={"messages": [{"id": "1", "subject": "hello"}]},
+        )
+        assert isinstance(rid, str)
+        assert len(rid) == 32  # uuid hex
+
+    def test_on_tool_result_skips_failures(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="calendar.list_events",
+            params={},
+            result={"ok": False, "error": "auth failed"},
+            success=False,
+        )
+        assert rid is None
+
+    def test_on_tool_result_skips_none(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="test.tool",
+            params={},
+            result=None,
+        )
+        assert rid is None
+
+    def test_on_tool_result_skips_empty_dict(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="test.tool",
+            params={},
+            result={},
+        )
+        assert rid is None
+
+    def test_on_tool_result_skips_empty_list(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="test.tool",
+            params={},
+            result=[],
+        )
+        assert rid is None
+
+    def test_summary_stored(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="gmail.search_email",
+            params={"query": "test"},
+            result={"messages": [{"id": "1"}]},
+            summary="Found 1 email",
+        )
+        record = bridge.store.get(rid)
+        assert record.summary == "Found 1 email"
+
+    def test_meta_includes_tool_info(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="calendar.list_events",
+            params={"date": "today"},
+            result={"events": [{"title": "Meeting"}]},
+            elapsed_ms=250,
+        )
+        record = bridge.store.get(rid)
+        assert record.meta["tool_name"] == "calendar.list_events"
+        assert record.meta["elapsed_ms"] == 250
+        assert record.meta["params"] == {"date": "today"}
+
+
+# ── IngestBridge: Classification ──────────────────────────────────
+
+class TestIngestBridgeClassification:
+    def test_read_tool_classified_ephemeral(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="gmail.search_email",
+            params={"query": "test"},
+            result={"messages": ["m1"]},
+        )
+        record = bridge.store.get(rid)
+        assert record.data_class == DataClass.EPHEMERAL
+
+    def test_write_tool_classified_session(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="gmail.send_email",
+            params={"to": "ali@x.com", "body": "hi"},
+            result={"ok": True, "message_id": "abc123"},
+        )
+        record = bridge.store.get(rid)
+        assert record.data_class == DataClass.SESSION
+
+    def test_contacts_classified_persistent(self, bridge):
+        rid = bridge.on_tool_result(
+            tool_name="contacts.search",
+            params={"query": "Ali"},
+            result={"contacts": [{"name": "Ali", "email": "ali@x.com"}]},
+        )
+        record = bridge.store.get(rid)
+        assert record.data_class == DataClass.PERSISTENT
+
+
+# ── IngestBridge: Cache Lookup ────────────────────────────────────
+
+class TestIngestBridgeCache:
+    def test_cache_hit(self, bridge):
+        """After ingesting, same tool+params should produce a cache hit."""
+        bridge.on_tool_result(
+            tool_name="gmail.search_email",
+            params={"query": "from:ali"},
+            result={"messages": [{"id": "1"}]},
+        )
+        cached = bridge.get_cached("gmail.search_email", {"query": "from:ali"})
+        assert cached is not None
+        assert cached.content["result"]["messages"][0]["id"] == "1"
+
+    def test_cache_miss(self, bridge):
+        """Different params should not cache-hit."""
+        bridge.on_tool_result(
+            tool_name="gmail.search_email",
+            params={"query": "from:ali"},
+            result={"messages": [{"id": "1"}]},
+        )
+        cached = bridge.get_cached("gmail.search_email", {"query": "from:veli"})
+        assert cached is None
+
+    def test_cache_max_age(self, bridge):
+        """Cached result older than max_age should be a miss."""
+        bridge.on_tool_result(
+            tool_name="gmail.search_email",
+            params={"query": "from:ali"},
+            result={"messages": []},
+        )
+        # max_age=0 means "only accept records created at this exact instant"
+        time.sleep(0.01)
+        cached = bridge.get_cached(
+            "gmail.search_email",
+            {"query": "from:ali"},
+            max_age=0.001,
+        )
+        assert cached is None
+
+
+# ── IngestBridge: Turn Stats ──────────────────────────────────────
+
+class TestIngestBridgeTurnStats:
+    def test_initial_stats_zero(self, bridge):
+        stats = bridge.reset_turn_stats()
+        assert stats["ingested"] == 0
+        assert stats["cache_hits"] == 0
+
+    def test_stats_track_ingests(self, bridge):
+        bridge.on_tool_result("t1", {}, {"data": 1})
+        bridge.on_tool_result("t2", {}, {"data": 2})
+        stats = bridge.reset_turn_stats()
+        assert stats["ingested"] == 2
+
+    def test_stats_track_cache_hits(self, bridge):
+        bridge.on_tool_result(
+            "gmail.search_email",
+            {"query": "test"},
+            {"messages": [1]},
+        )
+        bridge.get_cached("gmail.search_email", {"query": "test"})
+        stats = bridge.reset_turn_stats()
+        assert stats["cache_hits"] == 1
+
+    def test_stats_reset(self, bridge):
+        bridge.on_tool_result("t1", {}, {"data": 1})
+        bridge.reset_turn_stats()
+        stats = bridge.reset_turn_stats()
+        assert stats["ingested"] == 0
+
+    def test_failed_ingest_not_counted(self, bridge):
+        bridge.on_tool_result("t1", {}, None)  # None result → skipped
+        stats = bridge.reset_turn_stats()
+        assert stats["ingested"] == 0
+
+
+# ── IngestBridge: create_default ──────────────────────────────────
+
+class TestIngestBridgeCreateDefault:
+    def test_creates_instance(self, tmp_path):
+        db = tmp_path / "test_ingest.db"
+        b = IngestBridge.create_default(db_path=str(db))
+        assert b is not None
+        rid = b.on_tool_result("test", {}, {"ok": True})
+        assert rid is not None
+        b.close()
+
+    def test_fallback_on_error(self):
+        """If DB path is invalid, falls back to in-memory."""
+        b = IngestBridge.create_default(db_path="/nonexistent/path/db.sqlite")
+        # Should work with in-memory fallback
+        rid = b.on_tool_result("test", {}, {"ok": True})
+        assert rid is not None
+        b.close()
+
+
+# ── _stable_params ────────────────────────────────────────────────
+
+class TestStableParams:
+    def test_removes_unstable_keys(self):
+        params = {"query": "test", "page_token": "abc", "_request_id": "xyz"}
+        stable = _stable_params(params)
+        assert "query" in stable
+        assert "page_token" not in stable
+        assert "_request_id" not in stable
+
+    def test_preserves_normal_keys(self):
+        params = {"query": "from:ali", "max_results": 10}
+        stable = _stable_params(params)
+        assert stable == {"max_results": 10, "query": "from:ali"}
+
+    def test_sorted_keys(self):
+        params = {"z_key": 1, "a_key": 2}
+        stable = _stable_params(params)
+        keys = list(stable.keys())
+        assert keys == ["a_key", "z_key"]
+
+    def test_non_dict_passthrough(self):
+        assert _stable_params("string") == "string"
+        assert _stable_params(42) == 42

--- a/tests/test_ingest_store.py
+++ b/tests/test_ingest_store.py
@@ -1,0 +1,502 @@
+"""
+Tests for bantz.data.ingest_store — IngestStore, DataClass, fingerprinting.
+
+Issue #1288: Ingest Store + TTL Cache + Fingerprint
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import asyncio
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from bantz.data.ingest_store import (
+    IngestStore,
+    IngestRecord,
+    DataClass,
+    fingerprint,
+    classify_tool_result,
+    ttl_sweep_once,
+    start_ttl_sweeper,
+    _TTL_MAP,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────
+
+@pytest.fixture
+def store():
+    """In-memory IngestStore for tests."""
+    s = IngestStore(db_path=":memory:", auto_sweep=False)
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def store_with_sweep():
+    """In-memory IngestStore with auto-sweep enabled (interval=0 for immediate)."""
+    s = IngestStore(db_path=":memory:", auto_sweep=True, sweep_interval=0)
+    yield s
+    s.close()
+
+
+# ── DataClass ─────────────────────────────────────────────────────
+
+class TestDataClass:
+    def test_enum_values(self):
+        assert DataClass.EPHEMERAL.value == "EPHEMERAL"
+        assert DataClass.SESSION.value == "SESSION"
+        assert DataClass.PERSISTENT.value == "PERSISTENT"
+
+    def test_enum_from_string(self):
+        assert DataClass("EPHEMERAL") == DataClass.EPHEMERAL
+        assert DataClass("SESSION") == DataClass.SESSION
+        assert DataClass("PERSISTENT") == DataClass.PERSISTENT
+
+    def test_ttl_map_values(self):
+        assert _TTL_MAP[DataClass.EPHEMERAL] == 24 * 3600
+        assert _TTL_MAP[DataClass.SESSION] == 7 * 24 * 3600
+        assert _TTL_MAP[DataClass.PERSISTENT] is None
+
+
+# ── Fingerprinting ────────────────────────────────────────────────
+
+class TestFingerprint:
+    def test_deterministic(self):
+        """Same content + source always produces the same hash."""
+        fp1 = fingerprint({"key": "value"}, "gmail")
+        fp2 = fingerprint({"key": "value"}, "gmail")
+        assert fp1 == fp2
+
+    def test_different_content(self):
+        fp1 = fingerprint({"key": "value1"}, "gmail")
+        fp2 = fingerprint({"key": "value2"}, "gmail")
+        assert fp1 != fp2
+
+    def test_different_source(self):
+        fp1 = fingerprint({"key": "value"}, "gmail")
+        fp2 = fingerprint({"key": "value"}, "calendar")
+        assert fp1 != fp2
+
+    def test_dict_key_order_independent(self):
+        """JSON sort_keys ensures key order doesn't matter."""
+        fp1 = fingerprint({"b": 2, "a": 1}, "test")
+        fp2 = fingerprint({"a": 1, "b": 2}, "test")
+        assert fp1 == fp2
+
+    def test_sha256_length(self):
+        fp = fingerprint("test", "source")
+        assert len(fp) == 64  # SHA-256 hex digest
+
+    def test_list_content(self):
+        fp1 = fingerprint([1, 2, 3], "test")
+        fp2 = fingerprint([1, 2, 3], "test")
+        assert fp1 == fp2
+
+    def test_string_content(self):
+        fp1 = fingerprint("hello world", "test")
+        fp2 = fingerprint("hello world", "test")
+        assert fp1 == fp2
+
+    def test_unicode_content(self):
+        """Turkish characters should fingerprint correctly."""
+        fp1 = fingerprint({"konu": "Türkçe içerik"}, "gmail")
+        fp2 = fingerprint({"konu": "Türkçe içerik"}, "gmail")
+        assert fp1 == fp2
+
+
+# ── IngestStore: Basic CRUD ──────────────────────────────────────
+
+class TestIngestStoreCRUD:
+    def test_ingest_returns_id(self, store):
+        rid = store.ingest({"msg": "hello"}, source="test")
+        assert isinstance(rid, str)
+        assert len(rid) == 32  # uuid4 hex
+
+    def test_get_by_id(self, store):
+        rid = store.ingest({"msg": "hello"}, source="test")
+        record = store.get(rid)
+        assert record is not None
+        assert record.id == rid
+        assert record.content == {"msg": "hello"}
+        assert record.source == "test"
+
+    def test_get_nonexistent(self, store):
+        assert store.get("nonexistent_id") is None
+
+    def test_default_data_class(self, store):
+        rid = store.ingest({"x": 1}, source="test")
+        record = store.get(rid)
+        assert record.data_class == DataClass.EPHEMERAL
+
+    def test_explicit_data_class(self, store):
+        rid = store.ingest({"x": 1}, source="test", data_class=DataClass.PERSISTENT)
+        record = store.get(rid)
+        assert record.data_class == DataClass.PERSISTENT
+
+    def test_summary_stored(self, store):
+        rid = store.ingest({"x": 1}, source="test", summary="Test summary")
+        record = store.get(rid)
+        assert record.summary == "Test summary"
+
+    def test_meta_stored(self, store):
+        meta = {"tool_name": "gmail.search", "elapsed_ms": 150}
+        rid = store.ingest({"x": 1}, source="test", meta=meta)
+        record = store.get(rid)
+        assert record.meta == meta
+
+    def test_delete(self, store):
+        rid = store.ingest({"x": 1}, source="test")
+        assert store.delete(rid) is True
+        assert store.get(rid) is None
+
+    def test_delete_nonexistent(self, store):
+        assert store.delete("nonexistent") is False
+
+    def test_update_summary(self, store):
+        rid = store.ingest({"x": 1}, source="test")
+        store.update_summary(rid, "Updated summary")
+        record = store.get(rid)
+        assert record.summary == "Updated summary"
+
+    def test_update_meta_merge(self, store):
+        rid = store.ingest({"x": 1}, source="test", meta={"a": 1})
+        store.update_meta(rid, {"b": 2})
+        record = store.get(rid)
+        assert record.meta == {"a": 1, "b": 2}
+
+
+# ── IngestStore: Deduplication ────────────────────────────────────
+
+class TestIngestStoreDedup:
+    def test_same_content_same_source_dedup(self, store):
+        """Identical content from same source → single record."""
+        rid1 = store.ingest({"subject": "hello"}, source="gmail")
+        rid2 = store.ingest({"subject": "hello"}, source="gmail")
+        assert rid1 == rid2
+
+    def test_same_content_different_source_no_dedup(self, store):
+        """Same content from different sources → separate records."""
+        rid1 = store.ingest({"subject": "hello"}, source="gmail")
+        rid2 = store.ingest({"subject": "hello"}, source="calendar")
+        assert rid1 != rid2
+
+    def test_different_content_same_source_no_dedup(self, store):
+        rid1 = store.ingest({"subject": "hello"}, source="gmail")
+        rid2 = store.ingest({"subject": "world"}, source="gmail")
+        assert rid1 != rid2
+
+    def test_dedup_increments_access_count(self, store):
+        rid = store.ingest({"x": 1}, source="test")
+        record1 = store.get(rid)
+        initial_count = record1.access_count
+
+        # Ingest same content again — dedup should bump access_count
+        store.ingest({"x": 1}, source="test")
+        record2 = store.get(rid)
+        assert record2.access_count > initial_count
+
+    def test_dedup_updates_accessed_at(self, store):
+        rid = store.ingest({"x": 1}, source="test")
+        record1 = store.get(rid)
+        t1 = record1.accessed_at
+
+        time.sleep(0.01)  # Small delay
+        store.ingest({"x": 1}, source="test")  # Dedup
+        record2 = store.get(rid)
+        assert record2.accessed_at >= t1
+
+    def test_get_by_fingerprint(self, store):
+        rid = store.ingest({"hello": "world"}, source="test")
+        fp = fingerprint({"hello": "world"}, "test")
+        record = store.get_by_fingerprint(fp)
+        assert record is not None
+        assert record.id == rid
+
+
+# ── IngestStore: TTL / Expiration ─────────────────────────────────
+
+class TestIngestStoreTTL:
+    def test_ephemeral_has_expires_at(self, store):
+        rid = store.ingest({"x": 1}, source="test", data_class=DataClass.EPHEMERAL)
+        record = store.get(rid)
+        assert record.expires_at is not None
+        # Expires roughly 24h from now
+        expected = time.time() + 24 * 3600
+        assert abs(record.expires_at - expected) < 5
+
+    def test_session_has_expires_at(self, store):
+        rid = store.ingest({"x": 1}, source="test", data_class=DataClass.SESSION)
+        record = store.get(rid)
+        assert record.expires_at is not None
+        expected = time.time() + 7 * 24 * 3600
+        assert abs(record.expires_at - expected) < 5
+
+    def test_persistent_no_expires(self, store):
+        rid = store.ingest({"x": 1}, source="test", data_class=DataClass.PERSISTENT)
+        record = store.get(rid)
+        assert record.expires_at is None
+
+    def test_custom_ttl(self, store):
+        rid = store.ingest({"x": 1}, source="test", custom_ttl=60)
+        record = store.get(rid)
+        expected = time.time() + 60
+        assert abs(record.expires_at - expected) < 5
+
+    def test_expired_record_not_returned_by_get(self, store):
+        """Records past their TTL are invisible."""
+        rid = store.ingest({"x": 1}, source="test", custom_ttl=0.001)
+        time.sleep(0.01)
+        record = store.get(rid)
+        assert record is None
+
+    def test_sweep_deletes_expired(self, store):
+        store.ingest({"a": 1}, source="test", custom_ttl=0.001)
+        store.ingest({"b": 2}, source="test", custom_ttl=0.001)
+        store.ingest({"c": 3}, source="test", data_class=DataClass.PERSISTENT)
+        time.sleep(0.01)
+
+        deleted = store.sweep_expired()
+        assert deleted == 2
+        # Persistent record survives
+        stats = store.stats()
+        assert stats["total"] == 1
+
+    def test_sweep_returns_zero_when_nothing_expired(self, store):
+        store.ingest({"x": 1}, source="test", data_class=DataClass.PERSISTENT)
+        assert store.sweep_expired() == 0
+
+    def test_auto_sweep_on_ingest(self, store_with_sweep):
+        """Auto-sweep triggers during ingest when interval has passed."""
+        store_with_sweep.ingest({"a": 1}, source="test", custom_ttl=0.001)
+        time.sleep(0.01)
+        # Next ingest should trigger sweep
+        store_with_sweep.ingest({"b": 2}, source="test", data_class=DataClass.PERSISTENT)
+        stats = store_with_sweep.stats()
+        assert stats["expired_pending_sweep"] == 0
+
+
+# ── IngestStore: Query / Search ───────────────────────────────────
+
+class TestIngestStoreQuery:
+    def test_query_all(self, store):
+        store.ingest({"a": 1}, source="gmail")
+        store.ingest({"b": 2}, source="calendar")
+        store.ingest({"c": 3}, source="web")
+        results = store.query()
+        assert len(results) == 3
+
+    def test_query_by_source(self, store):
+        store.ingest({"a": 1}, source="gmail")
+        store.ingest({"b": 2}, source="calendar")
+        results = store.query(source="gmail")
+        assert len(results) == 1
+        assert results[0].source == "gmail"
+
+    def test_query_by_data_class(self, store):
+        store.ingest({"a": 1}, source="test", data_class=DataClass.EPHEMERAL)
+        store.ingest({"b": 2}, source="test", data_class=DataClass.PERSISTENT)
+        results = store.query(data_class=DataClass.PERSISTENT)
+        assert len(results) == 1
+        assert results[0].data_class == DataClass.PERSISTENT
+
+    def test_query_excludes_expired(self, store):
+        store.ingest({"a": 1}, source="test", custom_ttl=0.001)
+        store.ingest({"b": 2}, source="test", data_class=DataClass.PERSISTENT)
+        time.sleep(0.01)
+        results = store.query()
+        assert len(results) == 1
+
+    def test_query_include_expired(self, store):
+        store.ingest({"a": 1}, source="test", custom_ttl=0.001)
+        store.ingest({"b": 2}, source="test", data_class=DataClass.PERSISTENT)
+        time.sleep(0.01)
+        results = store.query(include_expired=True)
+        assert len(results) == 2
+
+    def test_query_limit(self, store):
+        for i in range(10):
+            store.ingest({f"item_{i}": i}, source="test")
+        results = store.query(limit=3)
+        assert len(results) == 3
+
+    def test_search_keyword(self, store):
+        store.ingest({"subject": "toplantı notları"}, source="gmail")
+        store.ingest({"subject": "alışveriş listesi"}, source="gmail")
+        results = store.search("toplantı")
+        assert len(results) == 1
+
+    def test_search_in_summary(self, store):
+        store.ingest({"x": 1}, source="test", summary="Ali toplantı planı")
+        results = store.search("Ali")
+        assert len(results) == 1
+
+    def test_search_by_source(self, store):
+        store.ingest({"msg": "hello"}, source="gmail")
+        store.ingest({"msg": "hello"}, source="calendar")
+        results = store.search("hello", source="gmail")
+        assert len(results) == 1
+
+
+# ── IngestStore: Promote ──────────────────────────────────────────
+
+class TestIngestStorePromote:
+    def test_promote_ephemeral_to_persistent(self, store):
+        rid = store.ingest({"contact": "Ali"}, source="test", data_class=DataClass.EPHEMERAL)
+        record = store.get(rid)
+        assert record.expires_at is not None
+
+        store.promote(rid, DataClass.PERSISTENT)
+        record = store.get(rid)
+        assert record.data_class == DataClass.PERSISTENT
+        assert record.expires_at is None
+
+    def test_promote_session_to_persistent(self, store):
+        rid = store.ingest({"x": 1}, source="test", data_class=DataClass.SESSION)
+        store.promote(rid, DataClass.PERSISTENT)
+        record = store.get(rid)
+        assert record.data_class == DataClass.PERSISTENT
+
+    def test_promote_nonexistent(self, store):
+        assert store.promote("fake_id", DataClass.PERSISTENT) is False
+
+
+# ── IngestStore: Stats ────────────────────────────────────────────
+
+class TestIngestStoreStats:
+    def test_empty_stats(self, store):
+        stats = store.stats()
+        assert stats["total"] == 0
+        assert stats["by_class"] == {}
+        assert stats["by_source"] == {}
+        assert stats["expired_pending_sweep"] == 0
+
+    def test_stats_count(self, store):
+        store.ingest({"a": 1}, source="gmail", data_class=DataClass.EPHEMERAL)
+        store.ingest({"b": 2}, source="gmail", data_class=DataClass.PERSISTENT)
+        store.ingest({"c": 3}, source="calendar", data_class=DataClass.EPHEMERAL)
+        stats = store.stats()
+        assert stats["total"] == 3
+        assert stats["by_class"]["EPHEMERAL"] == 2
+        assert stats["by_class"]["PERSISTENT"] == 1
+        assert stats["by_source"]["gmail"] == 2
+        assert stats["by_source"]["calendar"] == 1
+
+
+# ── IngestRecord ──────────────────────────────────────────────────
+
+class TestIngestRecord:
+    def test_is_expired_false(self, store):
+        rid = store.ingest({"x": 1}, source="test", data_class=DataClass.EPHEMERAL)
+        record = store.get(rid)
+        assert record.is_expired is False
+
+    def test_is_expired_persistent(self, store):
+        rid = store.ingest({"x": 1}, source="test", data_class=DataClass.PERSISTENT)
+        record = store.get(rid)
+        assert record.is_expired is False  # Never expires
+
+    def test_to_dict(self, store):
+        rid = store.ingest({"x": 1}, source="test", summary="sum", meta={"m": 1})
+        record = store.get(rid)
+        d = record.to_dict()
+        assert d["id"] == rid
+        assert d["source"] == "test"
+        assert d["content"] == {"x": 1}
+        assert d["summary"] == "sum"
+        assert d["meta"] == {"m": 1}
+        assert d["data_class"] == "EPHEMERAL"
+
+    def test_age_seconds(self, store):
+        rid = store.ingest({"x": 1}, source="test")
+        record = store.get(rid)
+        assert record.age_seconds >= 0
+        assert record.age_seconds < 5  # Should be very recent
+
+
+# ── classify_tool_result ──────────────────────────────────────────
+
+class TestClassifyToolResult:
+    def test_known_ephemeral(self):
+        assert classify_tool_result("gmail.search_email") == DataClass.EPHEMERAL
+        assert classify_tool_result("calendar.list_events") == DataClass.EPHEMERAL
+
+    def test_known_session(self):
+        assert classify_tool_result("gmail.send_email") == DataClass.SESSION
+        assert classify_tool_result("calendar.create_event") == DataClass.SESSION
+
+    def test_known_persistent(self):
+        assert classify_tool_result("contacts.search") == DataClass.PERSISTENT
+
+    def test_unknown_defaults_ephemeral(self):
+        assert classify_tool_result("unknown.tool") == DataClass.EPHEMERAL
+
+
+# ── TTL Sweeper ───────────────────────────────────────────────────
+
+class TestTTLSweeper:
+    def test_sync_sweep(self, store):
+        store.ingest({"a": 1}, source="test", custom_ttl=0.001)
+        time.sleep(0.01)
+        deleted = ttl_sweep_once(store)
+        assert deleted == 1
+
+    def test_async_sweeper_runs(self, store):
+        """Verify the async sweeper can complete at least one pass."""
+        store.ingest({"a": 1}, source="test", custom_ttl=0.001)
+        time.sleep(0.01)
+
+        async def run():
+            task = asyncio.create_task(start_ttl_sweeper(store, interval=0))
+            await asyncio.sleep(0.05)  # Let it run one pass
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        asyncio.run(run())
+        stats = store.stats()
+        assert stats["total"] == 0
+
+
+# ── Thread Safety ─────────────────────────────────────────────────
+
+class TestThreadSafety:
+    def test_concurrent_ingests(self, store):
+        """Multiple threads can ingest simultaneously without corruption."""
+        errors = []
+
+        def ingest_batch(batch_id):
+            try:
+                for i in range(20):
+                    store.ingest(
+                        {f"batch_{batch_id}_item_{i}": i},
+                        source=f"thread_{batch_id}",
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=ingest_batch, args=(b,)) for b in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        stats = store.stats()
+        assert stats["total"] == 80  # 4 threads × 20 items
+
+
+# ── Context Manager ───────────────────────────────────────────────
+
+class TestContextManager:
+    def test_with_statement(self):
+        with IngestStore(db_path=":memory:") as store:
+            rid = store.ingest({"x": 1}, source="test")
+            assert store.get(rid) is not None
+        # After exit, connection is closed


### PR DESCRIPTION
## Summary

Implements **Issue #1288 — Ingest Store + TTL Cache + Fingerprint** — the foundational data lifecycle layer for Bantz's Faz A Data Platform.

## What's New

### `src/bantz/data/` (new module)

| File | Description |
|------|-------------|
| `ingest_store.py` | SQLite-backed store with WAL journal, thread-safe (threading.Lock) |
| `ingest_bridge.py` | Orchestrator integration bridge — classifies & ingests tool results |
| `__init__.py` | Public API exports |

### Core Features

- **DataClass enum** — `EPHEMERAL` (24h TTL), `SESSION` (7d TTL), `PERSISTENT` (∞)
- **SHA-256 fingerprinting** — deterministic hash with JSON sort_keys for key-order independence
- **Deduplication** — same content+source → touch existing record (update accessed_at), no duplicates
- **Cache lookup** — `get_cached(tool, params)` finds previous results via cache_key in meta
- **TTL sweep** — sync `sweep_expired()` + async daemon `start_ttl_sweeper()`
- **Auto-classification** — `classify_tool_result()` maps tool names to default DataClass
- **CRUD** — `ingest()`, `get()`, `query()`, `search()`, `promote()`, `update_summary()`, `update_meta()`
- **Stats** — counts by class, by source, expired pending sweep

### Orchestrator Integration

4 integration points in `orchestrator_loop.py`:
1. `__init__` — initialize IngestBridge with fallback
2. `close()` — clean shutdown
3. `_execute_tools_phase()` — call `on_tool_result()` after successful tool execution
4. `_update_state_phase()` — log ingest stats to trace

### Tests

**86 tests, all passing** ✅
- 62 tests for `IngestStore` (CRUD, dedup, TTL, query, search, promote, stats, thread safety, context manager)
- 24 tests for `IngestBridge` (basic ingestion, classification, cache, turn stats, stable params)

## Architecture Decision

RAG stays as a separate module. Ingest Store is the **pure data lifecycle layer** — it handles storage, TTL, fingerprint dedup, and caching. The RAG system (embeddings, vector search) will come later with #1289 (Graf Bellek) and will read from Ingest Store via a clean interface.

Closes #1288