### PR TITLE
feat(overlay): TTS voice sync — word-boundary synchronization (#1415)

### DIFF
--- a/bantz-overlay/src/renderer/components/tts-sync.js
+++ b/bantz-overlay/src/renderer/components/tts-sync.js
@@ -1,0 +1,328 @@
+/**
+ * Bantz Overlay — TTS Voice Sync (#1415)
+ *
+ * Synchronizes typewriter text output with TTS voice playback
+ * so words appear on-screen as they are spoken.
+ *
+ * Listens for IPC `tts_word_boundary` events containing:
+ *   { word_index, timestamp, word }
+ *
+ * Modes:
+ *   - Synced: TTS active → typewriter follows word boundaries
+ *   - Fallback: No TTS data → token-rate-based timing (30ms/token)
+ *   - Mute: TTS disabled → typewriter runs independently
+ *
+ * @module tts-sync
+ */
+
+'use strict';
+
+// ── Config ────────────────────────────────────────────────────────
+const TTS_SYNC_CONFIG = {
+  highlightDuration:   200,   // ms to highlight spoken word
+  highlightColor:      '#ffffff',  // brighter white for spoken word
+  catchUpThreshold:    3,     // words behind before instant catch-up
+  fallbackTokenDelay:  30,    // ms per token when no TTS data
+  idleTimeout:         5000,  // ms without word boundary → assume TTS stopped
+  speakerFadeIn:       300,   // ms for speaker icon appear
+  speakerFadeOut:      500,   // ms for speaker icon disappear
+};
+
+/**
+ * TTS Voice Synchronizer.
+ *
+ * Bridges the gap between TTS word-boundary events and the
+ * typewriter visual output, keeping them perceptually in sync.
+ */
+class TTSVoiceSync {
+  /**
+   * @param {object} typewriter — TypewriterOutput instance
+   * @param {HTMLElement} hudPanel — Main HUD panel (for speaker icon)
+   */
+  constructor(typewriter, hudPanel) {
+    /** @type {object} */
+    this._typewriter = typewriter;
+    /** @type {HTMLElement} */
+    this._hud = hudPanel;
+
+    /** Whether TTS is currently active */
+    this._ttsActive = false;
+
+    /** Whether TTS is enabled (not muted) */
+    this._ttsEnabled = true;
+
+    /** Current word index from TTS */
+    this._currentWordIndex = 0;
+
+    /** Total tokens/words pushed to typewriter */
+    this._totalTokens = 0;
+
+    /** Words buffer for highlight tracking */
+    this._words = [];
+
+    /** Idle timeout handle */
+    this._idleTimer = null;
+
+    /** Speaker icon element */
+    this._speakerIcon = null;
+
+    this._createSpeakerIcon();
+
+    console.log('[TTSSync] Initialized');
+  }
+
+  // ── Public API ────────────────────────────────────────────────
+
+  /**
+   * Called when TTS playback starts.
+   */
+  onTTSStart() {
+    this._ttsActive = true;
+    this._currentWordIndex = 0;
+    this._totalTokens = 0;
+    this._words = [];
+    this._showSpeakerIcon();
+    this._resetIdleTimer();
+    console.log('[TTSSync] TTS started');
+  }
+
+  /**
+   * Called when TTS playback ends.
+   */
+  onTTSEnd() {
+    this._ttsActive = false;
+    this._hideSpeakerIcon();
+    this._clearIdleTimer();
+    console.log('[TTSSync] TTS ended');
+  }
+
+  /**
+   * Handle a TTS word boundary event.
+   *
+   * @param {object} event
+   * @param {number} event.word_index — Index of the word being spoken
+   * @param {number} event.timestamp  — Timestamp of the boundary
+   * @param {string} [event.word]     — The word itself
+   */
+  onWordBoundary(event) {
+    if (!this._ttsActive) return;
+    this._resetIdleTimer();
+
+    const targetIndex = event.word_index;
+
+    // Check if typewriter is behind — catch up if needed
+    if (targetIndex - this._currentWordIndex > TTS_SYNC_CONFIG.catchUpThreshold) {
+      // Catch up instantly: flush pending tokens
+      this._catchUp(targetIndex);
+    }
+
+    this._currentWordIndex = targetIndex;
+
+    // Highlight the currently spoken word
+    if (event.word) {
+      this._highlightWord(event.word);
+    }
+  }
+
+  /**
+   * Register a token being added to typewriter.
+   * Used to track how many tokens have been rendered.
+   *
+   * @param {string} token
+   */
+  trackToken(token) {
+    this._totalTokens++;
+    if (token.trim()) {
+      this._words.push(token.trim());
+    }
+  }
+
+  /**
+   * Set whether TTS is enabled (vs muted).
+   * When muted, typewriter runs at normal speed independently.
+   *
+   * @param {boolean} enabled
+   */
+  setTTSEnabled(enabled) {
+    this._ttsEnabled = !!enabled;
+    if (!enabled) {
+      this._ttsActive = false;
+      this._hideSpeakerIcon();
+    }
+  }
+
+  /**
+   * Whether TTS is currently active and syncing.
+   * @returns {boolean}
+   */
+  get isSyncing() {
+    return this._ttsActive && this._ttsEnabled;
+  }
+
+  /**
+   * Get the appropriate token delay based on sync state.
+   * - Synced: 0ms (typewriter waits for word boundaries)
+   * - Fallback: 30ms per token
+   * - Mute: 30ms per token
+   *
+   * @returns {number} Delay in ms
+   */
+  getTokenDelay() {
+    if (this._ttsActive && this._ttsEnabled) {
+      return 0; // TTS drives the timing
+    }
+    return TTS_SYNC_CONFIG.fallbackTokenDelay;
+  }
+
+  /** Cleanup */
+  destroy() {
+    this._clearIdleTimer();
+    if (this._speakerIcon && this._speakerIcon.parentNode) {
+      this._speakerIcon.parentNode.removeChild(this._speakerIcon);
+    }
+  }
+
+  // ── Internal ──────────────────────────────────────────────────
+
+  /**
+   * Catch up typewriter to match TTS position.
+   * @param {number} targetIndex
+   * @private
+   */
+  _catchUp(targetIndex) {
+    if (!this._typewriter) return;
+
+    // If typewriter supports instant flush, use it
+    const behind = targetIndex - this._currentWordIndex;
+    console.log(`[TTSSync] Catching up ${behind} words`);
+
+    // Signal typewriter to flush its queue
+    if (this._typewriter._flushQueue) {
+      this._typewriter._flushQueue();
+    }
+  }
+
+  /**
+   * Briefly highlight the currently spoken word in the typewriter.
+   * @param {string} word
+   * @private
+   */
+  _highlightWord(word) {
+    const container = this._typewriter?._container ||
+                      document.getElementById('typewriter-output');
+    if (!container) return;
+
+    const textEl = container.querySelector('#typewriter-text') ||
+                   container.querySelector('span');
+    if (!textEl) return;
+
+    // Find the word in the current text content
+    const text = textEl.textContent || '';
+    const wordStart = text.lastIndexOf(word);
+    if (wordStart < 0) return;
+
+    // Create a range and wrap the word temporarily
+    // Use a non-destructive approach: apply a CSS class via a span
+    const before = text.substring(0, wordStart);
+    const after = text.substring(wordStart + word.length);
+
+    textEl.innerHTML =
+      `${this._escapeHtml(before)}<span class="tts-spoken-word">${this._escapeHtml(word)}</span>${this._escapeHtml(after)}`;
+
+    // Remove highlight after duration
+    setTimeout(() => {
+      const highlight = textEl.querySelector('.tts-spoken-word');
+      if (highlight) {
+        highlight.classList.add('tts-spoken-word-fade');
+        setTimeout(() => {
+          // Restore plain text
+          textEl.textContent = text;
+        }, 100);
+      }
+    }, TTS_SYNC_CONFIG.highlightDuration);
+  }
+
+  /**
+   * Escape HTML entities.
+   * @param {string} str
+   * @returns {string}
+   * @private
+   */
+  _escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  /**
+   * Create the speaker icon indicator.
+   * @private
+   */
+  _createSpeakerIcon() {
+    const icon = document.createElement('div');
+    icon.className = 'tts-speaker-icon';
+    icon.textContent = '🔊';
+    icon.style.cssText = `
+      position: absolute;
+      bottom: 8px;
+      right: 12px;
+      font-size: 14px;
+      opacity: 0;
+      transition: opacity ${TTS_SYNC_CONFIG.speakerFadeIn}ms ease-out;
+      pointer-events: none;
+      z-index: 10;
+    `;
+    this._hud.appendChild(icon);
+    this._speakerIcon = icon;
+  }
+
+  /**
+   * Show the speaker icon.
+   * @private
+   */
+  _showSpeakerIcon() {
+    if (this._speakerIcon) {
+      this._speakerIcon.style.opacity = '0.6';
+    }
+  }
+
+  /**
+   * Hide the speaker icon.
+   * @private
+   */
+  _hideSpeakerIcon() {
+    if (this._speakerIcon) {
+      this._speakerIcon.style.transition =
+        `opacity ${TTS_SYNC_CONFIG.speakerFadeOut}ms ease-in`;
+      this._speakerIcon.style.opacity = '0';
+    }
+  }
+
+  /**
+   * Reset the idle timer (TTS seems active).
+   * @private
+   */
+  _resetIdleTimer() {
+    this._clearIdleTimer();
+    this._idleTimer = setTimeout(() => {
+      if (this._ttsActive) {
+        console.log('[TTSSync] TTS idle timeout — assuming stopped');
+        this.onTTSEnd();
+      }
+    }, TTS_SYNC_CONFIG.idleTimeout);
+  }
+
+  /**
+   * Clear idle timer.
+   * @private
+   */
+  _clearIdleTimer() {
+    if (this._idleTimer) {
+      clearTimeout(this._idleTimer);
+      this._idleTimer = null;
+    }
+  }
+}
+
+// ── Expose globally ───────────────────────────────────────────────
+window.TTSVoiceSync = TTSVoiceSync;

--- a/bantz-overlay/src/renderer/index.html
+++ b/bantz-overlay/src/renderer/index.html
@@ -54,6 +54,7 @@
   <script src="components/reasoning-chain.js"></script>
   <script src="components/glitch-effects.js"></script>
   <script src="components/panel-transitions.js"></script>
+  <script src="components/tts-sync.js"></script>
   <script type="module" src="renderer.js"></script>
 </body>
 </html>

--- a/bantz-overlay/src/renderer/renderer.js
+++ b/bantz-overlay/src/renderer/renderer.js
@@ -169,6 +169,19 @@ function initPanelTransitions() {
   console.log('[Overlay] Panel transitions initialized');
 }
 
+// ─── TTS Voice Sync ───────────────────────────────────────────
+let ttsSync = null;
+
+function initTTSSync() {
+  if (!window.TTSVoiceSync || !typewriter) {
+    console.warn('[Overlay] TTSVoiceSync or typewriter not available');
+    return;
+  }
+  ttsSync = new window.TTSVoiceSync(typewriter, hudPanel);
+  window.bantzTTSSync = ttsSync;
+  console.log('[Overlay] TTS voice sync initialized');
+}
+
 // ─── Reasoning Chain Display ─────────────────────────────────
 let reasoningChain = null;
 
@@ -376,15 +389,23 @@ function handleStateMessage(msg) {
   if (typewriter) {
     if (msg.speech_token) {
       typewriter.addToken(msg.speech_token);
+      if (ttsSync) ttsSync.trackToken(msg.speech_token);
     }
     if (msg.speech_start) {
       // End reasoning when speech begins
       if (reasoningChain) reasoningChain.end();
       typewriter.beginSpeech();
+      if (ttsSync) ttsSync.onTTSStart();
     }
     if (msg.speech_end) {
       typewriter.endSpeech();
+      if (ttsSync) ttsSync.onTTSEnd();
     }
+  }
+
+  // Handle TTS word boundary events
+  if (ttsSync && msg.tts_word_boundary) {
+    ttsSync.onWordBoundary(msg.tts_word_boundary);
   }
 
   // Handle reasoning tokens
@@ -532,6 +553,9 @@ initGlitchEffects();
 
 // ─── Initialize Panel Transitions ───────────────────────────
 initPanelTransitions();
+
+// ─── Initialize TTS Sync ───────────────────────────────────
+initTTSSync();
 
 // ─── Check First Boot / Absence ─────────────────────────────
 checkFirstBootOrAbsence();

--- a/bantz-overlay/src/renderer/styles.css
+++ b/bantz-overlay/src/renderer/styles.css
@@ -273,6 +273,24 @@ html, body {
   51%, 100% { opacity: 0; }
 }
 
+/* ── TTS Spoken Word Highlight ──────────────────────────────────── */
+.tts-spoken-word {
+  color: #ffffff;
+  text-shadow: 0 0 4px rgba(255, 180, 60, 0.5);
+  transition: color 0.1s ease-out, text-shadow 0.1s ease-out;
+}
+
+.tts-spoken-word-fade {
+  color: var(--color-text-amber);
+  text-shadow: none;
+}
+
+/* ── TTS Speaker Icon ───────────────────────────────────────────── */
+.tts-speaker-icon {
+  font-size: 14px;
+  filter: grayscale(0.3);
+}
+
 /* ── Terminal Sub-Panel Base ────────────────────────────────────── */
 .terminal-panel {
   position: absolute;


### PR DESCRIPTION
## Summary
Synchronize typewriter text output with TTS voice playback so words appear on-screen as they are spoken.

## Changes
- **tts-sync.js** — New `TTSVoiceSync` component
  - Listens for `tts_word_boundary` events (word_index, timestamp, word)
  - Highlights currently spoken word (white → amber, 200ms)
  - Catch-up: if TTS >3 words ahead, flush typewriter queue
  - Idle timeout: 5s without boundary → assume TTS stopped
  - Fallback: 30ms/token when no TTS data
  - Mute mode: typewriter runs independently when TTS disabled
  - Speaker icon 🔊 appears/disappears with TTS state
- **styles.css** — `.tts-spoken-word` highlight + fade classes
- **renderer.js** — Wire `trackToken()`, `onTTSStart/End`, `onWordBoundary`
- **index.html** — Added tts-sync.js script tag

## API
```js
window.bantzTTSSync.onTTSStart()
window.bantzTTSSync.onWordBoundary({ word_index: 5, word: 'merhaba' })
window.bantzTTSSync.onTTSEnd()
window.bantzTTSSync.setTTSEnabled(false) // mute mode
```

Closes #1415