### PR TITLE
refactor(logging): convert f-string to lazy % formatting (#1321)

### DIFF
--- a/src/bantz/brain/llm_router.py
+++ b/src/bantz/brain/llm_router.py
@@ -633,7 +633,7 @@ U: test@gmail.com'a merhaba gönder → {"route":"gmail","gmail_intent":"send","
             # Option 3: No health method → assume healthy (mock clients, etc.)
             return True
         except Exception as e:
-            logger.warning(f"[router_health] Health check failed: {e}")
+            logger.warning("[router_health] Health check failed: %s", e)
             return False
 
     def _fallback_route(self, user_input: str) -> "OrchestratorOutput":
@@ -966,7 +966,7 @@ ASSISTANT (sadece JSON):"""
             except Exception as e:
                 last_err = str(e)
                 was_repaired = True  # LLM re-prompt = heavy repair
-                logger.warning(f"Router JSON parse failed: {e}")
+                logger.warning("Router JSON parse failed: %s", e)
 
                 # Attempt repair by asking the model to re-emit strict JSON.
                 # Keep the repair prompt small and deterministic.
@@ -2425,7 +2425,7 @@ ASSISTANT (sadece JSON):"""
         Uses keyword-based route detection so the correct tool can still
         be executed even when the 7B model outputs malformed JSON.
         """
-        logger.warning(f"Orchestrator fallback triggered: {error}")
+        logger.warning("Orchestrator fallback triggered: %s", error)
 
         # Attempt keyword based route + tool resolution
         kw_route = self._detect_route_from_input(user_input)

--- a/tests/test_issue_1321_logging_format.py
+++ b/tests/test_issue_1321_logging_format.py
@@ -1,0 +1,91 @@
+"""Tests for Issue #1321: f-string → lazy % logging conversion.
+
+Verifies that all logger calls in llm_router.py and orchestrator_loop.py
+use lazy %-formatting instead of eager f-string interpolation.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Root of the project
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _find_fstring_logger_calls(filepath: Path) -> list[tuple[int, str]]:
+    """Return (line, code) for any logger call using an f-string argument."""
+    source = filepath.read_text()
+    tree = ast.parse(source, filename=str(filepath))
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match logger.warning(...), logger.info(...), etc.
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "logger"
+            and func.attr in ("debug", "info", "warning", "error", "exception", "critical")
+        ):
+            continue
+        # Check if the first positional arg is a JoinedStr (f-string)
+        if node.args and isinstance(node.args[0], ast.JoinedStr):
+            line = node.lineno
+            snippet = ast.get_source_segment(source, node) or "<unknown>"
+            violations.append((line, snippet[:120]))
+
+    return violations
+
+
+class TestNoFStringLoggerCalls:
+    """Ensure no f-string interpolation in logger calls for target files."""
+
+    def test_llm_router_no_fstring_loggers(self):
+        filepath = _PROJECT_ROOT / "src" / "bantz" / "brain" / "llm_router.py"
+        violations = _find_fstring_logger_calls(filepath)
+        assert violations == [], (
+            f"Found f-string logger calls in llm_router.py:\n"
+            + "\n".join(f"  L{line}: {code}" for line, code in violations)
+        )
+
+    def test_orchestrator_loop_no_fstring_loggers(self):
+        filepath = _PROJECT_ROOT / "src" / "bantz" / "brain" / "orchestrator_loop.py"
+        violations = _find_fstring_logger_calls(filepath)
+        assert violations == [], (
+            f"Found f-string logger calls in orchestrator_loop.py:\n"
+            + "\n".join(f"  L{line}: {code}" for line, code in violations)
+        )
+
+
+class TestLazyFormatStringsPresent:
+    """Spot-check that key log messages now use %-formatting."""
+
+    def test_router_health_check_lazy(self):
+        source = (_PROJECT_ROOT / "src" / "bantz" / "brain" / "llm_router.py").read_text()
+        assert 'logger.warning("[router_health] Health check failed: %s", e)' in source
+
+    def test_router_json_parse_lazy(self):
+        source = (_PROJECT_ROOT / "src" / "bantz" / "brain" / "llm_router.py").read_text()
+        assert 'logger.warning("Router JSON parse failed: %s", e)' in source
+
+    def test_orchestrator_fallback_lazy(self):
+        source = (_PROJECT_ROOT / "src" / "bantz" / "brain" / "llm_router.py").read_text()
+        assert 'logger.warning("Orchestrator fallback triggered: %s", error)' in source
+
+    def test_safety_violation_lazy(self):
+        source = (_PROJECT_ROOT / "src" / "bantz" / "brain" / "orchestrator_loop.py").read_text()
+        assert '"[SAFETY] Tool plan violation: %s", violation.reason' in source
+
+    def test_tool_denied_lazy(self):
+        source = (_PROJECT_ROOT / "src" / "bantz" / "brain" / "orchestrator_loop.py").read_text()
+        assert "\"[SAFETY] Tool '%s' denied: %s\", tool_name, deny_reason" in source
+
+    def test_firewall_confirmation_lazy(self):
+        source = (_PROJECT_ROOT / "src" / "bantz" / "brain" / "orchestrator_loop.py").read_text()
+        assert '"[FIREWALL] Tool %s (%s) requires confirmation.", tool_name, risk.value' in source

