### PR TITLE
feat(overlay): HUD iyileştirmeleri — env parser, image timeout (#1439)

### DIFF
--- a/bantz-overlay/src/main/main.js
+++ b/bantz-overlay/src/main/main.js
@@ -321,7 +321,7 @@ ipcMain.handle('system:get-weather', async () => {
             if (trimmed.startsWith('#') || !trimmed.includes('=')) continue;
             const [key, ...rest] = trimmed.split('=');
             const val = rest.join('=').trim();
-            if ((key.trim() === 'BANTZ_LOCATION' || key.trim() === 'BANTZ_DEFAULT_LOCATION') && val) {
+            if ((key.trim() === 'BANTZ_WEATHER_LOCATION' || key.trim() === 'BANTZ_LOCATION' || key.trim() === 'BANTZ_DEFAULT_LOCATION') && val) {
               location = val;
               break;
             }

--- a/bantz-overlay/src/renderer/components/demo-mode.js
+++ b/bantz-overlay/src/renderer/components/demo-mode.js
@@ -397,7 +397,11 @@ class DemoMode {
       if (!this._running) break;
       if (!article.link) continue;
       try {
-        const imageUrl = await window.overlayAPI.getArticleImage(article.link);
+        // 6s timeout per image (main process has 5s, add 1s buffer)
+        const imageUrl = await Promise.race([
+          window.overlayAPI.getArticleImage(article.link),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 6000)),
+        ]);
         if (imageUrl) {
           this._articleImages.push({
             image_url: imageUrl,
@@ -407,7 +411,9 @@ class DemoMode {
           });
           console.log(`[DemoMode] Got OG image for: ${article.title.slice(0, 40)}`);
         }
-      } catch {}
+      } catch {
+        console.warn(`[DemoMode] OG image fetch failed/timeout: ${article.title?.slice(0, 40)}`);
+      }
     }
     console.log(`[DemoMode] Fetched ${this._articleImages.length} article images`);
   }

--- a/config/bantz-env.example
+++ b/config/bantz-env.example
@@ -171,6 +171,7 @@ BANTZ_BRIEFING_HOUR=08
 # BANTZ_MEMORY_PII_FILTER=true             # PII filtering in memory
 # BANTZ_PROFILE_PATH=~/.bantz/profile.json # User profile JSON
 # BANTZ_LOCATION=                          # User location for context prompts
+# BANTZ_WEATHER_LOCATION=                  # Weather-specific location (overrides BANTZ_LOCATION)
 # BANTZ_DEFAULT_LOCATION=                  # Fallback location
 
 


### PR DESCRIPTION
## Değişiklikler

### 1. BANTZ_WEATHER_LOCATION Env Parser (main.js)
Overlay başlatırken `.bantz-env` dosyasından `BANTZ_WEATHER_LOCATION` değişkeni de okunuyor artık.

### 2. OG Image Fetch Timeout (demo-mode.js)
Demo modda haber resimlerinin çekilmesi için `Promise.race()` ile 6 saniye timeout eklendi. Yavaş/erişilemeyen sunucular artık UI'ı bloklamıyor.

### 3. bantz-env.example Dökümantasyonu
`BANTZ_WEATHER_LOCATION` değişkeni env example dosyasına eklendi.

**Overlay test**: 12/12 component initialized ✅

Closes #1439