### PR TITLE
feat(resilience): Graceful Degradation — Health Monitor + Fallback Registry (#1298)

### DIFF
--- a/config/permissions.yaml
+++ b/config/permissions.yaml
@@ -379,6 +379,27 @@ permissions:
     risk: "low"
     decision: "allow"
 
+  # ── Health & Degradation (Issue #1298) ─────────────────────
+  - tool: "system.health"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "system.health_service"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "system.circuit_breaker"
+    action: "read"
+    risk: "low"
+    decision: "allow"
+
+  - tool: "system.fallback"
+    action: "execute"
+    risk: "low"
+    decision: "allow"
+
   # ── Catch-all (unknown tools) ──────────────────────────────
   - tool: "*"
     action: "*"

--- a/src/bantz/core/events.py
+++ b/src/bantz/core/events.py
@@ -121,6 +121,14 @@ class EventType(Enum):
     BANTZ_MESSAGE = "bantz_message"
     COMMAND_RESULT = "command_result"
 
+    # === Health & Degradation (Issue #1298) ===
+    HEALTH_CHECK = "system.health_check"          # Sağlık kontrolü yapıldı
+    HEALTH_DEGRADED = "system.health_degraded"    # Servis bozuldu
+    HEALTH_RECOVERED = "system.health_recovered"  # Servis düzeldi
+    CIRCUIT_OPENED = "system.circuit_opened"      # Circuit breaker açıldı
+    CIRCUIT_CLOSED = "system.circuit_closed"      # Circuit breaker kapandı
+    FALLBACK_EXECUTED = "system.fallback_executed" # Fallback çalıştırıldı
+
 
 @dataclass
 class Event:

--- a/src/bantz/core/fallback_registry.py
+++ b/src/bantz/core/fallback_registry.py
@@ -1,0 +1,365 @@
+"""Fallback Registry — per-service fallback strategies for graceful degradation.
+
+Issue #1298: Graceful Degradation — Circuit Breaker + Health Monitor + Fallback.
+
+When a service is unhealthy, the FallbackRegistry determines the appropriate
+fallback strategy: use cached data, fall back to a simpler model, degrade
+functionality, or notify the user.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class FallbackStrategy(str, Enum):
+    """Supported fallback strategies."""
+
+    CACHE = "cache_fallback"          # Serve from cached data
+    SQLITE = "sqlite_fallback"       # Fall back to SQLite from graph DB
+    MODEL_DOWNGRADE = "model_downgrade"  # Use smaller/local model
+    GRACEFUL_ERROR = "graceful_error"    # Return user-friendly error
+    NONE = "none"                    # No fallback — propagate the error
+
+
+@dataclass
+class FallbackConfig:
+    """Configuration for a single service's fallback."""
+
+    service: str
+    strategy: FallbackStrategy
+    message_tr: str            # Turkish message for the user
+    message_en: str = ""       # English fallback (optional)
+    max_cache_age_s: int = 0   # Max staleness for cache fallback (seconds)
+    fallback_model: str = ""   # Alternative model for model_downgrade
+    fallback_fn: Optional[Callable[..., Any]] = None  # Custom fallback callable
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "service": self.service,
+            "strategy": self.strategy.value,
+            "message_tr": self.message_tr,
+        }
+        if self.max_cache_age_s:
+            d["max_cache_age_s"] = self.max_cache_age_s
+        if self.fallback_model:
+            d["fallback_model"] = self.fallback_model
+        return d
+
+
+@dataclass
+class FallbackResult:
+    """Result of executing a fallback."""
+
+    service: str
+    strategy: FallbackStrategy
+    success: bool
+    data: Any = None
+    message: str = ""
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "service": self.service,
+            "strategy": self.strategy.value,
+            "success": self.success,
+            "message": self.message,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+# ── Built-in Fallback Handlers ──────────────────────────────────
+
+def _cache_fallback(service: str, cache_dir: Path, max_age: int) -> FallbackResult:
+    """Try to serve from a cached response file."""
+    cache_file = cache_dir / f"{service}_cache.json"
+    try:
+        if not cache_file.exists():
+            return FallbackResult(
+                service=service,
+                strategy=FallbackStrategy.CACHE,
+                success=False,
+                message="Önbellek dosyası bulunamadı",
+            )
+
+        stat = cache_file.stat()
+        age_s = time.time() - stat.st_mtime
+        if max_age > 0 and age_s > max_age:
+            return FallbackResult(
+                service=service,
+                strategy=FallbackStrategy.CACHE,
+                success=False,
+                message=f"Önbellek çok eski ({age_s:.0f}s > {max_age}s)",
+            )
+
+        with open(cache_file) as f:
+            data = json.load(f)
+
+        return FallbackResult(
+            service=service,
+            strategy=FallbackStrategy.CACHE,
+            success=True,
+            data=data,
+            message=f"Önbellekten yanıt verildi ({age_s:.0f}s eski)",
+        )
+    except Exception as exc:
+        return FallbackResult(
+            service=service,
+            strategy=FallbackStrategy.CACHE,
+            success=False,
+            message=str(exc),
+        )
+
+
+def _sqlite_fallback(service: str) -> FallbackResult:
+    """Fall back from graph DB (Neo4j) to SQLite."""
+    try:
+        import sqlite3
+
+        db_path = Path.home() / ".bantz" / "bantz.db"
+        if not db_path.exists():
+            return FallbackResult(
+                service=service,
+                strategy=FallbackStrategy.SQLITE,
+                success=False,
+                message="SQLite veritabanı bulunamadı",
+            )
+
+        conn = sqlite3.connect(str(db_path), timeout=5)
+        conn.execute("SELECT 1")
+        conn.close()
+
+        return FallbackResult(
+            service=service,
+            strategy=FallbackStrategy.SQLITE,
+            success=True,
+            message="SQLite veritabanına yönlendirildi",
+        )
+    except Exception as exc:
+        return FallbackResult(
+            service=service,
+            strategy=FallbackStrategy.SQLITE,
+            success=False,
+            message=str(exc),
+        )
+
+
+def _model_downgrade(
+    service: str,
+    fallback_model: str,
+) -> FallbackResult:
+    """Attempt to use a smaller/alternative LLM model."""
+    if not fallback_model:
+        return FallbackResult(
+            service=service,
+            strategy=FallbackStrategy.MODEL_DOWNGRADE,
+            success=False,
+            message="Yedek model tanımlı değil",
+        )
+
+    return FallbackResult(
+        service=service,
+        strategy=FallbackStrategy.MODEL_DOWNGRADE,
+        success=True,
+        data={"model": fallback_model},
+        message=f"Model değiştirildi: {fallback_model}",
+    )
+
+
+# ── Fallback Registry ───────────────────────────────────────────
+
+# Default fallback configurations for Bantz services
+_DEFAULT_CONFIGS: Dict[str, FallbackConfig] = {
+    "ollama": FallbackConfig(
+        service="ollama",
+        strategy=FallbackStrategy.MODEL_DOWNGRADE,
+        message_tr="LLM servisi yanıt vermiyor, daha küçük model deneniyor.",
+        max_cache_age_s=0,
+        fallback_model="qwen2.5-coder:3b",
+    ),
+    "google": FallbackConfig(
+        service="google",
+        strategy=FallbackStrategy.CACHE,
+        message_tr="Google API erişilemiyor, önbellekteki veriler kullanılıyor.",
+        max_cache_age_s=3600,  # 1 hour
+    ),
+    "neo4j": FallbackConfig(
+        service="neo4j",
+        strategy=FallbackStrategy.SQLITE,
+        message_tr="Graf veritabanı erişilemiyor, SQLite'a geri dönülüyor.",
+    ),
+    "weather": FallbackConfig(
+        service="weather",
+        strategy=FallbackStrategy.CACHE,
+        message_tr="Hava durumu servisi yanıt vermiyor, son bilinen veriler kullanılıyor.",
+        max_cache_age_s=7200,  # 2 hours
+    ),
+    "spotify": FallbackConfig(
+        service="spotify",
+        strategy=FallbackStrategy.GRACEFUL_ERROR,
+        message_tr="Spotify erişilemiyor, müzik kontrol edilemiyor.",
+    ),
+}
+
+
+class FallbackRegistry:
+    """Registry of fallback strategies for graceful degradation.
+
+    When a service goes down (circuit breaker open, health check fail),
+    the registry determines how to handle the failure gracefully instead
+    of propagating errors to the user.
+
+    Usage:
+        registry = FallbackRegistry()
+        result = registry.execute_fallback("ollama")
+        if result.success:
+            use(result.data)
+        else:
+            show_error(result.message)
+    """
+
+    def __init__(
+        self,
+        *,
+        configs: Dict[str, FallbackConfig] | None = None,
+        cache_dir: Path | None = None,
+    ) -> None:
+        self._configs: Dict[str, FallbackConfig] = (
+            configs if configs is not None
+            else dict(_DEFAULT_CONFIGS)
+        )
+        self._cache_dir = cache_dir or Path.home() / ".bantz" / "cache"
+        self._history: list[FallbackResult] = []
+
+    def register(self, config: FallbackConfig) -> None:
+        """Register or update a fallback configuration."""
+        self._configs[config.service] = config
+
+    def unregister(self, service: str) -> None:
+        """Remove a fallback configuration."""
+        self._configs.pop(service, None)
+
+    def get_config(self, service: str) -> Optional[FallbackConfig]:
+        """Get fallback configuration for a service."""
+        return self._configs.get(service)
+
+    def list_services(self) -> list[str]:
+        """List all services with fallback configurations."""
+        return list(self._configs.keys())
+
+    def execute_fallback(self, service: str) -> FallbackResult:
+        """Execute the registered fallback for a service.
+
+        Returns a ``FallbackResult`` indicating whether the fallback
+        succeeded and any recovered data.
+        """
+        config = self._configs.get(service)
+        if config is None:
+            result = FallbackResult(
+                service=service,
+                strategy=FallbackStrategy.NONE,
+                success=False,
+                message=f"'{service}' için fallback tanımlı değil",
+            )
+            self._history.append(result)
+            return result
+
+        logger.info(
+            "[FallbackRegistry] Executing %s for '%s'",
+            config.strategy.value,
+            service,
+        )
+
+        # Dispatch by strategy
+        strategy = config.strategy
+
+        if strategy == FallbackStrategy.CACHE:
+            result = _cache_fallback(
+                service,
+                self._cache_dir,
+                config.max_cache_age_s,
+            )
+        elif strategy == FallbackStrategy.SQLITE:
+            result = _sqlite_fallback(service)
+        elif strategy == FallbackStrategy.MODEL_DOWNGRADE:
+            result = _model_downgrade(service, config.fallback_model)
+        elif strategy == FallbackStrategy.GRACEFUL_ERROR:
+            result = FallbackResult(
+                service=service,
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                success=True,
+                message=config.message_tr,
+            )
+        else:  # NONE
+            result = FallbackResult(
+                service=service,
+                strategy=FallbackStrategy.NONE,
+                success=False,
+                message="Fallback stratejisi yok",
+            )
+
+        # Custom handler override
+        if config.fallback_fn is not None:
+            try:
+                custom_data = config.fallback_fn(service)
+                result = FallbackResult(
+                    service=service,
+                    strategy=strategy,
+                    success=True,
+                    data=custom_data,
+                    message="Özel fallback çalıştırıldı",
+                )
+            except Exception as exc:
+                result = FallbackResult(
+                    service=service,
+                    strategy=strategy,
+                    success=False,
+                    message=f"Özel fallback başarısız: {exc}",
+                )
+
+        self._history.append(result)
+        return result
+
+    @property
+    def history(self) -> list[FallbackResult]:
+        """Get the history of fallback executions."""
+        return list(self._history)
+
+    def clear_history(self) -> None:
+        """Clear fallback execution history."""
+        self._history.clear()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize all configurations."""
+        return {
+            name: config.to_dict()
+            for name, config in self._configs.items()
+        }
+
+
+# ── Singleton ────────────────────────────────────────────────────
+
+_fallback_registry: Optional[FallbackRegistry] = None
+
+
+def get_fallback_registry(**kwargs: Any) -> FallbackRegistry:
+    """Get or create singleton FallbackRegistry."""
+    global _fallback_registry
+    if _fallback_registry is None:
+        _fallback_registry = FallbackRegistry(**kwargs)
+    return _fallback_registry
+
+
+def reset_fallback_registry() -> None:
+    """Reset singleton (for tests)."""
+    global _fallback_registry
+    _fallback_registry = None

--- a/src/bantz/core/health_monitor.py
+++ b/src/bantz/core/health_monitor.py
@@ -1,0 +1,456 @@
+"""Health Monitor — periodic health checks for all Bantz dependencies.
+
+Issue #1298: Graceful Degradation — Circuit Breaker + Health Monitor + Fallback.
+
+Monitors external service health (Ollama, Google API, SQLite, etc.)
+and publishes events when services degrade. Integrates with the
+EventBus and CircuitBreaker for coordinated failure handling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ServiceStatus(str, Enum):
+    """Health status of a monitored service."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"       # Slow but functional
+    UNHEALTHY = "unhealthy"     # Not responding / errors
+
+
+@dataclass
+class HealthStatus:
+    """Health status for a single service."""
+
+    service: str
+    status: ServiceStatus
+    latency_ms: float = 0.0
+    error: str = ""
+    last_check: datetime = field(default_factory=datetime.now)
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "service": self.service,
+            "status": self.status.value,
+            "latency_ms": round(self.latency_ms, 1),
+            "last_check": self.last_check.isoformat(),
+        }
+        if self.error:
+            d["error"] = self.error
+        if self.details:
+            d["details"] = self.details
+        return d
+
+
+@dataclass
+class HealthReport:
+    """Aggregated health report for all services."""
+
+    checks: Dict[str, HealthStatus]
+    overall: ServiceStatus
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "overall": self.overall.value,
+            "timestamp": self.timestamp.isoformat(),
+            "services": {
+                name: status.to_dict()
+                for name, status in self.checks.items()
+            },
+        }
+
+    @property
+    def healthy_services(self) -> List[str]:
+        return [
+            n for n, s in self.checks.items()
+            if s.status == ServiceStatus.HEALTHY
+        ]
+
+    @property
+    def unhealthy_services(self) -> List[str]:
+        return [
+            n for n, s in self.checks.items()
+            if s.status == ServiceStatus.UNHEALTHY
+        ]
+
+    @property
+    def degraded_services(self) -> List[str]:
+        return [
+            n for n, s in self.checks.items()
+            if s.status == ServiceStatus.DEGRADED
+        ]
+
+
+# ── Health Check Functions ───────────────────────────────────────
+
+# Thresholds: latency above this → DEGRADED
+_LATENCY_THRESHOLDS: Dict[str, float] = {
+    "sqlite": 100.0,    # 100ms
+    "ollama": 2000.0,   # 2s
+    "google": 3000.0,   # 3s
+    "neo4j": 1000.0,    # 1s
+    "weather": 5000.0,  # 5s
+}
+
+
+async def check_sqlite() -> HealthStatus:
+    """Check SQLite database is writable."""
+    start = time.monotonic()
+    try:
+        import sqlite3
+        from pathlib import Path
+
+        db_path = Path.home() / ".bantz" / "bantz.db"
+        if not db_path.exists():
+            # Look for any .db in common locations
+            for candidate in [
+                Path("data/bantz.db"),
+                Path("bantz.db"),
+            ]:
+                if candidate.exists():
+                    db_path = candidate
+                    break
+
+        conn = sqlite3.connect(str(db_path), timeout=5)
+        conn.execute("SELECT 1")
+        conn.close()
+
+        latency = (time.monotonic() - start) * 1000
+        threshold = _LATENCY_THRESHOLDS["sqlite"]
+        return HealthStatus(
+            service="sqlite",
+            status=(
+                ServiceStatus.DEGRADED if latency > threshold
+                else ServiceStatus.HEALTHY
+            ),
+            latency_ms=latency,
+        )
+    except Exception as exc:
+        latency = (time.monotonic() - start) * 1000
+        return HealthStatus(
+            service="sqlite",
+            status=ServiceStatus.UNHEALTHY,
+            latency_ms=latency,
+            error=str(exc),
+        )
+
+
+async def check_ollama() -> HealthStatus:
+    """Check Ollama LLM server is responding."""
+    import os
+
+    start = time.monotonic()
+    base_url = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(f"{base_url}/api/tags", method="GET")
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(
+            None,
+            lambda: urllib.request.urlopen(req, timeout=5),
+        )
+        data = response.read()
+
+        latency = (time.monotonic() - start) * 1000
+        threshold = _LATENCY_THRESHOLDS["ollama"]
+
+        import json
+
+        models = json.loads(data).get("models", [])
+        model_names = [m.get("name", "") for m in models[:5]]
+
+        return HealthStatus(
+            service="ollama",
+            status=(
+                ServiceStatus.DEGRADED if latency > threshold
+                else ServiceStatus.HEALTHY
+            ),
+            latency_ms=latency,
+            details={"models": model_names},
+        )
+    except Exception as exc:
+        latency = (time.monotonic() - start) * 1000
+        return HealthStatus(
+            service="ollama",
+            status=ServiceStatus.UNHEALTHY,
+            latency_ms=latency,
+            error=str(exc),
+        )
+
+
+async def check_google_api() -> HealthStatus:
+    """Check Google API token validity."""
+    start = time.monotonic()
+    try:
+        from pathlib import Path
+
+        token_path = Path("config/token.json")
+        if not token_path.exists():
+            token_path = Path.home() / ".bantz" / "token.json"
+
+        if not token_path.exists():
+            latency = (time.monotonic() - start) * 1000
+            return HealthStatus(
+                service="google",
+                status=ServiceStatus.UNHEALTHY,
+                latency_ms=latency,
+                error="Token dosyası bulunamadı",
+            )
+
+        import json
+
+        with open(token_path) as f:
+            token_data = json.load(f)
+
+        # Check if token has expired
+        expiry = token_data.get("expiry", "")
+        has_refresh = bool(token_data.get("refresh_token", ""))
+
+        latency = (time.monotonic() - start) * 1000
+        threshold = _LATENCY_THRESHOLDS["google"]
+
+        if not has_refresh:
+            return HealthStatus(
+                service="google",
+                status=ServiceStatus.DEGRADED,
+                latency_ms=latency,
+                error="Refresh token eksik",
+                details={"expiry": expiry},
+            )
+
+        return HealthStatus(
+            service="google",
+            status=(
+                ServiceStatus.DEGRADED if latency > threshold
+                else ServiceStatus.HEALTHY
+            ),
+            latency_ms=latency,
+            details={"expiry": expiry, "has_refresh": True},
+        )
+    except Exception as exc:
+        latency = (time.monotonic() - start) * 1000
+        return HealthStatus(
+            service="google",
+            status=ServiceStatus.UNHEALTHY,
+            latency_ms=latency,
+            error=str(exc),
+        )
+
+
+# ── Health Monitor ───────────────────────────────────────────────
+
+# Type for check functions
+HealthCheckFn = Callable[[], Any]  # Returns Awaitable[HealthStatus]
+
+
+class HealthMonitor:
+    """Monitors health of all Bantz dependencies.
+
+    Features:
+    - Pluggable health check functions per service
+    - Configurable check intervals
+    - EventBus integration for health degradation alerts
+    - Circuit breaker integration
+    - Async periodic monitoring
+    """
+
+    DEFAULT_CHECKS: Dict[str, HealthCheckFn] = {
+        "sqlite": check_sqlite,
+        "ollama": check_ollama,
+        "google": check_google_api,
+    }
+
+    def __init__(
+        self,
+        *,
+        checks: Dict[str, HealthCheckFn] | None = None,
+        event_bus: Any = None,
+        circuit_breaker: Any = None,
+        check_interval: int = 300,  # 5 minutes
+    ) -> None:
+        self._checks: Dict[str, HealthCheckFn] = (
+            checks if checks is not None
+            else dict(self.DEFAULT_CHECKS)
+        )
+        self._event_bus = event_bus
+        self._circuit_breaker = circuit_breaker
+        self._check_interval = check_interval
+        self._last_report: Optional[HealthReport] = None
+        self._running = False
+
+    def register_check(self, name: str, fn: HealthCheckFn) -> None:
+        """Register a new health check function."""
+        self._checks[name] = fn
+
+    def unregister_check(self, name: str) -> None:
+        """Remove a health check."""
+        self._checks.pop(name, None)
+
+    async def check_service(self, name: str) -> HealthStatus:
+        """Run a single service health check."""
+        fn = self._checks.get(name)
+        if fn is None:
+            return HealthStatus(
+                service=name,
+                status=ServiceStatus.UNHEALTHY,
+                error=f"Bilinmeyen servis: {name}",
+            )
+        try:
+            return await fn()
+        except Exception as exc:
+            logger.warning("[HealthMonitor] Check %s failed: %s", name, exc)
+            return HealthStatus(
+                service=name,
+                status=ServiceStatus.UNHEALTHY,
+                error=str(exc),
+            )
+
+    async def check_all(self) -> HealthReport:
+        """Run all health checks and return an aggregated report."""
+        results: Dict[str, HealthStatus] = {}
+
+        for name in self._checks:
+            results[name] = await self.check_service(name)
+
+        overall = self._compute_overall(results)
+        report = HealthReport(
+            checks=results,
+            overall=overall,
+        )
+        self._last_report = report
+
+        # Publish event if degraded or unhealthy
+        if overall != ServiceStatus.HEALTHY and self._event_bus:
+            try:
+                self._event_bus.publish(
+                    event_type="system.health_degraded",
+                    data=report.to_dict(),
+                    source="health_monitor",
+                )
+            except Exception as exc:
+                logger.debug("[HealthMonitor] Event publish failed: %s", exc)
+
+        # Update circuit breaker states
+        if self._circuit_breaker:
+            for name, status in results.items():
+                if status.status == ServiceStatus.UNHEALTHY:
+                    self._circuit_breaker.record_failure(name)
+                elif status.status == ServiceStatus.HEALTHY:
+                    self._circuit_breaker.record_success(name)
+
+        return report
+
+    @property
+    def last_report(self) -> Optional[HealthReport]:
+        """Get the most recent health report (if any)."""
+        return self._last_report
+
+    async def periodic_check(self) -> None:
+        """Run health checks periodically until stopped."""
+        self._running = True
+        logger.info(
+            "[HealthMonitor] Started — interval=%ds, services=%s",
+            self._check_interval,
+            list(self._checks.keys()),
+        )
+        try:
+            while self._running:
+                try:
+                    await self.check_all()
+                except Exception as exc:
+                    logger.error("[HealthMonitor] Check cycle error: %s", exc)
+                await asyncio.sleep(self._check_interval)
+        finally:
+            self._running = False
+
+    def stop(self) -> None:
+        """Stop the periodic check loop."""
+        self._running = False
+
+    @staticmethod
+    def _compute_overall(
+        checks: Dict[str, HealthStatus],
+    ) -> ServiceStatus:
+        """Compute overall status from individual checks."""
+        if not checks:
+            return ServiceStatus.HEALTHY
+
+        statuses = {s.status for s in checks.values()}
+
+        if ServiceStatus.UNHEALTHY in statuses:
+            return ServiceStatus.UNHEALTHY
+        if ServiceStatus.DEGRADED in statuses:
+            return ServiceStatus.DEGRADED
+        return ServiceStatus.HEALTHY
+
+    def format_report(self, report: Optional[HealthReport] = None) -> str:
+        """Format a health report for CLI display.
+
+        Returns a human-readable string with emoji indicators.
+        """
+        report = report or self._last_report
+        if not report:
+            return "Sağlık raporu yok — henüz kontrol yapılmadı."
+
+        _STATUS_ICONS = {
+            ServiceStatus.HEALTHY: "🟢",
+            ServiceStatus.DEGRADED: "🟡",
+            ServiceStatus.UNHEALTHY: "🔴",
+        }
+
+        _OVERALL_TEXT = {
+            ServiceStatus.HEALTHY: "✅ HEALTHY",
+            ServiceStatus.DEGRADED: "⚠️ DEGRADED",
+            ServiceStatus.UNHEALTHY: "❌ UNHEALTHY",
+        }
+
+        lines = ["🏥 Bantz Sağlık Raporu:"]
+        services = sorted(report.checks.items())
+        for i, (name, status) in enumerate(services):
+            is_last = i == len(services) - 1
+            prefix = "└──" if is_last else "├──"
+            icon = _STATUS_ICONS.get(status.status, "⚪")
+            detail = f"({status.latency_ms:.0f}ms)"
+            if status.error:
+                detail += f" — {status.error}"
+            lines.append(
+                f"  {prefix} {icon} {name:<12} {status.status.value:<10} {detail}"
+            )
+
+        lines.append("")
+        overall_text = _OVERALL_TEXT.get(report.overall, str(report.overall))
+        lines.append(f"Genel durum: {overall_text}")
+
+        return "\n".join(lines)
+
+
+# ── Singleton ────────────────────────────────────────────────────
+
+_health_monitor: Optional[HealthMonitor] = None
+
+
+def get_health_monitor(**kwargs: Any) -> HealthMonitor:
+    """Get or create singleton HealthMonitor."""
+    global _health_monitor
+    if _health_monitor is None:
+        _health_monitor = HealthMonitor(**kwargs)
+    return _health_monitor
+
+
+def reset_health_monitor() -> None:
+    """Reset singleton (for tests)."""
+    global _health_monitor
+    _health_monitor = None

--- a/tests/test_issue_1298_graceful_degradation.py
+++ b/tests/test_issue_1298_graceful_degradation.py
@@ -1,0 +1,866 @@
+"""Tests for Issue #1298 — Graceful Degradation.
+
+Covers:
+- HealthMonitor: check functions, aggregation, periodic loop
+- FallbackRegistry: config, strategy dispatch, custom handlers
+- CircuitBreaker enhancements: async call(), to_dict(), CircuitOpenError
+- EventType additions for health events
+- Integration: monitor → circuit breaker → fallback chain
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bantz.agent.circuit_breaker import (CircuitBreaker, CircuitOpenError,
+                                         CircuitState)
+from bantz.core.events import EventType
+from bantz.core.fallback_registry import (FallbackConfig, FallbackRegistry,
+                                          FallbackResult, FallbackStrategy,
+                                          get_fallback_registry,
+                                          reset_fallback_registry)
+from bantz.core.health_monitor import (HealthMonitor, HealthReport,
+                                       HealthStatus, ServiceStatus,
+                                       get_health_monitor,
+                                       reset_health_monitor)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Reset singletons before each test."""
+    reset_health_monitor()
+    reset_fallback_registry()
+    yield
+    reset_health_monitor()
+    reset_fallback_registry()
+
+
+# ── ServiceStatus ────────────────────────────────────────────────────
+
+
+class TestServiceStatus:
+    def test_values(self):
+        assert ServiceStatus.HEALTHY == "healthy"
+        assert ServiceStatus.DEGRADED == "degraded"
+        assert ServiceStatus.UNHEALTHY == "unhealthy"
+
+
+# ── HealthStatus ─────────────────────────────────────────────────────
+
+
+class TestHealthStatus:
+    def test_to_dict_healthy(self):
+        hs = HealthStatus(
+            service="sqlite",
+            status=ServiceStatus.HEALTHY,
+            latency_ms=12.345,
+        )
+        d = hs.to_dict()
+        assert d["service"] == "sqlite"
+        assert d["status"] == "healthy"
+        assert d["latency_ms"] == 12.3
+        assert "error" not in d
+
+    def test_to_dict_with_error(self):
+        hs = HealthStatus(
+            service="ollama",
+            status=ServiceStatus.UNHEALTHY,
+            latency_ms=5000.0,
+            error="Connection refused",
+        )
+        d = hs.to_dict()
+        assert d["error"] == "Connection refused"
+
+    def test_to_dict_with_details(self):
+        hs = HealthStatus(
+            service="ollama",
+            status=ServiceStatus.HEALTHY,
+            details={"models": ["qwen2.5"]},
+        )
+        d = hs.to_dict()
+        assert "models" in d["details"]
+
+
+# ── HealthReport ─────────────────────────────────────────────────────
+
+
+class TestHealthReport:
+    def test_overall_healthy(self):
+        checks = {
+            "a": HealthStatus(service="a", status=ServiceStatus.HEALTHY),
+            "b": HealthStatus(service="b", status=ServiceStatus.HEALTHY),
+        }
+        report = HealthReport(checks=checks, overall=ServiceStatus.HEALTHY)
+        assert report.healthy_services == ["a", "b"]
+        assert report.unhealthy_services == []
+        assert report.degraded_services == []
+
+    def test_overall_mixed(self):
+        checks = {
+            "a": HealthStatus(service="a", status=ServiceStatus.HEALTHY),
+            "b": HealthStatus(service="b", status=ServiceStatus.DEGRADED),
+            "c": HealthStatus(service="c", status=ServiceStatus.UNHEALTHY),
+        }
+        report = HealthReport(checks=checks, overall=ServiceStatus.UNHEALTHY)
+        assert report.healthy_services == ["a"]
+        assert report.degraded_services == ["b"]
+        assert report.unhealthy_services == ["c"]
+
+    def test_to_dict(self):
+        checks = {
+            "x": HealthStatus(service="x", status=ServiceStatus.HEALTHY, latency_ms=5.0),
+        }
+        report = HealthReport(checks=checks, overall=ServiceStatus.HEALTHY)
+        d = report.to_dict()
+        assert d["overall"] == "healthy"
+        assert "x" in d["services"]
+        assert "timestamp" in d
+
+
+# ── HealthMonitor ────────────────────────────────────────────────────
+
+
+class TestHealthMonitor:
+    @pytest.mark.asyncio
+    async def test_custom_check_healthy(self):
+        async def always_healthy():
+            return HealthStatus(
+                service="test_svc",
+                status=ServiceStatus.HEALTHY,
+                latency_ms=1.0,
+            )
+
+        monitor = HealthMonitor(checks={"test_svc": always_healthy})
+        status = await monitor.check_service("test_svc")
+        assert status.status == ServiceStatus.HEALTHY
+        assert status.service == "test_svc"
+
+    @pytest.mark.asyncio
+    async def test_custom_check_unhealthy(self):
+        async def always_fail():
+            return HealthStatus(
+                service="bad",
+                status=ServiceStatus.UNHEALTHY,
+                error="down",
+            )
+
+        monitor = HealthMonitor(checks={"bad": always_fail})
+        status = await monitor.check_service("bad")
+        assert status.status == ServiceStatus.UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_unknown_service(self):
+        monitor = HealthMonitor(checks={})
+        status = await monitor.check_service("nope")
+        assert status.status == ServiceStatus.UNHEALTHY
+        assert "Bilinmeyen" in status.error
+
+    @pytest.mark.asyncio
+    async def test_check_all_aggregation(self):
+        async def healthy():
+            return HealthStatus(service="a", status=ServiceStatus.HEALTHY)
+
+        async def degraded():
+            return HealthStatus(service="b", status=ServiceStatus.DEGRADED)
+
+        monitor = HealthMonitor(checks={"a": healthy, "b": degraded})
+        report = await monitor.check_all()
+        assert report.overall == ServiceStatus.DEGRADED
+        assert len(report.checks) == 2
+
+    @pytest.mark.asyncio
+    async def test_check_all_all_healthy(self):
+        async def healthy():
+            return HealthStatus(service="x", status=ServiceStatus.HEALTHY)
+
+        monitor = HealthMonitor(checks={"x": healthy, "y": healthy})
+        report = await monitor.check_all()
+        assert report.overall == ServiceStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_check_all_unhealthy_wins(self):
+        async def healthy():
+            return HealthStatus(service="a", status=ServiceStatus.HEALTHY)
+
+        async def bad():
+            return HealthStatus(service="b", status=ServiceStatus.UNHEALTHY)
+
+        monitor = HealthMonitor(checks={"a": healthy, "b": bad})
+        report = await monitor.check_all()
+        assert report.overall == ServiceStatus.UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_check_exception_in_check_fn(self):
+        async def boom():
+            raise RuntimeError("kaboom")
+
+        monitor = HealthMonitor(checks={"boom": boom})
+        status = await monitor.check_service("boom")
+        assert status.status == ServiceStatus.UNHEALTHY
+        assert "kaboom" in status.error
+
+    @pytest.mark.asyncio
+    async def test_last_report(self):
+        async def ok():
+            return HealthStatus(service="s", status=ServiceStatus.HEALTHY)
+
+        monitor = HealthMonitor(checks={"s": ok})
+        assert monitor.last_report is None
+        await monitor.check_all()
+        assert monitor.last_report is not None
+        assert monitor.last_report.overall == ServiceStatus.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_event_bus_publish_on_degraded(self):
+        async def bad():
+            return HealthStatus(service="x", status=ServiceStatus.UNHEALTHY)
+
+        bus = MagicMock()
+        monitor = HealthMonitor(checks={"x": bad}, event_bus=bus)
+        await monitor.check_all()
+        bus.publish.assert_called_once()
+        call_kwargs = bus.publish.call_args
+        assert call_kwargs[1]["event_type"] == "system.health_degraded"
+
+    @pytest.mark.asyncio
+    async def test_no_event_when_healthy(self):
+        async def ok():
+            return HealthStatus(service="s", status=ServiceStatus.HEALTHY)
+
+        bus = MagicMock()
+        monitor = HealthMonitor(checks={"s": ok}, event_bus=bus)
+        await monitor.check_all()
+        bus.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_integration(self):
+        async def bad():
+            return HealthStatus(service="x", status=ServiceStatus.UNHEALTHY)
+
+        async def ok():
+            return HealthStatus(service="y", status=ServiceStatus.HEALTHY)
+
+        cb = MagicMock()
+        monitor = HealthMonitor(checks={"x": bad, "y": ok}, circuit_breaker=cb)
+        await monitor.check_all()
+        cb.record_failure.assert_called_once_with("x")
+        cb.record_success.assert_called_once_with("y")
+
+    def test_register_unregister_check(self):
+        monitor = HealthMonitor(checks={})
+        assert "new" not in monitor._checks
+
+        async def new_check():
+            return HealthStatus(service="new", status=ServiceStatus.HEALTHY)
+
+        monitor.register_check("new", new_check)
+        assert "new" in monitor._checks
+
+        monitor.unregister_check("new")
+        assert "new" not in monitor._checks
+
+    @pytest.mark.asyncio
+    async def test_periodic_check_stop(self):
+        call_count = 0
+
+        async def counting():
+            nonlocal call_count
+            call_count += 1
+            return HealthStatus(service="s", status=ServiceStatus.HEALTHY)
+
+        monitor = HealthMonitor(checks={"s": counting}, check_interval=0)
+
+        async def run_then_stop():
+            task = asyncio.create_task(monitor.periodic_check())
+            await asyncio.sleep(0.1)
+            monitor.stop()
+            await task
+
+        await run_then_stop()
+        assert call_count >= 1
+
+    def test_format_report(self):
+        checks = {
+            "sqlite": HealthStatus(
+                service="sqlite", status=ServiceStatus.HEALTHY, latency_ms=5.0
+            ),
+            "ollama": HealthStatus(
+                service="ollama",
+                status=ServiceStatus.UNHEALTHY,
+                latency_ms=0,
+                error="refused",
+            ),
+        }
+        report = HealthReport(checks=checks, overall=ServiceStatus.UNHEALTHY)
+        monitor = HealthMonitor(checks={})
+        text = monitor.format_report(report)
+        assert "UNHEALTHY" in text
+        assert "ollama" in text
+        assert "sqlite" in text
+
+    def test_format_report_none(self):
+        monitor = HealthMonitor(checks={})
+        text = monitor.format_report()
+        assert "henüz" in text
+
+    def test_singleton(self):
+        m1 = get_health_monitor()
+        m2 = get_health_monitor()
+        assert m1 is m2
+
+    def test_compute_overall_empty(self):
+        assert HealthMonitor._compute_overall({}) == ServiceStatus.HEALTHY
+
+
+# ─── Fallback Registry ──────────────────────────────────────────────
+
+
+
+class TestFallbackStrategy:
+    def test_values(self):
+        assert FallbackStrategy.CACHE == "cache_fallback"
+        assert FallbackStrategy.SQLITE == "sqlite_fallback"
+        assert FallbackStrategy.MODEL_DOWNGRADE == "model_downgrade"
+        assert FallbackStrategy.GRACEFUL_ERROR == "graceful_error"
+        assert FallbackStrategy.NONE == "none"
+
+
+class TestFallbackConfig:
+    def test_to_dict(self):
+        cfg = FallbackConfig(
+            service="ollama",
+            strategy=FallbackStrategy.MODEL_DOWNGRADE,
+            message_tr="Model değiştirildi",
+            fallback_model="qwen2.5-coder:3b",
+        )
+        d = cfg.to_dict()
+        assert d["service"] == "ollama"
+        assert d["strategy"] == "model_downgrade"
+        assert d["fallback_model"] == "qwen2.5-coder:3b"
+
+    def test_to_dict_no_optionals(self):
+        cfg = FallbackConfig(
+            service="x",
+            strategy=FallbackStrategy.NONE,
+            message_tr="Yok",
+        )
+        d = cfg.to_dict()
+        assert "max_cache_age_s" not in d
+        assert "fallback_model" not in d
+
+
+class TestFallbackResult:
+    def test_to_dict(self):
+        result = FallbackResult(
+            service="google",
+            strategy=FallbackStrategy.CACHE,
+            success=True,
+            message="Cached",
+        )
+        d = result.to_dict()
+        assert d["success"] is True
+        assert d["strategy"] == "cache_fallback"
+
+
+class TestFallbackRegistry:
+    def test_default_configs(self):
+        registry = FallbackRegistry()
+        services = registry.list_services()
+        assert "ollama" in services
+        assert "google" in services
+        assert "neo4j" in services
+        assert "weather" in services
+
+    def test_register_unregister(self):
+        registry = FallbackRegistry(configs={})
+        cfg = FallbackConfig(
+            service="test_svc",
+            strategy=FallbackStrategy.GRACEFUL_ERROR,
+            message_tr="Test error",
+        )
+        registry.register(cfg)
+        assert registry.get_config("test_svc") is not None
+
+        registry.unregister("test_svc")
+        assert registry.get_config("test_svc") is None
+
+    def test_model_downgrade(self):
+        registry = FallbackRegistry(configs={
+            "ollama": FallbackConfig(
+                service="ollama",
+                strategy=FallbackStrategy.MODEL_DOWNGRADE,
+                message_tr="Downgrade",
+                fallback_model="qwen2.5-coder:3b",
+            ),
+        })
+        result = registry.execute_fallback("ollama")
+        assert result.success is True
+        assert result.data == {"model": "qwen2.5-coder:3b"}
+
+    def test_model_downgrade_no_model(self):
+        registry = FallbackRegistry(configs={
+            "ollama": FallbackConfig(
+                service="ollama",
+                strategy=FallbackStrategy.MODEL_DOWNGRADE,
+                message_tr="No model",
+                fallback_model="",
+            ),
+        })
+        result = registry.execute_fallback("ollama")
+        assert result.success is False
+
+    def test_graceful_error(self):
+        registry = FallbackRegistry(configs={
+            "spotify": FallbackConfig(
+                service="spotify",
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                message_tr="Spotify çalışmıyor",
+            ),
+        })
+        result = registry.execute_fallback("spotify")
+        assert result.success is True
+        assert "Spotify" in result.message
+
+    def test_unknown_service(self):
+        registry = FallbackRegistry(configs={})
+        result = registry.execute_fallback("unknown")
+        assert result.success is False
+        assert result.strategy == FallbackStrategy.NONE
+
+    def test_cache_fallback_no_file(self, tmp_path):
+        registry = FallbackRegistry(
+            configs={
+                "google": FallbackConfig(
+                    service="google",
+                    strategy=FallbackStrategy.CACHE,
+                    message_tr="Cache",
+                    max_cache_age_s=3600,
+                ),
+            },
+            cache_dir=tmp_path,
+        )
+        result = registry.execute_fallback("google")
+        assert result.success is False
+        assert "bulunamadı" in result.message
+
+    def test_cache_fallback_valid(self, tmp_path):
+        cache_file = tmp_path / "google_cache.json"
+        cache_file.write_text(json.dumps({"events": []}))
+
+        registry = FallbackRegistry(
+            configs={
+                "google": FallbackConfig(
+                    service="google",
+                    strategy=FallbackStrategy.CACHE,
+                    message_tr="Cache",
+                    max_cache_age_s=3600,
+                ),
+            },
+            cache_dir=tmp_path,
+        )
+        result = registry.execute_fallback("google")
+        assert result.success is True
+        assert result.data == {"events": []}
+
+    def test_cache_fallback_too_old(self, tmp_path):
+        cache_file = tmp_path / "google_cache.json"
+        cache_file.write_text(json.dumps({"events": []}))
+        # Set modification time to 2 hours ago
+        import os
+
+        old_time = time.time() - 7200
+        os.utime(cache_file, (old_time, old_time))
+
+        registry = FallbackRegistry(
+            configs={
+                "google": FallbackConfig(
+                    service="google",
+                    strategy=FallbackStrategy.CACHE,
+                    message_tr="Cache",
+                    max_cache_age_s=60,  # 1 minute max age
+                ),
+            },
+            cache_dir=tmp_path,
+        )
+        result = registry.execute_fallback("google")
+        assert result.success is False
+        assert "eski" in result.message
+
+    def test_none_strategy(self):
+        registry = FallbackRegistry(configs={
+            "x": FallbackConfig(
+                service="x",
+                strategy=FallbackStrategy.NONE,
+                message_tr="Nothing",
+            ),
+        })
+        result = registry.execute_fallback("x")
+        assert result.success is False
+
+    def test_custom_fallback_fn(self):
+        def custom_fn(service):
+            return {"custom": True, "service": service}
+
+        registry = FallbackRegistry(configs={
+            "custom": FallbackConfig(
+                service="custom",
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                message_tr="Custom",
+                fallback_fn=custom_fn,
+            ),
+        })
+        result = registry.execute_fallback("custom")
+        assert result.success is True
+        assert result.data["custom"] is True
+
+    def test_custom_fallback_fn_failure(self):
+        def bad_fn(service):
+            raise ValueError("custom fail")
+
+        registry = FallbackRegistry(configs={
+            "bad": FallbackConfig(
+                service="bad",
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                message_tr="Bad",
+                fallback_fn=bad_fn,
+            ),
+        })
+        result = registry.execute_fallback("bad")
+        assert result.success is False
+        assert "custom fail" in result.message
+
+    def test_history(self):
+        registry = FallbackRegistry(configs={
+            "x": FallbackConfig(
+                service="x",
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                message_tr="Test",
+            ),
+        })
+        registry.execute_fallback("x")
+        registry.execute_fallback("x")
+        assert len(registry.history) == 2
+        registry.clear_history()
+        assert len(registry.history) == 0
+
+    def test_to_dict(self):
+        registry = FallbackRegistry()
+        d = registry.to_dict()
+        assert "ollama" in d
+        assert d["ollama"]["strategy"] == "model_downgrade"
+
+    def test_singleton(self):
+        r1 = get_fallback_registry()
+        r2 = get_fallback_registry()
+        assert r1 is r2
+
+
+# ─── Circuit Breaker Enhancements ────────────────────────────────────
+
+
+class TestCircuitBreakerCall:
+    @pytest.mark.asyncio
+    async def test_call_sync_success(self):
+        cb = CircuitBreaker()
+
+        def add(a, b):
+            return a + b
+
+        result = await cb.call("test", add, 1, 2)
+        assert result == 3
+        assert cb.get_state("test") == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_call_async_success(self):
+        cb = CircuitBreaker()
+
+        async def async_add(a, b):
+            return a + b
+
+        result = await cb.call("test", async_add, 3, 4)
+        assert result == 7
+
+    @pytest.mark.asyncio
+    async def test_call_failure_records(self):
+        cb = CircuitBreaker(failure_threshold=2)
+
+        def fail():
+            raise ValueError("oops")
+
+        with pytest.raises(ValueError):
+            await cb.call("test", fail)
+
+        stats = cb.get_stats("test")
+        assert stats.failures == 1
+
+    @pytest.mark.asyncio
+    async def test_call_open_circuit_no_fallback(self):
+        cb = CircuitBreaker(failure_threshold=1)
+
+        def fail():
+            raise ValueError("oops")
+
+        with pytest.raises(ValueError):
+            await cb.call("test", fail)
+
+        with pytest.raises(CircuitOpenError) as exc_info:
+            await cb.call("test", fail)
+
+        assert exc_info.value.domain == "test"
+
+    @pytest.mark.asyncio
+    async def test_call_open_circuit_with_fallback(self):
+        cb = CircuitBreaker(failure_threshold=1)
+
+        def fail():
+            raise ValueError("oops")
+
+        def fallback():
+            return "fallback_value"
+
+        with pytest.raises(ValueError):
+            await cb.call("test", fail)
+
+        result = await cb.call("test", fail, fallback=fallback)
+        assert result == "fallback_value"
+
+    @pytest.mark.asyncio
+    async def test_call_open_circuit_with_async_fallback(self):
+        cb = CircuitBreaker(failure_threshold=1)
+
+        def fail():
+            raise ValueError("oops")
+
+        async def async_fallback():
+            return "async_fb"
+
+        with pytest.raises(ValueError):
+            await cb.call("test", fail)
+
+        result = await cb.call("test", fail, fallback=async_fallback)
+        assert result == "async_fb"
+
+    @pytest.mark.asyncio
+    async def test_call_failure_triggers_fallback(self):
+        """When fn fails AND circuit opens, fallback runs."""
+        cb = CircuitBreaker(failure_threshold=2)
+
+        call_count = 0
+
+        def fail():
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("fail")
+
+        def fb():
+            return "recovered"
+
+        # First failure — circuit still closed
+        with pytest.raises(ValueError):
+            await cb.call("svc", fail)
+
+        # Second failure — threshold reached, circuit opens, fallback runs
+        result = await cb.call("svc", fail, fallback=fb)
+        assert result == "recovered"
+        assert call_count == 2
+
+
+class TestCircuitBreakerToDict:
+    def test_empty(self):
+        cb = CircuitBreaker()
+        assert cb.to_dict() == {}
+
+    def test_with_domains(self):
+        cb = CircuitBreaker()
+        cb.record_failure("google")
+        cb.record_success("ollama")
+
+        d = cb.to_dict()
+        assert "google" in d
+        assert "ollama" in d
+        assert d["google"]["state"] == "closed"
+        assert d["google"]["failures"] == 1
+
+
+class TestCircuitOpenError:
+    def test_message(self):
+        err = CircuitOpenError("google")
+        assert err.domain == "google"
+        assert "google" in str(err)
+
+
+# ─── EventType Health Additions ──────────────────────────────────────
+
+
+class TestHealthEventTypes:
+    def test_health_check(self):
+        assert EventType.HEALTH_CHECK.value == "system.health_check"
+
+    def test_health_degraded(self):
+        assert EventType.HEALTH_DEGRADED.value == "system.health_degraded"
+
+    def test_health_recovered(self):
+        assert EventType.HEALTH_RECOVERED.value == "system.health_recovered"
+
+    def test_circuit_opened(self):
+        assert EventType.CIRCUIT_OPENED.value == "system.circuit_opened"
+
+    def test_circuit_closed(self):
+        assert EventType.CIRCUIT_CLOSED.value == "system.circuit_closed"
+
+    def test_fallback_executed(self):
+        assert EventType.FALLBACK_EXECUTED.value == "system.fallback_executed"
+
+
+# ─── Integration: Monitor → CB → Fallback ───────────────────────────
+
+
+class TestIntegration:
+    @pytest.mark.asyncio
+    async def test_monitor_opens_circuit_then_fallback(self):
+        """End-to-end: unhealthy check → CB open → fallback executed."""
+        cb = CircuitBreaker(failure_threshold=1)
+
+        async def unhealthy():
+            return HealthStatus(service="svc", status=ServiceStatus.UNHEALTHY)
+
+        monitor = HealthMonitor(
+            checks={"svc": unhealthy},
+            circuit_breaker=cb,
+        )
+        # Run health check — records failure in CB
+        await monitor.check_all()
+        # After threshold=1, circuit should be open
+        assert cb.is_open("svc")
+
+        # Now fallback should kick in
+        registry = FallbackRegistry(configs={
+            "svc": FallbackConfig(
+                service="svc",
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                message_tr="Servis çalışmıyor",
+            ),
+        })
+        result = registry.execute_fallback("svc")
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_monitor_event_bus_circuit_breaker_chain(self):
+        """Monitor publishes degraded event with bus, updates CB."""
+        cb = CircuitBreaker(failure_threshold=2)
+        bus = MagicMock()
+
+        async def degraded():
+            return HealthStatus(service="api", status=ServiceStatus.DEGRADED)
+
+        monitor = HealthMonitor(
+            checks={"api": degraded},
+            event_bus=bus,
+            circuit_breaker=cb,
+        )
+        await monitor.check_all()
+
+        # Degraded publishes event
+        bus.publish.assert_called_once()
+        # Degraded does NOT record failure in CB (only UNHEALTHY does)
+        assert cb.get_stats("api").failures == 0
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self):
+        """Service goes down → fallback → recovery → normal."""
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout=0.1)
+
+        # Phase 1: Service unhealthy
+        async def down():
+            return HealthStatus(service="db", status=ServiceStatus.UNHEALTHY)
+
+        monitor = HealthMonitor(checks={"db": down}, circuit_breaker=cb)
+        await monitor.check_all()
+        assert cb.is_open("db")
+
+        # Phase 2: Fallback
+        registry = FallbackRegistry(configs={
+            "db": FallbackConfig(
+                service="db",
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                message_tr="DB çöktü",
+            ),
+        })
+        fb = registry.execute_fallback("db")
+        assert fb.success
+
+        # Phase 3: Wait for reset_timeout, then recovery
+        import time
+        time.sleep(0.15)
+        # The is_open check will transition to half_open
+        assert not cb.is_open("db")  # transitions OPEN → HALF_OPEN
+
+        async def up():
+            return HealthStatus(service="db", status=ServiceStatus.HEALTHY)
+
+        monitor._checks["db"] = up
+        await monitor.check_all()
+
+        # CB should be closed now (success in half_open)
+        assert cb.get_state("db") == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_cb_call_with_health_aware_fallback(self):
+        """CircuitBreaker.call() with a fallback from the registry."""
+        cb = CircuitBreaker(failure_threshold=1)
+        registry = FallbackRegistry(configs={
+            "api": FallbackConfig(
+                service="api",
+                strategy=FallbackStrategy.GRACEFUL_ERROR,
+                message_tr="API çöktü",
+            ),
+        })
+
+        def api_call():
+            raise ConnectionError("refused")
+
+        def api_fallback():
+            return registry.execute_fallback("api")
+
+        # First call fails, opens circuit
+        with pytest.raises(ConnectionError):
+            await cb.call("api", api_call)
+
+        # Second call uses fallback
+        result = await cb.call("api", api_call, fallback=api_fallback)
+        assert isinstance(result, FallbackResult)
+        assert result.success is True
+
+
+# ─── SQLite Fallback ─────────────────────────────────────────────────
+
+
+class TestSqliteFallback:
+    def test_sqlite_fallback_no_db(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from bantz.core.fallback_registry import _sqlite_fallback
+
+        result = _sqlite_fallback("neo4j")
+        assert result.success is False
+
+    def test_sqlite_fallback_with_db(self, tmp_path, monkeypatch):
+        db_dir = tmp_path / ".bantz"
+        db_dir.mkdir()
+        import sqlite3
+
+        conn = sqlite3.connect(str(db_dir / "bantz.db"))
+        conn.execute("CREATE TABLE IF NOT EXISTS test (id INTEGER)")
+        conn.close()
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        from bantz.core.fallback_registry import _sqlite_fallback
+
+        result = _sqlite_fallback("neo4j")
+        assert result.success is True
+        assert "SQLite" in result.message


### PR DESCRIPTION
## Summary
Implements Issue #1298 — Graceful Degradation pattern for Bantz.

## New Files
- `src/bantz/core/health_monitor.py` — HealthMonitor with pluggable async checks (sqlite, ollama, google), periodic monitoring, EventBus & CircuitBreaker integration
- `src/bantz/core/fallback_registry.py` — FallbackRegistry with per-service strategies (cache, sqlite, model_downgrade, graceful_error)
- `tests/test_issue_1298_graceful_degradation.py` — 65 tests

## Modified Files
- `src/bantz/agent/circuit_breaker.py` — Added `async call()` wrapper with fallback support, `CircuitOpenError`, `to_dict()`
- `src/bantz/core/events.py` — 6 new EventTypes (HEALTH_CHECK, HEALTH_DEGRADED, HEALTH_RECOVERED, CIRCUIT_OPENED, CIRCUIT_CLOSED, FALLBACK_EXECUTED)
- `src/bantz/tools/register_all.py` — 4 new tools: system.health, system.health_service, system.circuit_breaker, system.fallback
- `config/permissions.yaml` — Allow rules for health tools

## Tests
65 tests covering:
- HealthMonitor: custom checks, aggregation, periodic loop, event bus, CB integration
- FallbackRegistry: all strategies, custom handlers, cache age, history
- CircuitBreaker: async call(), sync/async fn+fallback, CircuitOpenError, to_dict()
- Integration: full lifecycle (down → fallback → recovery → normal)

Closes #1298