### PR TITLE
feat(overlay): IPC Unix socket client for overlay.sock

### DIFF
--- a/bantz-overlay/src/main/ipc-client.js
+++ b/bantz-overlay/src/main/ipc-client.js
@@ -1,0 +1,373 @@
+/**
+ * Bantz Overlay — IPC Client
+ *
+ * Connects to the daemon's Unix domain socket (overlay.sock)
+ * using JSONL (newline-delimited JSON) wire protocol.
+ *
+ * Responsibilities:
+ * - Auto-connect on startup with retry logic
+ * - Parse incoming JSONL messages
+ * - Send ack/event/pong messages back to daemon
+ * - Emit connection state changes
+ * - Handle ping/pong heartbeat
+ *
+ * Wire format matches src/bantz/ipc/protocol.py:
+ *   Socket: ~/.local/share/bantz/ipc/overlay.sock
+ *   Each message: JSON object + '\n'
+ *   Common fields: v, type, ts, id
+ *
+ * @module ipc-client
+ */
+
+const net = require('net');
+const path = require('path');
+const fs = require('fs');
+const { EventEmitter } = require('events');
+const crypto = require('crypto');
+
+// Protocol version — must match Python IPC_VERSION
+const IPC_VERSION = 1;
+
+/**
+ * Default socket path: ~/.local/share/bantz/ipc/overlay.sock
+ */
+function getSocketPath() {
+  const xdgData = process.env.XDG_DATA_HOME || path.join(process.env.HOME, '.local/share');
+  return path.join(xdgData, 'bantz', 'ipc', 'overlay.sock');
+}
+
+/**
+ * Generate a 12-char hex message ID.
+ */
+function generateId() {
+  return crypto.randomBytes(6).toString('hex');
+}
+
+/**
+ * Get current timestamp in milliseconds.
+ */
+function nowMs() {
+  return Date.now();
+}
+
+/**
+ * Connection states.
+ * @enum {string}
+ */
+const ConnectionState = {
+  DISCONNECTED: 'disconnected',
+  CONNECTING: 'connecting',
+  CONNECTED: 'connected',
+};
+
+/**
+ * IPC Client for communicating with the Bantz daemon.
+ *
+ * Events emitted:
+ * - 'message'         (msg: object) — parsed JSONL message from daemon
+ * - 'state-change'    (state: ConnectionState) — connection state changed
+ * - 'error'           (err: Error) — socket error
+ *
+ * @extends EventEmitter
+ */
+class IPCClient extends EventEmitter {
+  /**
+   * @param {object} [options]
+   * @param {string} [options.socketPath]      - Override socket path
+   * @param {number} [options.retryIntervalMs] - Retry interval (default 2000)
+   * @param {number} [options.maxRetries]      - Max retries, 0 = infinite (default 0)
+   * @param {number} [options.pingTimeoutMs]   - Ping timeout (default 5000)
+   */
+  constructor(options = {}) {
+    super();
+
+    this._socketPath = options.socketPath || getSocketPath();
+    this._retryIntervalMs = options.retryIntervalMs || 2000;
+    this._maxRetries = options.maxRetries || 0;
+    this._pingTimeoutMs = options.pingTimeoutMs || 5000;
+
+    /** @type {net.Socket|null} */
+    this._socket = null;
+
+    /** @type {ConnectionState} */
+    this._state = ConnectionState.DISCONNECTED;
+
+    /** @type {number} */
+    this._retryCount = 0;
+
+    /** @type {NodeJS.Timeout|null} */
+    this._retryTimer = null;
+
+    /** @type {NodeJS.Timeout|null} */
+    this._pingTimer = null;
+
+    /** Incoming data buffer for partial JSONL messages. */
+    this._buffer = '';
+
+    /** Whether the client has been intentionally stopped. */
+    this._stopped = false;
+  }
+
+  // ─── Public API ─────────────────────────────────────────────
+
+  /**
+   * Current connection state.
+   * @returns {ConnectionState}
+   */
+  get state() {
+    return this._state;
+  }
+
+  /**
+   * Whether currently connected.
+   * @returns {boolean}
+   */
+  get connected() {
+    return this._state === ConnectionState.CONNECTED;
+  }
+
+  /**
+   * Start connecting to the daemon socket.
+   * Will retry automatically on failure.
+   */
+  connect() {
+    this._stopped = false;
+    this._retryCount = 0;
+    this._doConnect();
+  }
+
+  /**
+   * Disconnect and stop retrying.
+   */
+  disconnect() {
+    this._stopped = true;
+    this._clearRetryTimer();
+    this._clearPingTimer();
+
+    if (this._socket) {
+      this._socket.destroy();
+      this._socket = null;
+    }
+
+    this._setState(ConnectionState.DISCONNECTED);
+  }
+
+  /**
+   * Send a message to the daemon.
+   * @param {object} msg - Message object (will be JSON-serialized + '\n')
+   * @returns {boolean} - True if sent, false if not connected
+   */
+  send(msg) {
+    if (!this._socket || this._state !== ConnectionState.CONNECTED) {
+      return false;
+    }
+
+    // Ensure required fields
+    const envelope = {
+      v: IPC_VERSION,
+      id: generateId(),
+      ts: nowMs(),
+      ...msg,
+    };
+
+    try {
+      const line = JSON.stringify(envelope) + '\n';
+      this._socket.write(line, 'utf-8');
+      return true;
+    } catch (err) {
+      console.error('[IPC] Send error:', err.message);
+      return false;
+    }
+  }
+
+  /**
+   * Send an ACK for a received message.
+   * @param {string} msgId - ID of the message being acknowledged
+   */
+  sendAck(msgId) {
+    return this.send({ type: 'ack', id: msgId });
+  }
+
+  /**
+   * Send a pong reply.
+   */
+  sendPong() {
+    return this.send({ type: 'pong' });
+  }
+
+  /**
+   * Send an event message (overlay → daemon).
+   * @param {string} event - Event type: 'timeout' | 'dismissed'
+   * @param {string} [reason] - Reason: 'no_speech' | 'user_close' | 'internal'
+   */
+  sendEvent(event, reason = 'internal') {
+    return this.send({ type: 'event', event, reason });
+  }
+
+  // ─── Internal: Connection ───────────────────────────────────
+
+  /**
+   * Attempt to connect to the socket.
+   * @private
+   */
+  _doConnect() {
+    if (this._stopped) return;
+
+    // Check if socket file exists before attempting connection
+    if (!fs.existsSync(this._socketPath)) {
+      console.log(`[IPC] Socket not found: ${this._socketPath}`);
+      this._setState(ConnectionState.DISCONNECTED);
+      this._scheduleRetry();
+      return;
+    }
+
+    this._setState(ConnectionState.CONNECTING);
+
+    this._socket = new net.Socket();
+    this._buffer = '';
+
+    this._socket.connect(this._socketPath, () => {
+      console.log('[IPC] Connected to daemon');
+      this._retryCount = 0;
+      this._setState(ConnectionState.CONNECTED);
+    });
+
+    this._socket.on('data', (data) => {
+      this._onData(data);
+    });
+
+    this._socket.on('error', (err) => {
+      // ENOENT = socket doesn't exist, ECONNREFUSED = daemon not listening
+      if (err.code !== 'ENOENT' && err.code !== 'ECONNREFUSED') {
+        console.error('[IPC] Socket error:', err.message);
+      }
+      this.emit('error', err);
+    });
+
+    this._socket.on('close', () => {
+      console.log('[IPC] Connection closed');
+      this._socket = null;
+      this._setState(ConnectionState.DISCONNECTED);
+      this._clearPingTimer();
+      this._scheduleRetry();
+    });
+  }
+
+  /**
+   * Handle incoming data from socket.
+   * Accumulates into buffer and splits by newline (JSONL).
+   * @private
+   */
+  _onData(data) {
+    this._buffer += data.toString('utf-8');
+
+    // Process complete lines (JSONL: each message ends with \n)
+    let newlineIdx;
+    while ((newlineIdx = this._buffer.indexOf('\n')) !== -1) {
+      const line = this._buffer.substring(0, newlineIdx).trim();
+      this._buffer = this._buffer.substring(newlineIdx + 1);
+
+      if (!line) continue;
+
+      try {
+        const msg = JSON.parse(line);
+        this._handleMessage(msg);
+      } catch (err) {
+        console.error('[IPC] JSON parse error:', err.message, 'line:', line.substring(0, 100));
+      }
+    }
+  }
+
+  /**
+   * Process a parsed message.
+   * Auto-handles ping/pong; emits all messages.
+   * @private
+   */
+  _handleMessage(msg) {
+    // Auto-respond to pings
+    if (msg.type === 'ping') {
+      this.sendPong();
+    }
+
+    // Auto-acknowledge state messages
+    if (msg.type === 'state' && msg.id) {
+      this.sendAck(msg.id);
+    }
+
+    // Emit to listeners
+    this.emit('message', msg);
+  }
+
+  // ─── Internal: State Management ──────────────────────────────
+
+  /**
+   * @private
+   */
+  _setState(newState) {
+    if (this._state !== newState) {
+      const oldState = this._state;
+      this._state = newState;
+      console.log(`[IPC] ${oldState} → ${newState}`);
+      this.emit('state-change', newState);
+    }
+  }
+
+  // ─── Internal: Retry Logic ───────────────────────────────────
+
+  /**
+   * @private
+   */
+  _scheduleRetry() {
+    if (this._stopped) return;
+
+    if (this._maxRetries > 0 && this._retryCount >= this._maxRetries) {
+      console.log('[IPC] Max retries reached');
+      return;
+    }
+
+    this._clearRetryTimer();
+    this._retryCount++;
+
+    // Exponential backoff: 2s, 4s, 8s, max 30s
+    const delay = Math.min(
+      this._retryIntervalMs * Math.pow(1.5, Math.min(this._retryCount - 1, 6)),
+      30000
+    );
+
+    console.log(`[IPC] Retry #${this._retryCount} in ${Math.round(delay)}ms`);
+
+    this._retryTimer = setTimeout(() => {
+      this._retryTimer = null;
+      this._doConnect();
+    }, delay);
+  }
+
+  /**
+   * @private
+   */
+  _clearRetryTimer() {
+    if (this._retryTimer) {
+      clearTimeout(this._retryTimer);
+      this._retryTimer = null;
+    }
+  }
+
+  /**
+   * @private
+   */
+  _clearPingTimer() {
+    if (this._pingTimer) {
+      clearTimeout(this._pingTimer);
+      this._pingTimer = null;
+    }
+  }
+}
+
+module.exports = {
+  IPCClient,
+  ConnectionState,
+  getSocketPath,
+  generateId,
+  nowMs,
+  IPC_VERSION,
+};

