### PR TITLE
feat(google): unified OAuth + Contacts/Tasks/Keep/Classroom connectors (#1292)

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -120,6 +120,61 @@ permissions:
     risk: "medium"
     decision: "confirm"
 
+  # ── Google Suite Connectors (Issue #1292) ───────────────────
+  - tool: "google.contacts.search"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "google.contacts.get"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "google.contacts.create"
+    action: "write"
+    risk: "medium"
+    decision: "confirm"
+
+  - tool: "google.tasks.list"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "google.tasks.create"
+    action: "write"
+    risk: "medium"
+    decision: "confirm"
+    conditions:
+      max_per_day: 30
+
+  - tool: "google.tasks.complete"
+    action: "write"
+    risk: "medium"
+    decision: "confirm"
+
+  - tool: "google.tasks.delete"
+    action: "delete"
+    risk: "high"
+    decision: "confirm"
+    conditions:
+      max_per_day: 10
+
+  - tool: "google.keep.*"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "google.keep.create"
+    action: "write"
+    risk: "medium"
+    decision: "confirm"
+
+  - tool: "google.classroom.*"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
   # ── Catch-all (unknown tools) ──────────────────────────────
   - tool: "*"
     action: "*"

--- a/src/bantz/connectors/__init__.py
+++ b/src/bantz/connectors/__init__.py
@@ -1,0 +1,1 @@
+"""Bantz service connectors — unified interface for external APIs."""

--- a/src/bantz/connectors/google/__init__.py
+++ b/src/bantz/connectors/google/__init__.py
@@ -1,0 +1,14 @@
+"""Google Suite Super-Connector — Unified OAuth + service connectors.
+
+Issue #1292: Single OAuth2 token manager with incremental scope expansion,
+base connector interface, and service-specific connectors for
+Contacts, Tasks, Keep, and Classroom.
+"""
+
+from bantz.connectors.google.auth_manager import GoogleAuthManager
+from bantz.connectors.google.base import GoogleConnector
+
+__all__ = [
+    "GoogleAuthManager",
+    "GoogleConnector",
+]

--- a/src/bantz/connectors/google/auth_manager.py
+++ b/src/bantz/connectors/google/auth_manager.py
@@ -1,0 +1,544 @@
+"""Unified Google OAuth2 Token Manager — single refresh token, incremental scopes.
+
+Issue #1292: Replaces fragmented per-service tokens with a single
+``google_unified_token.json`` that can be incrementally expanded
+to cover new Google APIs without re-authenticating from scratch.
+
+Design
+------
+- One ``GoogleAuthManager`` instance per Bantz process.
+- ``SCOPE_REGISTRY`` maps service names to their Google OAuth scopes.
+- ``ensure_scope(service)`` checks whether the current token covers
+  the requested scopes; if not, triggers an incremental consent flow.
+- ``get_service(service_name)`` returns an authenticated
+  ``googleapiclient.discovery.Resource`` ready for use.
+- Atomic file writing with ``fcntl`` locking to prevent corruption.
+
+Backward Compatibility
+----------------------
+Existing per-service tokens (``token.json``, ``gmail_token.json``) are
+still supported.  ``GoogleAuthManager`` can optionally *migrate* them
+into the unified token on first use.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from bantz.security.secrets import mask_path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["GoogleAuthManager", "UnifiedAuthConfig"]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Scope Registry
+# ═══════════════════════════════════════════════════════════════════
+
+SCOPE_REGISTRY: dict[str, list[str]] = {
+    "gmail": [
+        "https://www.googleapis.com/auth/gmail.modify",
+    ],
+    "calendar": [
+        "https://www.googleapis.com/auth/calendar",
+    ],
+    "contacts": [
+        "https://www.googleapis.com/auth/contacts.readonly",
+    ],
+    "tasks": [
+        "https://www.googleapis.com/auth/tasks",
+    ],
+    "keep": [
+        "https://www.googleapis.com/auth/keep",
+    ],
+    "classroom": [
+        "https://www.googleapis.com/auth/classroom.courses.readonly",
+        "https://www.googleapis.com/auth/classroom.coursework.me",
+    ],
+}
+
+# Google API discovery service names + versions
+SERVICE_MAP: dict[str, tuple[str, str]] = {
+    "gmail": ("gmail", "v1"),
+    "calendar": ("calendar", "v3"),
+    "contacts": ("people", "v1"),
+    "tasks": ("tasks", "v1"),
+    "keep": ("keep", "v1"),
+    "classroom": ("classroom", "v1"),
+}
+
+# Implied scope map — prevents re-consent loops when a broader scope
+# already satisfies a narrower one.
+_IMPLIED_SCOPES: dict[str, set[str]] = {
+    "https://www.googleapis.com/auth/calendar": {
+        "https://www.googleapis.com/auth/calendar.readonly",
+        "https://www.googleapis.com/auth/calendar.events",
+        "https://www.googleapis.com/auth/calendar.events.readonly",
+    },
+    "https://www.googleapis.com/auth/gmail.modify": {
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.metadata",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/gmail.compose",
+    },
+    "https://www.googleapis.com/auth/contacts": {
+        "https://www.googleapis.com/auth/contacts.readonly",
+    },
+    "https://www.googleapis.com/auth/tasks": {
+        "https://www.googleapis.com/auth/tasks.readonly",
+    },
+    "https://www.googleapis.com/auth/classroom.courses": {
+        "https://www.googleapis.com/auth/classroom.courses.readonly",
+    },
+}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Configuration
+# ═══════════════════════════════════════════════════════════════════
+
+DEFAULT_UNIFIED_TOKEN_PATH = "~/.config/bantz/google/google_unified_token.json"
+DEFAULT_CLIENT_SECRET_PATH = "~/.config/bantz/google/client_secret.json"
+
+
+@dataclass(frozen=True)
+class UnifiedAuthConfig:
+    """Configuration for the unified Google auth manager."""
+    client_secret_path: Path
+    token_path: Path
+
+
+def _resolve_path(value: str) -> Path:
+    return Path(os.path.expanduser(value)).resolve()
+
+
+def _get_unified_config(
+    *,
+    client_secret_path: Optional[str] = None,
+    token_path: Optional[str] = None,
+) -> UnifiedAuthConfig:
+    """Resolve file paths for unified auth.
+
+    Env vars:
+    - ``BANTZ_GOOGLE_CLIENT_SECRET``
+    - ``BANTZ_GOOGLE_UNIFIED_TOKEN_PATH``
+    """
+    secret = (
+        client_secret_path
+        or os.getenv("BANTZ_GOOGLE_CLIENT_SECRET")
+        or DEFAULT_CLIENT_SECRET_PATH
+    )
+    token = (
+        token_path
+        or os.getenv("BANTZ_GOOGLE_UNIFIED_TOKEN_PATH")
+        or DEFAULT_UNIFIED_TOKEN_PATH
+    )
+    return UnifiedAuthConfig(
+        client_secret_path=_resolve_path(secret),
+        token_path=_resolve_path(token),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Lazy Google deps
+# ═══════════════════════════════════════════════════════════════════
+
+def _import_google_deps():
+    """Lazily import Google auth and API client libraries."""
+    try:
+        from google.auth.transport.requests import Request  # type: ignore
+        from google.oauth2.credentials import Credentials  # type: ignore
+        from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
+        from googleapiclient.discovery import build  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "Google API dependencies are not installed. "
+            "Install with: pip install google-api-python-client "
+            "google-auth-oauthlib google-auth-httplib2"
+        ) from exc
+    return Request, Credentials, InstalledAppFlow, build
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Auth Manager
+# ═══════════════════════════════════════════════════════════════════
+
+class GoogleAuthManager:
+    """Unified Google OAuth2 token manager with incremental scope expansion.
+
+    A single refresh token that is progressively expanded as new
+    Google services are enabled.  Replaces the fragmented per-service
+    token files used before Issue #1292.
+
+    Parameters
+    ----------
+    token_path : str, optional
+        Path to the unified token JSON file.
+    client_secret_path : str, optional
+        Path to the Google OAuth client secret JSON.
+    interactive : bool
+        If ``False``, raise ``RuntimeError`` instead of opening a browser
+        when re-consent is needed.  Defaults to ``True``.
+    """
+
+    def __init__(
+        self,
+        *,
+        token_path: Optional[str] = None,
+        client_secret_path: Optional[str] = None,
+        interactive: bool = True,
+    ):
+        self._cfg = _get_unified_config(
+            client_secret_path=client_secret_path,
+            token_path=token_path,
+        )
+        self._interactive = interactive
+        self._credentials: Any = None
+        self._service_cache: dict[str, Any] = {}
+
+    # ── public API ──────────────────────────────────────────────
+
+    @property
+    def token_path(self) -> Path:
+        return self._cfg.token_path
+
+    @property
+    def client_secret_path(self) -> Path:
+        return self._cfg.client_secret_path
+
+    def ensure_scope(self, service: str) -> Any:
+        """Ensure the token covers *service*'s scopes.  Returns credentials.
+
+        If the current token is missing the required scopes, triggers
+        an incremental consent flow (interactive) or raises
+        ``RuntimeError`` (non-interactive).
+        """
+        if service not in SCOPE_REGISTRY:
+            raise ValueError(
+                "Bilinmeyen Google servisi: %s. "
+                "Geçerli servisler: %s" % (service, ", ".join(sorted(SCOPE_REGISTRY)))
+            )
+
+        required = set(SCOPE_REGISTRY[service])
+        self._load_credentials()
+
+        if self._credentials is not None:
+            current = self._effective_scopes(
+                getattr(self._credentials, "scopes", None)
+            )
+            missing = required - current
+        else:
+            missing = required
+
+        if missing:
+            logger.info(
+                "Yeni scope gerekli: %s → %s", service, sorted(missing),
+            )
+            self._expand_scopes(list(missing))
+
+        return self._credentials
+
+    def get_service(self, service_name: str) -> Any:
+        """Return an authenticated Google API resource for *service_name*.
+
+        Results are cached per service to avoid repeated ``build()`` calls.
+        """
+        if service_name in self._service_cache:
+            return self._service_cache[service_name]
+
+        creds = self.ensure_scope(service_name)
+
+        if service_name not in SERVICE_MAP:
+            raise ValueError(
+                "Bilinmeyen Google servisi: %s" % service_name
+            )
+
+        api_name, api_version = SERVICE_MAP[service_name]
+        _Request, _Creds, _Flow, build = _import_google_deps()
+
+        svc = build(api_name, api_version, credentials=creds, cache_discovery=False)
+        self._service_cache[service_name] = svc
+        return svc
+
+    def get_credentials(self, *, scopes: list[str]) -> Any:
+        """Low-level: ensure the token covers *scopes* and return credentials.
+
+        This bridges the old ``get_credentials(scopes=...)`` pattern used by
+        ``bantz.google.auth`` and ``bantz.google.gmail_auth``.
+        """
+        self._load_credentials()
+
+        if self._credentials is not None:
+            current = self._effective_scopes(
+                getattr(self._credentials, "scopes", None)
+            )
+            missing = set(scopes) - current
+        else:
+            missing = set(scopes)
+
+        if missing:
+            self._expand_scopes(list(missing))
+
+        return self._credentials
+
+    def invalidate_cache(self, service_name: Optional[str] = None) -> None:
+        """Drop cached API service objects.
+
+        Call after a token refresh or scope expansion if services need
+        to be rebuilt with fresh credentials.
+        """
+        if service_name:
+            self._service_cache.pop(service_name, None)
+        else:
+            self._service_cache.clear()
+
+    def current_scopes(self) -> list[str]:
+        """Return the scopes the current token covers (empty if no token)."""
+        self._load_credentials()
+        if self._credentials is None:
+            return []
+        return list(getattr(self._credentials, "scopes", None) or [])
+
+    def connected_services(self) -> list[str]:
+        """Return service names whose scopes are fully covered."""
+        current = self._effective_scopes(
+            getattr(self._credentials, "scopes", None) if self._credentials else None
+        )
+        result = []
+        for svc, scopes in SCOPE_REGISTRY.items():
+            if set(scopes).issubset(current):
+                result.append(svc)
+        return sorted(result)
+
+    # ── internal ────────────────────────────────────────────────
+
+    def _load_credentials(self) -> None:
+        """Load credentials from disk if not already loaded."""
+        if self._credentials is not None:
+            return
+
+        _Request, Credentials, _Flow, _build = _import_google_deps()
+
+        if not self._cfg.token_path.exists():
+            return
+
+        try:
+            self._credentials = Credentials.from_authorized_user_file(
+                str(self._cfg.token_path)
+            )
+        except Exception as exc:
+            logger.warning("Token dosyası okunamadı: %s", exc)
+            self._credentials = None
+            return
+
+        # Refresh if expired
+        if (
+            getattr(self._credentials, "expired", False)
+            and getattr(self._credentials, "refresh_token", None)
+        ):
+            self._refresh_with_retry()
+
+    def _refresh_with_retry(self, max_retries: int = 3) -> None:
+        """Refresh the access token with exponential back-off."""
+        _Request, _Creds, _Flow, _build = _import_google_deps()
+        request = _Request()
+
+        for attempt in range(max_retries):
+            try:
+                self._credentials.refresh(request)
+                return
+            except Exception as exc:
+                if attempt < max_retries - 1:
+                    delay = 2 ** attempt
+                    logger.warning(
+                        "Token yenileme başarısız (deneme %d/%d): %s — %ds sonra tekrar",
+                        attempt + 1, max_retries, exc, delay,
+                    )
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        "Token yenileme %d denemeden sonra başarısız: %s",
+                        max_retries, exc,
+                    )
+                    raise
+
+    def _effective_scopes(self, granted: list[str] | None) -> set[str]:
+        """Expand *granted* scopes with implied sub-scopes."""
+        base = set(granted or [])
+        expanded = set(base)
+        for scope in list(base):
+            expanded |= _IMPLIED_SCOPES.get(scope, set())
+        return expanded
+
+    def _expand_scopes(self, additional_scopes: list[str]) -> None:
+        """Run a consent flow for *additional_scopes* and save the new token."""
+        if not self._interactive:
+            raise RuntimeError(
+                "Google OAuth yetkilendirmesi gerekli (yeni scope'lar: %s). "
+                "'/auth google' komutu ile yetkilendirme yapın. "
+                "client_secret=%s token=%s" % (
+                    ", ".join(sorted(additional_scopes)),
+                    mask_path(str(self._cfg.client_secret_path)),
+                    mask_path(str(self._cfg.token_path)),
+                )
+            )
+
+        if not self._cfg.client_secret_path.exists():
+            raise FileNotFoundError(
+                "Google client secret bulunamadı. BANTZ_GOOGLE_CLIENT_SECRET "
+                "env var'ını ayarlayın. Eksik: %s"
+                % mask_path(str(self._cfg.client_secret_path))
+            )
+
+        _Request, _Creds, InstalledAppFlow, _build = _import_google_deps()
+
+        # Combine existing + new scopes for the consent flow
+        current = list(getattr(self._credentials, "scopes", None) or [])
+        all_scopes = sorted(set(current) | set(additional_scopes))
+
+        flow = InstalledAppFlow.from_client_secrets_file(
+            str(self._cfg.client_secret_path), scopes=all_scopes
+        )
+
+        try:
+            self._credentials = flow.run_local_server(port=0, open_browser=True)
+        except Exception:
+            try:
+                self._credentials = flow.run_local_server(port=0, open_browser=False)
+            except Exception:
+                self._credentials = flow.run_console()
+
+        # Persist
+        self._save_token()
+        # Clear service cache — credentials changed
+        self._service_cache.clear()
+
+    def _save_token(self) -> None:
+        """Atomically save the current credentials to disk."""
+        if self._credentials is None:
+            return
+
+        self._cfg.token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_json = self._credentials.to_json()
+        dir_str = str(self._cfg.token_path.parent)
+
+        fd, tmp_path = tempfile.mkstemp(dir=dir_str, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fcntl.flock(fh, fcntl.LOCK_EX)
+                fh.write(token_json)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, str(self._cfg.token_path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    # ── migration helpers ───────────────────────────────────────
+
+    def migrate_legacy_tokens(self) -> dict[str, bool]:
+        """Import scopes from old per-service token files.
+
+        Reads ``token.json`` (Calendar/Contacts) and ``gmail_token.json``
+        and merges their scopes into the unified token.  The legacy files
+        are **not** deleted — users can remove them manually.
+
+        Returns a dict of ``{service: migrated_bool}``.
+        """
+        legacy_map = {
+            "calendar": _resolve_path(
+                os.getenv("BANTZ_GOOGLE_TOKEN_PATH")
+                or "~/.config/bantz/google/token.json"
+            ),
+            "gmail": _resolve_path(
+                os.getenv("BANTZ_GMAIL_TOKEN_PATH")
+                or "~/.config/bantz/google/gmail_token.json"
+            ),
+        }
+        result: dict[str, bool] = {}
+
+        _Request, Credentials, _Flow, _build = _import_google_deps()
+
+        merged_scopes: set[str] = set()
+        best_creds: Any = None
+
+        for svc, path in legacy_map.items():
+            if not path.exists():
+                result[svc] = False
+                continue
+            try:
+                creds = Credentials.from_authorized_user_file(str(path))
+                scopes = set(getattr(creds, "scopes", None) or [])
+                merged_scopes |= scopes
+
+                # Prefer the credential with a refresh token
+                if getattr(creds, "refresh_token", None):
+                    best_creds = creds
+
+                result[svc] = True
+                logger.info("Legacy token migrated: %s (%s)", svc, mask_path(str(path)))
+            except Exception as exc:
+                logger.warning("Legacy token okunamadı (%s): %s", svc, exc)
+                result[svc] = False
+
+        if best_creds is not None and merged_scopes:
+            # Set merged scopes on the best credential
+            best_creds.scopes = list(merged_scopes)
+            self._credentials = best_creds
+            self._save_token()
+            logger.info(
+                "Unified token oluşturuldu: %d scope → %s",
+                len(merged_scopes),
+                mask_path(str(self._cfg.token_path)),
+            )
+
+        return result
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Singleton
+# ═══════════════════════════════════════════════════════════════════
+
+_auth_manager: Optional[GoogleAuthManager] = None
+
+
+def get_auth_manager() -> Optional[GoogleAuthManager]:
+    """Return the global ``GoogleAuthManager`` instance (or ``None``)."""
+    return _auth_manager
+
+
+def setup_auth_manager(
+    *,
+    token_path: Optional[str] = None,
+    client_secret_path: Optional[str] = None,
+    interactive: bool = True,
+    auto_migrate: bool = False,
+) -> GoogleAuthManager:
+    """Create and store the global ``GoogleAuthManager``.
+
+    Called once during startup (e.g. from ``runtime_factory.py``).
+    """
+    global _auth_manager
+
+    _auth_manager = GoogleAuthManager(
+        token_path=token_path,
+        client_secret_path=client_secret_path,
+        interactive=interactive,
+    )
+
+    if auto_migrate:
+        _auth_manager.migrate_legacy_tokens()
+
+    return _auth_manager

--- a/src/bantz/connectors/google/base.py
+++ b/src/bantz/connectors/google/base.py
@@ -1,0 +1,99 @@
+"""Base Google Connector — abstract interface for all Google service connectors.
+
+Issue #1292: All Google connectors inherit from ``GoogleConnector``,
+sharing the unified ``GoogleAuthManager`` for authentication and
+exposing a standard ``get_tools()`` method for automatic tool registration.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from bantz.connectors.google.auth_manager import GoogleAuthManager
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["GoogleConnector", "ToolSchema"]
+
+
+class ToolSchema:
+    """Lightweight descriptor for a tool exposed by a connector.
+
+    Attributes
+    ----------
+    name : str
+        Dot-qualified tool name (e.g. ``"google.tasks.list"``).
+    description : str
+        Human-readable description shown to the LLM planner.
+    parameters : dict
+        JSON-Schema ``object`` describing accepted parameters.
+    handler : callable
+        The async or sync function implementing the tool.
+    risk : str
+        Risk level: ``"low"``, ``"medium"``, or ``"high"``.
+    confirm : bool
+        Whether the tool requires user confirmation before execution.
+    """
+
+    __slots__ = ("name", "description", "parameters", "handler", "risk", "confirm")
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        parameters: dict,
+        handler: Any,
+        risk: str = "low",
+        confirm: bool = False,
+    ):
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+        self.handler = handler
+        self.risk = risk
+        self.confirm = confirm
+
+
+class GoogleConnector(ABC):
+    """Abstract base class for Google service connectors.
+
+    Subclasses must implement:
+    - ``SERVICE_NAME`` class-level constant (e.g. ``"tasks"``).
+    - ``get_tools()`` returning a list of ``ToolSchema`` instances.
+
+    The base constructor authenticates via the unified auth manager
+    and creates a ``service`` attribute for the Google API client.
+    """
+
+    SERVICE_NAME: str = ""
+
+    def __init__(self, auth: GoogleAuthManager):
+        if not self.SERVICE_NAME:
+            raise NotImplementedError(
+                "%s must define SERVICE_NAME" % type(self).__name__
+            )
+        self._auth = auth
+        self._service: Any = None
+
+    @property
+    def service(self) -> Any:
+        """Lazy-initialized Google API service object."""
+        if self._service is None:
+            self._service = self._auth.get_service(self.SERVICE_NAME)
+        return self._service
+
+    @abstractmethod
+    def get_tools(self) -> list[ToolSchema]:
+        """Return the tool descriptors this connector provides."""
+        ...
+
+    def _ok(self, **data: Any) -> dict[str, Any]:
+        """Convenience: build a successful result dict."""
+        return {"ok": True, **data}
+
+    def _err(self, message: str, **data: Any) -> dict[str, Any]:
+        """Convenience: build an error result dict."""
+        return {"ok": False, "error": message, **data}

