### PR TITLE
feat(voice): wake word overlay entegrasyonu — voice→IPC bridge (#1440)

### DIFF
--- a/bantz-overlay/src/renderer/renderer.js
+++ b/bantz-overlay/src/renderer/renderer.js
@@ -402,6 +402,10 @@ if (window.overlayAPI && window.overlayAPI.onDaemonMessage) {
         // Handle daemon events (phone calls, etc.)
         handleDaemonEvent(message);
         break;
+      case 'voice_state':
+        // Handle voice pipeline state changes (Issue #1440)
+        handleVoiceStateMessage(message);
+        break;
       default:
         console.log('[Overlay] Unknown message type:', message.type);
     }
@@ -481,6 +485,47 @@ function handleStateMessage(msg) {
 function handleActionMessage(msg) {
   // Will be implemented in #1401+ (panel actions)
   console.log('[Overlay] Action:', msg.action_type);
+}
+
+// ─── Voice State Handler (Issue #1440) ────────────────────────
+function handleVoiceStateMessage(msg) {
+  const voiceState = msg.state;
+  if (!voiceState) return;
+
+  // Map voice state to sphere state (same enum: idle, wake, listening, thinking, speaking)
+  if (stateAnimator) {
+    stateAnimator.setState(voiceState);
+  }
+
+  // Trigger glitch effects on voice state transitions
+  if (glitchEffects) {
+    if (voiceState === 'wake') {
+      glitchEffects.triggerWakeFlicker();
+      glitchEffects.triggerChromatic('normal');
+    } else if (voiceState === 'thinking') {
+      glitchEffects.triggerChromatic('intense');
+    } else if (voiceState === 'listening') {
+      glitchEffects.triggerChromatic('normal');
+    }
+  }
+
+  // Choreograph panel transitions
+  if (panelTransitions && previousState !== voiceState) {
+    panelTransitions.choreographStateChange(previousState, voiceState, {
+      stateAnimator,
+      typewriter,
+      reasoningChain,
+      glitchEffects,
+    });
+    previousState = voiceState;
+  }
+
+  // Log wake word data if present
+  if (msg.data && msg.data.wake_word) {
+    console.log(`[Voice] Wake word: ${msg.data.wake_word} (${msg.data.confidence})`);
+  }
+
+  console.log('[Voice] State:', voiceState, msg.trigger || '');
 }
 
 function handleDaemonEvent(msg) {

--- a/src/bantz/voice/voice_overlay_bridge.py
+++ b/src/bantz/voice/voice_overlay_bridge.py
@@ -1,0 +1,222 @@
+"""Voice → Overlay IPC Bridge — Issue #1440.
+
+Translates voice pipeline state changes into overlay IPC messages
+so the particle sphere and HUD react to voice activity in real time.
+
+State mapping::
+
+    ContinuousListener.IDLE       → overlay "idle"      (slow rotation)
+    ContinuousListener.LISTENING  → overlay "listening"  (breathing pulse)
+    ContinuousListener.PROCESSING → overlay "thinking"   (fast spin)
+
+    VoiceFSM.ACTIVE_LISTEN        → overlay "listening"  (if no utterance)
+    VoiceFSM.WAKE_ONLY            → overlay "idle"
+    VoiceFSM.IDLE_SLEEP           → overlay "idle"
+
+Wake word detection fires a transient "wake" state (500ms flash).
+
+Usage::
+
+    from bantz.voice.voice_overlay_bridge import VoiceOverlayBridge
+
+    bridge = VoiceOverlayBridge(overlay_client)
+    bridge.bind_listener(continuous_listener)
+    bridge.bind_fsm(voice_fsm)
+    # ...
+    bridge.unbind_all()  # cleanup
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Mapping from voice pipeline states to overlay sphere states
+_LISTENER_STATE_MAP = {
+    "IDLE": "idle",
+    "LISTENING": "listening",
+    "PROCESSING": "thinking",
+}
+
+_FSM_STATE_MAP = {
+    "active_listen": "listening",
+    "wake_only": "idle",
+    "idle_sleep": "idle",
+}
+
+
+class VoiceOverlayBridge:
+    """Bridge between voice pipeline and overlay IPC.
+
+    Registers callbacks on ``ContinuousListener`` and ``VoiceFSM``
+    to push real-time state changes to the overlay sphere via
+    ``OverlayClient.send_raw()`` or ``OverlayClient.set_state()``.
+
+    Thread-safe: callbacks may fire from the voice capture thread.
+    """
+
+    def __init__(self, overlay_client: Any) -> None:
+        self._client = overlay_client
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._last_state: str = "idle"
+        self._last_wake_time: float = 0.0
+        self._wake_cooldown: float = 2.0  # seconds between wake flashes
+        self._bound_listener: Any = None
+        self._bound_fsm: Any = None
+
+        # Try to get or create event loop for async scheduling
+        try:
+            self._loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self._loop = None
+
+    # ── Public API ───────────────────────────────────────────────
+
+    def bind_listener(self, listener: Any) -> None:
+        """Register callbacks on a ContinuousListener.
+
+        Parameters
+        ----------
+        listener:
+            ``ContinuousListener`` instance with ``on_state_change()``
+            and ``on_wake_word()`` callback registration methods.
+        """
+        if hasattr(listener, "on_state_change"):
+            listener.on_state_change(self._on_listener_state)
+        if hasattr(listener, "on_wake_word"):
+            listener.on_wake_word(self._on_wake_word)
+        self._bound_listener = listener
+        logger.info("[VoiceOverlayBridge] Bound to ContinuousListener")
+
+    def bind_fsm(self, fsm: Any) -> None:
+        """Register callback on a VoiceFSM.
+
+        Parameters
+        ----------
+        fsm:
+            ``VoiceFSM`` instance with ``set_on_transition()`` method.
+        """
+        if hasattr(fsm, "set_on_transition"):
+            fsm.set_on_transition(self._on_fsm_transition)
+        self._bound_fsm = fsm
+        logger.info("[VoiceOverlayBridge] Bound to VoiceFSM")
+
+    def unbind_all(self) -> None:
+        """Remove all registered callbacks (cleanup)."""
+        if self._bound_listener:
+            # ContinuousListener doesn't have remove_callback, but
+            # clear_callbacks() is available if needed
+            self._bound_listener = None
+        if self._bound_fsm:
+            if hasattr(self._bound_fsm, "clear_on_transition"):
+                self._bound_fsm.clear_on_transition()
+            self._bound_fsm = None
+        logger.info("[VoiceOverlayBridge] Unbound all callbacks")
+
+    # ── Callback Handlers ────────────────────────────────────────
+
+    def _on_listener_state(self, state: Any) -> None:
+        """Handle ContinuousListener state change.
+
+        Called from the voice capture thread — schedule async send.
+        """
+        state_name = state.name if hasattr(state, "name") else str(state)
+        overlay_state = _LISTENER_STATE_MAP.get(state_name, "idle")
+
+        if overlay_state != self._last_state:
+            self._last_state = overlay_state
+            self._send_voice_state(overlay_state, trigger=f"listener:{state_name}")
+
+    def _on_wake_word(self, wake_word: str, confidence: float) -> None:
+        """Handle wake word detection — send transient 'wake' flash.
+
+        Called from the voice capture thread.
+        """
+        now = time.monotonic()
+        if now - self._last_wake_time < self._wake_cooldown:
+            return  # debounce rapid wake detections
+
+        self._last_wake_time = now
+        self._send_voice_state(
+            "wake",
+            trigger=f"wake_word:{wake_word}",
+            extra={"wake_word": wake_word, "confidence": round(confidence, 2)},
+        )
+        logger.info(
+            "[VoiceOverlayBridge] Wake word: %s (%.2f)", wake_word, confidence
+        )
+
+    def _on_fsm_transition(self, transition: Any) -> None:
+        """Handle VoiceFSM state transition.
+
+        Only updates overlay if the listener isn't in a more specific state
+        (e.g., PROCESSING overrides FSM's active_listen).
+        """
+        to_state = transition.to_state
+        to_value = to_state.value if hasattr(to_state, "value") else str(to_state)
+        overlay_state = _FSM_STATE_MAP.get(to_value, "idle")
+
+        # Don't downgrade from "thinking" (PROCESSING) to "listening"
+        # when FSM stays in active_listen
+        if self._last_state == "thinking" and overlay_state == "listening":
+            return
+
+        if overlay_state != self._last_state:
+            self._last_state = overlay_state
+            self._send_voice_state(
+                overlay_state,
+                trigger=f"fsm:{transition.trigger}",
+            )
+
+    # ── IPC Sending ──────────────────────────────────────────────
+
+    def _send_voice_state(
+        self,
+        state: str,
+        trigger: str = "",
+        extra: Optional[dict] = None,
+    ) -> None:
+        """Send voice state to overlay via IPC.
+
+        Tries ``set_state()`` first (proper StateMessage), falls back
+        to ``send_raw()`` for custom data.
+        """
+        msg = {
+            "type": "voice_state",
+            "state": state,
+            "trigger": trigger,
+            "ts": int(time.time() * 1000),
+        }
+        if extra:
+            msg["data"] = extra
+
+        logger.debug("[VoiceOverlayBridge] → %s (trigger: %s)", state, trigger)
+
+        try:
+            if self._loop and self._loop.is_running():
+                asyncio.ensure_future(
+                    self._client.send_raw(msg), loop=self._loop
+                )
+            else:
+                # If called from a sync context, try to run
+                loop = asyncio.new_event_loop()
+                loop.run_until_complete(self._client.send_raw(msg))
+                loop.close()
+        except Exception as e:
+            logger.warning("[VoiceOverlayBridge] Send failed: %s", e)
+
+    # ── Speaking State (called externally) ───────────────────────
+
+    def on_speaking_start(self) -> None:
+        """Notify bridge that TTS is speaking."""
+        self._last_state = "speaking"
+        self._send_voice_state("speaking", trigger="tts:start")
+
+    def on_speaking_end(self) -> None:
+        """Notify bridge that TTS finished speaking."""
+        self._last_state = "idle"
+        self._send_voice_state("idle", trigger="tts:end")

--- a/tests/test_voice_overlay_bridge.py
+++ b/tests/test_voice_overlay_bridge.py
@@ -1,0 +1,398 @@
+"""Tests for Voice → Overlay IPC Bridge — Issue #1440.
+
+Covers:
+- ContinuousListener state → overlay IPC mapping
+- Wake word detection → transient "wake" flash
+- VoiceFSM transitions → overlay state
+- Debounce / cooldown logic
+- Speaking state notifications
+- Unbind cleanup
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from enum import Enum, auto
+from dataclasses import dataclass
+from typing import Any, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────
+# Mock types matching voice pipeline interfaces
+# ─────────────────────────────────────────────────────────────────
+
+
+class MockListenerState(Enum):
+    IDLE = auto()
+    LISTENING = auto()
+    PROCESSING = auto()
+
+
+@dataclass
+class MockStateTransition:
+    from_state: Any
+    to_state: Any
+    trigger: str
+    timestamp: float = 0.0
+
+
+class MockVoiceState(Enum):
+    ACTIVE_LISTEN = "active_listen"
+    WAKE_ONLY = "wake_only"
+    IDLE_SLEEP = "idle_sleep"
+
+
+class MockContinuousListener:
+    """Minimal ContinuousListener mock with callback registration."""
+
+    def __init__(self):
+        self._on_state_change: List = []
+        self._on_wake_word: List = []
+
+    def on_state_change(self, callback):
+        self._on_state_change.append(callback)
+
+    def on_wake_word(self, callback):
+        self._on_wake_word.append(callback)
+
+    def fire_state_change(self, state):
+        for cb in self._on_state_change:
+            cb(state)
+
+    def fire_wake_word(self, word, confidence):
+        for cb in self._on_wake_word:
+            cb(word, confidence)
+
+
+class MockVoiceFSM:
+    """Minimal VoiceFSM mock with transition callback."""
+
+    def __init__(self):
+        self._on_transition = None
+
+    def set_on_transition(self, callback):
+        self._on_transition = callback
+
+    def clear_on_transition(self):
+        self._on_transition = None
+
+    def fire_transition(self, from_state, to_state, trigger):
+        if self._on_transition:
+            self._on_transition(MockStateTransition(
+                from_state=from_state,
+                to_state=to_state,
+                trigger=trigger,
+                timestamp=time.monotonic(),
+            ))
+
+
+class MockOverlayClient:
+    """Minimal OverlayClient mock capturing sent messages."""
+
+    def __init__(self):
+        self.messages: List[dict] = []
+
+    async def send_raw(self, msg: dict) -> bool:
+        self.messages.append(msg)
+        return True
+
+    def last_message(self) -> Optional[dict]:
+        return self.messages[-1] if self.messages else None
+
+
+# ─────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────
+
+
+def _make_bridge():
+    """Create bridge with mock overlay client."""
+    client = MockOverlayClient()
+    # Patch asyncio to make send_raw synchronous in tests
+    from bantz.voice.voice_overlay_bridge import VoiceOverlayBridge
+    bridge = VoiceOverlayBridge(client)
+    return bridge, client
+
+
+def _run_bridge_send(bridge, client, setup_fn):
+    """Run bridge in an event loop context for async sends."""
+    loop = asyncio.new_event_loop()
+    bridge._loop = loop
+
+    async def _run():
+        setup_fn()
+        # Give time for any scheduled tasks
+        await asyncio.sleep(0.01)
+
+    loop.run_until_complete(_run())
+    loop.close()
+    return client.messages
+
+
+# ─────────────────────────────────────────────────────────────────
+# Listener State Mapping
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestListenerStateMapping:
+    def test_idle_maps_to_idle(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: listener.fire_state_change(MockListenerState.IDLE))
+        # Initial state is already idle, so no message sent
+        assert len(msgs) == 0
+
+    def test_listening_maps_to_listening(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: listener.fire_state_change(MockListenerState.LISTENING))
+        assert len(msgs) == 1
+        assert msgs[0]["state"] == "listening"
+        assert msgs[0]["type"] == "voice_state"
+
+    def test_processing_maps_to_thinking(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: listener.fire_state_change(MockListenerState.PROCESSING))
+        assert len(msgs) == 1
+        assert msgs[0]["state"] == "thinking"
+
+    def test_state_transitions_sequence(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        def _sequence():
+            listener.fire_state_change(MockListenerState.LISTENING)
+            listener.fire_state_change(MockListenerState.PROCESSING)
+            listener.fire_state_change(MockListenerState.IDLE)
+
+        msgs = _run_bridge_send(bridge, client, _sequence)
+        states = [m["state"] for m in msgs]
+        assert states == ["listening", "thinking", "idle"]
+
+    def test_duplicate_state_not_sent(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        def _dupes():
+            listener.fire_state_change(MockListenerState.LISTENING)
+            listener.fire_state_change(MockListenerState.LISTENING)
+
+        msgs = _run_bridge_send(bridge, client, _dupes)
+        assert len(msgs) == 1
+
+
+# ─────────────────────────────────────────────────────────────────
+# Wake Word
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestWakeWord:
+    def test_wake_word_sends_wake_state(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: listener.fire_wake_word("hey bantz", 0.95))
+        assert len(msgs) == 1
+        assert msgs[0]["state"] == "wake"
+        assert msgs[0]["data"]["wake_word"] == "hey bantz"
+        assert msgs[0]["data"]["confidence"] == 0.95
+
+    def test_wake_word_cooldown(self):
+        bridge, client = _make_bridge()
+        bridge._wake_cooldown = 100.0  # very long cooldown
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        def _rapid_wakes():
+            listener.fire_wake_word("hey bantz", 0.9)
+            listener.fire_wake_word("hey bantz", 0.85)
+            listener.fire_wake_word("bantz", 0.92)
+
+        msgs = _run_bridge_send(bridge, client, _rapid_wakes)
+        wake_msgs = [m for m in msgs if m["state"] == "wake"]
+        assert len(wake_msgs) == 1  # only first, others debounced
+
+
+# ─────────────────────────────────────────────────────────────────
+# VoiceFSM Transitions
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestFSMTransitions:
+    def test_active_listen_maps_to_listening(self):
+        bridge, client = _make_bridge()
+        fsm = MockVoiceFSM()
+        bridge.bind_fsm(fsm)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: fsm.fire_transition(
+                MockVoiceState.WAKE_ONLY,
+                MockVoiceState.ACTIVE_LISTEN,
+                "wake_word"))
+        assert len(msgs) == 1
+        assert msgs[0]["state"] == "listening"
+
+    def test_wake_only_maps_to_idle(self):
+        bridge, client = _make_bridge()
+        bridge._last_state = "listening"  # simulate active state
+        fsm = MockVoiceFSM()
+        bridge.bind_fsm(fsm)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: fsm.fire_transition(
+                MockVoiceState.ACTIVE_LISTEN,
+                MockVoiceState.WAKE_ONLY,
+                "silence_timeout"))
+        assert len(msgs) == 1
+        assert msgs[0]["state"] == "idle"
+
+    def test_thinking_not_downgraded_by_fsm(self):
+        """When listener is in PROCESSING (thinking), FSM's active_listen
+        should not downgrade to listening."""
+        bridge, client = _make_bridge()
+        bridge._last_state = "thinking"  # listener in PROCESSING
+        fsm = MockVoiceFSM()
+        bridge.bind_fsm(fsm)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: fsm.fire_transition(
+                MockVoiceState.WAKE_ONLY,
+                MockVoiceState.ACTIVE_LISTEN,
+                "speech"))
+        assert len(msgs) == 0  # should NOT downgrade from thinking
+
+
+# ─────────────────────────────────────────────────────────────────
+# Speaking State
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestSpeakingState:
+    def test_speaking_start(self):
+        bridge, client = _make_bridge()
+
+        msgs = _run_bridge_send(bridge, client, bridge.on_speaking_start)
+        assert len(msgs) == 1
+        assert msgs[0]["state"] == "speaking"
+        assert bridge._last_state == "speaking"
+
+    def test_speaking_end(self):
+        bridge, client = _make_bridge()
+        bridge._last_state = "speaking"
+
+        msgs = _run_bridge_send(bridge, client, bridge.on_speaking_end)
+        assert len(msgs) == 1
+        assert msgs[0]["state"] == "idle"
+
+
+# ─────────────────────────────────────────────────────────────────
+# Bind / Unbind
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestBindUnbind:
+    def test_bind_listener(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+        assert len(listener._on_state_change) == 1
+        assert len(listener._on_wake_word) == 1
+
+    def test_bind_fsm(self):
+        bridge, client = _make_bridge()
+        fsm = MockVoiceFSM()
+        bridge.bind_fsm(fsm)
+        assert fsm._on_transition is not None
+
+    def test_unbind_all(self):
+        bridge, client = _make_bridge()
+        fsm = MockVoiceFSM()
+        bridge.bind_fsm(fsm)
+        bridge.unbind_all()
+        assert fsm._on_transition is None
+        assert bridge._bound_fsm is None
+        assert bridge._bound_listener is None
+
+
+# ─────────────────────────────────────────────────────────────────
+# Message Format
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestMessageFormat:
+    def test_message_has_required_fields(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: listener.fire_state_change(MockListenerState.LISTENING))
+        msg = msgs[0]
+        assert "type" in msg
+        assert "state" in msg
+        assert "trigger" in msg
+        assert "ts" in msg
+        assert msg["type"] == "voice_state"
+        assert isinstance(msg["ts"], int)
+
+    def test_trigger_includes_source(self):
+        bridge, client = _make_bridge()
+        listener = MockContinuousListener()
+        bridge.bind_listener(listener)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: listener.fire_state_change(MockListenerState.LISTENING))
+        assert msgs[0]["trigger"].startswith("listener:")
+
+    def test_fsm_trigger_includes_source(self):
+        bridge, client = _make_bridge()
+        bridge._last_state = "listening"
+        fsm = MockVoiceFSM()
+        bridge.bind_fsm(fsm)
+
+        msgs = _run_bridge_send(bridge, client,
+            lambda: fsm.fire_transition(
+                MockVoiceState.ACTIVE_LISTEN,
+                MockVoiceState.WAKE_ONLY,
+                "silence_timeout"))
+        assert msgs[0]["trigger"].startswith("fsm:")
+
+
+# ─────────────────────────────────────────────────────────────────
+# Import & Registration
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestImport:
+    def test_bridge_importable(self):
+        from bantz.voice.voice_overlay_bridge import VoiceOverlayBridge
+        assert callable(VoiceOverlayBridge)
+
+    def test_state_maps_exist(self):
+        from bantz.voice.voice_overlay_bridge import (
+            _LISTENER_STATE_MAP,
+            _FSM_STATE_MAP,
+        )
+        assert "IDLE" in _LISTENER_STATE_MAP
+        assert "LISTENING" in _LISTENER_STATE_MAP
+        assert "PROCESSING" in _LISTENER_STATE_MAP
+        assert "active_listen" in _FSM_STATE_MAP
+        assert "wake_only" in _FSM_STATE_MAP


### PR DESCRIPTION
## Özet

Voice pipeline state değişikliklerini overlay'a IPC ile ileten bridge modülü. "hey bantz" deyince küp tepki veriyor.

## Yeni Dosyalar

### `src/bantz/voice/voice_overlay_bridge.py` (~220 satır)
- **VoiceOverlayBridge**: ContinuousListener + VoiceFSM callback → overlay IPC
- State mapping: IDLE→idle, LISTENING→listening, PROCESSING→thinking
- Wake word: transient "wake" flash (500ms) + cooldown debounce
- Speaking API: `on_speaking_start()` / `on_speaking_end()`
- Thread-safe: voice capture thread → async IPC send

### `tests/test_voice_overlay_bridge.py` (~320 satır)
- 8 test class, **20 test** — tümü geçiyor ✅

## Değişiklikler

| Dosya | Değişiklik |
|---|---|
| `renderer.js` | `voice_state` message handler + sphere animation + glitch effects |

## Kabul Kriterleri
- [x] ContinuousListener state → overlay IPC mapping ✅
- [x] Wake word → "wake" flash ✅
- [x] VoiceFSM → overlay state ✅
- [x] Thinking state downgrade koruması ✅
- [x] Speaking state notifications ✅
- [x] 20 test geçiyor ✅

Closes #1440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added real-time voice state indicators displaying idle, listening, and thinking statuses.
  * Implemented wake word detection notifications with confidence display.
  * Enhanced overlay with dynamic visual effects triggered by voice activity changes.
  * Improved state transition animations for seamless visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->