--- a/bantz-overlay/src/main/main.js
+++ b/bantz-overlay/src/main/main.js
@@ -14,11 +14,18 @@
 
 const { app, BrowserWindow, globalShortcut, screen, ipcMain } = require('electron');
 const path = require('path');
+const { IPCClient, ConnectionState } = require('./ipc-client');
 
 let overlayWindow = null;
 
 /** Whether the overlay is currently visible. */
 let isVisible = true;
+
+/** IPC client instance for daemon communication. */
+const ipcClient = new IPCClient({
+  retryIntervalMs: 2000,
+  maxRetries: 0, // retry forever
+});
 
 /**
  * Detect the compositor: X11 or Wayland.
@@ -164,6 +171,45 @@ ipcMain.handle('overlay:get-display-info', () => {
   };
 });
 
+/**
+ * Renderer sends an event to the daemon.
+ */
+ipcMain.on('daemon:event', (_event, msg) => {
+  ipcClient.send(msg);
+});
+
+// ─── IPC: Daemon Socket ─────────────────────────────────────────────
+
+/**
+ * Start the IPC client and wire it to the renderer.
+ */
+function startIPCClient() {
+  // Forward daemon messages to renderer
+  ipcClient.on('message', (msg) => {
+    if (overlayWindow && overlayWindow.webContents) {
+      overlayWindow.webContents.send('daemon:message', msg);
+    }
+  });
+
+  // Forward connection state to renderer
+  ipcClient.on('state-change', (state) => {
+    if (overlayWindow && overlayWindow.webContents) {
+      overlayWindow.webContents.send('daemon:connection-state', state);
+    }
+    console.log(`[Main] IPC state: ${state}`);
+  });
+
+  ipcClient.on('error', (err) => {
+    // Only log non-routine errors
+    if (err.code !== 'ENOENT' && err.code !== 'ECONNREFUSED') {
+      console.error('[Main] IPC error:', err.message);
+    }
+  });
+
+  ipcClient.connect();
+  console.log('[Main] IPC client started');
+}
+
 // ─── App Lifecycle ──────────────────────────────────────────────────
 
 // Chromium flags for transparency on Linux