--- a/src/bantz/connectors/google/classroom.py
+++ b/src/bantz/connectors/google/classroom.py
@@ -1,0 +1,410 @@
+"""Google Classroom Connector — Classroom API integration.
+
+Issue #1292 / refs #840: Provides course listing, coursework listing,
+and submission status operations for Google Classroom via the unified
+``GoogleAuthManager``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from bantz.connectors.google.base import GoogleConnector, ToolSchema
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ClassroomConnector", "Course", "Assignment", "Submission"]
+
+
+@dataclass
+class Course:
+    """A Google Classroom course."""
+
+    id: str = ""
+    name: str = ""
+    section: str = ""
+    description: str = ""
+    state: str = ""  # ACTIVE, ARCHIVED, PROVISIONED, DECLINED, SUSPENDED
+    enrollment_code: str = ""
+    creation_time: str = ""
+    update_time: str = ""
+    teacher_name: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "section": self.section,
+            "description": self.description,
+            "state": self.state,
+            "enrollment_code": self.enrollment_code,
+            "creation_time": self.creation_time,
+            "update_time": self.update_time,
+            "teacher_name": self.teacher_name,
+        }
+
+
+@dataclass
+class Assignment:
+    """A Google Classroom course work item (assignment, quiz, etc.)."""
+
+    id: str = ""
+    course_id: str = ""
+    title: str = ""
+    description: str = ""
+    work_type: str = ""  # ASSIGNMENT, SHORT_ANSWER_QUESTION, MULTIPLE_CHOICE_QUESTION
+    state: str = ""  # PUBLISHED, DRAFT, DELETED
+    due_date: str = ""
+    due_time: str = ""
+    max_points: float = 0.0
+    creation_time: str = ""
+    update_time: str = ""
+
+    @property
+    def due_display(self) -> str:
+        """Human-readable due date string."""
+        if self.due_date:
+            return "%s %s" % (self.due_date, self.due_time) if self.due_time else self.due_date
+        return "Tarih yok"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "course_id": self.course_id,
+            "title": self.title,
+            "description": self.description,
+            "work_type": self.work_type,
+            "state": self.state,
+            "due_display": self.due_display,
+            "max_points": self.max_points,
+            "creation_time": self.creation_time,
+            "update_time": self.update_time,
+        }
+
+
+@dataclass
+class Submission:
+    """A student's submission for a course work item."""
+
+    id: str = ""
+    course_id: str = ""
+    coursework_id: str = ""
+    state: str = ""  # NEW, CREATED, TURNED_IN, RETURNED, RECLAIMED_BY_STUDENT
+    assigned_grade: Optional[float] = None
+    late: bool = False
+    update_time: str = ""
+
+    @property
+    def is_submitted(self) -> bool:
+        return self.state in ("TURNED_IN", "RETURNED")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "course_id": self.course_id,
+            "coursework_id": self.coursework_id,
+            "state": self.state,
+            "is_submitted": self.is_submitted,
+            "assigned_grade": self.assigned_grade,
+            "late": self.late,
+            "update_time": self.update_time,
+        }
+
+
+def _parse_due(due_date: dict | None, due_time: dict | None) -> tuple[str, str]:
+    """Parse Classroom dueDate + dueTime into strings."""
+    date_str = ""
+    time_str = ""
+    if due_date and isinstance(due_date, dict):
+        y = due_date.get("year", 0)
+        m = due_date.get("month", 0)
+        d = due_date.get("day", 0)
+        if y and m and d:
+            date_str = "%04d-%02d-%02d" % (y, m, d)
+    if due_time and isinstance(due_time, dict):
+        h = due_time.get("hours", 0)
+        mi = due_time.get("minutes", 0)
+        time_str = "%02d:%02d" % (h, mi)
+    return date_str, time_str
+
+
+class ClassroomConnector(GoogleConnector):
+    """Google Classroom service connector.
+
+    Provides:
+    - ``list_courses()`` — list all courses
+    - ``list_coursework(course_id)`` — list assignments for a course
+    - ``get_submission_status(course_id)`` — get submission statuses
+    """
+
+    SERVICE_NAME = "classroom"
+
+    async def list_courses(
+        self,
+        *,
+        state: str = "ACTIVE",
+        max_results: int = 50,
+    ) -> list[Course]:
+        """List Google Classroom courses.
+
+        Parameters
+        ----------
+        state : str
+            Course state filter: ``"ACTIVE"``, ``"ARCHIVED"``, etc.
+        max_results : int
+            Maximum number of courses to return.
+        """
+        try:
+            params: dict[str, Any] = {
+                "pageSize": min(max_results, 100),
+            }
+            if state:
+                params["courseStates"] = [state]
+
+            result = self.service.courses().list(**params).execute()
+            items = result.get("courses", [])
+
+            courses = []
+            for c in items:
+                # Try to get teacher name from ownerId
+                teacher_name = ""
+                owner_id = c.get("ownerId", "")
+                if owner_id:
+                    try:
+                        profile = (
+                            self.service.userProfiles()
+                            .get(userId=owner_id)
+                            .execute()
+                        )
+                        name_obj = profile.get("name", {})
+                        teacher_name = name_obj.get("fullName", "")
+                    except Exception:
+                        pass
+
+                courses.append(Course(
+                    id=c.get("id", ""),
+                    name=c.get("name", ""),
+                    section=c.get("section", ""),
+                    description=c.get("descriptionHeading", ""),
+                    state=c.get("courseState", ""),
+                    enrollment_code=c.get("enrollmentCode", ""),
+                    creation_time=c.get("creationTime", ""),
+                    update_time=c.get("updateTime", ""),
+                    teacher_name=teacher_name,
+                ))
+            return courses
+        except Exception as exc:
+            logger.error("Dersler alınamadı: %s", exc)
+            raise
+
+    async def list_coursework(
+        self,
+        course_id: str,
+        *,
+        max_results: int = 50,
+    ) -> list[Assignment]:
+        """List course work items (assignments, quizzes) for a course.
+
+        Parameters
+        ----------
+        course_id : str
+            The course ID.
+        max_results : int
+            Maximum number of items to return.
+        """
+        try:
+            result = (
+                self.service.courses()
+                .courseWork()
+                .list(courseId=course_id, pageSize=min(max_results, 100))
+                .execute()
+            )
+            items = result.get("courseWork", [])
+
+            assignments = []
+            for cw in items:
+                due_date, due_time = _parse_due(
+                    cw.get("dueDate"), cw.get("dueTime")
+                )
+                assignments.append(Assignment(
+                    id=cw.get("id", ""),
+                    course_id=course_id,
+                    title=cw.get("title", ""),
+                    description=cw.get("description", ""),
+                    work_type=cw.get("workType", ""),
+                    state=cw.get("state", ""),
+                    due_date=due_date,
+                    due_time=due_time,
+                    max_points=cw.get("maxPoints", 0.0),
+                    creation_time=cw.get("creationTime", ""),
+                    update_time=cw.get("updateTime", ""),
+                ))
+            return assignments
+        except Exception as exc:
+            logger.error("Ödevler alınamadı (ders %s): %s", course_id, exc)
+            raise
+
+    async def get_submission_status(
+        self,
+        course_id: str,
+        *,
+        coursework_id: Optional[str] = None,
+    ) -> list[Submission]:
+        """Get submission statuses for course work items.
+
+        Parameters
+        ----------
+        course_id : str
+            The course ID.
+        coursework_id : str, optional
+            Specific course work ID.  If ``None``, returns submissions
+            for all course work items.
+        """
+        try:
+            cw_id = coursework_id or "-"  # "-" means all coursework
+            result = (
+                self.service.courses()
+                .courseWork()
+                .studentSubmissions()
+                .list(
+                    courseId=course_id,
+                    courseWorkId=cw_id,
+                    userId="me",
+                )
+                .execute()
+            )
+            items = result.get("studentSubmissions", [])
+
+            submissions = []
+            for s in items:
+                submissions.append(Submission(
+                    id=s.get("id", ""),
+                    course_id=s.get("courseId", ""),
+                    coursework_id=s.get("courseWorkId", ""),
+                    state=s.get("state", ""),
+                    assigned_grade=s.get("assignedGrade"),
+                    late=s.get("late", False),
+                    update_time=s.get("updateTime", ""),
+                ))
+            return submissions
+        except Exception as exc:
+            logger.error(
+                "Teslim durumları alınamadı (ders %s): %s", course_id, exc,
+            )
+            raise
+
+    # ── Tool handlers ───────────────────────────────────────────
+
+    def _run_async(self, coro: Any) -> Any:
+        """Run an async coroutine from sync context."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    return pool.submit(asyncio.run, coro).result()
+            return loop.run_until_complete(coro)
+        except RuntimeError:
+            return asyncio.run(coro)
+
+    def _list_courses_tool(self, state: str = "ACTIVE", **_kw: Any) -> dict:
+        """Sync tool handler for listing courses."""
+        try:
+            courses = self._run_async(self.list_courses(state=state))
+            return self._ok(
+                courses=[c.to_dict() for c in courses],
+                count=len(courses),
+            )
+        except Exception as exc:
+            return self._err("Dersler alınamadı: %s" % exc)
+
+    def _list_coursework_tool(self, course_id: str, **_kw: Any) -> dict:
+        """Sync tool handler for listing assignments."""
+        try:
+            assignments = self._run_async(self.list_coursework(course_id))
+            return self._ok(
+                assignments=[a.to_dict() for a in assignments],
+                count=len(assignments),
+            )
+        except Exception as exc:
+            return self._err("Ödevler alınamadı: %s" % exc)
+
+    def _submission_status_tool(
+        self,
+        course_id: str,
+        coursework_id: Optional[str] = None,
+        **_kw: Any,
+    ) -> dict:
+        """Sync tool handler for getting submission statuses."""
+        try:
+            submissions = self._run_async(
+                self.get_submission_status(course_id, coursework_id=coursework_id)
+            )
+            return self._ok(
+                submissions=[s.to_dict() for s in submissions],
+                count=len(submissions),
+            )
+        except Exception as exc:
+            return self._err("Teslim durumları alınamadı: %s" % exc)
+
+    # ── ToolSchema registration ─────────────────────────────────
+
+    def get_tools(self) -> list[ToolSchema]:
+        """Return tool descriptors for the Classroom connector."""
+        return [
+            ToolSchema(
+                name="google.classroom.courses",
+                description="Google Classroom derslerini listele.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "description": "Ders durumu filtresi (ACTIVE, ARCHIVED)",
+                        },
+                    },
+                },
+                handler=self._list_courses_tool,
+                risk="low",
+            ),
+            ToolSchema(
+                name="google.classroom.coursework",
+                description="Google Classroom dersindeki ödevleri listele.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "course_id": {
+                            "type": "string",
+                            "description": "Ders ID",
+                        },
+                    },
+                    "required": ["course_id"],
+                },
+                handler=self._list_coursework_tool,
+                risk="low",
+            ),
+            ToolSchema(
+                name="google.classroom.submissions",
+                description="Google Classroom ödev teslim durumlarını getir.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "course_id": {
+                            "type": "string",
+                            "description": "Ders ID",
+                        },
+                        "coursework_id": {
+                            "type": "string",
+                            "description": "Ödev ID (opsiyonel, tüm ödevler için boş bırakın)",
+                        },
+                    },
+                    "required": ["course_id"],
+                },
+                handler=self._submission_status_tool,
+                risk="low",
+            ),
+        ]

--- a/src/bantz/connectors/google/contacts.py
+++ b/src/bantz/connectors/google/contacts.py
@@ -1,0 +1,366 @@
+"""Google Contacts Connector — People API integration.
+
+Issue #1292: Provides search, get, and create operations for Google Contacts
+via the unified ``GoogleAuthManager``.  Leverages the People API v1.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from bantz.connectors.google.base import GoogleConnector, ToolSchema
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ContactsConnector", "Contact"]
+
+# Fields to request from People API
+_PERSON_FIELDS = (
+    "names,emailAddresses,phoneNumbers,organizations,photos,"
+    "biographies,birthdays,addresses"
+)
+
+_SEARCH_READ_MASK = "names,emailAddresses,phoneNumbers,organizations,photos"
+
+
+@dataclass
+class Contact:
+    """A contact from Google People API."""
+
+    resource_name: str = ""
+    display_name: str = ""
+    given_name: str = ""
+    family_name: str = ""
+    emails: list[str] = field(default_factory=list)
+    phones: list[str] = field(default_factory=list)
+    organization: str = ""
+    photo_url: str = ""
+    birthday: str = ""
+    address: str = ""
+    notes: str = ""
+
+    @property
+    def primary_email(self) -> str:
+        return self.emails[0] if self.emails else ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "resource_name": self.resource_name,
+            "display_name": self.display_name,
+            "given_name": self.given_name,
+            "family_name": self.family_name,
+            "emails": self.emails,
+            "phones": self.phones,
+            "organization": self.organization,
+            "photo_url": self.photo_url,
+            "birthday": self.birthday,
+            "address": self.address,
+            "notes": self.notes,
+        }
+
+
+def _parse_person(person: dict) -> Contact:
+    """Parse a People API person resource into a ``Contact``."""
+    names = person.get("names", [])
+    emails = person.get("emailAddresses", [])
+    phones = person.get("phoneNumbers", [])
+    orgs = person.get("organizations", [])
+    photos = person.get("photos", [])
+    bdays = person.get("birthdays", [])
+    addrs = person.get("addresses", [])
+    bios = person.get("biographies", [])
+
+    return Contact(
+        resource_name=person.get("resourceName", ""),
+        display_name=names[0].get("displayName", "") if names else "",
+        given_name=names[0].get("givenName", "") if names else "",
+        family_name=names[0].get("familyName", "") if names else "",
+        emails=[e.get("value", "") for e in emails if e.get("value")],
+        phones=[p.get("value", "") for p in phones if p.get("value")],
+        organization=orgs[0].get("name", "") if orgs else "",
+        photo_url=photos[0].get("url", "") if photos else "",
+        birthday=_format_birthday(bdays[0].get("date", {})) if bdays else "",
+        address=_format_address(addrs[0]) if addrs else "",
+        notes=bios[0].get("value", "") if bios else "",
+    )
+
+
+def _format_birthday(date_obj: dict) -> str:
+    """Format a Google date object to ``YYYY-MM-DD`` or ``MM-DD``."""
+    year = date_obj.get("year")
+    month = date_obj.get("month", 0)
+    day = date_obj.get("day", 0)
+    if year:
+        return "%04d-%02d-%02d" % (year, month, day)
+    if month and day:
+        return "%02d-%02d" % (month, day)
+    return ""
+
+
+def _format_address(addr: dict) -> str:
+    """Concatenate address parts into a single string."""
+    return addr.get("formattedValue", "") or addr.get("streetAddress", "")
+
+
+class ContactsConnector(GoogleConnector):
+    """Google Contacts service connector.
+
+    Provides:
+    - ``search_contacts(query)`` — search by name, email, or phone
+    - ``get_contact(resource_name)`` — fetch full contact details
+    - ``create_contact(name, email, phone)`` — create a new contact
+    """
+
+    SERVICE_NAME = "contacts"
+
+    async def search_contacts(
+        self,
+        query: str,
+        *,
+        max_results: int = 10,
+    ) -> list[Contact]:
+        """Search Google Contacts by name, email, or phone.
+
+        Parameters
+        ----------
+        query : str
+            Free-text search query.
+        max_results : int
+            Maximum number of contacts to return.
+
+        Returns
+        -------
+        list[Contact]
+            Matching contacts.
+        """
+        try:
+            result = (
+                self.service.people()
+                .searchContacts(
+                    query=query,
+                    pageSize=min(max_results, 30),
+                    readMask=_SEARCH_READ_MASK,
+                )
+                .execute()
+            )
+            results = result.get("results", [])
+            return [
+                _parse_person(r.get("person", {}))
+                for r in results
+                if r.get("person")
+            ]
+        except Exception as exc:
+            logger.error("Contacts arama hatası: %s", exc)
+            raise
+
+    async def get_contact(self, resource_name: str) -> Optional[Contact]:
+        """Fetch a single contact by ``resourceName``.
+
+        Parameters
+        ----------
+        resource_name : str
+            The People API resource name (e.g. ``"people/c123"``).
+
+        Returns
+        -------
+        Contact or None
+            The contact, or ``None`` if not found.
+        """
+        try:
+            person = (
+                self.service.people()
+                .get(resourceName=resource_name, personFields=_PERSON_FIELDS)
+                .execute()
+            )
+            return _parse_person(person)
+        except Exception as exc:
+            logger.error("Contact getirme hatası (%s): %s", resource_name, exc)
+            return None
+
+    async def create_contact(
+        self,
+        name: str,
+        email: str,
+        phone: Optional[str] = None,
+    ) -> Optional[Contact]:
+        """Create a new Google contact.
+
+        Parameters
+        ----------
+        name : str
+            Full display name.
+        email : str
+            Primary email address.
+        phone : str, optional
+            Phone number.
+
+        Returns
+        -------
+        Contact or None
+            The created contact, or ``None`` on failure.
+        """
+        body: dict[str, Any] = {
+            "names": [{"givenName": name}],
+            "emailAddresses": [{"value": email}],
+        }
+        if phone:
+            body["phoneNumbers"] = [{"value": phone}]
+
+        try:
+            person = (
+                self.service.people()
+                .createContact(body=body)
+                .execute()
+            )
+            contact = _parse_person(person)
+            logger.info("Kişi oluşturuldu: %s (%s)", name, email)
+            return contact
+        except Exception as exc:
+            logger.error("Kişi oluşturma hatası: %s", exc)
+            return None
+
+    # ── Tool handlers (sync wrappers) ───────────────────────────
+
+    def _search_tool(self, query: str, **_kw: Any) -> dict:
+        """Sync tool handler for contacts search."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    contacts = pool.submit(
+                        asyncio.run, self.search_contacts(query)
+                    ).result()
+            else:
+                contacts = loop.run_until_complete(self.search_contacts(query))
+        except RuntimeError:
+            contacts = asyncio.run(self.search_contacts(query))
+        except Exception as exc:
+            return self._err("Kişi arama hatası: %s" % exc)
+
+        return self._ok(
+            contacts=[c.to_dict() for c in contacts],
+            count=len(contacts),
+        )
+
+    def _get_tool(self, resource_name: str, **_kw: Any) -> dict:
+        """Sync tool handler for contact get."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    contact = pool.submit(
+                        asyncio.run, self.get_contact(resource_name)
+                    ).result()
+            else:
+                contact = loop.run_until_complete(self.get_contact(resource_name))
+        except RuntimeError:
+            contact = asyncio.run(self.get_contact(resource_name))
+        except Exception as exc:
+            return self._err("Kişi getirme hatası: %s" % exc)
+
+        if contact is None:
+            return self._err("Kişi bulunamadı: %s" % resource_name)
+        return self._ok(contact=contact.to_dict())
+
+    def _create_tool(
+        self,
+        name: str,
+        email: str,
+        phone: Optional[str] = None,
+        **_kw: Any,
+    ) -> dict:
+        """Sync tool handler for contact creation."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    contact = pool.submit(
+                        asyncio.run, self.create_contact(name, email, phone)
+                    ).result()
+            else:
+                contact = loop.run_until_complete(
+                    self.create_contact(name, email, phone)
+                )
+        except RuntimeError:
+            contact = asyncio.run(self.create_contact(name, email, phone))
+        except Exception as exc:
+            return self._err("Kişi oluşturma hatası: %s" % exc)
+
+        if contact is None:
+            return self._err("Kişi oluşturulamadı")
+        return self._ok(contact=contact.to_dict())
+
+    # ── ToolSchema registration ─────────────────────────────────
+
+    def get_tools(self) -> list[ToolSchema]:
+        """Return tool descriptors for the contacts connector."""
+        return [
+            ToolSchema(
+                name="google.contacts.search",
+                description="Google kişilerinde arama yap — isim, email veya telefon.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Arama sorgusu (isim, email veya telefon)",
+                        },
+                    },
+                    "required": ["query"],
+                },
+                handler=self._search_tool,
+                risk="low",
+            ),
+            ToolSchema(
+                name="google.contacts.get",
+                description="Google kişisinin detaylı bilgisini getir.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "resource_name": {
+                            "type": "string",
+                            "description": "Kişi resource name (ör. people/c123)",
+                        },
+                    },
+                    "required": ["resource_name"],
+                },
+                handler=self._get_tool,
+                risk="low",
+            ),
+            ToolSchema(
+                name="google.contacts.create",
+                description="Yeni Google kişisi oluştur.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Kişi adı",
+                        },
+                        "email": {
+                            "type": "string",
+                            "description": "E-posta adresi",
+                        },
+                        "phone": {
+                            "type": "string",
+                            "description": "Telefon numarası (opsiyonel)",
+                        },
+                    },
+                    "required": ["name", "email"],
+                },
+                handler=self._create_tool,
+                risk="medium",
+                confirm=True,
+            ),
+        ]

--- a/src/bantz/connectors/google/entity_linker.py
+++ b/src/bantz/connectors/google/entity_linker.py
@@ -1,0 +1,310 @@
+"""Google Cross-Service Entity Linker — connects entities across Google services.
+
+Issue #1292: Links Calendar attendees to Contacts, Tasks to Events,
+and provides cross-service entity resolution.  Prepares entity
+relationships for the graf bellek (EPIC 2) integration.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["GoogleEntityLinker", "EntityLink"]
+
+
+@dataclass
+class EntityLink:
+    """A link between two entities across Google services.
+
+    Attributes
+    ----------
+    source_type : str
+        Source entity type (e.g. ``"CalendarAttendee"``).
+    source_id : str
+        Source entity identifier (e.g. email address).
+    edge_type : str
+        Relationship type (e.g. ``"HAS_CONTACT_INFO"``).
+    target_type : str
+        Target entity type (e.g. ``"Contact"``).
+    target_id : str
+        Target entity identifier (e.g. resource name).
+    metadata : dict
+        Additional metadata about the link.
+    """
+
+    source_type: str
+    source_id: str
+    edge_type: str
+    target_type: str
+    target_id: str
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_type": self.source_type,
+            "source_id": self.source_id,
+            "edge_type": self.edge_type,
+            "target_type": self.target_type,
+            "target_id": self.target_id,
+            "metadata": self.metadata,
+        }
+
+
+class GoogleEntityLinker:
+    """Cross-service entity linker for Google services.
+
+    Connects entities found in one Google service to their counterparts
+    in other services (e.g. Calendar attendee → Contact, Task → Event).
+
+    Parameters
+    ----------
+    contacts_connector : ContactsConnector, optional
+        For resolving email → contact lookups.
+    tasks_connector : TasksConnector, optional
+        For task-event matching.
+    calendar_service : callable, optional
+        A function that lists calendar events for a given date.
+    """
+
+    def __init__(
+        self,
+        *,
+        contacts_connector: Any = None,
+        tasks_connector: Any = None,
+        calendar_list_events: Any = None,
+    ):
+        self._contacts = contacts_connector
+        self._tasks = tasks_connector
+        self._calendar_list_events = calendar_list_events
+        self._links: list[EntityLink] = []
+
+    @property
+    def links(self) -> list[EntityLink]:
+        """All discovered entity links."""
+        return list(self._links)
+
+    def clear_links(self) -> None:
+        """Clear all discovered links."""
+        self._links.clear()
+
+    async def link_attendee_to_contact(
+        self,
+        attendee_email: str,
+    ) -> Optional[dict]:
+        """Find a Calendar attendee in Google Contacts.
+
+        Parameters
+        ----------
+        attendee_email : str
+            The email address of the calendar attendee.
+
+        Returns
+        -------
+        dict or None
+            Contact data if found, else ``None``.
+        """
+        if not self._contacts:
+            logger.debug("Contacts connector yok — link atlanıyor")
+            return None
+
+        try:
+            contacts = await self._contacts.search_contacts(attendee_email)
+            if not contacts:
+                return None
+
+            contact = contacts[0]
+            link = EntityLink(
+                source_type="CalendarAttendee",
+                source_id=attendee_email,
+                edge_type="HAS_CONTACT_INFO",
+                target_type="Contact",
+                target_id=contact.resource_name,
+                metadata={
+                    "display_name": contact.display_name,
+                    "phones": contact.phones,
+                    "organization": contact.organization,
+                },
+            )
+            self._links.append(link)
+            logger.info(
+                "Katılımcı→Kişi bağlantısı: %s → %s",
+                attendee_email, contact.display_name,
+            )
+            return contact.to_dict()
+        except Exception as exc:
+            logger.warning(
+                "Katılımcı→Kişi bağlantı hatası (%s): %s",
+                attendee_email, exc,
+            )
+            return None
+
+    async def link_attendees_to_contacts(
+        self,
+        attendee_emails: list[str],
+    ) -> dict[str, Optional[dict]]:
+        """Batch-link multiple calendar attendees to contacts.
+
+        Returns
+        -------
+        dict[str, dict | None]
+            Mapping of email → contact data (or ``None``).
+        """
+        results: dict[str, Optional[dict]] = {}
+        for email in attendee_emails:
+            results[email] = await self.link_attendee_to_contact(email)
+        return results
+
+    async def link_task_to_event(
+        self,
+        task_title: str,
+        task_due: str,
+        *,
+        similarity_threshold: float = 0.6,
+    ) -> Optional[dict]:
+        """Match a Task to a Calendar event on the same day.
+
+        Uses fuzzy title matching (``SequenceMatcher``) to find related
+        events.
+
+        Parameters
+        ----------
+        task_title : str
+            The task title.
+        task_due : str
+            The task due date in ``YYYY-MM-DD`` or RFC 3339 format.
+        similarity_threshold : float
+            Minimum similarity ratio to consider a match (0.0–1.0).
+
+        Returns
+        -------
+        dict or None
+            Matching event data if found, else ``None``.
+        """
+        if not self._calendar_list_events:
+            logger.debug("Calendar list_events yok — link atlanıyor")
+            return None
+
+        # Extract date portion
+        date_str = task_due[:10] if len(task_due) >= 10 else task_due
+        if not date_str:
+            return None
+
+        try:
+            events = await self._calendar_list_events(date=date_str)
+            if not events:
+                return None
+
+            best_match = None
+            best_score = 0.0
+
+            for event in events:
+                event_title = ""
+                if isinstance(event, dict):
+                    event_title = event.get("summary", "") or event.get("title", "")
+                    event_id = event.get("id", "")
+                elif hasattr(event, "summary"):
+                    event_title = getattr(event, "summary", "")
+                    event_id = getattr(event, "id", "")
+                else:
+                    continue
+
+                score = SequenceMatcher(
+                    None,
+                    task_title.lower(),
+                    event_title.lower(),
+                ).ratio()
+
+                if score > best_score and score >= similarity_threshold:
+                    best_score = score
+                    best_match = event
+                    best_match_id = event_id
+
+            if best_match is not None:
+                match_title = (
+                    best_match.get("summary", "")
+                    if isinstance(best_match, dict)
+                    else getattr(best_match, "summary", "")
+                )
+                link = EntityLink(
+                    source_type="Task",
+                    source_id=task_title,
+                    edge_type="RELATED_TO",
+                    target_type="CalendarEvent",
+                    target_id=best_match_id,
+                    metadata={
+                        "similarity": round(best_score, 3),
+                        "event_title": match_title,
+                        "date": date_str,
+                    },
+                )
+                self._links.append(link)
+                logger.info(
+                    "Görev→Etkinlik bağlantısı: '%s' → '%s' (sim=%.2f)",
+                    task_title, match_title, best_score,
+                )
+                if isinstance(best_match, dict):
+                    return best_match
+                return {"id": best_match_id, "summary": match_title}
+        except Exception as exc:
+            logger.warning(
+                "Görev→Etkinlik bağlantı hatası ('%s'): %s",
+                task_title, exc,
+            )
+
+        return None
+
+    async def resolve_event_attendees(
+        self,
+        event: dict,
+    ) -> dict:
+        """Enrich a calendar event with contact info for all attendees.
+
+        Parameters
+        ----------
+        event : dict
+            A calendar event dict with an ``attendees`` field.
+
+        Returns
+        -------
+        dict
+            The event dict with an added ``attendee_contacts`` field.
+        """
+        attendees = event.get("attendees", [])
+        emails = [
+            a.get("email", "")
+            for a in attendees
+            if a.get("email")
+        ]
+
+        if not emails:
+            event["attendee_contacts"] = []
+            return event
+
+        contacts = await self.link_attendees_to_contacts(emails)
+        event["attendee_contacts"] = [
+            {
+                "email": email,
+                "contact": contact_data,
+                "resolved": contact_data is not None,
+            }
+            for email, contact_data in contacts.items()
+        ]
+        return event
+
+    def get_links_summary(self) -> dict[str, Any]:
+        """Return a summary of all discovered entity links."""
+        by_type: dict[str, int] = {}
+        for link in self._links:
+            key = "%s→%s" % (link.source_type, link.target_type)
+            by_type[key] = by_type.get(key, 0) + 1
+
+        return {
+            "total_links": len(self._links),
+            "by_type": by_type,
+            "links": [link.to_dict() for link in self._links],
+        }

