### PR TITLE
fix(nlu): expand _ANAPHORA_TOKENS with missing Turkish forms (#1319)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -1900,14 +1900,29 @@ ASSISTANT (sadece JSON):"""
 
     # Issue #1212: Anaphoric follow-up detection for Turkish
     # Issue #1254: Added "başka", "içeriğinde", "ne var", "daha" etc.
+    # Issue #1319: Added missing Turkish demonstrative pronouns and
+    # anaphoric forms: accusatives (onu, bunu, şunu), genitives
+    # (bunun, onun), and context-reference words (yukarıdaki, önceki,
+    # aynı).  Note: bare "bu", "şu", "o" intentionally excluded to
+    # avoid false positives on common short utterances.
     _ANAPHORA_TOKENS: frozenset[str] = frozenset({
-        "onlar", "bunlar", "şunlar", "bunları", "onları", "şunları",
+        # Plural demonstratives
+        "onlar", "bunlar", "şunlar",
+        # Accusative forms
+        "bunları", "onları", "şunları",
+        "onu", "bunu", "şunu",
+        # Genitive forms
+        "bunun", "onun",
+        # Interrogative / follow-up
         "nelermiş", "neymiş", "neydi", "hangisi", "hangileri",
+        # Summarisation / continuation commands
         "özetle", "detay", "ayrıntı", "devam", "devamı",
         "tekrarla", "göster", "oku", "anlat",
         # Issue #1254: Common follow-up words missing from original set
         "başka", "içeriğinde", "içeriği", "içindeki", "daha",
-        "neler", "neymiş", "bana", "söyle", "açıkla",
+        "neler", "bana", "söyle", "açıkla",
+        # Issue #1319: Context-reference words
+        "yukarıdaki", "önceki", "aynı",
     })
 
     def _is_anaphoric_followup(self, user_input: str) -> bool:

--- a/tests/test_issue_1319_anaphoric_tokens.py
+++ b/tests/test_issue_1319_anaphoric_tokens.py
@@ -1,0 +1,121 @@
+"""Tests for issue #1319: _is_anaphoric_followup token expansion.
+
+Covers:
+1. Newly added Turkish demonstrative pronouns trigger follow-up detection
+2. Existing tokens still work
+3. Long inputs (>6 words) are rejected
+4. Non-anaphoric inputs are not matched
+5. Integration: _is_anaphoric_followup is callable from orchestrator_loop
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from bantz.brain.llm_router import JarvisLLMOrchestrator
+
+
+@pytest.fixture
+def router():
+    """Create a minimal JarvisLLMOrchestrator with a mock LLM."""
+    mock_llm = MagicMock()
+    mock_llm.health_check.return_value = True
+    return JarvisLLMOrchestrator(llm=mock_llm)
+
+
+# ── 1. Newly added tokens (Issue #1319) ──────────────────────────────────
+
+
+class TestNewTokensDetected:
+    """Verify newly added #1319 tokens are detected."""
+
+    @pytest.mark.parametrize("text", [
+        "onu aç",
+        "bunu sil",
+        "şunu göster",
+        "bunun detayları",
+        "onun içeriği",
+        "yukarıdaki ne",
+        "önceki sonuçlar",
+        "aynı şeyi yap",
+    ])
+    def test_new_tokens_trigger_followup(self, router, text):
+        assert router._is_anaphoric_followup(text) is True
+
+
+# ── 2. Existing tokens still work ────────────────────────────────────────
+
+
+class TestExistingTokens:
+    """Verify pre-existing tokens still trigger detection."""
+
+    @pytest.mark.parametrize("text", [
+        "nelermiş onlar",
+        "bunları özetle",
+        "devamını göster",
+        "hangisi",
+        "başka var mı",
+        "bana anlat",
+    ])
+    def test_existing_tokens_still_work(self, router, text):
+        assert router._is_anaphoric_followup(text) is True
+
+
+# ── 3. Long inputs rejected ──────────────────────────────────────────────
+
+
+class TestLongInputRejected:
+    """Inputs with >6 words should not match (avoid false positives)."""
+
+    def test_7_word_input_rejected(self, router):
+        long_text = "şu anda onu görmek istiyorum acaba mümkün müdür"
+        assert router._is_anaphoric_followup(long_text) is False
+
+
+# ── 4. Non-anaphoric inputs not matched ──────────────────────────────────
+
+
+class TestNonAnaphoric:
+    """Non-anaphoric inputs should not be detected as follow-ups."""
+
+    @pytest.mark.parametrize("text", [
+        "yarın toplantı ekle",
+        "hava durumu nasıl",
+        "spotify aç",
+        "mail gönder",
+        "",
+    ])
+    def test_non_anaphoric_not_matched(self, router, text):
+        assert router._is_anaphoric_followup(text) is False
+
+
+# ── 5. Token set completeness ────────────────────────────────────────────
+
+
+class TestTokenSetCompleteness:
+    """Verify _ANAPHORA_TOKENS contains all required tokens."""
+
+    def test_accusative_singular_forms_present(self):
+        tokens = JarvisLLMOrchestrator._ANAPHORA_TOKENS
+        for t in ["onu", "bunu", "şunu"]:
+            assert t in tokens, f"Missing accusative form: {t}"
+
+    def test_genitive_forms_present(self):
+        tokens = JarvisLLMOrchestrator._ANAPHORA_TOKENS
+        for t in ["bunun", "onun"]:
+            assert t in tokens, f"Missing genitive form: {t}"
+
+    def test_context_reference_words_present(self):
+        tokens = JarvisLLMOrchestrator._ANAPHORA_TOKENS
+        for t in ["yukarıdaki", "önceki", "aynı"]:
+            assert t in tokens, f"Missing context-reference word: {t}"
+
+    def test_bare_pronouns_excluded(self):
+        """'bu', 'şu', 'o' are intentionally excluded to avoid FP."""
+        tokens = JarvisLLMOrchestrator._ANAPHORA_TOKENS
+        for t in ["bu", "şu", "o"]:
+            assert t not in tokens, (
+                f"Bare pronoun '{t}' should be excluded to avoid false positives"
+            )


### PR DESCRIPTION
## Summary

Fixes #1319

### Changes

1. **Expanded `_ANAPHORA_TOKENS`** with missing Turkish demonstrative and anaphoric forms:
   - Accusative singular: `onu`, `bunu`, `şunu`
   - Genitive: `bunun`, `onun`
   - Context-reference: `yukarıdaki`, `önceki`, `aynı`

2. **Removed duplicate** `neymiş` entry from the set.

3. **Intentionally excluded** bare pronouns `bu`, `şu`, `o` to avoid false positives on common short utterances (e.g. "bu ne?").

### Note on "dead code" claim

The issue states `_is_anaphoric_followup()` is dead code not called from `route()`. Investigation shows it IS called from `orchestrator_loop.py` L1692:
```python
self.orchestrator._is_anaphoric_followup(_anaphoric_text)
```
This was integrated via issues #1212 and #1254. The method is functional; only the token set was incomplete.

### Tests

24 tests in `tests/test_issue_1319_anaphoric_tokens.py` covering new tokens, existing tokens, long input rejection, non-anaphoric rejection, and token set completeness.