--- a/tests/test_issue_1321_logging_format.py
+++ b/tests/test_issue_1321_logging_format.py
@@ -7,10 +7,7 @@ use lazy %-formatting instead of eager f-string interpolation.
 from __future__ import annotations
 
 import ast
-import textwrap
 from pathlib import Path
-
-import pytest
 
 # Root of the project
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -50,7 +47,7 @@ class TestNoFStringLoggerCalls:
         filepath = _PROJECT_ROOT / "src" / "bantz" / "brain" / "llm_router.py"
         violations = _find_fstring_logger_calls(filepath)
         assert violations == [], (
-            f"Found f-string logger calls in llm_router.py:\n"
+            "Found f-string logger calls in llm_router.py:\n"
             + "\n".join(f"  L{line}: {code}" for line, code in violations)
         )
 
@@ -58,7 +55,7 @@ class TestNoFStringLoggerCalls:
         filepath = _PROJECT_ROOT / "src" / "bantz" / "brain" / "orchestrator_loop.py"
         violations = _find_fstring_logger_calls(filepath)
         assert violations == [], (
-            f"Found f-string logger calls in orchestrator_loop.py:\n"
+            "Found f-string logger calls in orchestrator_loop.py:\n"
             + "\n".join(f"  L{line}: {code}" for line, code in violations)
         )
 


### PR DESCRIPTION
## Summary

Converts all eager f-string logger calls to lazy %-formatting in the two core brain modules. This prevents unnecessary string interpolation when the log level is disabled.

### Changes

**`src/bantz/brain/llm_router.py`** — 3 conversions:
- `logger.warning(f"[router_health] Health check failed: {e}")` → `logger.warning("...: %s", e)`
- `logger.warning(f"Router JSON parse failed: {e}")` → `logger.warning("...: %s", e)`
- `logger.warning(f"Orchestrator fallback triggered: {error}")` → `logger.warning("...: %s", error)`

**`src/bantz/brain/orchestrator_loop.py`** — 11 conversions:
- Safety guard violations, tool denials, arg validation
- Firewall confirmation logs
- Tool execution audit logs
- Orchestrator turn failure

### Tests
- 8 new tests in `tests/test_issue_1321_logging_format.py`
- AST-based detection ensures no f-string logger calls remain
- Spot-checks verify key messages use lazy formatting

### Out of scope (per issue)
- File splitting (>500 LOC threshold) — too risky for this PR
- Executor shutdown — already fixed in PR #1314

Closes #1321