--- a/src/bantz/connectors/google/keep.py
+++ b/src/bantz/connectors/google/keep.py
@@ -1,0 +1,316 @@
+"""Google Keep Connector — Keep API integration.
+
+Issue #1292: Provides list, create, and search operations for Google Keep
+notes.  Note: The Google Keep API (Enterprise) has limited availability —
+it requires a Google Workspace account and is not available for consumer
+accounts.  This connector degrades gracefully with a clear error message.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from bantz.connectors.google.base import GoogleConnector, ToolSchema
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["KeepConnector", "Note"]
+
+# Keep API availability flag — set to False if the API returns 403
+_KEEP_API_AVAILABLE: bool = True
+
+
+@dataclass
+class Note:
+    """A Google Keep note."""
+
+    name: str = ""  # Resource name e.g. "notes/abc123"
+    title: str = ""
+    body: str = ""
+    create_time: str = ""
+    update_time: str = ""
+    trashed: bool = False
+    labels: list[str] = field(default_factory=list)
+    pinned: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "title": self.title,
+            "body": self.body,
+            "create_time": self.create_time,
+            "update_time": self.update_time,
+            "trashed": self.trashed,
+            "labels": self.labels,
+            "pinned": self.pinned,
+        }
+
+
+def _parse_note(note: dict) -> Note:
+    """Parse a Keep API note resource into a ``Note``."""
+    body_content = ""
+    body_obj = note.get("body", {})
+    if isinstance(body_obj, dict):
+        # Text note
+        text_content = body_obj.get("text", {})
+        if isinstance(text_content, dict):
+            body_content = text_content.get("text", "")
+        elif isinstance(text_content, str):
+            body_content = text_content
+        # List note — concatenate items
+        list_content = body_obj.get("list", {})
+        if isinstance(list_content, dict):
+            items = list_content.get("listItems", [])
+            lines = []
+            for item in items:
+                text_obj = item.get("text", {})
+                text = text_obj.get("text", "") if isinstance(text_obj, dict) else str(text_obj)
+                checked = item.get("checked", False)
+                prefix = "☑" if checked else "☐"
+                lines.append("%s %s" % (prefix, text))
+            if lines:
+                body_content = "\n".join(lines)
+
+    return Note(
+        name=note.get("name", ""),
+        title=note.get("title", ""),
+        body=body_content,
+        create_time=note.get("createTime", ""),
+        update_time=note.get("updateTime", ""),
+        trashed=note.get("trashed", False),
+    )
+
+
+class KeepConnector(GoogleConnector):
+    """Google Keep service connector.
+
+    Provides:
+    - ``list_notes(filter)`` — list notes, optionally filtered
+    - ``create_note(title, body)`` — create a new note
+    - ``search_notes(query)`` — search notes by content
+
+    .. note::
+       The Google Keep API is only available for Google Workspace
+       (enterprise) accounts.  Consumer accounts will receive a clear
+       error message explaining this limitation.
+    """
+
+    SERVICE_NAME = "keep"
+
+    def _check_availability(self) -> Optional[str]:
+        """Return an error message if Keep API is not available, else ``None``."""
+        global _KEEP_API_AVAILABLE
+        if not _KEEP_API_AVAILABLE:
+            return (
+                "Google Keep API bu hesap türü için kullanılamıyor. "
+                "Keep API yalnızca Google Workspace (kurumsal) hesaplarda aktiftir."
+            )
+        return None
+
+    async def list_notes(
+        self,
+        *,
+        max_results: int = 50,
+        filter_str: Optional[str] = None,
+    ) -> list[Note]:
+        """List Google Keep notes.
+
+        Parameters
+        ----------
+        max_results : int
+            Maximum number of notes to return.
+        filter_str : str, optional
+            Filter string (e.g. ``"trashed=false"``).
+        """
+        global _KEEP_API_AVAILABLE
+        try:
+            kwargs: dict[str, Any] = {"pageSize": min(max_results, 100)}
+            if filter_str:
+                kwargs["filter"] = filter_str
+
+            result = self.service.notes().list(**kwargs).execute()
+            items = result.get("notes", [])
+            return [_parse_note(n) for n in items if not n.get("trashed")]
+        except Exception as exc:
+            error_str = str(exc)
+            if "403" in error_str or "not enabled" in error_str.lower():
+                _KEEP_API_AVAILABLE = False
+                logger.warning("Keep API kullanılamıyor: %s", exc)
+                raise RuntimeError(
+                    "Google Keep API bu hesap için aktif değil. "
+                    "Keep API yalnızca Google Workspace hesaplarında çalışır."
+                ) from exc
+            logger.error("Keep notları alınamadı: %s", exc)
+            raise
+
+    async def create_note(
+        self,
+        title: str,
+        body: str,
+    ) -> Note:
+        """Create a new Google Keep note.
+
+        Parameters
+        ----------
+        title : str
+            Note title.
+        body : str
+            Note body text.
+        """
+        global _KEEP_API_AVAILABLE
+        note_body: dict[str, Any] = {
+            "title": title,
+            "body": {
+                "text": {
+                    "text": body,
+                },
+            },
+        }
+        try:
+            result = self.service.notes().create(body=note_body).execute()
+            note = _parse_note(result)
+            logger.info("Not oluşturuldu: %s", title)
+            return note
+        except Exception as exc:
+            error_str = str(exc)
+            if "403" in error_str or "not enabled" in error_str.lower():
+                _KEEP_API_AVAILABLE = False
+            logger.error("Not oluşturma hatası: %s", exc)
+            raise
+
+    async def search_notes(
+        self,
+        query: str,
+        *,
+        max_results: int = 20,
+    ) -> list[Note]:
+        """Search notes by title or body content.
+
+        Parameters
+        ----------
+        query : str
+            Search query (case-insensitive substring match).
+        max_results : int
+            Maximum number of results.
+
+        Note: The Keep API does not support server-side full-text search,
+        so we fetch all notes and filter client-side.
+        """
+        all_notes = await self.list_notes(max_results=200)
+        query_lower = query.lower()
+        matches = [
+            n for n in all_notes
+            if query_lower in n.title.lower() or query_lower in n.body.lower()
+        ]
+        return matches[:max_results]
+
+    # ── Tool handlers ───────────────────────────────────────────
+
+    def _run_async(self, coro: Any) -> Any:
+        """Run an async coroutine from sync context."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    return pool.submit(asyncio.run, coro).result()
+            return loop.run_until_complete(coro)
+        except RuntimeError:
+            return asyncio.run(coro)
+
+    def _list_notes_tool(self, **_kw: Any) -> dict:
+        """Sync tool handler for listing notes."""
+        avail_err = self._check_availability()
+        if avail_err:
+            return self._err(avail_err)
+        try:
+            notes = self._run_async(self.list_notes())
+            return self._ok(
+                notes=[n.to_dict() for n in notes],
+                count=len(notes),
+            )
+        except Exception as exc:
+            return self._err("Notlar alınamadı: %s" % exc)
+
+    def _create_note_tool(self, title: str, body: str, **_kw: Any) -> dict:
+        """Sync tool handler for creating a note."""
+        avail_err = self._check_availability()
+        if avail_err:
+            return self._err(avail_err)
+        try:
+            note = self._run_async(self.create_note(title, body))
+            return self._ok(note=note.to_dict())
+        except Exception as exc:
+            return self._err("Not oluşturma hatası: %s" % exc)
+
+    def _search_notes_tool(self, query: str, **_kw: Any) -> dict:
+        """Sync tool handler for searching notes."""
+        avail_err = self._check_availability()
+        if avail_err:
+            return self._err(avail_err)
+        try:
+            notes = self._run_async(self.search_notes(query))
+            return self._ok(
+                notes=[n.to_dict() for n in notes],
+                count=len(notes),
+            )
+        except Exception as exc:
+            return self._err("Not arama hatası: %s" % exc)
+
+    # ── ToolSchema registration ─────────────────────────────────
+
+    def get_tools(self) -> list[ToolSchema]:
+        """Return tool descriptors for the Keep connector."""
+        return [
+            ToolSchema(
+                name="google.keep.list",
+                description="Google Keep notlarını listele.",
+                parameters={
+                    "type": "object",
+                    "properties": {},
+                },
+                handler=self._list_notes_tool,
+                risk="low",
+            ),
+            ToolSchema(
+                name="google.keep.create",
+                description="Yeni Google Keep notu oluştur.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Not başlığı",
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Not içeriği",
+                        },
+                    },
+                    "required": ["title", "body"],
+                },
+                handler=self._create_note_tool,
+                risk="medium",
+                confirm=True,
+            ),
+            ToolSchema(
+                name="google.keep.search",
+                description="Google Keep notlarında ara.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Arama sorgusu",
+                        },
+                    },
+                    "required": ["query"],
+                },
+                handler=self._search_notes_tool,
+                risk="low",
+            ),
+        ]

