### PR TITLE
fix(brain): replace session_context.pop() with .get() to prevent NLU data loss

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1353,10 +1353,15 @@ ASSISTANT (sadece JSON):"""
         # Issue #1276: Inject active entity context for cross-turn slot tracking
         # Placed after dialog summary, before retrieved memory (medium priority).
         # Budget: ~100 tokens max, only present when an active entity exists.
+        # Fix #1310: Use .get() instead of .pop() to avoid mutating caller's dict.
+        # Keys extracted here are excluded from SESSION_CONTEXT serialization below.
+        _extracted_keys: set[str] = set()
         if session_context and remaining > 50:
             _entity_ctx = None
             if isinstance(session_context, dict):
-                _entity_ctx = session_context.pop("active_entity", None)
+                _entity_ctx = session_context.get("active_entity")
+                if _entity_ctx is not None:
+                    _extracted_keys.add("active_entity")
             if _entity_ctx:
                 entity_header = "ACTIVE_ENTITY (önceki turda oluşturulan/değiştirilen varlık):\n"
                 entity_overhead = _estimate_tokens(entity_header) + 1
@@ -1400,9 +1405,11 @@ ASSISTANT (sadece JSON):"""
 
         # Issue #938: Extract and inject NLU slots as a dedicated block
         # before session_context so the 3B model sees pre-parsed entities.
+        # Fix #1310: Use .get() instead of .pop() to avoid mutating caller's dict.
         _nlu_slots = None
         if session_context and "nlu_slots" in session_context:
-            _nlu_slots = session_context.pop("nlu_slots")
+            _nlu_slots = session_context.get("nlu_slots")
+            _extracted_keys.add("nlu_slots")
             try:
                 slots_str = json.dumps(_nlu_slots, ensure_ascii=False)
             except Exception:
@@ -1419,10 +1426,17 @@ ASSISTANT (sadece JSON):"""
                 session_budget = max(0, session_budget - used)
 
         if session_context and session_budget > 0:
+            # Fix #1310: Exclude keys already injected as dedicated blocks
+            # (active_entity, nlu_slots) to avoid duplication in SESSION_CONTEXT.
+            _ctx_to_serialize = (
+                {k: v for k, v in session_context.items() if k not in _extracted_keys}
+                if _extracted_keys
+                else session_context
+            )
             try:
-                ctx_str = json.dumps(session_context, ensure_ascii=False, indent=2)
+                ctx_str = json.dumps(_ctx_to_serialize, ensure_ascii=False, indent=2)
             except Exception:
-                ctx_str = str(session_context)
+                ctx_str = str(_ctx_to_serialize)
 
             header = "SESSION_CONTEXT:\n"
             overhead = _estimate_tokens(header) + 1


### PR DESCRIPTION
## Summary

Fixes #1310 — `_build_prompt()` used `.pop()` to extract `nlu_slots` and `active_entity` from the caller's `session_context` dict, permanently deleting these keys.

## Problem

`llm_router.py` L1359 and L1405:

```python
_entity_ctx = session_context.pop("active_entity", None)
_nlu_slots = session_context.pop("nlu_slots")
```

This caused:

1. **Data loss on retry path** — `route()` calls `_build_prompt()` twice with the same dict when budget is tight. After the first call, `nlu_slots` and `active_entity` are gone.
2. **Broken cross-turn entity resolution** — entity context deleted after first prompt build.
3. **NLU slots unavailable** for hard-guard rebuild path.

## Solution

- **`.pop()` → `.get()`** — the caller's dict is never mutated.
- **`_extracted_keys: set[str]`** tracks which keys were already injected as dedicated prompt blocks (`ACTIVE_ENTITY`, `PRE_EXTRACTED_SLOTS`).
- **SESSION_CONTEXT serialization** excludes `_extracted_keys` to prevent duplication in the prompt.

## Changes

| File | Change |
|------|--------|
| `src/bantz/brain/llm_router.py` | `.pop()` → `.get()` + exclude logic |
| `tests/test_prompt_budget_manager.py` | 5 new tests in `TestBuildPromptNoMutation` |

## Tests Added

| Test | Verifies |
|------|----------|
| `test_session_context_not_mutated_after_build_prompt` | Dict unchanged after call |
| `test_nlu_slots_survive_double_build` | nlu_slots present after 2 calls (retry path) |
| `test_active_entity_survives_double_build` | active_entity present after 2 calls |
| `test_extracted_keys_not_duplicated_in_session_block` | No duplication in SESSION_CONTEXT |
| `test_empty_session_context_no_error` | None/empty dict handled gracefully |

## Test Results

```
5 passed in 0.17s (TestBuildPromptNoMutation)
9928 passed total (zero regression)
```

Pre-existing failures (179) unrelated — `test_calendar_idempotency`, `test_web_tools`, `test_ttft_monitoring` etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended modifications to session context data during prompt building operations, ensuring consistency across consecutive operations and retry scenarios.
  * Eliminated duplicate key entries when serializing session context information in prompts.

* **Tests**
  * Added comprehensive test coverage validating that session context data remains unmodified across consecutive build cycles and various edge case configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->