### PR TITLE
fix(overlay): HUD panel daraltma + terminal panel büyütme (#1441)

### DIFF
--- a/bantz-overlay/src/renderer/components/clock-panel.js
+++ b/bantz-overlay/src/renderer/components/clock-panel.js
@@ -10,8 +10,8 @@
 'use strict';
 
 const CLOCK_CONFIG = {
-  panelWidth: 220,
-  panelHeight: 95,
+  panelWidth: 260,
+  panelHeight: 100,
   refreshMs: 1000,
 };
 

--- a/bantz-overlay/src/renderer/components/daily-tasks.js
+++ b/bantz-overlay/src/renderer/components/daily-tasks.js
@@ -9,8 +9,8 @@
 
 // ─── Configuration ──────────────────────────────────────────────
 const AGENDA_CONFIG = {
-  panelWidth: 310,
-  panelHeight: 380,
+  panelWidth: 360,
+  panelHeight: 420,
   refreshInterval: 5 * 60 * 1000, // 5 minutes
   emptyMessage: 'Bugün takvimde etkinlik yok, efendim.',
 };

--- a/bantz-overlay/src/renderer/components/news-feed.js
+++ b/bantz-overlay/src/renderer/components/news-feed.js
@@ -17,8 +17,8 @@ const NEWS_CONFIG = {
   scrollSpeed: 30,           // px/s auto-scroll
   highlightDuration: 3000,   // ms for active article highlight
   tooltipDelay: 400,         // ms before showing tooltip
-  panelWidth: 340,
-  panelHeight: 440,
+  panelWidth: 380,
+  panelHeight: 480,
 };
 
 /**

--- a/bantz-overlay/src/renderer/components/panel-layout.js
+++ b/bantz-overlay/src/renderer/components/panel-layout.js
@@ -40,28 +40,28 @@ const REPOSITION_DEBOUNCE = 150;  // ms
 const SLOT_DEFINITIONS = {
   left: {
     anchor: 'left',
-    overflowPct: 0.65,       // 65% of panel width overflows left
+    overflowPct: 0.75,       // 75% of panel width overflows left
     baseZIndex: 20,
     slideAnim: 'slide-in-left',
-    verticalAlign: 0.06,     // 6% from top
+    verticalAlign: 0.05,     // 5% from top
   },
   right: {
     anchor: 'right',
-    overflowPct: 0.65,       // 65% of panel width overflows right
+    overflowPct: 0.75,       // 75% of panel width overflows right
     baseZIndex: 20,
     slideAnim: 'slide-in-right',
-    verticalAlign: 0.06,
+    verticalAlign: 0.05,
   },
   'bottom-left': {
     anchor: 'bottom-left',
-    overflowPct: 0.55,       // 55% overflow on both bottom and left
+    overflowPct: 0.65,       // 65% overflow on both bottom and left
     baseZIndex: 15,
     slideAnim: 'slide-in-bottom',
     verticalAlign: null,     // computed from bottom
   },
   'bottom-right': {
     anchor: 'bottom-right',
-    overflowPct: 0.55,       // 55% overflow on both bottom and right
+    overflowPct: 0.65,       // 65% overflow on both bottom and right
     baseZIndex: 15,
     slideAnim: 'slide-in-bottom',
     verticalAlign: null,

--- a/bantz-overlay/src/renderer/components/system-status.js
+++ b/bantz-overlay/src/renderer/components/system-status.js
@@ -9,8 +9,8 @@
 
 // ─── Configuration ──────────────────────────────────────────────
 const SYSTEM_CONFIG = {
-  panelWidth: 280,
-  panelHeight: 210,
+  panelWidth: 320,
+  panelHeight: 240,
   systemRefreshMs: 10000,    // 10s for system metrics
   barWidth: 10,              // characters in progress bar
   thresholds: {

--- a/bantz-overlay/src/renderer/styles.css
+++ b/bantz-overlay/src/renderer/styles.css
@@ -83,10 +83,10 @@ html, body {
 /* ── HUD Panel (main transparent rectangle) ─────────────────────── */
 .hud-panel {
   position: relative;
-  width: 44vw;
-  height: 52vh;
-  min-width: 440px;
-  min-height: 380px;
+  width: 36vw;
+  height: 50vh;
+  min-width: 360px;
+  min-height: 340px;
 
   /* Glass morphism: transparent orange base + blur */
   background: var(--color-base);


### PR DESCRIPTION
## Değişiklikler

HUD panelleri küçültüldü, terminal paneller büyütüldü — ekran alanı optimizasyonu.

### HUD Panel (.hud-panel)
- width: 44vw → 36vw
- height: 52vh → 50vh
- min-width: 440px → 360px
- min-height: 380px → 340px

### Terminal Paneller
- **news-feed**: 340×440 → 380×480
- **daily-tasks**: 310×380 → 360×420
- **system-status**: 280×210 → 320×240
- **clock-panel**: 220×95 → 260×100

### Panel Layout
- overflowPct left/right: 0.65 → 0.75
- overflowPct bottom: 0.55 → 0.65
- verticalAlign: 0.06 → 0.05

**Overlay test**: 12/12 component initialized ✅

Closes #1441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased dimensions for clock, daily tasks, news feed, and system status panels for better visibility.
  * Adjusted panel positioning and overflow percentages for improved layout spacing.
  * Fine-tuned responsive sizing and minimum dimensions for the HUD panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->