--- a/src/bantz/connectors/google/tasks.py
+++ b/src/bantz/connectors/google/tasks.py
@@ -1,0 +1,429 @@
+"""Google Tasks Connector — Tasks API integration.
+
+Issue #1292: Provides list, create, complete, and delete operations
+for Google Tasks via the unified ``GoogleAuthManager``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from bantz.connectors.google.base import GoogleConnector, ToolSchema
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["TasksConnector", "Task", "TaskList"]
+
+
+@dataclass
+class TaskList:
+    """A Google Tasks task list."""
+
+    id: str = ""
+    title: str = ""
+    updated: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "updated": self.updated,
+        }
+
+
+@dataclass
+class Task:
+    """A Google Tasks task."""
+
+    id: str = ""
+    title: str = ""
+    notes: str = ""
+    status: str = ""  # "needsAction" or "completed"
+    due: str = ""  # RFC 3339 date
+    completed: str = ""
+    parent: str = ""
+    position: str = ""
+    updated: str = ""
+    links: list[dict[str, str]] = field(default_factory=list)
+
+    @property
+    def is_completed(self) -> bool:
+        return self.status == "completed"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "notes": self.notes,
+            "status": self.status,
+            "due": self.due,
+            "completed": self.completed,
+            "updated": self.updated,
+            "is_completed": self.is_completed,
+        }
+
+
+def _parse_task(t: dict) -> Task:
+    """Parse a Tasks API task resource into a ``Task``."""
+    return Task(
+        id=t.get("id", ""),
+        title=t.get("title", ""),
+        notes=t.get("notes", ""),
+        status=t.get("status", ""),
+        due=t.get("due", ""),
+        completed=t.get("completed", ""),
+        parent=t.get("parent", ""),
+        position=t.get("position", ""),
+        updated=t.get("updated", ""),
+        links=t.get("links", []),
+    )
+
+
+class TasksConnector(GoogleConnector):
+    """Google Tasks service connector.
+
+    Provides:
+    - ``list_task_lists()`` — list all task lists
+    - ``list_tasks(task_list)`` — list tasks in a task list
+    - ``create_task(title, due, notes, task_list)`` — create a new task
+    - ``complete_task(task_id, task_list)`` — mark a task as completed
+    - ``delete_task(task_id, task_list)`` — delete a task
+    """
+
+    SERVICE_NAME = "tasks"
+
+    async def list_task_lists(self) -> list[TaskList]:
+        """List all task lists for the user."""
+        try:
+            result = self.service.tasklists().list(maxResults=100).execute()
+            items = result.get("items", [])
+            return [
+                TaskList(
+                    id=item.get("id", ""),
+                    title=item.get("title", ""),
+                    updated=item.get("updated", ""),
+                )
+                for item in items
+            ]
+        except Exception as exc:
+            logger.error("Görev listeleri alınamadı: %s", exc)
+            raise
+
+    async def list_tasks(
+        self,
+        task_list: str = "@default",
+        *,
+        show_completed: bool = False,
+        max_results: int = 100,
+    ) -> list[Task]:
+        """List tasks in a task list.
+
+        Parameters
+        ----------
+        task_list : str
+            Task list ID or ``"@default"`` for the primary list.
+        show_completed : bool
+            Whether to include completed tasks.
+        max_results : int
+            Maximum number of tasks to return.
+        """
+        try:
+            result = (
+                self.service.tasks()
+                .list(
+                    tasklist=task_list,
+                    showCompleted=show_completed,
+                    maxResults=min(max_results, 100),
+                )
+                .execute()
+            )
+            items = result.get("items", [])
+            return [_parse_task(t) for t in items]
+        except Exception as exc:
+            logger.error("Görevler alınamadı: %s", exc)
+            raise
+
+    async def create_task(
+        self,
+        title: str,
+        *,
+        due: Optional[str] = None,
+        notes: Optional[str] = None,
+        task_list: str = "@default",
+    ) -> Task:
+        """Create a new task.
+
+        Parameters
+        ----------
+        title : str
+            Task title.
+        due : str, optional
+            Due date in RFC 3339 format (e.g. ``"2025-01-15T00:00:00Z"``).
+        notes : str, optional
+            Additional notes.
+        task_list : str
+            Task list ID.
+        """
+        body: dict[str, Any] = {"title": title}
+        if due:
+            body["due"] = due
+        if notes:
+            body["notes"] = notes
+
+        try:
+            result = (
+                self.service.tasks()
+                .insert(tasklist=task_list, body=body)
+                .execute()
+            )
+            task = _parse_task(result)
+            logger.info("Görev oluşturuldu: %s", title)
+            return task
+        except Exception as exc:
+            logger.error("Görev oluşturma hatası: %s", exc)
+            raise
+
+    async def complete_task(
+        self,
+        task_id: str,
+        *,
+        task_list: str = "@default",
+    ) -> Task:
+        """Mark a task as completed.
+
+        Parameters
+        ----------
+        task_id : str
+            The task ID.
+        task_list : str
+            Task list ID.
+        """
+        try:
+            # First get the task
+            task_data = (
+                self.service.tasks()
+                .get(tasklist=task_list, task=task_id)
+                .execute()
+            )
+            task_data["status"] = "completed"
+            result = (
+                self.service.tasks()
+                .update(tasklist=task_list, task=task_id, body=task_data)
+                .execute()
+            )
+            task = _parse_task(result)
+            logger.info("Görev tamamlandı: %s", task.title)
+            return task
+        except Exception as exc:
+            logger.error("Görev tamamlama hatası: %s", exc)
+            raise
+
+    async def delete_task(
+        self,
+        task_id: str,
+        *,
+        task_list: str = "@default",
+    ) -> bool:
+        """Delete a task.
+
+        Parameters
+        ----------
+        task_id : str
+            The task ID.
+        task_list : str
+            Task list ID.
+
+        Returns
+        -------
+        bool
+            ``True`` if deleted successfully.
+        """
+        try:
+            self.service.tasks().delete(
+                tasklist=task_list, task=task_id
+            ).execute()
+            logger.info("Görev silindi: %s", task_id)
+            return True
+        except Exception as exc:
+            logger.error("Görev silme hatası: %s", exc)
+            raise
+
+    # ── Tool handlers (sync wrappers) ───────────────────────────
+
+    def _run_async(self, coro: Any) -> Any:
+        """Run an async coroutine from sync context."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    return pool.submit(asyncio.run, coro).result()
+            return loop.run_until_complete(coro)
+        except RuntimeError:
+            return asyncio.run(coro)
+
+    def _list_tasks_tool(
+        self,
+        task_list: str = "@default",
+        show_completed: bool = False,
+        **_kw: Any,
+    ) -> dict:
+        """Sync tool handler for listing tasks."""
+        try:
+            tasks = self._run_async(
+                self.list_tasks(task_list, show_completed=show_completed)
+            )
+            return self._ok(
+                tasks=[t.to_dict() for t in tasks],
+                count=len(tasks),
+            )
+        except Exception as exc:
+            return self._err("Görevler alınamadı: %s" % exc)
+
+    def _create_task_tool(
+        self,
+        title: str,
+        due: Optional[str] = None,
+        notes: Optional[str] = None,
+        task_list: str = "@default",
+        **_kw: Any,
+    ) -> dict:
+        """Sync tool handler for creating a task."""
+        try:
+            task = self._run_async(
+                self.create_task(title, due=due, notes=notes, task_list=task_list)
+            )
+            return self._ok(task=task.to_dict())
+        except Exception as exc:
+            return self._err("Görev oluşturma hatası: %s" % exc)
+
+    def _complete_task_tool(
+        self,
+        task_id: str,
+        task_list: str = "@default",
+        **_kw: Any,
+    ) -> dict:
+        """Sync tool handler for completing a task."""
+        try:
+            task = self._run_async(
+                self.complete_task(task_id, task_list=task_list)
+            )
+            return self._ok(task=task.to_dict())
+        except Exception as exc:
+            return self._err("Görev tamamlama hatası: %s" % exc)
+
+    def _delete_task_tool(
+        self,
+        task_id: str,
+        task_list: str = "@default",
+        **_kw: Any,
+    ) -> dict:
+        """Sync tool handler for deleting a task."""
+        try:
+            self._run_async(
+                self.delete_task(task_id, task_list=task_list)
+            )
+            return self._ok(message="Görev silindi")
+        except Exception as exc:
+            return self._err("Görev silme hatası: %s" % exc)
+
+    # ── ToolSchema registration ─────────────────────────────────
+
+    def get_tools(self) -> list[ToolSchema]:
+        """Return tool descriptors for the tasks connector."""
+        return [
+            ToolSchema(
+                name="google.tasks.list",
+                description="Google Tasks görevlerini listele.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "task_list": {
+                            "type": "string",
+                            "description": "Görev listesi ID (varsayılan: @default)",
+                        },
+                        "show_completed": {
+                            "type": "boolean",
+                            "description": "Tamamlanan görevleri de göster",
+                        },
+                    },
+                },
+                handler=self._list_tasks_tool,
+                risk="low",
+            ),
+            ToolSchema(
+                name="google.tasks.create",
+                description="Yeni Google Tasks görevi oluştur.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Görev başlığı",
+                        },
+                        "due": {
+                            "type": "string",
+                            "description": "Bitiş tarihi (YYYY-MM-DDT00:00:00Z)",
+                        },
+                        "notes": {
+                            "type": "string",
+                            "description": "Ek notlar (opsiyonel)",
+                        },
+                        "task_list": {
+                            "type": "string",
+                            "description": "Görev listesi ID (varsayılan: @default)",
+                        },
+                    },
+                    "required": ["title"],
+                },
+                handler=self._create_task_tool,
+                risk="medium",
+                confirm=True,
+            ),
+            ToolSchema(
+                name="google.tasks.complete",
+                description="Google Tasks görevini tamamlandı olarak işaretle.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "task_id": {
+                            "type": "string",
+                            "description": "Görev ID",
+                        },
+                        "task_list": {
+                            "type": "string",
+                            "description": "Görev listesi ID (varsayılan: @default)",
+                        },
+                    },
+                    "required": ["task_id"],
+                },
+                handler=self._complete_task_tool,
+                risk="medium",
+                confirm=True,
+            ),
+            ToolSchema(
+                name="google.tasks.delete",
+                description="Google Tasks görevini sil.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "task_id": {
+                            "type": "string",
+                            "description": "Görev ID",
+                        },
+                        "task_list": {
+                            "type": "string",
+                            "description": "Görev listesi ID (varsayılan: @default)",
+                        },
+                    },
+                    "required": ["task_id"],
+                },
+                handler=self._delete_task_tool,
+                risk="high",
+                confirm=True,
+            ),
+        ]

