### PR TITLE
feat(proactive): Proactive Secretary Engine — signals + rules + daily brief (#1293)

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -175,6 +175,17 @@ permissions:
     risk: "low"
     decision: "allow"
 
+  # ── Proactive Secretary (Issue #1293) ──────────────────────
+  - tool: "proactive.daily_brief"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "proactive.status"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
   # ── Catch-all (unknown tools) ──────────────────────────────
   - tool: "*"
     action: "*"

--- a/config/proactive.yaml
+++ b/config/proactive.yaml
@@ -1,0 +1,94 @@
+# ─── Proactive Secretary Engine — Configuration ────────────────
+# Issue #1293
+#
+# This file controls the Proactive Secretary: daily briefs,
+# signal collection, rule evaluation, and notification delivery.
+
+# ── Scheduler ───────────────────────────────────────────────────
+scheduler:
+  # Enable/disable the entire proactive engine
+  enabled: true
+  # Poll interval for the scheduler (seconds)
+  poll_interval_seconds: 30
+
+# ── Daily Brief ─────────────────────────────────────────────────
+daily_brief:
+  # Time to generate the morning brief (HH:MM, 24h)
+  time: "08:00"
+  # Enable/disable daily brief generation
+  enabled: true
+  # Maximum number of suggestions to include
+  max_suggestions: 5
+
+# ── Signal Collectors ───────────────────────────────────────────
+signals:
+  calendar:
+    enabled: true
+  email:
+    enabled: true
+  weather:
+    enabled: true
+  tasks:
+    enabled: true
+  news:
+    enabled: false  # refs #839, enable when news skill is ready
+
+# ── Work Hours (for free-slot detection) ────────────────────────
+work_hours:
+  start: 9
+  end: 18
+
+# ── Rules ───────────────────────────────────────────────────────
+# Enable/disable individual proactive rules
+rules:
+  rain_alert:
+    enabled: true
+    priority: 2
+  pending_rsvp:
+    enabled: true
+    priority: 3
+  deadline_approaching:
+    enabled: true
+    priority: 4
+  free_slot_suggestion:
+    enabled: true
+    priority: 1
+  urgent_mail:
+    enabled: true
+    priority: 4
+  high_unread:
+    enabled: true
+    priority: 2
+  overdue_tasks:
+    enabled: true
+    priority: 5
+
+# ── LLM Reasoning ──────────────────────────────────────────────
+llm_reasoning:
+  # Enable LLM-augmented contextual suggestions
+  enabled: false
+  # Model to use for reasoning (via Ollama/Gemini)
+  model: "gemini-2.0-flash"
+
+# ── Delivery Channels ──────────────────────────────────────────
+delivery:
+  terminal:
+    enabled: true
+  desktop_notification:
+    enabled: true
+    urgency: "normal"
+    timeout_ms: 10000
+  eventbus:
+    enabled: true
+
+# ── Notification Policy ────────────────────────────────────────
+notification_policy:
+  # Minimum severity to trigger a notification (info, warning, critical)
+  min_severity: "info"
+  # Quiet hours — no notifications during this period
+  quiet_start: "23:00"
+  quiet_end: "07:00"
+  # Rate limit per check (max notifications per hour)
+  max_per_hour: 3
+  # Cooldown between same-check notifications (seconds)
+  cooldown_seconds: 1800

--- a/src/bantz/proactive/__init__.py
+++ b/src/bantz/proactive/__init__.py
@@ -5,26 +5,33 @@ checks (morning briefing, weather×calendar cross-analysis, email digest),
 combining results from multiple tools, and notifying the user with actionable
 suggestions.
 
-Issue #835
+The Proactive Secretary (Issue #1293) adds structured signal collection,
+a hybrid rule + LLM reasoning engine, composable daily briefs, and
+configurable delivery channels.
+
+Issues #835, #1293
 """
 from __future__ import annotations
 
-from bantz.proactive.models import (
-    ProactiveCheck,
-    CheckSchedule,
-    CheckResult,
-    CrossAnalysis,
-    Insight,
-    InsightSeverity,
-    Suggestion,
-    NotificationPolicy,
-    ProactiveNotification,
-)
-from bantz.proactive.engine import ProactiveEngine
 from bantz.proactive.cross_analyzer import CrossAnalyzer
+from bantz.proactive.daily_brief import DailyBriefGenerator
+from bantz.proactive.delivery import (CallbackDelivery, DeliveryChannel,
+                                      DesktopNotificationDelivery,
+                                      EventBusDelivery, TerminalDelivery)
+from bantz.proactive.engine import ProactiveEngine
+from bantz.proactive.models import (CheckResult, CheckSchedule, CrossAnalysis,
+                                    Insight, InsightSeverity,
+                                    NotificationPolicy, ProactiveCheck,
+                                    ProactiveNotification, Suggestion)
 from bantz.proactive.notification_queue import NotificationQueue
+from bantz.proactive.rule_engine import (DEFAULT_RULES, ProactiveRuleEngine,
+                                         Rule, RuleSuggestion)
+from bantz.proactive.signals import (CalendarSignal, DailySignals, EmailSignal,
+                                     FreeSlot, NewsSignal, SignalCollector,
+                                     TaskSignal, WeatherSignal)
 
 __all__ = [
+    # Models (Issue #835)
     "ProactiveCheck",
     "CheckSchedule",
     "CheckResult",
@@ -34,7 +41,30 @@ __all__ = [
     "Suggestion",
     "NotificationPolicy",
     "ProactiveNotification",
+    # Engine (Issue #835)
     "ProactiveEngine",
     "CrossAnalyzer",
     "NotificationQueue",
+    # Signals (Issue #1293)
+    "CalendarSignal",
+    "DailySignals",
+    "EmailSignal",
+    "FreeSlot",
+    "NewsSignal",
+    "SignalCollector",
+    "TaskSignal",
+    "WeatherSignal",
+    # Rule Engine (Issue #1293)
+    "DEFAULT_RULES",
+    "ProactiveRuleEngine",
+    "Rule",
+    "RuleSuggestion",
+    # Daily Brief (Issue #1293)
+    "DailyBriefGenerator",
+    # Delivery (Issue #1293)
+    "CallbackDelivery",
+    "DeliveryChannel",
+    "DesktopNotificationDelivery",
+    "EventBusDelivery",
+    "TerminalDelivery",
 ]

--- a/src/bantz/proactive/daily_brief.py
+++ b/src/bantz/proactive/daily_brief.py
@@ -1,0 +1,207 @@
+"""Daily Brief Generator for the Proactive Secretary Engine.
+
+Combines :class:`SignalCollector` + :class:`ProactiveRuleEngine` to produce
+a formatted morning brief and deliver it through registered channels.
+
+Issue #1293
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from bantz.proactive.rule_engine import ProactiveRuleEngine, RuleSuggestion
+from bantz.proactive.signals import DailySignals, SignalCollector
+
+logger = logging.getLogger(__name__)
+
+
+class DailyBriefGenerator:
+    """Generates and delivers a daily brief.
+
+    Parameters
+    ----------
+    collector:
+        The :class:`SignalCollector` to gather signals.
+    rule_engine:
+        The :class:`ProactiveRuleEngine` to evaluate rules.
+    delivery_channels:
+        List of :class:`DeliveryChannel` instances.
+    """
+
+    def __init__(
+        self,
+        collector: SignalCollector,
+        rule_engine: ProactiveRuleEngine,
+        delivery_channels: Optional[list] = None,
+    ) -> None:
+        self._collector = collector
+        self._rule_engine = rule_engine
+        self._channels = delivery_channels or []
+        self._last_brief: Optional[str] = None
+        self._last_signals: Optional[DailySignals] = None
+        self._last_suggestions: Optional[list[RuleSuggestion]] = None
+        self._last_generated_at: Optional[datetime] = None
+
+    # ── Public API ──────────────────────────────────────────────
+
+    async def generate(self) -> str:
+        """Collect signals, evaluate rules, format and deliver brief.
+
+        Returns the formatted brief text.
+        """
+        # 1) Collect signals
+        signals = await self._collector.collect_all()
+        self._last_signals = signals
+
+        # 2) Evaluate rules
+        suggestions = await self._rule_engine.evaluate(signals)
+        self._last_suggestions = suggestions
+
+        # 3) Format brief
+        brief = self.format_brief(signals, suggestions)
+        self._last_brief = brief
+        self._last_generated_at = datetime.now()
+
+        # 4) Deliver through all channels
+        await self._deliver(brief)
+
+        logger.info("Daily brief generated (%d chars, %d suggestions)", len(brief), len(suggestions))
+        return brief
+
+    def format_brief(
+        self,
+        signals: DailySignals,
+        suggestions: list[RuleSuggestion],
+    ) -> str:
+        """Format signals and suggestions into a readable brief.
+
+        Returns
+        -------
+        str
+            Multi-line Turkish brief text.
+        """
+        sections: list[str] = []
+        sections.append("🌅 Günaydın! İşte bugünün özeti:\n")
+
+        # ── Calendar ────────────────────────────────────────────
+        cal = signals.calendar
+        n_today = len(cal.today_events)
+        if n_today:
+            sections.append(f"📅 {n_today} toplantı bugün:")
+            for evt in cal.today_events[:5]:
+                if isinstance(evt, dict):
+                    time_str = self._extract_time(evt)
+                    summary = evt.get("summary", evt.get("title", "?"))
+                    sections.append(f"   • {time_str} {summary}")
+        else:
+            sections.append("📅 Bugün toplantı yok — boş bir gün!")
+
+        # ── Email ───────────────────────────────────────────────
+        email = signals.emails
+        if email.unread_count > 0:
+            parts = [f"📧 {email.unread_count} okunmamış mail"]
+            if email.urgent:
+                parts.append(f"({len(email.urgent)} acil)")
+            sections.append(" ".join(parts))
+        else:
+            sections.append("📧 Okunmamış mail yok — inbox sıfır!")
+
+        # ── Weather ─────────────────────────────────────────────
+        wx = signals.weather
+        if wx.temperature is not None:
+            sections.append(f"\n🌤️ {wx.temperature}°C, {wx.condition}")
+            if wx.rain_probability > 0.5:
+                sections.append(f"   🌧️ Yağmur olasılığı: %{int(wx.rain_probability * 100)}")
+            if wx.alerts:
+                for alert in wx.alerts[:2]:
+                    sections.append(f"   ⚠️ {alert}")
+
+        # ── Tasks ───────────────────────────────────────────────
+        tasks = signals.tasks
+        task_parts: list[str] = []
+        if tasks.overdue:
+            task_parts.append(f"{len(tasks.overdue)} gecikmiş")
+        if tasks.due_today:
+            task_parts.append(f"{len(tasks.due_today)} bugün")
+        if tasks.due_tomorrow:
+            task_parts.append(f"{len(tasks.due_tomorrow)} yarın")
+        if task_parts:
+            sections.append(f"\n📋 Görevler: {', '.join(task_parts)}")
+            for t in tasks.overdue[:2]:
+                if isinstance(t, dict):
+                    sections.append(f"   🚨 {t.get('title', '?')} (gecikmiş)")
+            for t in tasks.due_today[:2]:
+                if isinstance(t, dict):
+                    sections.append(f"   📌 {t.get('title', '?')} (bugün)")
+
+        # ── News ────────────────────────────────────────────────
+        if signals.news.headlines:
+            sections.append("\n📰 Gündem:")
+            for hl in signals.news.headlines[:3]:
+                title = hl.get("title", "?") if isinstance(hl, dict) else str(hl)
+                sections.append(f"   • {title}")
+
+        # ── Suggestions ─────────────────────────────────────────
+        if suggestions:
+            sections.append("\n💡 Öneriler:")
+            for s in suggestions[:5]:
+                sections.append(f"   • {s.message}")
+
+        return "\n".join(sections)
+
+    @property
+    def last_brief(self) -> Optional[str]:
+        """The most recently generated brief."""
+        return self._last_brief
+
+    @property
+    def last_signals(self) -> Optional[DailySignals]:
+        """Signals from the most recent collection."""
+        return self._last_signals
+
+    @property
+    def last_generated_at(self) -> Optional[datetime]:
+        """When the last brief was generated."""
+        return self._last_generated_at
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return status information about the brief generator."""
+        return {
+            "last_generated_at": (
+                self._last_generated_at.isoformat()
+                if self._last_generated_at else None
+            ),
+            "has_brief": self._last_brief is not None,
+            "brief_length": len(self._last_brief) if self._last_brief else 0,
+            "suggestion_count": (
+                len(self._last_suggestions) if self._last_suggestions else 0
+            ),
+            "delivery_channels": len(self._channels),
+        }
+
+    # ── Internal ────────────────────────────────────────────────
+
+    async def _deliver(self, brief: str) -> None:
+        """Deliver brief through all registered channels."""
+        for channel in self._channels:
+            try:
+                await channel.deliver(brief)
+            except Exception as exc:
+                logger.warning(
+                    "Delivery channel %s failed: %s",
+                    type(channel).__name__, exc,
+                )
+
+    @staticmethod
+    def _extract_time(event: Dict[str, Any]) -> str:
+        """Extract a human-readable time string from a calendar event."""
+        start = event.get("start", "")
+        if isinstance(start, dict):
+            start = start.get("dateTime", start.get("date", ""))
+        if isinstance(start, str) and "T" in start:
+            return start.split("T")[1][:5]
+        if isinstance(start, str) and len(start) == 5 and ":" in start:
+            return start
+        return "??:??"

--- a/src/bantz/proactive/delivery.py
+++ b/src/bantz/proactive/delivery.py
@@ -1,0 +1,105 @@
+"""Delivery Channels for the Proactive Secretary Engine.
+
+Each channel implements the :class:`DeliveryChannel` ABC and is
+responsible for presenting a brief or notification to the user
+through a specific medium (terminal, desktop notification, etc.).
+
+Issue #1293
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from abc import ABC, abstractmethod
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class DeliveryChannel(ABC):
+    """Abstract base for brief/notification delivery."""
+
+    @abstractmethod
+    async def deliver(self, text: str) -> None:
+        """Deliver a text message to the user."""
+        ...
+
+    @property
+    def name(self) -> str:
+        return type(self).__name__
+
+
+class TerminalDelivery(DeliveryChannel):
+    """Print the brief to stdout (terminal session)."""
+
+    async def deliver(self, text: str) -> None:
+        print(text)
+
+
+class DesktopNotificationDelivery(DeliveryChannel):
+    """Send a Linux desktop notification via ``notify-send``."""
+
+    def __init__(
+        self,
+        *,
+        title: str = "Bantz Daily Brief",
+        urgency: str = "normal",
+        timeout_ms: int = 10_000,
+    ) -> None:
+        self._title = title
+        self._urgency = urgency
+        self._timeout_ms = timeout_ms
+
+    async def deliver(self, text: str) -> None:
+        # Truncate body to avoid dbus limits
+        body = text[:500]
+        try:
+            subprocess.run(
+                [
+                    "notify-send",
+                    f"--urgency={self._urgency}",
+                    f"--expire-time={self._timeout_ms}",
+                    self._title,
+                    body,
+                ],
+                check=False,
+                capture_output=True,
+                timeout=5,
+            )
+        except FileNotFoundError:
+            logger.debug("notify-send not available — desktop notification skipped")
+        except Exception as exc:
+            logger.warning("Desktop notification failed: %s", exc)
+
+
+class EventBusDelivery(DeliveryChannel):
+    """Publish the brief through the Bantz EventBus.
+
+    This allows the CLI and any future UI to receive the brief
+    reactively.
+    """
+
+    def __init__(self, event_bus: Any) -> None:
+        self._event_bus = event_bus
+
+    async def deliver(self, text: str) -> None:
+        if self._event_bus is None:
+            return
+        try:
+            self._event_bus.publish(
+                event_type="bantz_message",
+                data={"text": text, "proactive": True, "type": "daily_brief"},
+            )
+        except Exception as exc:
+            logger.warning("EventBus delivery failed: %s", exc)
+
+
+class CallbackDelivery(DeliveryChannel):
+    """Deliver via an arbitrary async callback — useful for testing."""
+
+    def __init__(self, callback: Any) -> None:
+        self._callback = callback
+
+    async def deliver(self, text: str) -> None:
+        if self._callback:
+            await self._callback(text)

--- a/src/bantz/proactive/rule_engine.py
+++ b/src/bantz/proactive/rule_engine.py
@@ -1,0 +1,348 @@
+"""Proactive Rule Engine — Hybrid rule + LLM reasoning.
+
+The :class:`ProactiveRuleEngine` evaluates collected :class:`DailySignals`
+against a set of declarative **rules** and optionally augments the
+output with LLM-generated contextual suggestions.
+
+Each :class:`Rule` has a callable ``condition`` that receives a
+``DailySignals`` instance along with an ``action`` template rendered
+when the condition is met.
+
+Issue #1293
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from bantz.proactive.models import InsightSeverity
+from bantz.proactive.signals import DailySignals
+
+logger = logging.getLogger(__name__)
+
+
+# ── Rule Definition ─────────────────────────────────────────────
+
+
+@dataclass
+class Rule:
+    """A single proactive rule.
+
+    Parameters
+    ----------
+    name:
+        Unique identifier.
+    condition:
+        Callable ``(DailySignals) -> bool``.
+    action:
+        Message template (may contain ``{var}`` placeholders).
+    priority:
+        Higher = more important (1–5, default 1).
+    severity:
+        How urgently the user should know about this.
+    enabled:
+        Whether the rule is currently active.
+    """
+
+    name: str
+    condition: Callable[[DailySignals], bool]
+    action: str
+    priority: int = 1
+    severity: InsightSeverity = InsightSeverity.INFO
+    enabled: bool = True
+
+
+@dataclass
+class RuleSuggestion:
+    """Result of a single rule evaluation."""
+
+    rule_name: str
+    message: str
+    priority: int = 1
+    severity: InsightSeverity = InsightSeverity.INFO
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "rule": self.rule_name,
+            "message": self.message,
+            "priority": self.priority,
+            "severity": self.severity.value,
+            "metadata": self.metadata,
+        }
+
+
+# ── Built-in Rules ──────────────────────────────────────────────
+
+
+def _rain_alert(signals: DailySignals) -> bool:
+    """Trigger when rain probability > 60%."""
+    return signals.weather.rain_probability > 0.6
+
+
+def _pending_rsvp(signals: DailySignals) -> bool:
+    """Trigger when there are pending RSVPs for tomorrow."""
+    return len(signals.calendar.pending_rsvp) > 0
+
+
+def _deadline_approaching(signals: DailySignals) -> bool:
+    """Trigger when any task is due today or overdue."""
+    return len(signals.tasks.due_today) > 0 or len(signals.tasks.overdue) > 0
+
+
+def _free_slot_suggestion(signals: DailySignals) -> bool:
+    """Trigger when there are free slots and pending tasks."""
+    return len(signals.calendar.free_slots) > 0 and signals.tasks.has_pending
+
+
+def _urgent_mail(signals: DailySignals) -> bool:
+    """Trigger when there are urgent unread emails."""
+    return len(signals.emails.urgent) > 0
+
+
+def _high_unread(signals: DailySignals) -> bool:
+    """Trigger when unread count exceeds threshold."""
+    return signals.emails.unread_count >= 15
+
+
+def _overdue_tasks(signals: DailySignals) -> bool:
+    """Trigger when there are overdue tasks."""
+    return len(signals.tasks.overdue) > 0
+
+
+DEFAULT_RULES: list[Rule] = [
+    Rule(
+        name="rain_alert",
+        condition=_rain_alert,
+        action="🌧️ Bugün yağmur olasılığı yüksek — şemsiye almayı unutma!",
+        priority=2,
+        severity=InsightSeverity.WARNING,
+    ),
+    Rule(
+        name="pending_rsvp",
+        condition=_pending_rsvp,
+        action="⚠️ Yarınki toplantılarda kabul edilmemiş davetler var.",
+        priority=3,
+        severity=InsightSeverity.WARNING,
+    ),
+    Rule(
+        name="deadline_approaching",
+        condition=_deadline_approaching,
+        action="📋 Yaklaşan veya gecikmiş görevler var!",
+        priority=4,
+        severity=InsightSeverity.WARNING,
+    ),
+    Rule(
+        name="free_slot_suggestion",
+        condition=_free_slot_suggestion,
+        action="💡 Bugün boş slotlarınız var — bekleyen görevler için çalışma bloğu koyalım mı?",
+        priority=1,
+        severity=InsightSeverity.INFO,
+    ),
+    Rule(
+        name="urgent_mail",
+        condition=_urgent_mail,
+        action="⚡ Acil okunmamış mailler var!",
+        priority=4,
+        severity=InsightSeverity.CRITICAL,
+    ),
+    Rule(
+        name="high_unread",
+        condition=_high_unread,
+        action="📧 Okunmamış mail sayısı çok yüksek — inbox temizliği gerekebilir.",
+        priority=2,
+        severity=InsightSeverity.WARNING,
+    ),
+    Rule(
+        name="overdue_tasks",
+        condition=_overdue_tasks,
+        action="🚨 Süresi geçmiş görevler var — hemen ilgilenilmeli!",
+        priority=5,
+        severity=InsightSeverity.CRITICAL,
+    ),
+]
+
+
+# ── Rule Engine ─────────────────────────────────────────────────
+
+
+class ProactiveRuleEngine:
+    """Hybrid rule-based + LLM reasoning engine.
+
+    Evaluates a set of :class:`Rule` objects against collected
+    :class:`DailySignals`.  When ``llm_callback`` is provided,
+    an LLM can generate additional contextual suggestions beyond
+    the static rules.
+
+    Parameters
+    ----------
+    rules:
+        Initial rule set.  Defaults to :data:`DEFAULT_RULES`.
+    llm_callback:
+        Optional async callable ``(DailySignals, list[RuleSuggestion]) -> list[RuleSuggestion]``
+        for LLM-augmented reasoning.
+    """
+
+    def __init__(
+        self,
+        rules: Optional[List[Rule]] = None,
+        llm_callback: Optional[Callable] = None,
+    ) -> None:
+        self._rules: Dict[str, Rule] = {}
+        for rule in (rules if rules is not None else DEFAULT_RULES):
+            self._rules[rule.name] = rule
+        self._llm_callback = llm_callback
+
+    # ── Public API ──────────────────────────────────────────────
+
+    @property
+    def rule_names(self) -> list[str]:
+        """Return names of all registered rules."""
+        return list(self._rules.keys())
+
+    def add_rule(self, rule: Rule) -> None:
+        """Register a custom rule."""
+        self._rules[rule.name] = rule
+
+    def remove_rule(self, name: str) -> bool:
+        """Remove a rule by name.  Returns ``True`` if found."""
+        return self._rules.pop(name, None) is not None
+
+    def get_rule(self, name: str) -> Optional[Rule]:
+        """Get a rule by name."""
+        return self._rules.get(name)
+
+    def enable_rule(self, name: str) -> bool:
+        """Enable a rule.  Returns ``True`` if found."""
+        rule = self._rules.get(name)
+        if rule:
+            rule.enabled = True
+            return True
+        return False
+
+    def disable_rule(self, name: str) -> bool:
+        """Disable a rule.  Returns ``True`` if found."""
+        rule = self._rules.get(name)
+        if rule:
+            rule.enabled = False
+            return True
+        return False
+
+    async def evaluate(self, signals: DailySignals) -> list[RuleSuggestion]:
+        """Evaluate all enabled rules against collected signals.
+
+        Steps:
+        1. Run each enabled rule's condition
+        2. Build ``RuleSuggestion`` for matched rules
+        3. Enrich with context-specific metadata
+        4. Optionally run LLM callback for additional suggestions
+        5. Return sorted by priority (highest first)
+        """
+        suggestions: list[RuleSuggestion] = []
+
+        for rule in self._rules.values():
+            if not rule.enabled:
+                continue
+            try:
+                if rule.condition(signals):
+                    suggestion = self._build_suggestion(rule, signals)
+                    suggestions.append(suggestion)
+            except Exception as exc:
+                logger.warning("Rule '%s' evaluation failed: %s", rule.name, exc)
+
+        # LLM augmentation
+        if self._llm_callback is not None:
+            try:
+                llm_suggestions = await self._llm_callback(signals, suggestions)
+                if isinstance(llm_suggestions, list):
+                    suggestions.extend(llm_suggestions)
+            except Exception as exc:
+                logger.warning("LLM reasoning failed: %s", exc)
+
+        # Sort by priority (descending)
+        suggestions.sort(key=lambda s: s.priority, reverse=True)
+        return suggestions
+
+    def evaluate_sync(self, signals: DailySignals) -> list[RuleSuggestion]:
+        """Synchronous version of :meth:`evaluate` (no LLM)."""
+        suggestions: list[RuleSuggestion] = []
+        for rule in self._rules.values():
+            if not rule.enabled:
+                continue
+            try:
+                if rule.condition(signals):
+                    suggestions.append(self._build_suggestion(rule, signals))
+            except Exception as exc:
+                logger.warning("Rule '%s' evaluation failed: %s", rule.name, exc)
+        suggestions.sort(key=lambda s: s.priority, reverse=True)
+        return suggestions
+
+    # ── Internal ────────────────────────────────────────────────
+
+    def _build_suggestion(
+        self,
+        rule: Rule,
+        signals: DailySignals,
+    ) -> RuleSuggestion:
+        """Create a ``RuleSuggestion`` with context-enriched metadata."""
+        metadata: Dict[str, Any] = {}
+        message = rule.action
+
+        if rule.name == "rain_alert":
+            prob = signals.weather.rain_probability
+            message = f"🌧️ Bugün yağmur olasılığı %{int(prob * 100)} — şemsiye almayı unutma!"
+            metadata["rain_probability"] = prob
+
+        elif rule.name == "pending_rsvp":
+            count = len(signals.calendar.pending_rsvp)
+            message = f"⚠️ Yarınki toplantılarda {count} katılımcı henüz kabul etmedi."
+            metadata["pending_count"] = count
+            metadata["events"] = [
+                e.get("summary", "?") for e in signals.calendar.pending_rsvp[:3]
+            ]
+
+        elif rule.name == "deadline_approaching":
+            today_names = [t.get("title", "?") for t in signals.tasks.due_today[:3]]
+            overdue_names = [t.get("title", "?") for t in signals.tasks.overdue[:3]]
+            parts = []
+            if today_names:
+                parts.append(f"Bugün: {', '.join(today_names)}")
+            if overdue_names:
+                parts.append(f"Gecikmiş: {', '.join(overdue_names)}")
+            message = f"📋 Yaklaşan görevler — {'; '.join(parts)}"
+            metadata["due_today"] = today_names
+            metadata["overdue"] = overdue_names
+
+        elif rule.name == "free_slot_suggestion":
+            slot = signals.calendar.free_slots[0] if signals.calendar.free_slots else None
+            task = signals.tasks.active_tasks[0] if signals.tasks.active_tasks else None
+            if slot and task:
+                message = (
+                    f"💡 {slot.start}-{slot.end} arası boş — "
+                    f"'{task.get('title', '?')}' için çalışma bloğu koyalım mı?"
+                )
+                metadata["slot"] = slot.to_dict()
+                metadata["task"] = task.get("title", "?")
+
+        elif rule.name == "urgent_mail":
+            count = len(signals.emails.urgent)
+            message = f"⚡ {count} acil okunmamış mail var!"
+            metadata["urgent_count"] = count
+
+        elif rule.name == "high_unread":
+            message = f"📧 {signals.emails.unread_count} okunmamış mail birikmiş — inbox temizliği gerekebilir."
+            metadata["unread_count"] = signals.emails.unread_count
+
+        elif rule.name == "overdue_tasks":
+            names = [t.get("title", "?") for t in signals.tasks.overdue[:5]]
+            message = f"🚨 {len(signals.tasks.overdue)} süresi geçmiş görev: {', '.join(names)}"
+            metadata["overdue_tasks"] = names
+
+        return RuleSuggestion(
+            rule_name=rule.name,
+            message=message,
+            priority=rule.priority,
+            severity=rule.severity,
+            metadata=metadata,
+        )

--- a/src/bantz/proactive/signals.py
+++ b/src/bantz/proactive/signals.py
@@ -1,0 +1,485 @@
+"""Signal Collectors for the Proactive Secretary Engine.
+
+Each collector gathers ambient context from a specific data source
+(calendar, email, weather, tasks, news) and returns a typed signal
+dataclass.  ``SignalCollector`` orchestrates all collectors in parallel
+via ``asyncio.gather()``.
+
+Issue #1293
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Signal Data Models ──────────────────────────────────────────
+
+
+@dataclass
+class FreeSlot:
+    """A gap in the calendar that can be suggested for focused work."""
+
+    start: str  # HH:MM
+    end: str    # HH:MM
+
+    @property
+    def duration_minutes(self) -> int:
+        """Duration in minutes."""
+        try:
+            sh, sm = map(int, self.start.split(":"))
+            eh, em = map(int, self.end.split(":"))
+            return (eh * 60 + em) - (sh * 60 + sm)
+        except (ValueError, AttributeError):
+            return 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"start": self.start, "end": self.end, "duration_minutes": self.duration_minutes}
+
+
+@dataclass
+class CalendarSignal:
+    """Signal from Google Calendar."""
+
+    today_events: List[Dict[str, Any]] = field(default_factory=list)
+    tomorrow_events: List[Dict[str, Any]] = field(default_factory=list)
+    pending_rsvp: List[Dict[str, Any]] = field(default_factory=list)
+    free_slots: List[FreeSlot] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "today_count": len(self.today_events),
+            "tomorrow_count": len(self.tomorrow_events),
+            "pending_rsvp_count": len(self.pending_rsvp),
+            "free_slots": [s.to_dict() for s in self.free_slots],
+        }
+
+
+@dataclass
+class EmailSignal:
+    """Signal from Gmail."""
+
+    unread_count: int = 0
+    urgent: List[Dict[str, Any]] = field(default_factory=list)
+    needs_follow_up: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "unread_count": self.unread_count,
+            "urgent_count": len(self.urgent),
+            "follow_up_count": len(self.needs_follow_up),
+        }
+
+
+@dataclass
+class WeatherSignal:
+    """Signal from weather service (refs #838)."""
+
+    temperature: Optional[float] = None
+    condition: str = ""
+    rain_probability: float = 0.0
+    alerts: List[str] = field(default_factory=list)
+    tomorrow_condition: str = ""
+    tomorrow_temperature: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "temperature": self.temperature,
+            "condition": self.condition,
+            "rain_probability": self.rain_probability,
+            "alerts": self.alerts,
+        }
+
+
+@dataclass
+class TaskSignal:
+    """Signal from Google Tasks."""
+
+    active_tasks: List[Dict[str, Any]] = field(default_factory=list)
+    overdue: List[Dict[str, Any]] = field(default_factory=list)
+    due_today: List[Dict[str, Any]] = field(default_factory=list)
+    due_tomorrow: List[Dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def has_pending(self) -> bool:
+        return len(self.active_tasks) > 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "active_count": len(self.active_tasks),
+            "overdue_count": len(self.overdue),
+            "due_today_count": len(self.due_today),
+            "due_tomorrow_count": len(self.due_tomorrow),
+        }
+
+
+@dataclass
+class NewsSignal:
+    """Signal from news sources (refs #839)."""
+
+    headlines: List[Dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"headline_count": len(self.headlines)}
+
+
+@dataclass
+class DailySignals:
+    """Aggregated signals from all collectors."""
+
+    calendar: CalendarSignal = field(default_factory=CalendarSignal)
+    emails: EmailSignal = field(default_factory=EmailSignal)
+    weather: WeatherSignal = field(default_factory=WeatherSignal)
+    tasks: TaskSignal = field(default_factory=TaskSignal)
+    news: NewsSignal = field(default_factory=NewsSignal)
+    collected_at: Optional[datetime] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "calendar": self.calendar.to_dict(),
+            "emails": self.emails.to_dict(),
+            "weather": self.weather.to_dict(),
+            "tasks": self.tasks.to_dict(),
+            "news": self.news.to_dict(),
+            "collected_at": self.collected_at.isoformat() if self.collected_at else None,
+        }
+
+
+# ── Tool Helper ─────────────────────────────────────────────────
+
+
+def _call_tool_sync(
+    tool_registry: Any,
+    tool_name: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Call a registered tool synchronously (same helper as checks.py)."""
+    try:
+        tool = tool_registry.get(tool_name)
+        if tool is None:
+            return {"ok": False, "error": f"Tool '{tool_name}' not found"}
+        handler = getattr(tool, "handler", None) or getattr(tool, "function", None)
+        if handler is None:
+            return {"ok": False, "error": f"Tool '{tool_name}' has no handler"}
+        result = handler(**(params or {}))
+        return result if isinstance(result, dict) else {"ok": True, "data": result}
+    except Exception as exc:
+        logger.warning("Signal collector tool call '%s' failed: %s", tool_name, exc)
+        return {"ok": False, "error": str(exc)}
+
+
+# ── Signal Collector ────────────────────────────────────────────
+
+
+class SignalCollector:
+    """Gathers ambient context signals from multiple Bantz tools.
+
+    Uses ``asyncio.gather()`` to collect all signals in parallel,
+    with per-source error isolation.
+
+    Parameters
+    ----------
+    tool_registry:
+        The Bantz ToolRegistry for calling tools.
+    work_hours:
+        Tuple of (start_hour, end_hour) for free-slot calculation.
+    """
+
+    def __init__(
+        self,
+        tool_registry: Any = None,
+        *,
+        work_hours: tuple[int, int] = (9, 18),
+    ) -> None:
+        self._tool_registry = tool_registry
+        self._work_hours = work_hours
+
+    async def collect_all(self) -> DailySignals:
+        """Collect all signals in parallel."""
+        results = await asyncio.gather(
+            self.collect_calendar(),
+            self.collect_emails(),
+            self.collect_weather(),
+            self.collect_tasks(),
+            self.collect_news(),
+            return_exceptions=True,
+        )
+
+        # Unpack — any exception becomes an empty signal
+        signals = DailySignals(collected_at=datetime.now())
+
+        if not isinstance(results[0], BaseException):
+            signals.calendar = results[0]
+        else:
+            logger.warning("Calendar signal failed: %s", results[0])
+
+        if not isinstance(results[1], BaseException):
+            signals.emails = results[1]
+        else:
+            logger.warning("Email signal failed: %s", results[1])
+
+        if not isinstance(results[2], BaseException):
+            signals.weather = results[2]
+        else:
+            logger.warning("Weather signal failed: %s", results[2])
+
+        if not isinstance(results[3], BaseException):
+            signals.tasks = results[3]
+        else:
+            logger.warning("Tasks signal failed: %s", results[3])
+
+        if not isinstance(results[4], BaseException):
+            signals.news = results[4]
+        else:
+            logger.warning("News signal failed: %s", results[4])
+
+        return signals
+
+    # ── Individual Collectors ───────────────────────────────────
+
+    async def collect_calendar(self) -> CalendarSignal:
+        """Today + tomorrow events, pending RSVPs, free slots."""
+        signal = CalendarSignal()
+        if not self._tool_registry:
+            return signal
+
+        # Today events
+        result = await asyncio.to_thread(
+            _call_tool_sync, self._tool_registry, "calendar.list_events",
+        )
+        if result.get("ok"):
+            events = result.get("events", result.get("data", []))
+            if isinstance(events, list):
+                signal.today_events = events
+
+        # Tomorrow events
+        tomorrow = (date.today() + timedelta(days=1)).isoformat()
+        result2 = await asyncio.to_thread(
+            _call_tool_sync, self._tool_registry, "calendar.list_events",
+            {"date": tomorrow},
+        )
+        if result2.get("ok"):
+            events2 = result2.get("events", result2.get("data", []))
+            if isinstance(events2, list):
+                signal.tomorrow_events = events2
+                # Check for pending RSVPs
+                for evt in events2:
+                    if isinstance(evt, dict):
+                        attendees = evt.get("attendees", [])
+                        if isinstance(attendees, list):
+                            for att in attendees:
+                                if isinstance(att, dict):
+                                    status = att.get("responseStatus", "")
+                                    if status in ("needsAction", "tentative"):
+                                        signal.pending_rsvp.append(evt)
+                                        break
+
+        # Free slots
+        signal.free_slots = self._find_free_slots(
+            signal.today_events, self._work_hours,
+        )
+
+        return signal
+
+    async def collect_emails(self) -> EmailSignal:
+        """Unread count + urgency detection."""
+        signal = EmailSignal()
+        if not self._tool_registry:
+            return signal
+
+        result = await asyncio.to_thread(
+            _call_tool_sync, self._tool_registry, "gmail.unread_count",
+        )
+        if result.get("ok"):
+            signal.unread_count = result.get("unread", result.get("count", 0))
+
+        # Try to get urgent emails (search for important/starred)
+        urgent_result = await asyncio.to_thread(
+            _call_tool_sync, self._tool_registry, "gmail.search",
+            {"query": "is:unread is:important", "max_results": 5},
+        )
+        if urgent_result.get("ok"):
+            msgs = urgent_result.get("messages", urgent_result.get("data", []))
+            if isinstance(msgs, list):
+                signal.urgent = msgs
+
+        return signal
+
+    async def collect_weather(self) -> WeatherSignal:
+        """Current weather conditions."""
+        signal = WeatherSignal()
+        if not self._tool_registry:
+            return signal
+
+        result = await asyncio.to_thread(
+            _call_tool_sync, self._tool_registry, "weather.get_current",
+        )
+        if result.get("ok"):
+            data = result.get("data", result)
+            signal.temperature = data.get("temperature")
+            signal.condition = data.get("condition", "")
+            signal.rain_probability = data.get("rain_probability", 0.0)
+            alerts = data.get("alerts", [])
+            if isinstance(alerts, list):
+                signal.alerts = [str(a) for a in alerts]
+
+        return signal
+
+    async def collect_tasks(self) -> TaskSignal:
+        """Active tasks, overdue, due today/tomorrow."""
+        signal = TaskSignal()
+        if not self._tool_registry:
+            return signal
+
+        result = await asyncio.to_thread(
+            _call_tool_sync, self._tool_registry, "google.tasks.list",
+        )
+        if result.get("ok"):
+            tasks = result.get("tasks", result.get("data", []))
+            if isinstance(tasks, list):
+                today_str = date.today().isoformat()
+                tomorrow_str = (date.today() + timedelta(days=1)).isoformat()
+
+                for task in tasks:
+                    if not isinstance(task, dict):
+                        continue
+                    status = task.get("status", "")
+                    if status == "completed":
+                        continue
+
+                    signal.active_tasks.append(task)
+                    due = task.get("due", "")
+                    if isinstance(due, str) and len(due) >= 10:
+                        due_date = due[:10]
+                        if due_date < today_str:
+                            signal.overdue.append(task)
+                        elif due_date == today_str:
+                            signal.due_today.append(task)
+                        elif due_date == tomorrow_str:
+                            signal.due_tomorrow.append(task)
+
+        return signal
+
+    async def collect_news(self) -> NewsSignal:
+        """News headlines (refs #839)."""
+        signal = NewsSignal()
+        if not self._tool_registry:
+            return signal
+
+        result = await asyncio.to_thread(
+            _call_tool_sync, self._tool_registry, "news.headlines",
+        )
+        if result.get("ok"):
+            headlines = result.get("headlines", result.get("data", []))
+            if isinstance(headlines, list):
+                signal.headlines = [
+                    h if isinstance(h, dict) else {"title": str(h)}
+                    for h in headlines[:5]
+                ]
+
+        return signal
+
+    # ── Free Slot Calculator ────────────────────────────────────
+
+    @staticmethod
+    def _find_free_slots(
+        events: List[Dict[str, Any]],
+        work_hours: tuple[int, int],
+    ) -> List[FreeSlot]:
+        """Find free slots in the calendar based on work hours.
+
+        Parameters
+        ----------
+        events:
+            List of event dicts with 'start'/'end' time strings.
+        work_hours:
+            ``(start_hour, end_hour)`` tuple.
+
+        Returns
+        -------
+        list[FreeSlot]
+            Gaps of at least 30 minutes.
+        """
+        start_h, end_h = work_hours
+        min_gap_minutes = 30
+
+        # Extract busy intervals as (start_minutes, end_minutes)
+        busy: list[tuple[int, int]] = []
+        for evt in events:
+            if not isinstance(evt, dict):
+                continue
+            evt_start = evt.get("start", "")
+            evt_end = evt.get("end", "")
+
+            s_min = _parse_time_to_minutes(evt_start)
+            e_min = _parse_time_to_minutes(evt_end)
+            if s_min is not None and e_min is not None and e_min > s_min:
+                busy.append((s_min, e_min))
+
+        busy.sort()
+
+        # Merge overlapping intervals
+        merged: list[tuple[int, int]] = []
+        for s, e in busy:
+            if merged and s <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+            else:
+                merged.append((s, e))
+
+        # Find gaps
+        slots: list[FreeSlot] = []
+        current = start_h * 60
+        work_end = end_h * 60
+
+        for s, e in merged:
+            if s > current and (s - current) >= min_gap_minutes:
+                slots.append(FreeSlot(
+                    start=f"{current // 60:02d}:{current % 60:02d}",
+                    end=f"{s // 60:02d}:{s % 60:02d}",
+                ))
+            current = max(current, e)
+
+        # Final gap after last event
+        if current < work_end and (work_end - current) >= min_gap_minutes:
+            slots.append(FreeSlot(
+                start=f"{current // 60:02d}:{current % 60:02d}",
+                end=f"{work_end // 60:02d}:{work_end % 60:02d}",
+            ))
+
+        return slots
+
+
+# ── Utility ─────────────────────────────────────────────────────
+
+
+def _parse_time_to_minutes(value: Any) -> Optional[int]:
+    """Extract HH:MM from various time formats and return total minutes.
+
+    Supports:
+    - ``"10:00"``
+    - ``"2025-01-15T10:00:00"``
+    - ``{"dateTime": "2025-01-15T10:00:00+03:00"}``
+    """
+    if isinstance(value, dict):
+        value = value.get("dateTime", value.get("date", ""))
+    if not isinstance(value, str):
+        return None
+
+    # Try to find HH:MM in the string
+    if "T" in value:
+        time_part = value.split("T")[1][:5]
+    elif len(value) == 5 and ":" in value:
+        time_part = value
+    else:
+        return None
+
+    try:
+        h, m = map(int, time_part.split(":"))
+        return h * 60 + m
+    except (ValueError, AttributeError):
+        return None

--- a/tests/test_issue_1293_proactive_secretary.py
+++ b/tests/test_issue_1293_proactive_secretary.py
@@ -1,0 +1,749 @@
+"""Tests for Issue #1293 — Proactive Secretary Engine.
+
+Tests cover:
+- Signal data models (FreeSlot, CalendarSignal, EmailSignal, etc.)
+- SignalCollector (parallel collection, free-slot detection, error isolation)
+- Rule definitions and ProactiveRuleEngine evaluation
+- DailyBriefGenerator (generate, format, status)
+- Delivery channels (Terminal, Desktop, EventBus, Callback)
+- Engine integration (_init_secretary, YAML config loading)
+- Proactive tools registration (daily_brief, status)
+
+Target: ≥ 35 tests
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ═══════════════════════════════════════════════════════════════
+# Signal Data Models
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestFreeSlot:
+    def test_duration_minutes(self):
+        from bantz.proactive.signals import FreeSlot
+
+        slot = FreeSlot(start="09:00", end="10:30")
+        assert slot.duration_minutes == 90
+
+    def test_duration_minutes_zero(self):
+        from bantz.proactive.signals import FreeSlot
+
+        slot = FreeSlot(start="bad", end="data")
+        assert slot.duration_minutes == 0
+
+    def test_to_dict(self):
+        from bantz.proactive.signals import FreeSlot
+
+        slot = FreeSlot(start="14:00", end="15:00")
+        d = slot.to_dict()
+        assert d["start"] == "14:00"
+        assert d["end"] == "15:00"
+        assert d["duration_minutes"] == 60
+
+
+class TestCalendarSignal:
+    def test_empty_signal(self):
+        from bantz.proactive.signals import CalendarSignal
+
+        sig = CalendarSignal()
+        d = sig.to_dict()
+        assert d["today_count"] == 0
+        assert d["pending_rsvp_count"] == 0
+
+    def test_with_events(self):
+        from bantz.proactive.signals import CalendarSignal
+
+        sig = CalendarSignal(
+            today_events=[{"summary": "A"}, {"summary": "B"}],
+            pending_rsvp=[{"summary": "C"}],
+        )
+        assert sig.to_dict()["today_count"] == 2
+        assert sig.to_dict()["pending_rsvp_count"] == 1
+
+
+class TestEmailSignal:
+    def test_to_dict(self):
+        from bantz.proactive.signals import EmailSignal
+
+        sig = EmailSignal(unread_count=5, urgent=[{"id": "1"}])
+        d = sig.to_dict()
+        assert d["unread_count"] == 5
+        assert d["urgent_count"] == 1
+
+
+class TestWeatherSignal:
+    def test_to_dict(self):
+        from bantz.proactive.signals import WeatherSignal
+
+        sig = WeatherSignal(temperature=22.5, condition="sunny", rain_probability=0.1)
+        d = sig.to_dict()
+        assert d["temperature"] == 22.5
+        assert d["condition"] == "sunny"
+
+
+class TestTaskSignal:
+    def test_has_pending(self):
+        from bantz.proactive.signals import TaskSignal
+
+        sig = TaskSignal(active_tasks=[{"title": "X"}])
+        assert sig.has_pending is True
+
+    def test_no_pending(self):
+        from bantz.proactive.signals import TaskSignal
+
+        sig = TaskSignal()
+        assert sig.has_pending is False
+
+
+class TestNewsSignal:
+    def test_to_dict(self):
+        from bantz.proactive.signals import NewsSignal
+
+        sig = NewsSignal(headlines=[{"title": "Breaking"}])
+        assert sig.to_dict()["headline_count"] == 1
+
+
+class TestDailySignals:
+    def test_to_dict(self):
+        from bantz.proactive.signals import DailySignals
+
+        signals = DailySignals(collected_at=datetime(2025, 1, 15, 8, 0))
+        d = signals.to_dict()
+        assert d["collected_at"] is not None
+        assert d["calendar"]["today_count"] == 0
+
+    def test_empty_signals(self):
+        from bantz.proactive.signals import DailySignals
+
+        signals = DailySignals()
+        assert signals.collected_at is None
+        d = signals.to_dict()
+        assert d["collected_at"] is None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Time Parsing Utility
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestParseTimeToMinutes:
+    def test_simple_time(self):
+        from bantz.proactive.signals import _parse_time_to_minutes
+
+        assert _parse_time_to_minutes("10:30") == 630
+
+    def test_iso_datetime(self):
+        from bantz.proactive.signals import _parse_time_to_minutes
+
+        assert _parse_time_to_minutes("2025-01-15T14:00:00+03:00") == 840
+
+    def test_dict_with_datetime(self):
+        from bantz.proactive.signals import _parse_time_to_minutes
+
+        assert _parse_time_to_minutes({"dateTime": "2025-01-15T09:00:00"}) == 540
+
+    def test_invalid(self):
+        from bantz.proactive.signals import _parse_time_to_minutes
+
+        assert _parse_time_to_minutes(None) is None
+        assert _parse_time_to_minutes(123) is None
+        assert _parse_time_to_minutes("bad") is None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Free Slot Calculator
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestFreeSlotCalculator:
+    def test_no_events(self):
+        from bantz.proactive.signals import SignalCollector
+
+        slots = SignalCollector._find_free_slots([], (9, 18))
+        assert len(slots) == 1
+        assert slots[0].start == "09:00"
+        assert slots[0].end == "18:00"
+
+    def test_with_one_event(self):
+        from bantz.proactive.signals import SignalCollector
+
+        events = [{"start": "10:00", "end": "11:00"}]
+        slots = SignalCollector._find_free_slots(events, (9, 18))
+        # 09:00-10:00, 11:00-18:00
+        assert len(slots) == 2
+        assert slots[0].start == "09:00"
+        assert slots[0].end == "10:00"
+        assert slots[1].start == "11:00"
+        assert slots[1].end == "18:00"
+
+    def test_gap_too_small(self):
+        from bantz.proactive.signals import SignalCollector
+
+        events = [
+            {"start": "09:00", "end": "09:20"},
+            {"start": "09:20", "end": "18:00"},
+        ]
+        # No gap ≥ 30 min
+        slots = SignalCollector._find_free_slots(events, (9, 18))
+        assert len(slots) == 0
+
+    def test_overlapping_events(self):
+        from bantz.proactive.signals import SignalCollector
+
+        events = [
+            {"start": "09:00", "end": "11:00"},
+            {"start": "10:00", "end": "12:00"},
+        ]
+        # Merged: 09:00-12:00 → free: 12:00-18:00
+        slots = SignalCollector._find_free_slots(events, (9, 18))
+        assert len(slots) == 1
+        assert slots[0].start == "12:00"
+
+
+# ═══════════════════════════════════════════════════════════════
+# SignalCollector
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestSignalCollector:
+    @pytest.mark.asyncio
+    async def test_collect_all_no_registry(self):
+        from bantz.proactive.signals import SignalCollector
+
+        collector = SignalCollector(tool_registry=None)
+        signals = await collector.collect_all()
+        assert signals.collected_at is not None
+        assert signals.calendar.today_events == []
+
+    @pytest.mark.asyncio
+    async def test_collect_calendar_with_mock(self):
+        from bantz.proactive.signals import SignalCollector
+
+        mock_reg = MagicMock()
+        tool = MagicMock()
+        tool.function.return_value = {"ok": True, "events": [{"summary": "Test"}]}
+        tool.handler = None  # Force fallback to function
+        mock_reg.get.return_value = tool
+
+        collector = SignalCollector(tool_registry=mock_reg)
+        cal = await collector.collect_calendar()
+        assert len(cal.today_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_collect_emails_with_mock(self):
+        from bantz.proactive.signals import SignalCollector
+
+        mock_reg = MagicMock()
+        tool = MagicMock()
+        tool.function.return_value = {"ok": True, "unread": 7}
+        tool.handler = None
+        mock_reg.get.return_value = tool
+
+        collector = SignalCollector(tool_registry=mock_reg)
+        email = await collector.collect_emails()
+        assert email.unread_count == 7
+
+    @pytest.mark.asyncio
+    async def test_collect_all_error_isolation(self):
+        """If one collector fails, others still return data."""
+        from bantz.proactive.signals import SignalCollector
+
+        mock_reg = MagicMock()
+        # Every tool call raises
+        mock_reg.get.side_effect = RuntimeError("boom")
+
+        collector = SignalCollector(tool_registry=mock_reg)
+        signals = await collector.collect_all()
+        # Should not raise — all signals are empty defaults
+        assert signals.collected_at is not None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Rule Engine
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestRule:
+    def test_rule_fields(self):
+        from bantz.proactive.rule_engine import Rule
+
+        r = Rule(name="test", condition=lambda s: True, action="do stuff")
+        assert r.name == "test"
+        assert r.enabled is True
+        assert r.priority == 1
+
+
+class TestRuleSuggestion:
+    def test_to_dict(self):
+        from bantz.proactive.models import InsightSeverity
+        from bantz.proactive.rule_engine import RuleSuggestion
+
+        rs = RuleSuggestion(
+            rule_name="rain",
+            message="Take umbrella",
+            priority=3,
+            severity=InsightSeverity.WARNING,
+        )
+        d = rs.to_dict()
+        assert d["rule"] == "rain"
+        assert d["severity"] == "warning"
+        assert d["priority"] == 3
+
+
+class TestDefaultRules:
+    def test_count(self):
+        from bantz.proactive.rule_engine import DEFAULT_RULES
+
+        assert len(DEFAULT_RULES) >= 7
+
+    def test_all_have_conditions(self):
+        from bantz.proactive.rule_engine import DEFAULT_RULES
+
+        for rule in DEFAULT_RULES:
+            assert callable(rule.condition)
+
+
+class TestProactiveRuleEngine:
+    def test_rule_names(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+
+        engine = ProactiveRuleEngine()
+        names = engine.rule_names
+        assert "rain_alert" in names
+        assert "urgent_mail" in names
+
+    def test_add_remove_rule(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine, Rule
+
+        engine = ProactiveRuleEngine(rules=[])
+        engine.add_rule(Rule(name="custom", condition=lambda s: True, action="hi"))
+        assert "custom" in engine.rule_names
+        assert engine.remove_rule("custom") is True
+        assert "custom" not in engine.rule_names
+
+    def test_enable_disable_rule(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+
+        engine = ProactiveRuleEngine()
+        assert engine.disable_rule("rain_alert") is True
+        r = engine.get_rule("rain_alert")
+        assert r is not None and r.enabled is False
+        assert engine.enable_rule("rain_alert") is True
+        assert r.enabled is True
+
+    @pytest.mark.asyncio
+    async def test_evaluate_rain_alert(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import DailySignals, WeatherSignal
+
+        signals = DailySignals(weather=WeatherSignal(rain_probability=0.8))
+        engine = ProactiveRuleEngine()
+        suggestions = await engine.evaluate(signals)
+        rain_msgs = [s for s in suggestions if s.rule_name == "rain_alert"]
+        assert len(rain_msgs) == 1
+        assert "yağmur" in rain_msgs[0].message.lower() or "şemsiye" in rain_msgs[0].message.lower()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_no_triggers(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import DailySignals
+
+        signals = DailySignals()
+        engine = ProactiveRuleEngine()
+        suggestions = await engine.evaluate(signals)
+        assert len(suggestions) == 0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_multiple_rules(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import (DailySignals, EmailSignal,
+                                             TaskSignal, WeatherSignal)
+
+        signals = DailySignals(
+            weather=WeatherSignal(rain_probability=0.9),
+            emails=EmailSignal(unread_count=20, urgent=[{"id": "1"}]),
+            tasks=TaskSignal(overdue=[{"title": "old task"}]),
+        )
+        engine = ProactiveRuleEngine()
+        suggestions = await engine.evaluate(signals)
+        rule_names = [s.rule_name for s in suggestions]
+        assert "rain_alert" in rule_names
+        assert "urgent_mail" in rule_names
+        assert "overdue_tasks" in rule_names
+        # Should be sorted by priority descending
+        priorities = [s.priority for s in suggestions]
+        assert priorities == sorted(priorities, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_evaluate_with_llm_callback(self):
+        from bantz.proactive.rule_engine import (ProactiveRuleEngine,
+                                                 RuleSuggestion)
+        from bantz.proactive.signals import DailySignals
+
+        async def mock_llm(signals, existing):
+            return [RuleSuggestion(
+                rule_name="llm_insight",
+                message="LLM says hello",
+                priority=10,
+            )]
+
+        engine = ProactiveRuleEngine(llm_callback=mock_llm)
+        suggestions = await engine.evaluate(DailySignals())
+        assert any(s.rule_name == "llm_insight" for s in suggestions)
+
+    def test_evaluate_sync(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import DailySignals, WeatherSignal
+
+        signals = DailySignals(weather=WeatherSignal(rain_probability=0.8))
+        engine = ProactiveRuleEngine()
+        suggestions = engine.evaluate_sync(signals)
+        assert any(s.rule_name == "rain_alert" for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_disabled_rule_not_triggered(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import DailySignals, WeatherSignal
+
+        signals = DailySignals(weather=WeatherSignal(rain_probability=0.9))
+        engine = ProactiveRuleEngine()
+        engine.disable_rule("rain_alert")
+        suggestions = await engine.evaluate(signals)
+        assert not any(s.rule_name == "rain_alert" for s in suggestions)
+
+    @pytest.mark.asyncio
+    async def test_rule_condition_error_handled(self):
+        from bantz.proactive.rule_engine import ProactiveRuleEngine, Rule
+        from bantz.proactive.signals import DailySignals
+
+        def bad_condition(signals):
+            raise ValueError("broken")
+
+        engine = ProactiveRuleEngine(rules=[
+            Rule(name="broken", condition=bad_condition, action="x"),
+        ])
+        # Should not raise
+        suggestions = await engine.evaluate(DailySignals())
+        assert len(suggestions) == 0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Daily Brief Generator
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestDailyBriefGenerator:
+    @pytest.mark.asyncio
+    async def test_generate_brief(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import (CalendarSignal, DailySignals,
+                                             EmailSignal, SignalCollector,
+                                             WeatherSignal)
+
+        # Mock collector
+        mock_collector = MagicMock(spec=SignalCollector)
+        mock_signals = DailySignals(
+            calendar=CalendarSignal(today_events=[
+                {"summary": "Proje sync", "start": "10:00"},
+            ]),
+            emails=EmailSignal(unread_count=3),
+            weather=WeatherSignal(temperature=18, condition="cloudy"),
+            collected_at=datetime.now(),
+        )
+        mock_collector.collect_all = AsyncMock(return_value=mock_signals)
+
+        rule_engine = ProactiveRuleEngine()
+        gen = DailyBriefGenerator(mock_collector, rule_engine)
+        brief = await gen.generate()
+
+        assert "Günaydın" in brief
+        assert "Proje sync" in brief
+        assert "3 okunmamış" in brief
+        assert gen.last_brief == brief
+        assert gen.last_generated_at is not None
+
+    def test_format_brief_empty(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import DailySignals, SignalCollector
+
+        gen = DailyBriefGenerator(
+            MagicMock(spec=SignalCollector),
+            ProactiveRuleEngine(),
+        )
+        brief = gen.format_brief(DailySignals(), [])
+        assert "Günaydın" in brief
+        assert "toplantı yok" in brief
+
+    def test_format_brief_with_suggestions(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+        from bantz.proactive.rule_engine import (ProactiveRuleEngine,
+                                                 RuleSuggestion)
+        from bantz.proactive.signals import (DailySignals, SignalCollector,
+                                             WeatherSignal)
+
+        gen = DailyBriefGenerator(
+            MagicMock(spec=SignalCollector),
+            ProactiveRuleEngine(),
+        )
+        brief = gen.format_brief(
+            DailySignals(weather=WeatherSignal(temperature=22, condition="sunny")),
+            [RuleSuggestion(rule_name="test", message="Do something", priority=1)],
+        )
+        assert "Öneriler" in brief
+        assert "Do something" in brief
+
+    def test_get_status_no_brief(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+        from bantz.proactive.rule_engine import ProactiveRuleEngine
+        from bantz.proactive.signals import SignalCollector
+
+        gen = DailyBriefGenerator(
+            MagicMock(spec=SignalCollector),
+            ProactiveRuleEngine(),
+        )
+        status = gen.get_status()
+        assert status["has_brief"] is False
+        assert status["last_generated_at"] is None
+
+    def test_extract_time_iso(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+
+        assert DailyBriefGenerator._extract_time({"start": "2025-01-15T10:30:00"}) == "10:30"
+
+    def test_extract_time_dict(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+
+        evt = {"start": {"dateTime": "2025-01-15T14:00:00+03:00"}}
+        assert DailyBriefGenerator._extract_time(evt) == "14:00"
+
+    def test_extract_time_simple(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+
+        assert DailyBriefGenerator._extract_time({"start": "09:00"}) == "09:00"
+
+    def test_extract_time_unknown(self):
+        from bantz.proactive.daily_brief import DailyBriefGenerator
+
+        assert DailyBriefGenerator._extract_time({"start": "bad"}) == "??:??"
+
+
+# ═══════════════════════════════════════════════════════════════
+# Delivery Channels
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestDeliveryChannels:
+    @pytest.mark.asyncio
+    async def test_terminal_delivery(self, capsys):
+        from bantz.proactive.delivery import TerminalDelivery
+
+        channel = TerminalDelivery()
+        await channel.deliver("Hello!")
+        captured = capsys.readouterr()
+        assert "Hello!" in captured.out
+
+    @pytest.mark.asyncio
+    async def test_callback_delivery(self):
+        from bantz.proactive.delivery import CallbackDelivery
+
+        received = []
+
+        async def cb(text):
+            received.append(text)
+
+        channel = CallbackDelivery(cb)
+        await channel.deliver("Test brief")
+        assert received == ["Test brief"]
+
+    @pytest.mark.asyncio
+    async def test_eventbus_delivery(self):
+        from bantz.proactive.delivery import EventBusDelivery
+
+        bus = MagicMock()
+        channel = EventBusDelivery(bus)
+        await channel.deliver("Brief text")
+        bus.publish.assert_called_once()
+        call_kwargs = bus.publish.call_args
+        assert call_kwargs[1]["data"]["proactive"] is True
+
+    @pytest.mark.asyncio
+    async def test_eventbus_delivery_no_bus(self):
+        from bantz.proactive.delivery import EventBusDelivery
+
+        channel = EventBusDelivery(None)
+        # Should not raise
+        await channel.deliver("ignored")
+
+    @pytest.mark.asyncio
+    async def test_desktop_notification_no_binary(self):
+        from bantz.proactive.delivery import DesktopNotificationDelivery
+
+        channel = DesktopNotificationDelivery()
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            # Should not raise
+            await channel.deliver("Test")
+
+    def test_channel_name(self):
+        from bantz.proactive.delivery import TerminalDelivery
+
+        assert TerminalDelivery().name == "TerminalDelivery"
+
+
+# ═══════════════════════════════════════════════════════════════
+# Engine Integration
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestEngineSecretary:
+    def test_init_secretary(self):
+        from bantz.proactive.engine import ProactiveEngine
+
+        engine = ProactiveEngine()
+        # Secretary components should be initialized
+        assert engine.signal_collector is not None
+        assert engine.rule_engine is not None
+        assert engine.brief_generator is not None
+
+    def test_secretary_rule_engine_has_rules(self):
+        from bantz.proactive.engine import ProactiveEngine
+
+        engine = ProactiveEngine()
+        re = engine.rule_engine
+        assert len(re.rule_names) >= 7
+
+    def test_load_yaml_config(self):
+        from bantz.proactive.engine import ProactiveEngine
+
+        engine = ProactiveEngine()
+        config = engine._load_yaml_config()
+        # Should load from config/proactive.yaml
+        assert isinstance(config, dict)
+        # Even if pyyaml is missing, should return empty dict
+
+    def test_brief_generator_has_channels(self):
+        from bantz.proactive.engine import ProactiveEngine
+
+        engine = ProactiveEngine()
+        gen = engine.brief_generator
+        assert gen is not None
+        status = gen.get_status()
+        # Should have at least terminal channel
+        assert status["delivery_channels"] >= 1
+
+
+# ═══════════════════════════════════════════════════════════════
+# YAML Config
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestYAMLConfig:
+    def test_config_file_exists(self):
+        from pathlib import Path
+
+        yaml_path = Path(__file__).resolve().parents[1] / "config" / "proactive.yaml"
+        assert yaml_path.exists()
+
+    def test_config_loads(self):
+        from pathlib import Path
+
+        yaml_path = Path(__file__).resolve().parents[1] / "config" / "proactive.yaml"
+        try:
+            import yaml
+
+            config = yaml.safe_load(yaml_path.read_text())
+            assert "scheduler" in config
+            assert "daily_brief" in config
+            assert "rules" in config
+            assert "delivery" in config
+            assert config["daily_brief"]["time"] == "08:00"
+        except ImportError:
+            pytest.skip("pyyaml not installed")
+
+    def test_rules_section(self):
+        from pathlib import Path
+
+        yaml_path = Path(__file__).resolve().parents[1] / "config" / "proactive.yaml"
+        try:
+            import yaml
+
+            config = yaml.safe_load(yaml_path.read_text())
+            rules = config["rules"]
+            assert "rain_alert" in rules
+            assert "pending_rsvp" in rules
+            assert "deadline_approaching" in rules
+            assert "free_slot_suggestion" in rules
+            assert "urgent_mail" in rules
+        except ImportError:
+            pytest.skip("pyyaml not installed")
+
+
+# ═══════════════════════════════════════════════════════════════
+# Rule Conditions (unit test each rule function)
+# ═══════════════════════════════════════════════════════════════
+
+
+class TestRuleConditions:
+    def test_rain_alert_triggers(self):
+        from bantz.proactive.rule_engine import _rain_alert
+        from bantz.proactive.signals import DailySignals, WeatherSignal
+
+        assert _rain_alert(DailySignals(weather=WeatherSignal(rain_probability=0.7))) is True
+
+    def test_rain_alert_no_trigger(self):
+        from bantz.proactive.rule_engine import _rain_alert
+        from bantz.proactive.signals import DailySignals, WeatherSignal
+
+        assert _rain_alert(DailySignals(weather=WeatherSignal(rain_probability=0.3))) is False
+
+    def test_pending_rsvp_triggers(self):
+        from bantz.proactive.rule_engine import _pending_rsvp
+        from bantz.proactive.signals import CalendarSignal, DailySignals
+
+        sig = DailySignals(calendar=CalendarSignal(pending_rsvp=[{"summary": "X"}]))
+        assert _pending_rsvp(sig) is True
+
+    def test_deadline_approaching_overdue(self):
+        from bantz.proactive.rule_engine import _deadline_approaching
+        from bantz.proactive.signals import DailySignals, TaskSignal
+
+        sig = DailySignals(tasks=TaskSignal(overdue=[{"title": "old"}]))
+        assert _deadline_approaching(sig) is True
+
+    def test_free_slot_suggestion(self):
+        from bantz.proactive.rule_engine import _free_slot_suggestion
+        from bantz.proactive.signals import (CalendarSignal, DailySignals,
+                                             FreeSlot, TaskSignal)
+
+        sig = DailySignals(
+            calendar=CalendarSignal(free_slots=[FreeSlot("09:00", "10:00")]),
+            tasks=TaskSignal(active_tasks=[{"title": "T"}]),
+        )
+        assert _free_slot_suggestion(sig) is True
+
+    def test_urgent_mail(self):
+        from bantz.proactive.rule_engine import _urgent_mail
+        from bantz.proactive.signals import DailySignals, EmailSignal
+
+        sig = DailySignals(emails=EmailSignal(urgent=[{"id": "1"}]))
+        assert _urgent_mail(sig) is True
+
+    def test_high_unread(self):
+        from bantz.proactive.rule_engine import _high_unread
+        from bantz.proactive.signals import DailySignals, EmailSignal
+
+        assert _high_unread(DailySignals(emails=EmailSignal(unread_count=20))) is True
+        assert _high_unread(DailySignals(emails=EmailSignal(unread_count=5))) is False
+
+    def test_overdue_tasks(self):
+        from bantz.proactive.rule_engine import _overdue_tasks
+        from bantz.proactive.signals import DailySignals, TaskSignal
+
+        sig = DailySignals(tasks=TaskSignal(overdue=[{"title": "X"}]))
+        assert _overdue_tasks(sig) is True


### PR DESCRIPTION
## Summary

Implements **#1293 — Proactive Secretary Engine** EPIC.

Adds a proactive intelligence layer that collects ambient signals from Calendar, Email, Weather, Tasks, and News, evaluates them against configurable rules, and delivers actionable daily briefs to the user.

## Changes

### New Files

| File | Description |
|------|-------------|
| `proactive/signals.py` | `SignalCollector` — parallel async collection via `asyncio.gather()`, 7 signal models, free-slot calculator |
| `proactive/rule_engine.py` | `ProactiveRuleEngine` — 7 built-in rules + optional LLM callback |
| `proactive/daily_brief.py` | `DailyBriefGenerator` — composable Turkish brief + multi-channel delivery |
| `proactive/delivery.py` | `DeliveryChannel` ABC + Terminal, Desktop, EventBus, Callback channels |
| `config/proactive.yaml` | Declarative YAML config: scheduler, signals, rules, delivery, work hours |

### Modified Files

| File | Change |
|------|--------|
| `proactive/engine.py` | Added `_init_secretary()`, YAML config loader, properties |
| `proactive/__init__.py` | Exports all new types |
| `tools/register_all.py` | Added `proactive.daily_brief` + `proactive.status` tools |
| `config/permissions.yaml` | Permission rules for proactive tools |

### Architecture

```
ProactiveEngine (existing #835)
├── ProactiveScheduler (30s poll loop)
├── Built-in Checks (morning_briefing, weather_calendar, email_digest)
├── CrossAnalyzer (3 rules)
├── NotificationQueue (policy-based filtering)
│
└── 🆕 Proactive Secretary (#1293)
    ├── SignalCollector → collect_all() → DailySignals
    │   ├── collect_calendar() → CalendarSignal
    │   ├── collect_emails() → EmailSignal
    │   ├── collect_weather() → WeatherSignal
    │   ├── collect_tasks() → TaskSignal
    │   └── collect_news() → NewsSignal
    │
    ├── ProactiveRuleEngine → evaluate() → [RuleSuggestion]
    │   ├── rain_alert (rain_prob > 0.6)
    │   ├── pending_rsvp (unaccepted invites)
    │   ├── deadline_approaching (due today / overdue)
    │   ├── free_slot_suggestion (gaps + pending tasks)
    │   ├── urgent_mail (important unread)
    │   ├── high_unread (≥15 unread)
    │   ├── overdue_tasks (past due date)
    │   └── [optional] LLM callback
    │
    ├── DailyBriefGenerator → format_brief() → Turkish text
    │
    └── DeliveryChannels
        ├── TerminalDelivery
        ├── DesktopNotificationDelivery
        └── EventBusDelivery
```

### Rules Configuration (`config/proactive.yaml`)

All 7 rules can be enabled/disabled and reprioritized via YAML config.

### On-Demand Brief Tool

Users can say **"brief'imi göster"** to trigger `proactive.daily_brief`.

## Test Results

```
67 new tests passed in 0.23s
93 existing proactive tests: no regressions
```

Closes #1293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Proactive Secretary system that generates daily briefings by aggregating calendar events, emails, weather, tasks, and news.
  * Added rule-based intelligence engine that evaluates signals and provides contextual suggestions (deadlines, free slots, urgent messages, weather alerts).
  * Enabled multiple delivery channels: terminal output, desktop notifications, and event-based delivery.
  * New tools for on-demand brief generation and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->