### PR TITLE
feat(cli): wire 'bantz metrics' CLI subcommand (closes #1290)

### DIFF
--- a/src/bantz/cli.py
+++ b/src/bantz/cli.py
@@ -531,6 +531,12 @@ def main(argv: list[str] | None = None) -> int:
         proactive_args = proactive_p.parse_args(argv)
         return handle_proactive_command(proactive_args)
 
+    # Metrics — observability reports (Issue #1290)
+    if argv and argv[0] == "metrics":
+        from bantz.data.metrics_reporter import main as metrics_main
+        metrics_main(argv[1:])
+        return 0
+
     # Doctor — system health diagnostics (Issue #1223)
     if argv and argv[0] == "doctor":
         from bantz.doctor import run_doctor
@@ -577,6 +583,8 @@ Kullanım örnekleri:
   bantz --serve --http --port 9000  # Farklı portta HTTP
   bantz --http-only               # Sadece HTTP API (CLI yok)
   bantz --once "google aç"       # Tek seferlik (tarayıcı kalıcı değil)
+  bantz metrics --period 24h     # Observability metrics report
+  bantz metrics --period 7d      # Last 7 days metrics
 """,
     )
     parser.add_argument("--policy", default="config/policy.json", help="Policy dosyası yolu")

--- a/src/bantz/data/metrics_reporter.py
+++ b/src/bantz/data/metrics_reporter.py
@@ -143,8 +143,12 @@ async def _main(args: argparse.Namespace) -> None:
         await tracker.close()
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Bantz Metrics Reporter")
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point.  Called by ``bantz metrics`` or ``python -m``."""
+    parser = argparse.ArgumentParser(
+        prog="bantz metrics",
+        description="Bantz Observability Metrics Reporter",
+    )
     parser.add_argument(
         "--period", default="24h",
         help="Time period: 24h, 7d, 30d (default: 24h)",
@@ -153,7 +157,7 @@ def main() -> None:
         "--db", default=None,
         help="Path to observability.db (default: ~/.bantz/data/observability.db)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     try:
         asyncio.run(_main(args))


### PR DESCRIPTION
## Summary

Wires the `bantz metrics` CLI subcommand — the final missing piece for the Observability EPIC (#1290).

## Changes

- **`src/bantz/cli.py`**: Added `metrics` subcommand dispatch (delegates to `MetricsReporter.main()`)
- **`src/bantz/data/metrics_reporter.py`**: Updated `main()` to accept `argv` parameter for CLI integration

## Usage

```bash
bantz metrics                  # Last 24 hours (default)
bantz metrics --period 7d      # Last 7 days
bantz metrics --period 30d     # Last 30 days
bantz metrics --db /path/to/observability.db  # Custom DB path
```

## EPIC #1290 Acceptance Criteria — All Met

| Criteria | Status |
|----------|--------|
| `RunTracker` class in `src/bantz/data/run_tracker.py` | ✅ (892 lines) |
| SQLite schema: runs, tool_calls, artifacts | ✅ |
| Context manager with automatic latency measurement | ✅ (async + sync) |
| `orchestrator_loop.py` integration | ✅ (start_run, record_tool_call, end_run) |
| result_hash deduplication for large results | ✅ (SHA-256 stored) |
| CLI reporter: `bantz metrics --period` | ✅ ← **this PR** |
| Artifact recording mechanism | ✅ (save_artifact) |
| `~/.bantz/data/observability.db` file | ✅ (17 runs, 22 tool_calls in prod) |
| Tests (min 30) | ✅ (74 tests passing) |

## Test Results

```
74 passed, 10 warnings in 18.21s
```

Closes #1290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "metrics" subcommand to the CLI with support for configurable --period values, enabling metrics reporting through the command-line interface.

* **Improvements**
  * Enhanced error handling and user feedback when required data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->