--- a/src/bantz/google/consent_wizard.py
+++ b/src/bantz/google/consent_wizard.py
@@ -133,11 +133,48 @@ _SERVICE_REGISTRY: list[ServiceDefinition] = [
         default_token_path="~/.config/bantz/google/token.json",
         auth_module="bantz.google.auth",
     ),
+    # ── Issue #1292: New Google Suite connectors ──────────────
+    ServiceDefinition(
+        id="tasks",
+        name="Google Tasks",
+        icon="✅",
+        description_tr="Görev oluşturma, listeleme ve tamamlama",
+        scopes=[
+            "https://www.googleapis.com/auth/tasks",
+        ],
+        permissions_tr=[
+            "Görevlerinizi okuma ve listeleme",
+            "Yeni görev oluşturma",
+            "Görev tamamlama ve silme",
+        ],
+        token_path_key="BANTZ_GOOGLE_UNIFIED_TOKEN_PATH",
+        default_token_path="~/.config/bantz/google/google_unified_token.json",
+        auth_module="bantz.connectors.google.auth_manager",
+    ),
+    ServiceDefinition(
+        id="classroom",
+        name="Google Classroom",
+        icon="🎓",
+        description_tr="Ders, ödev ve teslim durumu takibi",
+        scopes=[
+            "https://www.googleapis.com/auth/classroom.courses.readonly",
+            "https://www.googleapis.com/auth/classroom.coursework.me",
+        ],
+        permissions_tr=[
+            "Derslerinizi görüntüleme",
+            "Ödev listesini okuma",
+            "Teslim durumlarınızı kontrol etme",
+        ],
+        token_path_key="BANTZ_GOOGLE_UNIFIED_TOKEN_PATH",
+        default_token_path="~/.config/bantz/google/google_unified_token.json",
+        auth_module="bantz.connectors.google.auth_manager",
+        optional=True,
+    ),
 ]
 
 # Future services (shown as "coming soon")
 _FUTURE_SERVICES: list[dict[str, str]] = [
-    {"id": "classroom", "name": "Google Classroom", "icon": "🎓", "desc": "Ödev kontrolü + deadline takibi"},
+    {"id": "keep", "name": "Google Keep", "icon": "📝", "desc": "Not oluşturma ve arama (Workspace hesabı gerekir)"},
     {"id": "drive", "name": "Google Drive", "icon": "📁", "desc": "Dosya arama ve paylaşım"},
     {"id": "whatsapp", "name": "WhatsApp", "icon": "💬", "desc": "Mesaj gönderme ve okuma"},
     {"id": "youtube", "name": "YouTube", "icon": "🎬", "desc": "Video arama ve özetleme"},

--- a/src/bantz/tools/register_all.py
+++ b/src/bantz/tools/register_all.py
@@ -14,7 +14,7 @@ Usage
 from __future__ import annotations
 
 import logging
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from bantz.agent.tools import ToolRegistry
@@ -41,6 +41,7 @@ def register_all_tools(registry: "ToolRegistry") -> int:
     count += _register_calendar(registry)
     count += _register_system(registry)
     count += _register_time(registry)
+    count += _register_google_connectors(registry)
     logger.info(f"[ToolGap] Total tools registered: {count}")
     return count
 
@@ -107,12 +108,17 @@ def _register_web(registry: "ToolRegistry") -> int:
 
 def _register_browser(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.browser_tools import (
-            browser_open_tool, browser_scan_tool, browser_click_tool,
-            browser_type_tool, browser_back_tool, browser_info_tool,
-            browser_detail_tool, browser_wait_tool, browser_search_tool,
-            browser_scroll_down_tool, browser_scroll_up_tool,
-        )
+        from bantz.tools.browser_tools import (browser_back_tool,
+                                               browser_click_tool,
+                                               browser_detail_tool,
+                                               browser_info_tool,
+                                               browser_open_tool,
+                                               browser_scan_tool,
+                                               browser_scroll_down_tool,
+                                               browser_scroll_up_tool,
+                                               browser_search_tool,
+                                               browser_type_tool,
+                                               browser_wait_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] browser import: {e}")
         return 0
@@ -163,10 +169,11 @@ def _register_browser(registry: "ToolRegistry") -> int:
 
 def _register_pc(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.pc_tools import (
-            pc_hotkey_tool, pc_type_tool, pc_mouse_move_tool, pc_mouse_click_tool,
-            pc_mouse_scroll_tool, clipboard_set_tool, clipboard_get_tool,
-        )
+        from bantz.tools.pc_tools import (clipboard_get_tool,
+                                          clipboard_set_tool, pc_hotkey_tool,
+                                          pc_mouse_click_tool,
+                                          pc_mouse_move_tool,
+                                          pc_mouse_scroll_tool, pc_type_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] pc import: {e}")
         return 0
@@ -200,10 +207,9 @@ def _register_pc(registry: "ToolRegistry") -> int:
 
 def _register_file(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.file_tools import (
-            file_read_tool, file_write_tool, file_edit_tool,
-            file_create_tool, file_undo_tool, file_search_tool,
-        )
+        from bantz.tools.file_tools import (file_create_tool, file_edit_tool,
+                                            file_read_tool, file_search_tool,
+                                            file_undo_tool, file_write_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] file import: {e}")
         return 0
@@ -242,10 +248,10 @@ def _register_file(registry: "ToolRegistry") -> int:
 
 def _register_terminal(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.terminal_tools import (
-            terminal_run_tool, terminal_background_tool,
-            terminal_background_list_tool, terminal_background_kill_tool,
-        )
+        from bantz.tools.terminal_tools import (terminal_background_kill_tool,
+                                                terminal_background_list_tool,
+                                                terminal_background_tool,
+                                                terminal_run_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] terminal import: {e}")
         return 0
@@ -271,11 +277,12 @@ def _register_terminal(registry: "ToolRegistry") -> int:
 
 def _register_code(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.code_tools import (
-            code_format_tool, code_replace_function_tool,
-            project_info_tool, project_tree_tool,
-            project_symbols_tool, project_search_symbol_tool,
-        )
+        from bantz.tools.code_tools import (code_format_tool,
+                                            code_replace_function_tool,
+                                            project_info_tool,
+                                            project_search_symbol_tool,
+                                            project_symbols_tool,
+                                            project_tree_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] code import: {e}")
         return 0
@@ -310,11 +317,12 @@ def _register_code(registry: "ToolRegistry") -> int:
 
 def _register_gmail(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.gmail_tools import (
-            gmail_unread_count_tool, gmail_list_messages_tool,
-            gmail_get_message_tool, gmail_send_tool,
-            gmail_smart_search_tool, gmail_list_categories_tool,
-        )
+        from bantz.tools.gmail_tools import (gmail_get_message_tool,
+                                             gmail_list_categories_tool,
+                                             gmail_list_messages_tool,
+                                             gmail_send_tool,
+                                             gmail_smart_search_tool,
+                                             gmail_unread_count_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] gmail import: {e}")
         return 0
@@ -349,14 +357,13 @@ def _register_gmail(registry: "ToolRegistry") -> int:
 def _register_gmail_extended(registry: "ToolRegistry") -> int:
     try:
         from bantz.tools.gmail_extended_tools import (
-            gmail_list_labels_tool, gmail_add_label_tool,
-            gmail_remove_label_tool, gmail_mark_read_tool,
-            gmail_mark_unread_tool, gmail_archive_tool,
-            gmail_batch_modify_tool, gmail_download_attachment_tool,
-            gmail_create_draft_tool, gmail_list_drafts_tool,
-            gmail_update_draft_tool, gmail_send_draft_tool,
-            gmail_delete_draft_tool, gmail_generate_reply_tool,
-        )
+            gmail_add_label_tool, gmail_archive_tool, gmail_batch_modify_tool,
+            gmail_create_draft_tool, gmail_delete_draft_tool,
+            gmail_download_attachment_tool, gmail_generate_reply_tool,
+            gmail_list_drafts_tool, gmail_list_labels_tool,
+            gmail_mark_read_tool, gmail_mark_unread_tool,
+            gmail_remove_label_tool, gmail_send_draft_tool,
+            gmail_update_draft_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] gmail_extended import: {e}")
         return 0
@@ -421,10 +428,10 @@ def _register_gmail_extended(registry: "ToolRegistry") -> int:
 
 def _register_contacts(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.contacts_tools import (
-            contacts_search_tool, contacts_get_tool,
-            contacts_list_tool, contacts_add_tool,
-        )
+        from bantz.tools.contacts_tools import (contacts_add_tool,
+                                                contacts_get_tool,
+                                                contacts_list_tool,
+                                                contacts_search_tool)
     except ImportError as e:
         logger.warning(f"[ToolGap] contacts import: {e}")
         return 0
@@ -462,12 +469,10 @@ def _register_coding_skill(registry: "ToolRegistry") -> int:
 
 def _register_calendar(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.calendar_tools import (
-            calendar_list_events_tool,
-            calendar_create_event_tool,
-            calendar_update_event_tool,
-            calendar_delete_event_tool,
-        )
+        from bantz.tools.calendar_tools import (calendar_create_event_tool,
+                                                calendar_delete_event_tool,
+                                                calendar_list_events_tool,
+                                                calendar_update_event_tool)
     except ImportError:
         return 0
 
@@ -506,11 +511,9 @@ def _register_calendar(registry: "ToolRegistry") -> int:
 
 def _register_system(registry: "ToolRegistry") -> int:
     try:
-        from bantz.tools.system_tools import (
-            system_status,
-            system_notify_tool,
-            system_screenshot_tool,
-        )
+        from bantz.tools.system_tools import (system_notify_tool,
+                                              system_screenshot_tool,
+                                              system_status)
     except ImportError:
         return 0
 
@@ -538,4 +541,106 @@ def _register_time(registry: "ToolRegistry") -> int:
     n += _reg(registry, "time.now", "Get current date and time.",
               _obj(("timezone", "string", "Timezone (default: local)")),
               time_now_tool)
+    return n
+
+
+# ── Google Suite Connectors (Issue #1292) ────────────────────────
+
+def _register_google_connectors(registry: "ToolRegistry") -> int:
+    """Register tools from all Google Suite connectors.
+
+    Uses the unified ``GoogleAuthManager`` to provide Contacts, Tasks,
+    Keep, and Classroom tools.  Fails gracefully if the auth manager
+    or dependencies are not available.
+    """
+    try:
+        from bantz.connectors.google.auth_manager import (get_auth_manager,
+                                                          setup_auth_manager)
+    except ImportError as e:
+        logger.warning("[ToolGap] google connectors import: %s", e)
+        return 0
+
+    # Get or create the auth manager (non-interactive for tool registration)
+    auth = get_auth_manager()
+    if auth is None:
+        try:
+            auth = setup_auth_manager(interactive=False)
+        except Exception as e:
+            logger.warning("[ToolGap] google auth manager setup: %s", e)
+            return 0
+
+    n = 0
+
+    # ── Contacts ────────────────────────────────────────────────
+    try:
+        from bantz.connectors.google.contacts import ContactsConnector
+
+        connector = ContactsConnector(auth)
+        for tool_schema in connector.get_tools():
+            n += _reg(
+                registry,
+                tool_schema.name,
+                tool_schema.description,
+                tool_schema.parameters,
+                tool_schema.handler,
+                risk=tool_schema.risk,
+                confirm=tool_schema.confirm,
+            )
+    except Exception as e:
+        logger.warning("[ToolGap] google contacts connector: %s", e)
+
+    # ── Tasks ───────────────────────────────────────────────────
+    try:
+        from bantz.connectors.google.tasks import TasksConnector
+
+        connector = TasksConnector(auth)
+        for tool_schema in connector.get_tools():
+            n += _reg(
+                registry,
+                tool_schema.name,
+                tool_schema.description,
+                tool_schema.parameters,
+                tool_schema.handler,
+                risk=tool_schema.risk,
+                confirm=tool_schema.confirm,
+            )
+    except Exception as e:
+        logger.warning("[ToolGap] google tasks connector: %s", e)
+
+    # ── Keep ────────────────────────────────────────────────────
+    try:
+        from bantz.connectors.google.keep import KeepConnector
+
+        connector = KeepConnector(auth)
+        for tool_schema in connector.get_tools():
+            n += _reg(
+                registry,
+                tool_schema.name,
+                tool_schema.description,
+                tool_schema.parameters,
+                tool_schema.handler,
+                risk=tool_schema.risk,
+                confirm=tool_schema.confirm,
+            )
+    except Exception as e:
+        logger.warning("[ToolGap] google keep connector: %s", e)
+
+    # ── Classroom ───────────────────────────────────────────────
+    try:
+        from bantz.connectors.google.classroom import ClassroomConnector
+
+        connector = ClassroomConnector(auth)
+        for tool_schema in connector.get_tools():
+            n += _reg(
+                registry,
+                tool_schema.name,
+                tool_schema.description,
+                tool_schema.parameters,
+                tool_schema.handler,
+                risk=tool_schema.risk,
+                confirm=tool_schema.confirm,
+            )
+    except Exception as e:
+        logger.warning("[ToolGap] google classroom connector: %s", e)
+
     return n

--- a/tests/test_issue_1292_google_suite.py
+++ b/tests/test_issue_1292_google_suite.py
@@ -1,0 +1,829 @@
+"""Tests for Issue #1292 — Google Suite Super-Connector.
+
+Tests cover:
+- GoogleAuthManager (unified token, scope management, migration)
+- GoogleConnector base class
+- ContactsConnector, TasksConnector, KeepConnector, ClassroomConnector
+- GoogleEntityLinker (cross-service linking)
+- Tool registration via register_all.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ═══════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def tmp_token_dir(tmp_path: Path):
+    """Create a temp directory for token files."""
+    token_dir = tmp_path / "google"
+    token_dir.mkdir()
+    return token_dir
+
+
+@pytest.fixture
+def mock_credentials():
+    """Create a mock Google OAuth Credentials object."""
+    creds = MagicMock()
+    creds.scopes = [
+        "https://www.googleapis.com/auth/calendar",
+        "https://www.googleapis.com/auth/gmail.modify",
+    ]
+    creds.expired = False
+    creds.valid = True
+    creds.refresh_token = "fake-refresh-token"
+    creds.to_json.return_value = json.dumps({
+        "token": "fake-token",
+        "refresh_token": "fake-refresh-token",
+        "scopes": creds.scopes,
+    })
+    creds.has_scopes = MagicMock(return_value=True)
+    return creds
+
+
+@pytest.fixture
+def mock_google_deps(mock_credentials):
+    """Patch Google API imports."""
+    mock_request = MagicMock()
+    mock_creds_cls = MagicMock()
+    mock_creds_cls.from_authorized_user_file.return_value = mock_credentials
+    mock_flow = MagicMock()
+    mock_build = MagicMock()
+
+    with patch(
+        "bantz.connectors.google.auth_manager._import_google_deps",
+        return_value=(mock_request, mock_creds_cls, mock_flow, mock_build),
+    ):
+        yield {
+            "Request": mock_request,
+            "Credentials": mock_creds_cls,
+            "InstalledAppFlow": mock_flow,
+            "build": mock_build,
+        }
+
+
+@pytest.fixture
+def auth_manager(tmp_token_dir, mock_google_deps, mock_credentials):
+    """Create a GoogleAuthManager with temp paths and mocked deps."""
+    from bantz.connectors.google.auth_manager import GoogleAuthManager
+
+    token_path = str(tmp_token_dir / "google_unified_token.json")
+    secret_path = str(tmp_token_dir / "client_secret.json")
+
+    # Write a fake client secret
+    (tmp_token_dir / "client_secret.json").write_text(
+        json.dumps({"installed": {"client_id": "fake", "client_secret": "fake"}}),
+        encoding="utf-8",
+    )
+
+    # Write a fake token
+    Path(token_path).write_text(mock_credentials.to_json(), encoding="utf-8")
+
+    mgr = GoogleAuthManager(
+        token_path=token_path,
+        client_secret_path=secret_path,
+        interactive=False,
+    )
+    return mgr
+
+
+# ═══════════════════════════════════════════════════════════════════
+# GoogleAuthManager tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestGoogleAuthManager:
+    """Tests for the unified GoogleAuthManager."""
+
+    def test_scope_registry_contains_all_services(self):
+        from bantz.connectors.google.auth_manager import SCOPE_REGISTRY
+
+        expected_services = {"gmail", "calendar", "contacts", "tasks", "keep", "classroom"}
+        assert set(SCOPE_REGISTRY.keys()) == expected_services
+
+    def test_service_map_matches_scope_registry(self):
+        from bantz.connectors.google.auth_manager import (SCOPE_REGISTRY,
+                                                          SERVICE_MAP)
+
+        assert set(SERVICE_MAP.keys()) == set(SCOPE_REGISTRY.keys())
+
+    def test_ensure_scope_known_service(self, auth_manager):
+        creds = auth_manager.ensure_scope("calendar")
+        assert creds is not None
+
+    def test_ensure_scope_unknown_service_raises(self, auth_manager):
+        with pytest.raises(ValueError, match="Bilinmeyen Google servisi"):
+            auth_manager.ensure_scope("nonexistent")
+
+    def test_get_service_returns_cached(self, auth_manager, mock_google_deps):
+        svc1 = auth_manager.get_service("calendar")
+        svc2 = auth_manager.get_service("calendar")
+        # build() should only be called once
+        assert mock_google_deps["build"].call_count == 1
+        assert svc1 is svc2
+
+    def test_invalidate_cache_specific(self, auth_manager, mock_google_deps):
+        auth_manager.get_service("calendar")
+        auth_manager.invalidate_cache("calendar")
+        auth_manager.get_service("calendar")
+        assert mock_google_deps["build"].call_count == 2
+
+    def test_invalidate_cache_all(self, auth_manager, mock_google_deps):
+        auth_manager.get_service("calendar")
+        auth_manager.invalidate_cache()
+        auth_manager.get_service("calendar")
+        assert mock_google_deps["build"].call_count == 2
+
+    def test_current_scopes(self, auth_manager):
+        scopes = auth_manager.current_scopes()
+        assert isinstance(scopes, list)
+
+    def test_connected_services(self, auth_manager):
+        services = auth_manager.connected_services()
+        assert isinstance(services, list)
+
+    def test_effective_scopes_expands_implied(self, auth_manager):
+        granted = ["https://www.googleapis.com/auth/gmail.modify"]
+        effective = auth_manager._effective_scopes(granted)
+        assert "https://www.googleapis.com/auth/gmail.readonly" in effective
+        assert "https://www.googleapis.com/auth/gmail.send" in effective
+
+    def test_effective_scopes_calendar(self, auth_manager):
+        granted = ["https://www.googleapis.com/auth/calendar"]
+        effective = auth_manager._effective_scopes(granted)
+        assert "https://www.googleapis.com/auth/calendar.readonly" in effective
+        assert "https://www.googleapis.com/auth/calendar.events" in effective
+
+    def test_effective_scopes_empty(self, auth_manager):
+        effective = auth_manager._effective_scopes(None)
+        assert effective == set()
+
+    def test_get_credentials_bridge(self, auth_manager):
+        creds = auth_manager.get_credentials(
+            scopes=["https://www.googleapis.com/auth/calendar"]
+        )
+        assert creds is not None
+
+    def test_expand_scopes_non_interactive_raises(self, auth_manager):
+        # Force credentials to None so a scope expansion is needed
+        auth_manager._credentials = None
+        auth_manager._load_credentials = MagicMock()  # prevent file load
+
+        with pytest.raises(RuntimeError, match="yetkilendirmesi gerekli"):
+            auth_manager._expand_scopes(["https://www.googleapis.com/auth/tasks"])
+
+    def test_save_token_atomic(self, auth_manager, mock_credentials):
+        auth_manager._credentials = mock_credentials
+        auth_manager._save_token()
+        assert auth_manager.token_path.exists()
+        content = json.loads(auth_manager.token_path.read_text(encoding="utf-8"))
+        assert "token" in content
+
+    def test_migrate_legacy_no_files(self, auth_manager):
+        result = auth_manager.migrate_legacy_tokens()
+        # Both files likely don't exist at the temp path
+        assert isinstance(result, dict)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Singleton tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestSingleton:
+    """Tests for the auth manager singleton pattern."""
+
+    def test_setup_and_get(self, tmp_token_dir, mock_google_deps):
+        import bantz.connectors.google.auth_manager as mod
+        from bantz.connectors.google.auth_manager import (get_auth_manager,
+                                                          setup_auth_manager)
+
+        # Save and restore singleton
+        prev = mod._auth_manager
+        try:
+            mod._auth_manager = None
+
+            mgr = setup_auth_manager(
+                token_path=str(tmp_token_dir / "test_token.json"),
+                client_secret_path=str(tmp_token_dir / "test_secret.json"),
+                interactive=False,
+            )
+            assert mgr is not None
+            assert get_auth_manager() is mgr
+        finally:
+            mod._auth_manager = prev
+
+
+# ═══════════════════════════════════════════════════════════════════
+# GoogleConnector base tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestGoogleConnectorBase:
+    """Tests for the GoogleConnector abstract base class."""
+
+    def test_service_name_required(self, auth_manager):
+        from bantz.connectors.google.base import GoogleConnector
+
+        class BadConnector(GoogleConnector):
+            def get_tools(self):
+                return []
+
+        with pytest.raises(NotImplementedError, match="SERVICE_NAME"):
+            BadConnector(auth_manager)
+
+    def test_ok_helper(self, auth_manager):
+        from bantz.connectors.google.contacts import ContactsConnector
+
+        c = ContactsConnector(auth_manager)
+        result = c._ok(foo="bar")
+        assert result == {"ok": True, "foo": "bar"}
+
+    def test_err_helper(self, auth_manager):
+        from bantz.connectors.google.contacts import ContactsConnector
+
+        c = ContactsConnector(auth_manager)
+        result = c._err("something failed")
+        assert result == {"ok": False, "error": "something failed"}
+
+
+# ═══════════════════════════════════════════════════════════════════
+# ContactsConnector tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestContactsConnector:
+    """Tests for the Google Contacts connector."""
+
+    def test_parse_person(self):
+        from bantz.connectors.google.contacts import _parse_person
+
+        person = {
+            "resourceName": "people/c123",
+            "names": [{"displayName": "Ali Yılmaz", "givenName": "Ali", "familyName": "Yılmaz"}],
+            "emailAddresses": [{"value": "ali@example.com"}],
+            "phoneNumbers": [{"value": "+905551234567"}],
+            "organizations": [{"name": "Bantz Inc"}],
+            "photos": [{"url": "https://photo.example.com/ali"}],
+        }
+        contact = _parse_person(person)
+        assert contact.display_name == "Ali Yılmaz"
+        assert contact.primary_email == "ali@example.com"
+        assert contact.phones == ["+905551234567"]
+        assert contact.organization == "Bantz Inc"
+
+    def test_parse_person_empty(self):
+        from bantz.connectors.google.contacts import _parse_person
+
+        contact = _parse_person({})
+        assert contact.display_name == ""
+        assert contact.emails == []
+        assert contact.resource_name == ""
+
+    def test_contact_to_dict(self):
+        from bantz.connectors.google.contacts import Contact
+
+        c = Contact(display_name="Test", emails=["test@test.com"])
+        d = c.to_dict()
+        assert d["display_name"] == "Test"
+        assert d["emails"] == ["test@test.com"]
+
+    def test_get_tools_returns_three(self, auth_manager):
+        from bantz.connectors.google.contacts import ContactsConnector
+
+        c = ContactsConnector(auth_manager)
+        tools = c.get_tools()
+        assert len(tools) == 3
+        names = {t.name for t in tools}
+        assert "google.contacts.search" in names
+        assert "google.contacts.get" in names
+        assert "google.contacts.create" in names
+
+    def test_format_birthday_full(self):
+        from bantz.connectors.google.contacts import _format_birthday
+
+        assert _format_birthday({"year": 1990, "month": 5, "day": 15}) == "1990-05-15"
+
+    def test_format_birthday_month_day(self):
+        from bantz.connectors.google.contacts import _format_birthday
+
+        assert _format_birthday({"month": 12, "day": 25}) == "12-25"
+
+    def test_format_birthday_empty(self):
+        from bantz.connectors.google.contacts import _format_birthday
+
+        assert _format_birthday({}) == ""
+
+
+# ═══════════════════════════════════════════════════════════════════
+# TasksConnector tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestTasksConnector:
+    """Tests for the Google Tasks connector."""
+
+    def test_parse_task(self):
+        from bantz.connectors.google.tasks import _parse_task
+
+        t = _parse_task({
+            "id": "task123",
+            "title": "Rapor hazırla",
+            "status": "needsAction",
+            "due": "2025-01-15T00:00:00Z",
+            "notes": "Acil",
+        })
+        assert t.id == "task123"
+        assert t.title == "Rapor hazırla"
+        assert not t.is_completed
+
+    def test_task_completed(self):
+        from bantz.connectors.google.tasks import Task
+
+        t = Task(status="completed")
+        assert t.is_completed
+
+    def test_task_to_dict(self):
+        from bantz.connectors.google.tasks import Task
+
+        t = Task(id="t1", title="Test", status="needsAction")
+        d = t.to_dict()
+        assert d["id"] == "t1"
+        assert d["is_completed"] is False
+
+    def test_task_list_to_dict(self):
+        from bantz.connectors.google.tasks import TaskList
+
+        tl = TaskList(id="list1", title="My Tasks")
+        d = tl.to_dict()
+        assert d["id"] == "list1"
+        assert d["title"] == "My Tasks"
+
+    def test_get_tools_returns_four(self, auth_manager):
+        from bantz.connectors.google.tasks import TasksConnector
+
+        c = TasksConnector(auth_manager)
+        tools = c.get_tools()
+        assert len(tools) == 4
+        names = {t.name for t in tools}
+        assert "google.tasks.list" in names
+        assert "google.tasks.create" in names
+        assert "google.tasks.complete" in names
+        assert "google.tasks.delete" in names
+
+
+# ═══════════════════════════════════════════════════════════════════
+# KeepConnector tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestKeepConnector:
+    """Tests for the Google Keep connector."""
+
+    def test_parse_note_text(self):
+        from bantz.connectors.google.keep import _parse_note
+
+        note = _parse_note({
+            "name": "notes/abc123",
+            "title": "Alışveriş Listesi",
+            "body": {"text": {"text": "Süt, yumurta, ekmek"}},
+        })
+        assert note.name == "notes/abc123"
+        assert note.title == "Alışveriş Listesi"
+        assert note.body == "Süt, yumurta, ekmek"
+
+    def test_parse_note_list(self):
+        from bantz.connectors.google.keep import _parse_note
+
+        note = _parse_note({
+            "name": "notes/list1",
+            "title": "Yapılacaklar",
+            "body": {
+                "list": {
+                    "listItems": [
+                        {"text": {"text": "Süt al"}, "checked": False},
+                        {"text": {"text": "Yumurta al"}, "checked": True},
+                    ]
+                }
+            },
+        })
+        assert "☐ Süt al" in note.body
+        assert "☑ Yumurta al" in note.body
+
+    def test_parse_note_empty(self):
+        from bantz.connectors.google.keep import _parse_note
+
+        note = _parse_note({})
+        assert note.name == ""
+        assert note.body == ""
+
+    def test_note_to_dict(self):
+        from bantz.connectors.google.keep import Note
+
+        n = Note(name="notes/1", title="Test", body="Content")
+        d = n.to_dict()
+        assert d["name"] == "notes/1"
+        assert d["title"] == "Test"
+
+    def test_get_tools_returns_three(self, auth_manager):
+        from bantz.connectors.google.keep import KeepConnector
+
+        c = KeepConnector(auth_manager)
+        tools = c.get_tools()
+        assert len(tools) == 3
+        names = {t.name for t in tools}
+        assert "google.keep.list" in names
+        assert "google.keep.create" in names
+        assert "google.keep.search" in names
+
+    def test_check_availability_when_unavailable(self, auth_manager):
+        import bantz.connectors.google.keep as keep_mod
+        from bantz.connectors.google.keep import KeepConnector
+
+        c = KeepConnector(auth_manager)
+        # Simulate API unavailable
+        prev = keep_mod._KEEP_API_AVAILABLE
+        try:
+            keep_mod._KEEP_API_AVAILABLE = False
+            err = c._check_availability()
+            assert err is not None
+            assert "Workspace" in err
+        finally:
+            keep_mod._KEEP_API_AVAILABLE = prev
+
+
+# ═══════════════════════════════════════════════════════════════════
+# ClassroomConnector tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestClassroomConnector:
+    """Tests for the Google Classroom connector."""
+
+    def test_parse_due_full(self):
+        from bantz.connectors.google.classroom import _parse_due
+
+        date_str, time_str = _parse_due(
+            {"year": 2025, "month": 3, "day": 15},
+            {"hours": 23, "minutes": 59},
+        )
+        assert date_str == "2025-03-15"
+        assert time_str == "23:59"
+
+    def test_parse_due_no_time(self):
+        from bantz.connectors.google.classroom import _parse_due
+
+        date_str, time_str = _parse_due(
+            {"year": 2025, "month": 1, "day": 1},
+            None,
+        )
+        assert date_str == "2025-01-01"
+        assert time_str == ""
+
+    def test_parse_due_empty(self):
+        from bantz.connectors.google.classroom import _parse_due
+
+        date_str, time_str = _parse_due(None, None)
+        assert date_str == ""
+        assert time_str == ""
+
+    def test_course_to_dict(self):
+        from bantz.connectors.google.classroom import Course
+
+        c = Course(id="c1", name="Matematik", state="ACTIVE")
+        d = c.to_dict()
+        assert d["id"] == "c1"
+        assert d["name"] == "Matematik"
+
+    def test_assignment_due_display(self):
+        from bantz.connectors.google.classroom import Assignment
+
+        a = Assignment(due_date="2025-03-15", due_time="23:59")
+        assert a.due_display == "2025-03-15 23:59"
+
+        a2 = Assignment(due_date="2025-03-15")
+        assert a2.due_display == "2025-03-15"
+
+        a3 = Assignment()
+        assert a3.due_display == "Tarih yok"
+
+    def test_submission_is_submitted(self):
+        from bantz.connectors.google.classroom import Submission
+
+        s = Submission(state="TURNED_IN")
+        assert s.is_submitted
+
+        s2 = Submission(state="NEW")
+        assert not s2.is_submitted
+
+    def test_get_tools_returns_three(self, auth_manager):
+        from bantz.connectors.google.classroom import ClassroomConnector
+
+        c = ClassroomConnector(auth_manager)
+        tools = c.get_tools()
+        assert len(tools) == 3
+        names = {t.name for t in tools}
+        assert "google.classroom.courses" in names
+        assert "google.classroom.coursework" in names
+        assert "google.classroom.submissions" in names
+
+
+# ═══════════════════════════════════════════════════════════════════
+# GoogleEntityLinker tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestGoogleEntityLinker:
+    """Tests for cross-service entity linking."""
+
+    def test_link_no_connectors(self):
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        linker = GoogleEntityLinker()
+        assert linker.links == []
+
+    @pytest.mark.asyncio
+    async def test_link_attendee_to_contact(self):
+        from bantz.connectors.google.contacts import Contact
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        mock_contacts = MagicMock()
+        mock_contacts.search_contacts = AsyncMock(return_value=[
+            Contact(
+                resource_name="people/c123",
+                display_name="Ali Yılmaz",
+                emails=["ali@example.com"],
+                phones=["+905551234567"],
+            )
+        ])
+
+        linker = GoogleEntityLinker(contacts_connector=mock_contacts)
+        result = await linker.link_attendee_to_contact("ali@example.com")
+
+        assert result is not None
+        assert result["display_name"] == "Ali Yılmaz"
+        assert len(linker.links) == 1
+        assert linker.links[0].edge_type == "HAS_CONTACT_INFO"
+
+    @pytest.mark.asyncio
+    async def test_link_attendee_not_found(self):
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        mock_contacts = MagicMock()
+        mock_contacts.search_contacts = AsyncMock(return_value=[])
+
+        linker = GoogleEntityLinker(contacts_connector=mock_contacts)
+        result = await linker.link_attendee_to_contact("unknown@example.com")
+
+        assert result is None
+        assert len(linker.links) == 0
+
+    @pytest.mark.asyncio
+    async def test_link_attendee_no_connector(self):
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        linker = GoogleEntityLinker()
+        result = await linker.link_attendee_to_contact("test@example.com")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_link_task_to_event(self):
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        async def mock_list_events(date: str):
+            return [
+                {"id": "evt1", "summary": "Rapor toplantısı"},
+                {"id": "evt2", "summary": "Öğle yemeği"},
+            ]
+
+        linker = GoogleEntityLinker(calendar_list_events=mock_list_events)
+        result = await linker.link_task_to_event(
+            "Rapor toplantısı notları", "2025-01-15T00:00:00Z",
+        )
+
+        # "Rapor toplantısı notları" vs "Rapor toplantısı" should match (high similarity)
+        assert result is not None
+        assert len(linker.links) == 1
+        assert linker.links[0].edge_type == "RELATED_TO"
+
+    @pytest.mark.asyncio
+    async def test_link_task_no_match(self):
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        async def mock_list_events(date: str):
+            return [{"id": "evt1", "summary": "Tamamen farklı bir konu"}]
+
+        linker = GoogleEntityLinker(calendar_list_events=mock_list_events)
+        result = await linker.link_task_to_event(
+            "Alışveriş yap", "2025-01-15",
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_batch_link_attendees(self):
+        from bantz.connectors.google.contacts import Contact
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        mock_contacts = MagicMock()
+
+        async def search_side_effect(query):
+            if "ali" in query:
+                return [Contact(resource_name="p/1", display_name="Ali")]
+            return []
+
+        mock_contacts.search_contacts = AsyncMock(side_effect=search_side_effect)
+
+        linker = GoogleEntityLinker(contacts_connector=mock_contacts)
+        results = await linker.link_attendees_to_contacts(
+            ["ali@test.com", "unknown@test.com"]
+        )
+
+        assert results["ali@test.com"] is not None
+        assert results["unknown@test.com"] is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_event_attendees(self):
+        from bantz.connectors.google.contacts import Contact
+        from bantz.connectors.google.entity_linker import GoogleEntityLinker
+
+        mock_contacts = MagicMock()
+        mock_contacts.search_contacts = AsyncMock(return_value=[
+            Contact(resource_name="p/1", display_name="Ali")
+        ])
+
+        linker = GoogleEntityLinker(contacts_connector=mock_contacts)
+        event = {
+            "id": "evt1",
+            "attendees": [
+                {"email": "ali@test.com"},
+                {"email": "mehmet@test.com"},
+            ],
+        }
+
+        enriched = await linker.resolve_event_attendees(event)
+        assert "attendee_contacts" in enriched
+        assert len(enriched["attendee_contacts"]) == 2
+
+    def test_links_summary(self):
+        from bantz.connectors.google.entity_linker import (EntityLink,
+                                                           GoogleEntityLinker)
+
+        linker = GoogleEntityLinker()
+        linker._links = [
+            EntityLink("A", "1", "LINK", "B", "2"),
+            EntityLink("A", "3", "LINK", "B", "4"),
+        ]
+        summary = linker.get_links_summary()
+        assert summary["total_links"] == 2
+        assert "A→B" in summary["by_type"]
+
+    def test_clear_links(self):
+        from bantz.connectors.google.entity_linker import (EntityLink,
+                                                           GoogleEntityLinker)
+
+        linker = GoogleEntityLinker()
+        linker._links = [EntityLink("A", "1", "LINK", "B", "2")]
+        linker.clear_links()
+        assert len(linker.links) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════
+# ToolSchema tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestToolSchema:
+    """Tests for the ToolSchema descriptor."""
+
+    def test_tool_schema_fields(self):
+        from bantz.connectors.google.base import ToolSchema
+
+        ts = ToolSchema(
+            name="test.tool",
+            description="Test tool",
+            parameters={"type": "object", "properties": {}},
+            handler=lambda: None,
+            risk="low",
+            confirm=False,
+        )
+        assert ts.name == "test.tool"
+        assert ts.risk == "low"
+        assert ts.confirm is False
+
+    def test_tool_schema_defaults(self):
+        from bantz.connectors.google.base import ToolSchema
+
+        ts = ToolSchema(
+            name="t", description="d", parameters={}, handler=lambda: None,
+        )
+        assert ts.risk == "low"
+        assert ts.confirm is False
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Auth bridge tests (legacy → unified)
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestAuthBridge:
+    """Test that legacy auth functions delegate to unified manager."""
+
+    def test_google_auth_bridge(self, auth_manager, mock_google_deps):
+        """When unified manager is available, get_credentials delegates."""
+        import bantz.connectors.google.auth_manager as mod
+
+        prev = mod._auth_manager
+        try:
+            mod._auth_manager = auth_manager
+
+            from bantz.google.auth import get_credentials
+
+            # This should use the unified manager
+            creds = get_credentials(
+                scopes=["https://www.googleapis.com/auth/calendar"],
+            )
+            assert creds is not None
+        finally:
+            mod._auth_manager = prev
+
+    def test_gmail_auth_bridge(self, auth_manager, mock_google_deps):
+        """When unified manager is available, get_gmail_credentials delegates."""
+        import bantz.connectors.google.auth_manager as mod
+
+        prev = mod._auth_manager
+        try:
+            mod._auth_manager = auth_manager
+
+            from bantz.google.gmail_auth import get_gmail_credentials
+
+            creds = get_gmail_credentials(
+                scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+            )
+            assert creds is not None
+        finally:
+            mod._auth_manager = prev
+
+
+# ═══════════════════════════════════════════════════════════════════
+# EntityLink tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestEntityLink:
+    """Tests for the EntityLink dataclass."""
+
+    def test_to_dict(self):
+        from bantz.connectors.google.entity_linker import EntityLink
+
+        link = EntityLink(
+            source_type="Task",
+            source_id="t1",
+            edge_type="RELATED_TO",
+            target_type="Event",
+            target_id="e1",
+            metadata={"similarity": 0.85},
+        )
+        d = link.to_dict()
+        assert d["source_type"] == "Task"
+        assert d["edge_type"] == "RELATED_TO"
+        assert d["metadata"]["similarity"] == 0.85
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Config tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestUnifiedAuthConfig:
+    """Tests for UnifiedAuthConfig and path resolution."""
+
+    def test_default_config(self):
+        from bantz.connectors.google.auth_manager import _get_unified_config
+
+        cfg = _get_unified_config()
+        assert str(cfg.token_path).endswith("google_unified_token.json")
+        assert str(cfg.client_secret_path).endswith("client_secret.json")
+
+    def test_custom_config(self, tmp_path):
+        from bantz.connectors.google.auth_manager import _get_unified_config
+
+        cfg = _get_unified_config(
+            token_path=str(tmp_path / "my_token.json"),
+            client_secret_path=str(tmp_path / "my_secret.json"),
+        )
+        assert cfg.token_path == (tmp_path / "my_token.json").resolve()
+
+    def test_env_var_override(self, tmp_path, monkeypatch):
+        from bantz.connectors.google.auth_manager import _get_unified_config
+
+        monkeypatch.setenv("BANTZ_GOOGLE_UNIFIED_TOKEN_PATH", str(tmp_path / "env_token.json"))
+        cfg = _get_unified_config()
+        assert "env_token.json" in str(cfg.token_path)


### PR DESCRIPTION
## Summary

Implements **#1292 — Google Suite Super-Connector** EPIC.

Builds a unified Google OAuth2 connector framework with incremental scope management and 4 new service connectors, bringing the Google integration from Gmail+Calendar to a full suite.

## Changes

### New: `src/bantz/connectors/google/` package

| File | Description |
|------|-------------|
| `auth_manager.py` | Unified token manager — single refresh token, incremental scopes, atomic writes (`fcntl`), legacy migration |
| `base.py` | `GoogleConnector` ABC + `ToolSchema` descriptor |
| `contacts.py` | People API connector — search, get, create (3 tools) |
| `tasks.py` | Tasks API connector — list, create, complete, delete (4 tools) |
| `keep.py` | Keep API connector — list, create, search + graceful degradation (3 tools) |
| `classroom.py` | Classroom API connector — courses, coursework, submissions (3 tools) |
| `entity_linker.py` | Cross-service linking — attendee→contact, task→event (fuzzy `SequenceMatcher`) |

### Modified

- **`google/auth.py`** — Bridge to unified auth manager for backward compat
- **`google/gmail_auth.py`** — Same bridge pattern
- **`tools/register_all.py`** — New `_register_google_connectors()` auto-registering 13 tools
- **`google/consent_wizard.py`** — Added Tasks + Classroom service definitions
- **`config/permissions.yaml`** — Permission rules for all `google.*` tools

### Tests

- **63 tests** covering all components (auth manager, connectors, entity linker, bridges)

## Architecture

```
GoogleAuthManager (singleton)
├── unified_token.json (single refresh token)
├── SCOPE_REGISTRY (6 services × scopes)
└── get_service(name) → cached API client

GoogleConnector (ABC)
├── ContactsConnector → People API
├── TasksConnector → Tasks API
├── KeepConnector → Keep API (Workspace-only)
└── ClassroomConnector → Classroom API

GoogleEntityLinker
├── attendee → contact resolution
└── task → event fuzzy matching
```

## Test Results

```
63 passed in 0.29s
```

Closes #1292