### PR TITLE
feat(overlay): auto-start with daemon via systemd + XDG (#1417)

### DIFF
--- a/config/bantz-overlay.desktop
+++ b/config/bantz-overlay.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Bantz Overlay
+Comment=Bantz AI assistant desktop overlay HUD
+Exec=/usr/bin/electron /opt/bantz/overlay/main.js
+Icon=bantz
+Terminal=false
+Categories=Utility;
+StartupNotify=false
+X-GNOME-Autostart-enabled=true
+X-KDE-autostart-after-phase=2

--- a/scripts/install_overlay.sh
+++ b/scripts/install_overlay.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Install BANTZ Overlay systemd user service and XDG autostart entry.
+#
+# Usage:
+#   bash scripts/install_overlay.sh [BANTZ_ROOT]
+#
+# If BANTZ_ROOT is omitted, uses the parent directory of this script.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BANTZ_ROOT="${1:-$(dirname "$SCRIPT_DIR")}"
+SERVICE_SRC="$BANTZ_ROOT/systemd/user"
+SERVICE_DST="$HOME/.config/systemd/user"
+AUTOSTART_DIR="$HOME/.config/autostart"
+OVERLAY_DIR="$BANTZ_ROOT/bantz-overlay"
+
+echo "=== BANTZ Overlay Installer ==="
+echo "BANTZ_ROOT : $BANTZ_ROOT"
+echo "Overlay dir: $OVERLAY_DIR"
+echo ""
+
+# ── Preflight checks ─────────────────────────────────────────────
+if ! command -v electron &>/dev/null; then
+    echo "⚠  electron not found in PATH."
+    echo "   Install with: npm install -g electron"
+    echo "   Or: sudo apt install electron (Debian/Ubuntu)"
+    echo ""
+fi
+
+if [[ ! -f "$OVERLAY_DIR/src/main/main.js" ]]; then
+    echo "✗ Overlay entry point not found: $OVERLAY_DIR/src/main/main.js"
+    exit 1
+fi
+
+# ── Create directories ───────────────────────────────────────────
+mkdir -p "$SERVICE_DST" "$AUTOSTART_DIR"
+
+# ── Install systemd user service ─────────────────────────────────
+SVC_FILE="bantz-overlay.service"
+SVC_SRC="$SERVICE_SRC/$SVC_FILE"
+SVC_DST="$SERVICE_DST/$SVC_FILE"
+
+if [[ -f "$SVC_SRC" ]]; then
+    sed "s|%h/Desktop/Bantz|$BANTZ_ROOT|g" "$SVC_SRC" > "$SVC_DST"
+    echo "✓ Installed $SVC_FILE → $SVC_DST"
+else
+    echo "✗ Service file not found: $SVC_SRC"
+    exit 1
+fi
+
+# ── Update bantz.target to include overlay ────────────────────────
+TARGET_DST="$SERVICE_DST/bantz.target"
+if [[ -f "$TARGET_DST" ]]; then
+    if ! grep -q "bantz-overlay.service" "$TARGET_DST"; then
+        sed -i 's/^Wants=\(.*\)/Wants=\1 bantz-overlay.service/' "$TARGET_DST"
+        echo "✓ Added bantz-overlay.service to bantz.target"
+    else
+        echo "• bantz.target already includes overlay (skipped)"
+    fi
+else
+    echo "• bantz.target not found (run install_services.sh first)"
+fi
+
+# ── Install XDG autostart desktop entry ──────────────────────────
+DESKTOP_SRC="$BANTZ_ROOT/config/bantz-overlay.desktop"
+DESKTOP_DST="$AUTOSTART_DIR/bantz-overlay.desktop"
+
+if [[ -f "$DESKTOP_SRC" ]]; then
+    # Replace /opt/bantz/overlay with actual path
+    sed "s|/opt/bantz/overlay/main.js|$OVERLAY_DIR/src/main/main.js|g" \
+        "$DESKTOP_SRC" > "$DESKTOP_DST"
+    echo "✓ Installed autostart → $DESKTOP_DST"
+else
+    echo "⚠ Desktop file not found: $DESKTOP_SRC (skipped)"
+fi
+
+# ── Reload systemd ───────────────────────────────────────────────
+systemctl --user daemon-reload
+echo ""
+echo "✓ systemd reloaded"
+
+# ── Usage instructions ───────────────────────────────────────────
+echo ""
+echo "Usage:"
+echo "  # Enable overlay to start with daemon:"
+echo "  systemctl --user enable bantz-overlay.service"
+echo ""
+echo "  # Start overlay now:"
+echo "  systemctl --user start bantz-overlay.service"
+echo ""
+echo "  # Or start the full stack (includes overlay):"
+echo "  systemctl --user start bantz.target"
+echo ""
+echo "  # Check status:"
+echo "  systemctl --user status bantz-overlay.service"
+echo ""
+echo "  # View logs:"
+echo "  journalctl --user -u bantz-overlay.service -f"
+echo ""
+echo "For non-systemd setups, the XDG autostart entry at"
+echo "  $DESKTOP_DST"
+echo "will start the overlay on login."

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -33,7 +33,7 @@ fi
 # ── Install service files (replace %h placeholders) ──────────────
 for f in bantz-core.service bantz-voice.service bantz.target \
          bantz-voice-watchdog.service bantz-vllm-watchdog.service \
-         bantz-resume.service; do
+         bantz-resume.service bantz-overlay.service; do
     src="$SERVICE_SRC/$f"
     dst="$SERVICE_DST/$f"
     if [[ -f "$src" ]]; then

--- a/systemd/user/bantz-overlay.service
+++ b/systemd/user/bantz-overlay.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=BANTZ Desktop Overlay HUD
+Documentation=https://github.com/miclaldogan/bantz
+After=bantz-core.service graphical-session.target
+PartOf=bantz-core.service
+BindsTo=bantz-core.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/electron %h/Desktop/Bantz/bantz-overlay/src/main/main.js
+WorkingDirectory=%h/Desktop/Bantz/bantz-overlay
+EnvironmentFile=-%h/.config/bantz/env
+Environment=DISPLAY=:0
+Environment=ELECTRON_ENABLE_LOGGING=1
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus
+Environment=NODE_ENV=production
+Restart=on-failure
+RestartSec=3
+StartLimitBurst=3
+StartLimitIntervalSec=60
+
+[Install]
+WantedBy=default.target

--- a/systemd/user/bantz.target
+++ b/systemd/user/bantz.target
@@ -1,7 +1,7 @@
 [Unit]
 Description=BANTZ Full Stack (Core + Voice + Watchdogs)
 Documentation=https://github.com/miclaldogan/bantz
-Wants=bantz-core.service bantz-voice.service bantz-voice-watchdog.service bantz-vllm-watchdog.service
+Wants=bantz-core.service bantz-voice.service bantz-voice-watchdog.service bantz-vllm-watchdog.service bantz-overlay.service
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary
Overlay auto-starts when the Bantz daemon starts and stops when it stops, via systemd user service dependency chain. XDG autostart fallback for non-systemd DEs.

## Files Created
- **systemd/user/bantz-overlay.service** — `PartOf=bantz-core.service`, `BindsTo=bantz-core.service`, `After=bantz-core.service`, `Restart=on-failure` (3s)
- **config/bantz-overlay.desktop** — XDG autostart entry for GNOME/KDE/etc.
- **scripts/install_overlay.sh** — Installer with electron preflight check, path substitution, bantz.target patching

## Files Modified
- **systemd/user/bantz.target** — Added `bantz-overlay.service` to `Wants=`
- **scripts/install_services.sh** — Include overlay in service install loop

## Service Dependency Chain
```
bantz.target
  ├── bantz-core.service
  │     └── bantz-overlay.service (PartOf + BindsTo)
  ├── bantz-voice.service
  ├── bantz-voice-watchdog.service
  └── bantz-vllm-watchdog.service
```

Closes #1417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added systemd user service installation support for the BANTZ Overlay with autostart configuration on Linux systems.
  * Added desktop launcher entry for the Overlay application.

* **Chores**
  * Updated service installation process to include the Overlay service alongside existing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->