### PR TITLE
fix(llm): close streaming connections in finally blocks (#1311)

### DIFF
--- a/src/bantz/llm/gemini_client.py
+++ b/src/bantz/llm/gemini_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import time
 import os
+from dataclasses import dataclass
 from typing import Iterator, List, Optional
 
 import requests
@@ -57,9 +58,6 @@ RETRY_BASE_DELAY = 1.0  # seconds
 RETRY_MAX_DELAY = 30.0  # seconds
 RETRY_BACKOFF_FACTOR = 2.0
 RETRYABLE_STATUS_CODES = {429, 500, 502, 503}
-
-
-from dataclasses import dataclass
 
 
 @dataclass
@@ -374,7 +372,7 @@ class GeminiClient(LLMClient):
 
             except requests.RequestException as e:
                 elapsed_ms = int((time.perf_counter() - t0) * 1000)
-                last_exception = e
+                last_exception = e  # noqa: F841 — kept for debugger inspection
                 if _metrics_enabled():
                     metrics_logger.info(
                         "llm_call_failed backend=%s model=%s latency_ms=%s "
@@ -420,7 +418,7 @@ class GeminiClient(LLMClient):
                         attempt,
                     )
                 raise LLMInvalidResponseError(
-                    f"Gemini parse_error reason=parse_error"
+                    "Gemini parse_error reason=parse_error"
                 ) from e
 
         # Should not reach here, but safety net

--- a/src/bantz/llm/gemini_client.py
+++ b/src/bantz/llm/gemini_client.py
@@ -2,31 +2,20 @@ from __future__ import annotations
 
 import json
 import logging
-import time
 import os
+import time
 from dataclasses import dataclass
 from typing import Iterator, List, Optional
 
 import requests
 
-from bantz.llm.base import (
-    LLMClient,
-    LLMMessage,
-    LLMResponse,
-    LLMConnectionError,
-    LLMModelNotFoundError,
-    LLMTimeoutError,
-    LLMInvalidResponseError,
-)
-
-from bantz.llm.privacy import redact_for_cloud, minimize_for_cloud
-from bantz.llm.quota_tracker import (
-    QuotaTracker,
-    QuotaExceeded,
-    CircuitBreaker,
-    CircuitOpen,
-)
-
+from bantz.llm.base import (LLMClient, LLMConnectionError,
+                            LLMInvalidResponseError, LLMMessage,
+                            LLMModelNotFoundError, LLMResponse,
+                            LLMTimeoutError)
+from bantz.llm.privacy import minimize_for_cloud, redact_for_cloud
+from bantz.llm.quota_tracker import (CircuitBreaker, CircuitOpen,
+                                     QuotaExceeded, QuotaTracker)
 
 logger = logging.getLogger(__name__)
 metrics_logger = logging.getLogger("bantz.llm.metrics")

--- a/src/bantz/llm/vllm_openai_client.py
+++ b/src/bantz/llm/vllm_openai_client.py
@@ -33,19 +33,13 @@ import logging
 import os
 import threading
 import time
-from typing import List, Optional, Iterator, Any
 from dataclasses import dataclass
+from typing import Any, Iterator, List, Optional
 
-from bantz.llm.base import (
-    LLMClient,
-    LLMMessage,
-    LLMResponse,
-    LLMToolCall,
-    LLMConnectionError,
-    LLMModelNotFoundError,
-    LLMTimeoutError,
-    LLMInvalidResponseError,
-)
+from bantz.llm.base import (LLMClient, LLMConnectionError,
+                            LLMInvalidResponseError, LLMMessage,
+                            LLMModelNotFoundError, LLMResponse,
+                            LLMTimeoutError, LLMToolCall)
 
 logger = logging.getLogger(__name__)
 
@@ -428,7 +422,8 @@ class VLLMOpenAIClient(LLMClient):
             # Issue #1104: Classify OpenAI typed exceptions first, then
             # fall back to string matching for generic exceptions.
             try:
-                from openai import RateLimitError, AuthenticationError, APITimeoutError
+                from openai import (APITimeoutError, AuthenticationError,
+                                    RateLimitError)
                 if isinstance(e, RateLimitError):
                     raise LLMConnectionError(
                         "vLLM rate_limited (429). Retry later."

--- a/src/bantz/llm/vllm_openai_client.py
+++ b/src/bantz/llm/vllm_openai_client.py
@@ -282,7 +282,7 @@ class VLLMOpenAIClient(LLMClient):
         max_retries = 3
         last_exc: Exception | None = None
         for attempt in range(max_retries):
-            t0 = time.perf_counter()
+            t0 = time.perf_counter()  # noqa: F841 — kept for future latency logging
             try:
                 return self._do_chat_request(
                     client, openai_messages,
@@ -431,11 +431,11 @@ class VLLMOpenAIClient(LLMClient):
                 from openai import RateLimitError, AuthenticationError, APITimeoutError
                 if isinstance(e, RateLimitError):
                     raise LLMConnectionError(
-                        f"vLLM rate_limited (429). Retry later."
+                        "vLLM rate_limited (429). Retry later."
                     ) from e
                 if isinstance(e, AuthenticationError):
                     raise LLMConnectionError(
-                        f"vLLM authentication failed. Check VLLM_API_KEY."
+                        "vLLM authentication failed. Check VLLM_API_KEY."
                     ) from e
                 if isinstance(e, APITimeoutError):
                     raise LLMTimeoutError(

--- a/tests/test_issue_1311_streaming_connection_leak.py
+++ b/tests/test_issue_1311_streaming_connection_leak.py
@@ -11,9 +11,7 @@ underlying HTTP connections/streams in all scenarios:
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
-from typing import Iterator
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -24,8 +22,8 @@ from bantz.llm.base import (
     LLMTimeoutError,
     LLMInvalidResponseError,
 )
-from bantz.llm.vllm_openai_client import VLLMOpenAIClient, StreamChunk
-from bantz.llm.gemini_client import GeminiClient, GeminiStreamChunk
+from bantz.llm.vllm_openai_client import VLLMOpenAIClient
+from bantz.llm.gemini_client import GeminiClient
 
 
 # ======================================================================

--- a/tests/test_issue_1311_streaming_connection_leak.py
+++ b/tests/test_issue_1311_streaming_connection_leak.py
@@ -1,0 +1,390 @@
+"""Tests for Issue #1311: Streaming connection leak prevention.
+
+Verifies that both vLLM and Gemini streaming clients properly close
+underlying HTTP connections/streams in all scenarios:
+  - Normal completion (generator fully consumed)
+  - Early exit (caller breaks out of generator)
+  - Exception during iteration
+  - Gemini retry loop (429/500 responses closed before retry)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterator
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+import requests
+
+from bantz.llm.base import (
+    LLMMessage,
+    LLMConnectionError,
+    LLMTimeoutError,
+    LLMInvalidResponseError,
+)
+from bantz.llm.vllm_openai_client import VLLMOpenAIClient, StreamChunk
+from bantz.llm.gemini_client import GeminiClient, GeminiStreamChunk
+
+
+# ======================================================================
+# Helpers
+# ======================================================================
+
+
+def _vllm_client() -> VLLMOpenAIClient:
+    """Create a vLLM client for testing (no real server)."""
+    return VLLMOpenAIClient(
+        base_url="http://127.0.0.1:9999",
+        model="test-model",
+        track_ttft=False,
+    )
+
+
+def _gemini_client() -> GeminiClient:
+    """Create a Gemini client for testing."""
+    return GeminiClient(
+        api_key="test-key",
+        model="gemini-2.0-flash",
+        timeout_seconds=5.0,
+        use_default_gates=False,
+    )
+
+
+def _messages() -> list[LLMMessage]:
+    return [LLMMessage(role="user", content="test")]
+
+
+def _mock_openai_chunk(content: str, finish_reason: str | None = None):
+    """Build a mock OpenAI-style streaming chunk."""
+    delta = MagicMock()
+    delta.content = content
+
+    choice = MagicMock()
+    choice.delta = delta
+    choice.finish_reason = finish_reason
+
+    chunk = MagicMock()
+    chunk.choices = [choice]
+    chunk.usage = None
+    return chunk
+
+
+def _mock_openai_stream(chunks: list):
+    """Create a mock stream object that supports iteration and close()."""
+    stream = MagicMock()
+    stream.__iter__ = MagicMock(return_value=iter(chunks))
+    stream.close = MagicMock()
+    return stream
+
+
+def _gemini_stream_response(chunks: list[dict], status_code: int = 200):
+    """Create a mock Gemini streaming response."""
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.headers = {}
+
+    lines = ["["]
+    for i, chunk in enumerate(chunks):
+        prefix = "," if i > 0 else ""
+        lines.append(f"{prefix}{json.dumps(chunk)}")
+    lines.append("]")
+
+    resp.iter_lines = MagicMock(return_value=iter(lines))
+    resp.close = MagicMock()
+    return resp
+
+
+def _gemini_chunk(text: str, finish_reason: str | None = None) -> dict:
+    """Build a single Gemini stream chunk dict."""
+    cand: dict = {"content": {"parts": [{"text": text}]}}
+    if finish_reason:
+        cand["finishReason"] = finish_reason
+    return {"candidates": [cand]}
+
+
+# ======================================================================
+# vLLM Stream Cleanup Tests
+# ======================================================================
+
+
+class TestVLLMStreamCleanup:
+    """Verify vLLM chat_stream() closes the stream in all scenarios."""
+
+    @patch.object(VLLMOpenAIClient, "_get_client")
+    @patch.object(VLLMOpenAIClient, "_resolve_auto_model")
+    def test_stream_closed_after_full_consumption(self, _mock_resolve, mock_get_client):
+        """Stream.close() is called when generator is fully consumed."""
+        chunks = [
+            _mock_openai_chunk("Hello "),
+            _mock_openai_chunk("world!", "stop"),
+        ]
+        stream = _mock_openai_stream(chunks)
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream
+        mock_get_client.return_value = mock_client
+
+        client = _vllm_client()
+        result = list(client.chat_stream(_messages()))
+
+        assert len(result) >= 1
+        stream.close.assert_called_once()
+
+    @patch.object(VLLMOpenAIClient, "_get_client")
+    @patch.object(VLLMOpenAIClient, "_resolve_auto_model")
+    def test_stream_closed_on_early_exit(self, _mock_resolve, mock_get_client):
+        """Stream.close() is called when caller breaks out of generator early."""
+        chunks = [
+            _mock_openai_chunk("Hello "),
+            _mock_openai_chunk("world "),
+            _mock_openai_chunk("this "),
+            _mock_openai_chunk("is "),
+            _mock_openai_chunk("long!", "stop"),
+        ]
+        stream = _mock_openai_stream(chunks)
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream
+        mock_get_client.return_value = mock_client
+
+        client = _vllm_client()
+        gen = client.chat_stream(_messages())
+        first_chunk = next(gen)
+        assert first_chunk.content == "Hello "
+        # Simulate early exit — caller closes generator
+        gen.close()
+
+        stream.close.assert_called_once()
+
+    @patch.object(VLLMOpenAIClient, "_get_client")
+    @patch.object(VLLMOpenAIClient, "_resolve_auto_model")
+    def test_stream_closed_on_iteration_error(self, _mock_resolve, mock_get_client):
+        """Stream.close() is called when iteration raises an exception."""
+        def _exploding_iter():
+            yield _mock_openai_chunk("Hello ")
+            raise ConnectionError("connection reset")
+
+        stream = MagicMock()
+        stream.__iter__ = MagicMock(return_value=_exploding_iter())
+        stream.close = MagicMock()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream
+        mock_get_client.return_value = mock_client
+
+        client = _vllm_client()
+        with pytest.raises(LLMConnectionError):
+            list(client.chat_stream(_messages()))
+
+        stream.close.assert_called_once()
+
+    @patch.object(VLLMOpenAIClient, "_get_client")
+    @patch.object(VLLMOpenAIClient, "_resolve_auto_model")
+    def test_stream_closed_on_timeout_error(self, _mock_resolve, mock_get_client):
+        """Stream.close() is called on timeout during iteration."""
+        def _timeout_iter():
+            yield _mock_openai_chunk("partial")
+            raise TimeoutError("request timeout exceeded")
+
+        stream = MagicMock()
+        stream.__iter__ = MagicMock(return_value=_timeout_iter())
+        stream.close = MagicMock()
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream
+        mock_get_client.return_value = mock_client
+
+        client = _vllm_client()
+        with pytest.raises(LLMTimeoutError):
+            list(client.chat_stream(_messages()))
+
+        stream.close.assert_called_once()
+
+    @patch.object(VLLMOpenAIClient, "_get_client")
+    @patch.object(VLLMOpenAIClient, "_resolve_auto_model")
+    def test_no_error_if_stream_creation_fails(self, _mock_resolve, mock_get_client):
+        """No crash in finally when stream was never created (creation error)."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = ConnectionError("refused")
+        mock_get_client.return_value = mock_client
+
+        client = _vllm_client()
+        with pytest.raises(LLMConnectionError):
+            list(client.chat_stream(_messages()))
+        # Should not crash — stream is None, finally handles gracefully
+
+    @patch.object(VLLMOpenAIClient, "_get_client")
+    @patch.object(VLLMOpenAIClient, "_resolve_auto_model")
+    def test_empty_stream_still_closed(self, _mock_resolve, mock_get_client):
+        """Stream.close() called even when stream yields no content chunks."""
+        stream = _mock_openai_stream([])
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = stream
+        mock_get_client.return_value = mock_client
+
+        client = _vllm_client()
+        result = list(client.chat_stream(_messages()))
+        assert result == []
+        stream.close.assert_called_once()
+
+
+# ======================================================================
+# Gemini Stream Cleanup Tests
+# ======================================================================
+
+
+class TestGeminiStreamCleanup:
+    """Verify GeminiClient.chat_stream() closes responses in all scenarios."""
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_response_closed_after_full_consumption(self, mock_post):
+        """Response.close() called when stream is fully consumed."""
+        resp = _gemini_stream_response([
+            _gemini_chunk("Merhaba "),
+            _gemini_chunk("efendim!", "STOP"),
+        ])
+        mock_post.return_value = resp
+
+        client = _gemini_client()
+        chunks = list(client.chat_stream(_messages()))
+
+        assert len(chunks) >= 1
+        resp.close.assert_called()
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_response_closed_on_early_exit(self, mock_post):
+        """Response.close() called when caller breaks out early."""
+        resp = _gemini_stream_response([
+            _gemini_chunk("chunk1 "),
+            _gemini_chunk("chunk2 "),
+            _gemini_chunk("chunk3!", "STOP"),
+        ])
+        mock_post.return_value = resp
+
+        client = _gemini_client()
+        gen = client.chat_stream(_messages())
+        first = next(gen)
+        assert first.content == "chunk1 "
+        gen.close()
+
+        resp.close.assert_called()
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_response_closed_on_error_status(self, mock_post):
+        """Response.close() called even when status indicates error."""
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = 401
+        resp.headers = {}
+        resp.close = MagicMock()
+        mock_post.return_value = resp
+
+        client = _gemini_client()
+        with pytest.raises(LLMConnectionError, match="auth_error"):
+            list(client.chat_stream(_messages()))
+
+        resp.close.assert_called()
+
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_response_closed_on_parse_error(self, mock_post):
+        """Response.close() called when JSON parsing fails."""
+        resp = MagicMock(spec=requests.Response)
+        resp.status_code = 200
+        resp.headers = {}
+        resp.iter_lines = MagicMock(return_value=iter(["not valid json {"]))
+        resp.close = MagicMock()
+        mock_post.return_value = resp
+
+        client = _gemini_client()
+        # Stream should complete without error (partial JSON buffered)
+        # or raise parse_error — either way, response must be closed
+        try:
+            list(client.chat_stream(_messages()))
+        except (LLMInvalidResponseError, StopIteration):
+            pass
+
+        resp.close.assert_called()
+
+
+class TestGeminiRetryCleanup:
+    """Verify Gemini retry loop closes responses before retrying."""
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_429_response_closed_before_retry(self, mock_post, mock_sleep):
+        """On 429, response is closed before the next retry attempt."""
+        # First call: 429, second call: success
+        resp_429 = MagicMock(spec=requests.Response)
+        resp_429.status_code = 429
+        resp_429.headers = {}
+        resp_429.close = MagicMock()
+
+        resp_ok = _gemini_stream_response([_gemini_chunk("ok", "STOP")])
+        mock_post.side_effect = [resp_429, resp_ok]
+
+        client = _gemini_client()
+        chunks = list(client.chat_stream(_messages()))
+
+        assert len(chunks) >= 1
+        # The 429 response must have been closed
+        resp_429.close.assert_called()
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_500_response_closed_before_retry(self, mock_post, mock_sleep):
+        """On 500, response is closed before the next retry attempt."""
+        resp_500 = MagicMock(spec=requests.Response)
+        resp_500.status_code = 500
+        resp_500.headers = {}
+        resp_500.close = MagicMock()
+
+        resp_ok = _gemini_stream_response([_gemini_chunk("ok", "STOP")])
+        mock_post.side_effect = [resp_500, resp_ok]
+
+        client = _gemini_client()
+        chunks = list(client.chat_stream(_messages()))
+
+        assert len(chunks) >= 1
+        resp_500.close.assert_called()
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_multiple_retries_all_closed(self, mock_post, mock_sleep):
+        """Multiple failed responses are all closed before final success."""
+        resp_429 = MagicMock(spec=requests.Response)
+        resp_429.status_code = 429
+        resp_429.headers = {}
+        resp_429.close = MagicMock()
+
+        resp_500 = MagicMock(spec=requests.Response)
+        resp_500.status_code = 500
+        resp_500.headers = {}
+        resp_500.close = MagicMock()
+
+        resp_ok = _gemini_stream_response([_gemini_chunk("ok", "STOP")])
+        mock_post.side_effect = [resp_429, resp_500, resp_ok]
+
+        client = _gemini_client()
+        chunks = list(client.chat_stream(_messages()))
+
+        assert len(chunks) >= 1
+        resp_429.close.assert_called()
+        resp_500.close.assert_called()
+
+    @patch("bantz.llm.gemini_client.time.sleep")
+    @patch("bantz.llm.gemini_client.requests.post")
+    def test_all_retries_exhausted_last_response_closed(self, mock_post, mock_sleep):
+        """When all retries fail with 500, the final response is also closed."""
+        responses = []
+        for _ in range(3):
+            resp = MagicMock(spec=requests.Response)
+            resp.status_code = 500
+            resp.headers = {}
+            resp.close = MagicMock()
+            responses.append(resp)
+        mock_post.side_effect = responses
+
+        client = _gemini_client()
+        with pytest.raises(LLMConnectionError, match="server_error"):
+            list(client.chat_stream(_messages()))
+
+        # First two closed in retry loop, last closed in finally
+        for resp in responses:
+            resp.close.assert_called()

--- a/tests/test_issue_1311_streaming_connection_leak.py
+++ b/tests/test_issue_1311_streaming_connection_leak.py
@@ -16,15 +16,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from bantz.llm.base import (
-    LLMMessage,
-    LLMConnectionError,
-    LLMTimeoutError,
-    LLMInvalidResponseError,
-)
-from bantz.llm.vllm_openai_client import VLLMOpenAIClient
+from bantz.llm.base import (LLMConnectionError, LLMInvalidResponseError,
+                            LLMMessage, LLMTimeoutError)
 from bantz.llm.gemini_client import GeminiClient
-
+from bantz.llm.vllm_openai_client import VLLMOpenAIClient
 
 # ======================================================================
 # Helpers


### PR DESCRIPTION
## Summary

Fixes #1311 — Streaming connection leak in vLLM and Gemini clients.

## Problem

Long-running daemon gradually exhausts the HTTP connection pool because streaming responses were never explicitly closed:

- **vLLM**: `chat_stream()` had no `finally` block — if the caller stopped consuming the generator early (or an error occurred), the underlying HTTP stream remained open
- **Gemini**: Retry loop on 429/500 opened new `requests.post()` calls without closing the previous response. Additionally, no `finally: r.close()` existed for the stream iteration block

Each leaked connection holds a socket + buffer memory. In daemon mode this leads to "Connection pool exhausted" errors.

## Changes

### `src/bantz/llm/vllm_openai_client.py`
- Initialize `stream = None` before `try` block
- Add `finally: stream.close()` to guarantee cleanup on all exit paths (full consumption, early exit, exceptions, GC)

### `src/bantz/llm/gemini_client.py`
- Add `r.close()` before `continue` in retry loop (429 and 500 branches)
- Add `finally: r.close()` after the stream iteration `try/except` block

### `tests/test_issue_1311_streaming_connection_leak.py` (new, 14 tests)
**vLLM (6 tests):**
- `test_stream_closed_after_full_consumption`
- `test_stream_closed_on_early_exit`
- `test_stream_closed_on_iteration_error`
- `test_stream_closed_on_timeout_error`
- `test_no_error_if_stream_creation_fails`
- `test_empty_stream_still_closed`

**Gemini stream (4 tests):**
- `test_response_closed_after_full_consumption`
- `test_response_closed_on_early_exit`
- `test_response_closed_on_error_status`
- `test_response_closed_on_parse_error`

**Gemini retry (4 tests):**
- `test_429_response_closed_before_retry`
- `test_500_response_closed_before_retry`
- `test_multiple_retries_all_closed`
- `test_all_retries_exhausted_last_response_closed`

## Test Results
- 14/14 new tests passing
- 35/35 existing streaming tests passing (0 regression)