@@ -177,6 +223,7 @@ if (detectDisplayServer() === 'wayland') {
 
 app.whenReady().then(() => {
   createOverlayWindow();
+  startIPCClient();
 
   // Register global toggle shortcut
   const registered = globalShortcut.register('Super+Shift+B', toggleOverlay);
@@ -198,4 +245,5 @@ app.on('window-all-closed', () => {
 // Mark quitting so the close handler doesn't prevent exit
 app.on('before-quit', () => {
   app.isQuitting = true;
+  ipcClient.disconnect();
 });

--- a/bantz-overlay/src/main/preload.js
+++ b/bantz-overlay/src/main/preload.js
@@ -41,6 +41,15 @@ contextBridge.exposeInMainWorld('overlayAPI', {
    */
   sendDaemonEvent: (event) => ipcRenderer.send('daemon:event', event),
 
+  /**
+   * Register a callback for daemon connection state changes.
+   * State: 'connected' | 'connecting' | 'disconnected'
+   * @param {(state: string) => void} callback
+   */
+  onDaemonConnectionState: (callback) => {
+    ipcRenderer.on('daemon:connection-state', (_event, state) => callback(state));
+  },
+
   // ─── Lifecycle ─────────────────────────────────────────────────
   /**
    * Listen for overlay visibility changes.

--- a/bantz-overlay/src/renderer/renderer.js
+++ b/bantz-overlay/src/renderer/renderer.js
@@ -55,6 +55,14 @@
   // Start as connecting
   updateConnectionStatus('connecting');
 
+  // ─── Daemon Connection State ──────────────────────────────────
+  // Listen for connection state changes from the IPC client.
+  if (window.overlayAPI && window.overlayAPI.onDaemonConnectionState) {
+    window.overlayAPI.onDaemonConnectionState((state) => {
+      updateConnectionStatus(state);
+    });
+  }
+
   // ─── Daemon Message Handler ───────────────────────────────────
   // Future issues (#1399, #1405-#1410) will add real handlers here.
   // For now, just log and update connection status on first message.

--- a/bantz-overlay/tests/test_ipc_client.js
+++ b/bantz-overlay/tests/test_ipc_client.js
@@ -1,0 +1,295 @@
+/**
+ * Bantz Overlay — IPC Client Tests
+ *
+ * Unit tests for the IPC client module.
+ * Uses a mock Unix socket server to verify the client behavior.
+ *
+ * Run: node bantz-overlay/tests/test_ipc_client.js
+ */
+
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const assert = require('assert');
+const { IPCClient, ConnectionState, IPC_VERSION, generateId, nowMs } = require('../src/main/ipc-client');
+
+// Test socket in temp dir to avoid polluting real paths
+const TEST_SOCKET = path.join(os.tmpdir(), `bantz-test-ipc-${process.pid}.sock`);
+
+// Clean up socket file
+function cleanup() {
+  try { fs.unlinkSync(TEST_SOCKET); } catch (_) {}
+}
+
+/**
+ * Create a mock daemon server on the test socket.
+ * @returns {Promise<net.Server>}
+ */
+function createMockServer() {
+  return new Promise((resolve) => {
+    cleanup();
+    const server = net.createServer();
+    server.listen(TEST_SOCKET, () => resolve(server));
+  });
+}
+
+/**
+ * Collect messages from a socket connection.
+ * @param {net.Socket} socket
+ * @returns {{ messages: object[] }}
+ */
+function messageCollector(socket) {
+  const collector = { messages: [], buffer: '' };
+  socket.on('data', (data) => {
+    collector.buffer += data.toString();
+    let idx;
+    while ((idx = collector.buffer.indexOf('\n')) !== -1) {
+      const line = collector.buffer.substring(0, idx).trim();
+      collector.buffer = collector.buffer.substring(idx + 1);
+      if (line) {
+        try { collector.messages.push(JSON.parse(line)); } catch (_) {}
+      }
+    }
+  });
+  return collector;
+}
+
+/**
+ * Wait for a condition with timeout.
+ */
+function waitFor(condFn, timeoutMs = 3000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (condFn()) return resolve();
+      if (Date.now() - start > timeoutMs) return reject(new Error('Timeout'));
+      setTimeout(check, 50);
+    };
+    check();
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failed++;
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${err.message}`);
+  }
+}
+
+async function runTests() {
+  console.log('IPC Client Tests\n');
+
+  // ── Test: generateId returns 12-char hex
+  await test('generateId returns 12-char hex string', async () => {
+    const id = generateId();
+    assert.strictEqual(id.length, 12);
+    assert.ok(/^[0-9a-f]{12}$/.test(id));
+  });
+
+  // ── Test: nowMs returns reasonable timestamp
+  await test('nowMs returns current millisecond timestamp', async () => {
+    const ts = nowMs();
+    assert.ok(ts > 1700000000000); // after ~2023
+    assert.ok(ts < 2000000000000); // before ~2033
+  });
+
+  // ── Test: Client starts disconnected
+  await test('client starts in DISCONNECTED state', async () => {
+    const client = new IPCClient({ socketPath: TEST_SOCKET });
+    assert.strictEqual(client.state, ConnectionState.DISCONNECTED);
+    assert.strictEqual(client.connected, false);
+  });
+
+  // ── Test: Client connects to mock server
+  await test('client connects to mock daemon', async () => {
+    const server = await createMockServer();
+    const client = new IPCClient({ socketPath: TEST_SOCKET, retryIntervalMs: 100 });
+
+    const stateChanges = [];
+    client.on('state-change', (s) => stateChanges.push(s));
+
+    server.on('connection', () => {}); // accept connection
+
+    client.connect();
+    await waitFor(() => client.connected);
+
+    assert.strictEqual(client.state, ConnectionState.CONNECTED);
+    assert.ok(stateChanges.includes(ConnectionState.CONNECTING));
+    assert.ok(stateChanges.includes(ConnectionState.CONNECTED));
+
+    client.disconnect();
+    server.close();
+    cleanup();
+  });
+
+  // ── Test: Client receives JSONL messages
+  await test('client receives and parses JSONL messages', async () => {
+    const server = await createMockServer();
+    const client = new IPCClient({ socketPath: TEST_SOCKET, retryIntervalMs: 100 });
+
+    const received = [];
+    client.on('message', (msg) => received.push(msg));
+
+    server.on('connection', (socket) => {
+      // Send a state message
+      const msg = { v: 1, type: 'state', id: 'test123', ts: Date.now(), state: 'idle' };
+      socket.write(JSON.stringify(msg) + '\n');
+    });
+
+    client.connect();
+    await waitFor(() => received.length > 0);
+
+    assert.strictEqual(received[0].type, 'state');
+    assert.strictEqual(received[0].state, 'idle');
+    assert.strictEqual(received[0].id, 'test123');
+
+    client.disconnect();
+    server.close();
+    cleanup();
+  });
+
+  // ── Test: Client auto-responds to ping
+  await test('client auto-responds pong to ping', async () => {
+    const server = await createMockServer();
+    const client = new IPCClient({ socketPath: TEST_SOCKET, retryIntervalMs: 100 });
+    let collector;
+
+    server.on('connection', (socket) => {
+      collector = messageCollector(socket);
+      // Send ping
+      socket.write(JSON.stringify({ v: 1, type: 'ping', id: 'ping1', ts: Date.now() }) + '\n');
+    });
+
+    client.connect();
+    await waitFor(() => collector && collector.messages.some((m) => m.type === 'pong'), 3000);
+
+    const pong = collector.messages.find((m) => m.type === 'pong');
+    assert.ok(pong, 'Pong message not found');
+    assert.strictEqual(pong.type, 'pong');
+    assert.strictEqual(pong.v, IPC_VERSION);
+
+    client.disconnect();
+    server.close();
+    cleanup();
+  });
+
+  // ── Test: Client auto-acks state messages
+  await test('client auto-acks state messages', async () => {
+    const server = await createMockServer();
+    const client = new IPCClient({ socketPath: TEST_SOCKET, retryIntervalMs: 100 });
+    let collector;
+
+    server.on('connection', (socket) => {
+      collector = messageCollector(socket);
+      // Send state message
+      socket.write(JSON.stringify({
+        v: 1, type: 'state', id: 'state42', ts: Date.now(), state: 'thinking'
+      }) + '\n');
+    });
+
+    client.connect();
+    await waitFor(() => collector && collector.messages.some((m) => m.type === 'ack'), 3000);
+
+    const ack = collector.messages.find((m) => m.type === 'ack');
+    assert.ok(ack, 'ACK not found');
+    assert.strictEqual(ack.id, 'state42');
+
+    client.disconnect();
+    server.close();
+    cleanup();
+  });
+
+  // ── Test: Client sends event messages
+  await test('client.sendEvent sends correct format', async () => {
+    const server = await createMockServer();
+    const client = new IPCClient({ socketPath: TEST_SOCKET, retryIntervalMs: 100 });
+    let collector;
+
+    server.on('connection', (socket) => {
+      collector = messageCollector(socket);
+    });
+
+    client.connect();
+    await waitFor(() => client.connected);
+
+    client.sendEvent('dismissed', 'user_close');
+    await waitFor(() => collector && collector.messages.some((m) => m.type === 'event'));
+
+    const event = collector.messages.find((m) => m.type === 'event');
+    assert.ok(event);
+    assert.strictEqual(event.event, 'dismissed');
+    assert.strictEqual(event.reason, 'user_close');
+    assert.strictEqual(event.v, IPC_VERSION);
+
+    client.disconnect();
+    server.close();
+    cleanup();
+  });
+
+  // ── Test: Client handles multiple JSONL in one chunk
+  await test('client handles multiple messages in one data chunk', async () => {
+    const server = await createMockServer();
+    const client = new IPCClient({ socketPath: TEST_SOCKET, retryIntervalMs: 100 });
+    const received = [];
+    client.on('message', (msg) => received.push(msg));
+
+    server.on('connection', (socket) => {
+      // Send two messages in one write (batched)
+      const msg1 = JSON.stringify({ v: 1, type: 'state', id: 'a', ts: 1, state: 'idle' });
+      const msg2 = JSON.stringify({ v: 1, type: 'state', id: 'b', ts: 2, state: 'thinking' });
+      socket.write(msg1 + '\n' + msg2 + '\n');
+    });
+
+    client.connect();
+    await waitFor(() => received.length >= 2);
+
+    assert.strictEqual(received[0].id, 'a');
+    assert.strictEqual(received[1].id, 'b');
+
+    client.disconnect();
+    server.close();
+    cleanup();
+  });
+
+  // ── Test: send returns false when disconnected
+  await test('send returns false when disconnected', async () => {
+    const client = new IPCClient({ socketPath: TEST_SOCKET });
+    const result = client.send({ type: 'event', event: 'timeout' });
+    assert.strictEqual(result, false);
+  });
+
+  // ── Test: Disconnect stops retrying
+  await test('disconnect stops retry loop', async () => {
+    const client = new IPCClient({ socketPath: TEST_SOCKET, retryIntervalMs: 100 });
+
+    client.connect();
+    // Wait a bit for retry to start
+    await new Promise((r) => setTimeout(r, 150));
+    client.disconnect();
+
+    assert.strictEqual(client.state, ConnectionState.DISCONNECTED);
+    assert.strictEqual(client._retryTimer, null);
+  });
+
+  // ── Summary ────
+  console.log(`\n${passed + failed} tests, ${passed} passed, ${failed} failed`);
+  cleanup();
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((err) => {
+  console.error('Test runner error:', err);
+  cleanup();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Adds the IPC client that connects the overlay to the Bantz daemon via Unix domain socket.

**Closes #1399** | **Depends on**: #1398 | **Parent Epic**: #1397

## Changes
- **`src/main/ipc-client.js`** — IPCClient class (EventEmitter): auto-connect, exponential backoff retry, JSONL parser, ping/pong, auto-ack, send API
- **`src/main/main.js`** — integrated IPC client, daemon message forwarding to renderer, event forwarding from renderer
- **`src/main/preload.js`** — added `onDaemonConnectionState` callback
- **`src/renderer/renderer.js`** — connection state indicator updated from IPC
- **`tests/test_ipc_client.js`** — 11 unit tests with mock Unix socket server

## Wire Protocol
- Socket: `~/.local/share/bantz/ipc/overlay.sock`
- Format: JSONL (JSON + \n)
- Protocol version: 1
- Auto ping/pong, auto state ACK

## Testing
- 11/11 IPC client tests passing
- Mock server validates: connect, JSONL parse, ping/pong, ACK, event send, batched messages, disconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daemon communication support with automatic connection management and retry handling.
  * Real-time daemon connection status tracking and visibility in the overlay.
  * Enhanced overlay responsiveness to background service availability.

* **Tests**
  * Added comprehensive test coverage for the new daemon communication layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->