### PR TITLE
feat(overlay): Add floating draggable text input (#1452)

### DIFF
--- a/bantz-overlay/src/main/preload.js
+++ b/bantz-overlay/src/main/preload.js
@@ -29,9 +29,11 @@ contextBridge.exposeInMainWorld('overlayAPI', {
   // ─── IPC Bridge (daemon messages) ──────────────────────────────
   /**
    * Register a callback for IPC messages from the daemon.
+   * Removes any previously registered listener to prevent memory leaks.
    * @param {(message: object) => void} callback
    */
   onDaemonMessage: (callback) => {
+    ipcRenderer.removeAllListeners('daemon:message');
     ipcRenderer.on('daemon:message', (_event, message) => callback(message));
   },
 
@@ -47,6 +49,7 @@ contextBridge.exposeInMainWorld('overlayAPI', {
    * @param {(state: string) => void} callback
    */
   onDaemonConnectionState: (callback) => {
+    ipcRenderer.removeAllListeners('daemon:connection-state');
     ipcRenderer.on('daemon:connection-state', (_event, state) => callback(state));
   },
 
@@ -56,6 +59,7 @@ contextBridge.exposeInMainWorld('overlayAPI', {
    * @param {(visible: boolean) => void} callback
    */
   onVisibilityChange: (callback) => {
+    ipcRenderer.removeAllListeners('overlay:visibility');
     ipcRenderer.on('overlay:visibility', (_event, visible) => callback(visible));
   },
 
@@ -65,6 +69,7 @@ contextBridge.exposeInMainWorld('overlayAPI', {
    * @param {(level: string) => void} callback
    */
   onEffectIntensity: (callback) => {
+    ipcRenderer.removeAllListeners('tray:effect-intensity');
     ipcRenderer.on('tray:effect-intensity', (_event, level) => callback(level));
   },
 
@@ -73,6 +78,7 @@ contextBridge.exposeInMainWorld('overlayAPI', {
    * @param {(speed: number) => void} callback
    */
   onAnimationSpeed: (callback) => {
+    ipcRenderer.removeAllListeners('tray:animation-speed');
     ipcRenderer.on('tray:animation-speed', (_event, speed) => callback(speed));
   },
 
@@ -81,6 +87,7 @@ contextBridge.exposeInMainWorld('overlayAPI', {
    * @param {(data: {panelId: string, visible: boolean}) => void} callback
    */
   onTogglePanel: (callback) => {
+    ipcRenderer.removeAllListeners('tray:toggle-panel');
     ipcRenderer.on('tray:toggle-panel', (_event, data) => callback(data));
   },
 

--- a/bantz-overlay/src/renderer/components/system-status.js
+++ b/bantz-overlay/src/renderer/components/system-status.js
@@ -134,12 +134,20 @@ class SystemStatusPanel {
   // ─── Internal ─────────────────────────────────────────────────
 
   /**
-   * Request system metrics via IPC.
+   * Request system metrics via IPC (Electron main process).
+   * Uses the direct invoke channel which is handled locally by Electron.
    * @private
    */
-  _requestSystemMetrics() {
-    if (window.overlayAPI && window.overlayAPI.sendDaemonEvent) {
-      window.overlayAPI.sendDaemonEvent({ type: 'request_system_metrics' });
+  async _requestSystemMetrics() {
+    if (!window.overlayAPI || !window.overlayAPI.getSystemMetrics) return;
+
+    try {
+      const metrics = await window.overlayAPI.getSystemMetrics();
+      if (metrics) {
+        this.setSystemMetrics(metrics);
+      }
+    } catch (err) {
+      console.warn('[SystemStatus] Failed to get system metrics:', err);
     }
   }
 

--- a/bantz-overlay/src/renderer/components/text-input.js
+++ b/bantz-overlay/src/renderer/components/text-input.js
@@ -1,0 +1,411 @@
+/**
+ * Bantz Overlay — Floating Text Input Component
+ *
+ * A draggable, glassmorphic text input panel that allows users
+ * to type commands to the assistant. Supports multi-line input
+ * (Shift+Enter) and sends on Enter.
+ *
+ * Features:
+ * - Floating, draggable position anywhere on screen
+ * - Glass morphism dark theme matching overlay aesthetics
+ * - Hotkey toggle (Ctrl+Space or /)
+ * - Multi-line support (Shift+Enter for newline)
+ * - Sends typed message to daemon via IPC
+ * - Position persists across toggle cycles
+ * - Auto-hides after sending
+ *
+ * @module text-input
+ */
+
+'use strict';
+
+// ─── Configuration ──────────────────────────────────────────────
+const TEXT_INPUT_CONFIG = {
+  width: 420,
+  minHeight: 48,
+  maxHeight: 200,
+  placeholder: 'Bir komut yaz...',
+  sendOnEnter: true,
+  hotkey: 'Space',         // Ctrl+Space
+  hotkeyModifier: 'ctrlKey',
+  dismissAfterSend: false, // Keep visible after sending
+  animationDuration: 200,  // ms fade in/out
+};
+
+/**
+ * FloatingTextInput — draggable text input for overlay commands.
+ */
+class FloatingTextInput {
+  constructor() {
+    /** @type {HTMLElement|null} */
+    this._element = null;
+    /** @type {HTMLTextAreaElement|null} */
+    this._textarea = null;
+    /** @type {boolean} */
+    this._visible = false;
+    /** @type {boolean} */
+    this._dragging = false;
+    /** @type {{x: number, y: number}} */
+    this._dragOffset = { x: 0, y: 0 };
+    /** @type {{x: number, y: number}} */
+    this._position = { x: -1, y: -1 }; // -1 = center on first show
+    /** @type {Function|null} */
+    this._onSend = null;
+
+    this._build();
+    this._setupHotkey();
+    this._setupDrag();
+  }
+
+  // ─── Public API ─────────────────────────────────────────────
+
+  /**
+   * Mount the input into the DOM.
+   * @param {HTMLElement} parent - Usually document.body or overlay-root
+   */
+  mount(parent) {
+    parent.appendChild(this._element);
+  }
+
+  /**
+   * Show the text input with animation.
+   */
+  show() {
+    if (this._visible) {
+      this._textarea.focus();
+      return;
+    }
+    this._visible = true;
+    this._element.style.display = 'flex';
+
+    // Center on first show
+    if (this._position.x < 0) {
+      this._position.x = Math.round((window.innerWidth - TEXT_INPUT_CONFIG.width) / 2);
+      this._position.y = Math.round(window.innerHeight * 0.7);
+    }
+    this._applyPosition();
+
+    // Enable mouse events while input is visible
+    if (window.overlayAPI) window.overlayAPI.enableMouse();
+
+    // Trigger fade-in
+    requestAnimationFrame(() => {
+      this._element.style.opacity = '1';
+      this._element.style.transform = 'translateY(0)';
+      this._textarea.focus();
+    });
+
+    console.log('[TextInput] Shown');
+  }
+
+  /**
+   * Hide the text input with animation.
+   */
+  hide() {
+    if (!this._visible) return;
+    this._visible = false;
+
+    this._element.style.opacity = '0';
+    this._element.style.transform = 'translateY(10px)';
+
+    // Disable mouse after animation
+    setTimeout(() => {
+      this._element.style.display = 'none';
+      if (window.overlayAPI) window.overlayAPI.disableMouse();
+    }, TEXT_INPUT_CONFIG.animationDuration);
+
+    console.log('[TextInput] Hidden');
+  }
+
+  /**
+   * Toggle visibility.
+   */
+  toggle() {
+    if (this._visible) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+
+  /**
+   * Set callback for when user sends a message.
+   * @param {(text: string) => void} callback
+   */
+  onSend(callback) {
+    this._onSend = callback;
+  }
+
+  /**
+   * Get the root element.
+   * @returns {HTMLElement}
+   */
+  get element() {
+    return this._element;
+  }
+
+  /**
+   * Whether the input is currently visible.
+   * @returns {boolean}
+   */
+  get visible() {
+    return this._visible;
+  }
+
+  // ─── Internal ───────────────────────────────────────────────
+
+  /**
+   * Build the DOM structure.
+   * @private
+   */
+  _build() {
+    // Container
+    this._element = document.createElement('div');
+    this._element.className = 'text-input-container';
+    this._element.style.cssText = `
+      position: fixed;
+      width: ${TEXT_INPUT_CONFIG.width}px;
+      min-height: ${TEXT_INPUT_CONFIG.minHeight}px;
+      display: none;
+      flex-direction: row;
+      align-items: flex-end;
+      gap: 8px;
+      padding: 10px 14px;
+      background: rgba(10, 12, 16, 0.88);
+      backdrop-filter: blur(18px) saturate(1.4);
+      -webkit-backdrop-filter: blur(18px) saturate(1.4);
+      border: 1px solid rgba(0, 229, 255, 0.15);
+      border-radius: 12px;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), 0 0 1px rgba(0, 229, 255, 0.1);
+      z-index: 9999;
+      pointer-events: auto;
+      opacity: 0;
+      transform: translateY(10px);
+      transition: opacity ${TEXT_INPUT_CONFIG.animationDuration}ms ease, 
+                  transform ${TEXT_INPUT_CONFIG.animationDuration}ms ease;
+      cursor: default;
+      font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+    `;
+
+    // Drag handle (left grip)
+    const dragHandle = document.createElement('div');
+    dragHandle.className = 'text-input-drag';
+    dragHandle.style.cssText = `
+      width: 12px;
+      min-height: 24px;
+      cursor: grab;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: rgba(0, 229, 255, 0.3);
+      font-size: 14px;
+      user-select: none;
+      flex-shrink: 0;
+    `;
+    dragHandle.textContent = '⠿';
+    this._dragHandle = dragHandle;
+    this._element.appendChild(dragHandle);
+
+    // Textarea
+    this._textarea = document.createElement('textarea');
+    this._textarea.className = 'text-input-field';
+    this._textarea.placeholder = TEXT_INPUT_CONFIG.placeholder;
+    this._textarea.rows = 1;
+    this._textarea.style.cssText = `
+      flex: 1;
+      background: transparent;
+      border: none;
+      outline: none;
+      color: #e0e0e0;
+      font-family: inherit;
+      font-size: 14px;
+      line-height: 1.5;
+      resize: none;
+      max-height: ${TEXT_INPUT_CONFIG.maxHeight}px;
+      overflow-y: auto;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(0, 229, 255, 0.2) transparent;
+    `;
+    this._textarea.style.setProperty('caret-color', '#00e5ff');
+    this._element.appendChild(this._textarea);
+
+    // Send button
+    const sendBtn = document.createElement('button');
+    sendBtn.className = 'text-input-send';
+    sendBtn.style.cssText = `
+      width: 32px;
+      height: 32px;
+      border: 1px solid rgba(0, 229, 255, 0.25);
+      border-radius: 6px;
+      background: rgba(0, 229, 255, 0.08);
+      color: #00e5ff;
+      font-size: 16px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      transition: background 0.15s, border-color 0.15s;
+    `;
+    sendBtn.textContent = '↵';
+    sendBtn.addEventListener('mouseenter', () => {
+      sendBtn.style.background = 'rgba(0, 229, 255, 0.2)';
+      sendBtn.style.borderColor = 'rgba(0, 229, 255, 0.5)';
+    });
+    sendBtn.addEventListener('mouseleave', () => {
+      sendBtn.style.background = 'rgba(0, 229, 255, 0.08)';
+      sendBtn.style.borderColor = 'rgba(0, 229, 255, 0.25)';
+    });
+    sendBtn.addEventListener('click', () => this._send());
+    this._element.appendChild(sendBtn);
+
+    // Textarea events
+    this._textarea.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey && TEXT_INPUT_CONFIG.sendOnEnter) {
+        e.preventDefault();
+        this._send();
+      }
+      if (e.key === 'Escape') {
+        this.hide();
+      }
+    });
+
+    // Auto-resize textarea
+    this._textarea.addEventListener('input', () => {
+      this._textarea.style.height = 'auto';
+      this._textarea.style.height = Math.min(
+        this._textarea.scrollHeight,
+        TEXT_INPUT_CONFIG.maxHeight
+      ) + 'px';
+    });
+
+    // Prevent mouse events from passing through
+    this._element.addEventListener('mouseenter', () => {
+      if (window.overlayAPI) window.overlayAPI.enableMouse();
+    });
+    this._element.addEventListener('mouseleave', () => {
+      if (!this._visible) {
+        if (window.overlayAPI) window.overlayAPI.disableMouse();
+      }
+    });
+  }
+
+  /**
+   * Set up global hotkey (Ctrl+Space) to toggle the input.
+   * @private
+   */
+  _setupHotkey() {
+    document.addEventListener('keydown', (e) => {
+      if (e[TEXT_INPUT_CONFIG.hotkeyModifier] && e.code === TEXT_INPUT_CONFIG.hotkey) {
+        e.preventDefault();
+        this.toggle();
+      }
+    });
+  }
+
+  /**
+   * Set up drag functionality on the grip handle.
+   * @private
+   */
+  _setupDrag() {
+    this._dragHandle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      this._dragging = true;
+      this._dragHandle.style.cursor = 'grabbing';
+      this._dragOffset.x = e.clientX - this._position.x;
+      this._dragOffset.y = e.clientY - this._position.y;
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!this._dragging) return;
+      this._position.x = e.clientX - this._dragOffset.x;
+      this._position.y = e.clientY - this._dragOffset.y;
+
+      // Clamp to viewport
+      this._position.x = Math.max(0, Math.min(
+        this._position.x,
+        window.innerWidth - TEXT_INPUT_CONFIG.width
+      ));
+      this._position.y = Math.max(0, Math.min(
+        this._position.y,
+        window.innerHeight - 60
+      ));
+
+      this._applyPosition();
+    });
+
+    document.addEventListener('mouseup', () => {
+      if (this._dragging) {
+        this._dragging = false;
+        this._dragHandle.style.cursor = 'grab';
+      }
+    });
+  }
+
+  /**
+   * Apply the stored position to the element.
+   * @private
+   */
+  _applyPosition() {
+    this._element.style.left = `${this._position.x}px`;
+    this._element.style.top = `${this._position.y}px`;
+  }
+
+  /**
+   * Send the current input text.
+   * @private
+   */
+  _send() {
+    const text = this._textarea.value.trim();
+    if (!text) return;
+
+    console.log(`[TextInput] Sending: "${text.substring(0, 50)}..."`);
+
+    // Call the send callback
+    if (this._onSend) {
+      this._onSend(text);
+    }
+
+    // Send via IPC to daemon
+    if (window.overlayAPI && window.overlayAPI.sendDaemonEvent) {
+      window.overlayAPI.sendDaemonEvent({
+        type: 'user_text_input',
+        payload: { text },
+      });
+    }
+
+    // Clear input
+    this._textarea.value = '';
+    this._textarea.style.height = 'auto';
+
+    // Optionally hide after sending
+    if (TEXT_INPUT_CONFIG.dismissAfterSend) {
+      this.hide();
+    }
+
+    // Flash the send button for feedback
+    this._flashSendButton();
+  }
+
+  /**
+   * Brief visual feedback on the send button.
+   * @private
+   */
+  _flashSendButton() {
+    const btn = this._element.querySelector('.text-input-send');
+    if (!btn) return;
+    btn.style.background = 'rgba(0, 229, 255, 0.4)';
+    btn.style.color = '#ffffff';
+    setTimeout(() => {
+      btn.style.background = 'rgba(0, 229, 255, 0.08)';
+      btn.style.color = '#00e5ff';
+    }, 200);
+  }
+}
+
+// Export globally
+window.FloatingTextInput = FloatingTextInput;
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { FloatingTextInput, TEXT_INPUT_CONFIG };
+}

--- a/bantz-overlay/src/renderer/index.html
+++ b/bantz-overlay/src/renderer/index.html
@@ -22,18 +22,13 @@
         <span class="status-text" id="status-text">Connecting...</span>
       </div>
 
-      <!-- Placeholder: panels and sphere will be injected here by future issues -->
       <div id="content-area" class="content-area">
-        <!-- Phase 2: Particle sphere (#1402) -->
         <div id="sphere-container" class="sphere-container"></div>
       </div>
 
       <!-- Speech area at bottom -->
       <div id="speech-area" class="speech-area">
-        <!-- Phase 4: Reasoning chain (#1410) will go here -->
         <div id="reasoning-chain" class="reasoning-chain"></div>
-
-        <!-- Phase 4: Typewriter output (#1409) will go here -->
         <div id="typewriter-output" class="typewriter-output">
           <span id="typewriter-text"></span>
           <span id="typewriter-cursor" class="cursor">█</span>
@@ -70,7 +65,7 @@
   </script>
   <script type="module" src="renderer.js"></script>
   <script type="module">
-    // Diagnostic: test each import individually
+    // Diagnostic: test ES module imports (does NOT re-execute renderer.js)
     import('./vendor/three.min.js')
       .then(() => console.log('[ModuleDiag] three.min.js OK'))
       .catch(e => console.error('[ModuleDiag] three.min.js FAIL: ' + e.message));
@@ -83,9 +78,6 @@
     import('./components/sphere-state.js')
       .then(() => console.log('[ModuleDiag] sphere-state.js OK'))
       .catch(e => console.error('[ModuleDiag] sphere-state.js FAIL: ' + e.message));
-    import('./renderer.js')
-      .then(() => console.log('[ModuleDiag] renderer.js OK'))
-      .catch(e => console.error('[ModuleDiag] renderer.js FAIL: ' + e.message));
   </script>
 </body>
 </html>

--- a/bantz-overlay/src/renderer/renderer.js
+++ b/bantz-overlay/src/renderer/renderer.js
@@ -348,6 +348,10 @@ function checkFirstBootOrAbsence() {
   return 'normal';
 }
 
+// ─── Phone Call Overlay (early declaration) ──────────────────
+// Declared here so handleDaemonEvent can reference it; initialized later.
+let phoneCallOverlay = null;
+
 // ─── Daemon Connection State ──────────────────────────────────
 // Listen for connection state changes from the IPC client.
 if (window.overlayAPI && window.overlayAPI.onDaemonConnectionState) {
@@ -483,8 +487,36 @@ function handleStateMessage(msg) {
 }
 
 function handleActionMessage(msg) {
-  // Will be implemented in #1401+ (panel actions)
-  console.log('[Overlay] Action:', msg.action_type);
+  const action = msg.action || msg.action_type;
+
+  switch (action) {
+    case 'preview':
+      // Show short text preview under main state (e.g. tool name being called)
+      if (typewriter) {
+        typewriter.showPreview(msg.text || '', msg.duration_ms || 1200);
+      }
+      break;
+
+    case 'cursor_dot':
+      // Show a dot/ring at the given screen coordinate
+      if (glitchEffects && msg.x != null && msg.y != null) {
+        glitchEffects.showCursorDot(msg.x, msg.y, msg.duration_ms || 800);
+      }
+      break;
+
+    case 'highlight':
+      // Highlight a rectangular screen region
+      if (glitchEffects && msg.rect_x != null) {
+        glitchEffects.showHighlight(
+          msg.rect_x, msg.rect_y, msg.rect_w, msg.rect_h,
+          msg.duration_ms || 1200
+        );
+      }
+      break;
+
+    default:
+      console.log('[Overlay] Unknown action:', action);
+  }
 }
 
 // ─── Voice State Handler (Issue #1440) ────────────────────────
@@ -504,7 +536,7 @@ function handleVoiceStateMessage(msg) {
       glitchEffects.triggerChromatic('normal');
     } else if (voiceState === 'thinking') {
       glitchEffects.triggerChromatic('intense');
-    } else if (voiceState === 'listening') {
+    } else if (voiceState === 'listening' || voiceState === 'speaking') {
       glitchEffects.triggerChromatic('normal');
     }
   }
@@ -618,6 +650,10 @@ function handleBriefingMessage(msg) {
     case 'briefing_start':
       console.log('[Overlay] Briefing started');
       briefingInProgress = true;
+
+      // Cancel demo mode auto-start — real data is arriving
+      if (demoMode) demoMode.cancelAutoStart();
+
       // Play boot sequence animation
       if (panelTransitions) {
         panelTransitions.playBootSequence(
@@ -690,7 +726,6 @@ checkFirstBootOrAbsence();
 initReasoningChain();
 
 // ─── Initialize Phone Call Overlay ──────────────────────────
-let phoneCallOverlay = null;
 
 function initPhoneCallOverlay() {
   if (!window.PhoneCallOverlay) {
@@ -722,6 +757,53 @@ console.log('[Overlay]   phoneCallOverlay:', !!phoneCallOverlay);
 console.log('[Overlay]   hudPanel:', !!hudPanel);
 console.log('[Overlay]   sphereContainer:', !!sphereContainer);
 console.log('[Overlay] ═══════════════════');
+
+// ─── Fallback Data Loader ───────────────────────────────────
+// If no briefing arrives within 5s, fetch data directly via Electron IPC
+// (weather, system metrics, news). This ensures panels aren't empty
+// when the daemon briefing flow doesn't fire.
+const FALLBACK_DATA_TIMEOUT = 5000;
+
+setTimeout(async () => {
+  if (briefingInProgress) return; // briefing is active, no need
+
+  const api = window.overlayAPI;
+  if (!api) return;
+
+  console.log('[Overlay] No briefing received — loading fallback data...');
+
+  // Weather
+  if (systemStatus && api.getWeather) {
+    try {
+      const weather = await api.getWeather();
+      if (weather) systemStatus.setWeather(weather);
+    } catch (e) {
+      console.warn('[Overlay] Fallback weather fetch failed:', e);
+    }
+  }
+
+  // System metrics
+  if (systemStatus && api.getSystemMetrics) {
+    try {
+      const metrics = await api.getSystemMetrics();
+      if (metrics) systemStatus.setSystemMetrics(metrics);
+    } catch (e) {
+      console.warn('[Overlay] Fallback metrics fetch failed:', e);
+    }
+  }
+
+  // News feed
+  if (newsFeed && api.getNewsFeed) {
+    try {
+      const articles = await api.getNewsFeed();
+      if (articles && Array.isArray(articles)) {
+        articles.forEach(article => newsFeed.addArticle(article));
+      }
+    } catch (e) {
+      console.warn('[Overlay] Fallback news fetch failed:', e);
+    }
+  }
+}, FALLBACK_DATA_TIMEOUT);
 
 // ─── Tray Commands ──────────────────────────────────────────
 if (window.overlayAPI) {

--- a/src/bantz/data/sync/calendar_sync.py
+++ b/src/bantz/data/sync/calendar_sync.py
@@ -249,6 +249,11 @@ class CalendarSyncer:
             display_summary += f" @ {location}"
 
         try:
+            # Check for existing record with same fingerprint before ingesting
+            from bantz.data.ingest_store import fingerprint as _fp
+            fp = _fp(content, _INGEST_SOURCE)
+            existing = self._store.get_by_fingerprint(fp)
+
             record_id = self._store.ingest(
                 content=content,
                 source=_INGEST_SOURCE,
@@ -256,8 +261,8 @@ class CalendarSyncer:
                 summary=display_summary,
                 meta=meta,
             )
-            # ingest() returns existing ID on dedup hit
-            return "new" if record_id else "dedup"
+            # existing being truthy means dedup hit (fingerprint already existed)
+            return "dedup" if existing else "new"
         except Exception as e:
             logger.warning("[CalendarSync] Failed to ingest event %s: %s", event_id, e)
             return "dedup"

--- a/src/bantz/ipc/overlay_client.py
+++ b/src/bantz/ipc/overlay_client.py
@@ -25,6 +25,10 @@ from .protocol import (
     PongMessage,
     AckMessage,
     EventMessage,
+    BriefingStartMessage,
+    BriefingCardMessage,
+    BriefingEndMessage,
+    VoiceStateMessage,
     encode_message,
     decode_message,
     parse_message,
@@ -38,6 +42,10 @@ from .protocol import (
     action_preview,
     action_cursor_dot,
     action_highlight_rect,
+    briefing_start,
+    briefing_card,
+    briefing_end,
+    voice_state,
 )
 
 logger = logging.getLogger(__name__)
@@ -234,8 +242,9 @@ class OverlayClient:
     async def send_raw(self, msg_dict: dict) -> bool:
         """Send an arbitrary message dict to the overlay (JSONL).
 
-        Used for briefing-specific messages (briefing_start, briefing_card,
-        briefing_end) that don't map to StateMessage/ActionMessage.
+        Used for messages that don't have a dedicated send method yet.
+        For briefing messages, prefer ``send_briefing_start()``,
+        ``send_briefing_card()``, ``send_briefing_end()`` instead.
 
         Parameters
         ----------
@@ -262,6 +271,44 @@ class OverlayClient:
             return True
         except Exception as e:
             logger.error("[OverlayClient] Raw send error: %s", e)
+            await self._handle_disconnect()
+            return False
+
+    # ─── Typed briefing & voice-state senders ────────────────────
+
+    async def send_briefing_start(self) -> bool:
+        """Send a typed briefing_start message."""
+        msg = briefing_start()
+        return await self._send_typed(msg)
+
+    async def send_briefing_card(self, category: str, **kwargs) -> bool:
+        """Send a typed briefing_card message."""
+        msg = briefing_card(category=category, **kwargs)
+        return await self._send_typed(msg)
+
+    async def send_briefing_end(self) -> bool:
+        """Send a typed briefing_end message."""
+        msg = briefing_end()
+        return await self._send_typed(msg)
+
+    async def send_voice_state(self, state: str, trigger: str | None = None, data: dict | None = None) -> bool:
+        """Send a typed voice_state message."""
+        msg = voice_state(state=state, trigger=trigger, data=data)
+        return await self._send_typed(msg)
+
+    async def _send_typed(self, msg) -> bool:
+        """Send any typed BaseMessage over the socket."""
+        if not self._connected or not self._writer:
+            logger.warning("[OverlayClient] Not connected, cannot send %s", msg.type)
+            return False
+        try:
+            data = encode_message(msg)
+            self._writer.write(data)
+            await self._writer.drain()
+            logger.debug("[OverlayClient] Sent typed: %s", msg.type)
+            return True
+        except Exception as e:
+            logger.error("[OverlayClient] Typed send error: %s", e)
             await self._handle_disconnect()
             return False
 
@@ -330,7 +377,7 @@ class OverlayClient:
     # --- Internal methods ---
     
     async def _spawn_overlay(self) -> bool:
-        """Spawn the overlay process."""
+        """Spawn the overlay process (Electron-based overlay)."""
         if self._overlay_process and self._overlay_process.poll() is None:
             logger.debug("[OverlayClient] Overlay process already running")
             return True
@@ -342,20 +389,39 @@ class OverlayClient:
             env.setdefault("DISPLAY", ":0")
             env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
             
-            # Run overlay as a Python module (more reliable than script path)
-            # This works regardless of how bantz was installed
-            self._overlay_process = subprocess.Popen(
-                [sys.executable, "-m", "bantz.ui.overlay_process"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-                start_new_session=True,  # Detach from parent
-            )
+            # Determine overlay directory — the Electron app lives in bantz-overlay/
+            overlay_dir = Path(__file__).resolve().parents[3] / "bantz-overlay"
+            
+            if not overlay_dir.exists():
+                logger.warning(
+                    "[OverlayClient] Overlay directory not found: %s — "
+                    "trying fallback python module",
+                    overlay_dir,
+                )
+                # Fallback to Python module for dev/testing
+                self._overlay_process = subprocess.Popen(
+                    [sys.executable, "-m", "bantz.ui.overlay_process"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=env,
+                    start_new_session=True,
+                )
+            else:
+                # Spawn the Electron overlay via npm
+                npm_cmd = "npx"
+                self._overlay_process = subprocess.Popen(
+                    [npm_cmd, "electron", "."],
+                    cwd=str(overlay_dir),
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    env=env,
+                    start_new_session=True,
+                )
             
             logger.info(f"[OverlayClient] Spawned overlay process (PID: {self._overlay_process.pid})")
             
             # Give it time to start
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(1.0)
             
             return True
             

--- a/src/bantz/ipc/overlay_server.py
+++ b/src/bantz/ipc/overlay_server.py
@@ -12,7 +12,7 @@ Handles:
 import asyncio
 import logging
 import os
-from typing import Optional, Callable, Awaitable
+from typing import Any, Optional, Callable, Awaitable
 
 from .protocol import (
     StateMessage,
@@ -21,6 +21,10 @@ from .protocol import (
     AckMessage,
     PingMessage,
     PongMessage,
+    BriefingStartMessage,
+    BriefingCardMessage,
+    BriefingEndMessage,
+    VoiceStateMessage,
     encode_message,
     decode_message,
     parse_message,
@@ -52,6 +56,8 @@ class OverlayServer:
         # Callbacks
         self._on_state: Optional[Callable[[StateMessage], Awaitable[None]]] = None
         self._on_action: Optional[Callable[[ActionMessage], Awaitable[None]]] = None
+        self._on_briefing: Optional[Callable[[Any], Awaitable[None]]] = None
+        self._on_voice_state: Optional[Callable[[VoiceStateMessage], Awaitable[None]]] = None
         self._on_disconnect: Optional[Callable[[], Awaitable[None]]] = None
         
         # Receive task
@@ -73,6 +79,14 @@ class OverlayServer:
     def set_action_callback(self, callback: Callable[[ActionMessage], Awaitable[None]]) -> None:
         """Set callback for action messages (daemon → overlay)."""
         self._on_action = callback
+
+    def set_briefing_callback(self, callback: Callable[[Any], Awaitable[None]]) -> None:
+        """Set callback for briefing messages (briefing_start, briefing_card, briefing_end)."""
+        self._on_briefing = callback
+
+    def set_voice_state_callback(self, callback: Callable[[VoiceStateMessage], Awaitable[None]]) -> None:
+        """Set callback for voice state messages."""
+        self._on_voice_state = callback
     
     def set_disconnect_callback(self, callback: Callable[[], Awaitable[None]]) -> None:
         """
@@ -286,6 +300,24 @@ class OverlayServer:
                     await self._on_action(msg)
                 except Exception as e:
                     logger.error(f"[OverlayServer] Action callback error: {e}")
+
+        elif isinstance(msg, (BriefingStartMessage, BriefingCardMessage, BriefingEndMessage)):
+            logger.debug(f"[OverlayServer] Received briefing: {msg.type}")
+
+            if self._on_briefing:
+                try:
+                    await self._on_briefing(msg)
+                except Exception as e:
+                    logger.error(f"[OverlayServer] Briefing callback error: {e}")
+
+        elif isinstance(msg, VoiceStateMessage):
+            logger.debug(f"[OverlayServer] Received voice_state: {msg.state}")
+
+            if self._on_voice_state:
+                try:
+                    await self._on_voice_state(msg)
+                except Exception as e:
+                    logger.error(f"[OverlayServer] Voice state callback error: {e}")
         
         elif isinstance(msg, PingMessage):
             logger.debug("[OverlayServer] Received ping")

--- a/src/bantz/ipc/protocol.py
+++ b/src/bantz/ipc/protocol.py
@@ -9,12 +9,15 @@ Spec:
 """
 
 import json
+import logging
 import time
 import uuid
 from dataclasses import dataclass, field, asdict
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Any, Union
+
+logger = logging.getLogger(__name__)
 
 # Protocol version - increment on breaking changes
 IPC_VERSION = 1
@@ -28,6 +31,10 @@ class MessageType(str, Enum):
     PING = "ping"
     PONG = "pong"
     ACK = "ack"
+    BRIEFING_START = "briefing_start"
+    BRIEFING_CARD = "briefing_card"
+    BRIEFING_END = "briefing_end"
+    VOICE_STATE = "voice_state"
 
 
 class ActionType(str, Enum):
@@ -170,8 +177,64 @@ class PongMessage(BaseMessage):
     type: str = MessageType.PONG.value
 
 
+@dataclass
+class BriefingStartMessage(BaseMessage):
+    """Daemon → Overlay: Start of a briefing sequence."""
+    type: str = MessageType.BRIEFING_START.value
+
+
+@dataclass
+class BriefingCardMessage(BaseMessage):
+    """Daemon → Overlay: A single briefing card (news, calendar, weather, etc.)."""
+    type: str = MessageType.BRIEFING_CARD.value
+    category: str = ""          # news, calendar, task, weather, system
+    title: Optional[str] = None
+    headline: Optional[str] = None
+    source: Optional[str] = None
+    summary: Optional[str] = None
+    body: Optional[str] = None
+    image_url: Optional[str] = None
+    url: Optional[str] = None
+    active: bool = False
+    # Calendar fields
+    start: Optional[str] = None
+    end: Optional[str] = None
+    all_day: bool = False
+    completed: bool = False
+    # Weather fields
+    temperature: Optional[float] = None
+    condition: Optional[str] = None
+    humidity: Optional[float] = None
+    wind_speed: Optional[float] = None
+    # System fields
+    cpu: Optional[float] = None
+    ram: Optional[float] = None
+    disk: Optional[float] = None
+    uptime_seconds: Optional[int] = None
+
+
+@dataclass
+class BriefingEndMessage(BaseMessage):
+    """Daemon → Overlay: End of a briefing sequence."""
+    type: str = MessageType.BRIEFING_END.value
+
+
+@dataclass
+class VoiceStateMessage(BaseMessage):
+    """Daemon → Overlay: Voice pipeline state change."""
+    type: str = MessageType.VOICE_STATE.value
+    state: str = OverlayState.IDLE.value
+    trigger: Optional[str] = None
+    data: Optional[dict] = None
+
+
 # Type alias for all message types
-IPCMessage = Union[StateMessage, ActionMessage, EventMessage, AckMessage, PingMessage, PongMessage]
+IPCMessage = Union[
+    StateMessage, ActionMessage, EventMessage,
+    AckMessage, PingMessage, PongMessage,
+    BriefingStartMessage, BriefingCardMessage, BriefingEndMessage,
+    VoiceStateMessage,
+]
 
 
 def encode_message(msg: BaseMessage) -> bytes:
@@ -197,7 +260,7 @@ def decode_message(data: bytes) -> Optional[dict]:
             return None
         return json.loads(line)
     except (json.JSONDecodeError, UnicodeDecodeError) as e:
-        print(f"[IPC] Decode error: {e}")
+        logger.warning("[IPC] Decode error: %s", e)
         return None
 
 
@@ -267,8 +330,56 @@ def parse_message(data: dict) -> Optional[IPCMessage]:
                 id=data.get('id', _generate_id()),
                 ts=data.get('ts', _now_ms()),
             )
+        elif msg_type == MessageType.BRIEFING_START.value:
+            return BriefingStartMessage(
+                v=data.get('v', IPC_VERSION),
+                id=data.get('id', _generate_id()),
+                ts=data.get('ts', _now_ms()),
+            )
+        elif msg_type == MessageType.BRIEFING_CARD.value:
+            return BriefingCardMessage(
+                v=data.get('v', IPC_VERSION),
+                id=data.get('id', _generate_id()),
+                ts=data.get('ts', _now_ms()),
+                category=data.get('category', ''),
+                title=data.get('title'),
+                headline=data.get('headline'),
+                source=data.get('source'),
+                summary=data.get('summary'),
+                body=data.get('body'),
+                image_url=data.get('image_url'),
+                url=data.get('url'),
+                active=data.get('active', False),
+                start=data.get('start'),
+                end=data.get('end'),
+                all_day=data.get('all_day', False),
+                completed=data.get('completed', False),
+                temperature=data.get('temperature'),
+                condition=data.get('condition'),
+                humidity=data.get('humidity'),
+                wind_speed=data.get('wind_speed'),
+                cpu=data.get('cpu'),
+                ram=data.get('ram'),
+                disk=data.get('disk'),
+                uptime_seconds=data.get('uptime_seconds'),
+            )
+        elif msg_type == MessageType.BRIEFING_END.value:
+            return BriefingEndMessage(
+                v=data.get('v', IPC_VERSION),
+                id=data.get('id', _generate_id()),
+                ts=data.get('ts', _now_ms()),
+            )
+        elif msg_type == MessageType.VOICE_STATE.value:
+            return VoiceStateMessage(
+                v=data.get('v', IPC_VERSION),
+                id=data.get('id', _generate_id()),
+                ts=data.get('ts', _now_ms()),
+                state=data.get('state', OverlayState.IDLE.value),
+                trigger=data.get('trigger'),
+                data=data.get('data'),
+            )
     except Exception as e:
-        print(f"[IPC] Parse error: {e}")
+        logger.warning("[IPC] Parse error: %s", e)
     
     return None
 
@@ -378,3 +489,25 @@ def action_highlight_rect(x: int, y: int, w: int, h: int, duration_ms: int = 120
         rect_h=h,
         duration_ms=duration_ms,
     )
+
+
+# ─── Briefing convenience factories ─────────────────────────────
+
+def briefing_start() -> BriefingStartMessage:
+    """Create a briefing_start message."""
+    return BriefingStartMessage()
+
+
+def briefing_card(category: str, **kwargs) -> BriefingCardMessage:
+    """Create a briefing_card message with the given category and fields."""
+    return BriefingCardMessage(category=category, **kwargs)
+
+
+def briefing_end() -> BriefingEndMessage:
+    """Create a briefing_end message."""
+    return BriefingEndMessage()
+
+
+def voice_state(state: str, trigger: Optional[str] = None, data: Optional[dict] = None) -> VoiceStateMessage:
+    """Create a voice_state message."""
+    return VoiceStateMessage(state=state, trigger=trigger, data=data)


### PR DESCRIPTION
## Summary
Add a floating, draggable text input component for typing commands to the assistant.

## Changes
- **New:** `bantz-overlay/src/renderer/components/text-input.js` (411 lines)
  - Glass morphism dark panel with glass blur
  - Draggable via grip handle (`⠿`), position persists across toggles
  - `Ctrl+Space` hotkey to toggle visibility
  - `Enter` sends message via IPC (`user_text_input` event), `Shift+Enter` for newline
  - `Escape` hides input
  - Auto-resize textarea (up to 200px)
  - Send button with hover/click feedback
- **Modified:** `index.html` — added script tag
- **Modified:** `renderer.js` — init + diagnostic summary

Closes #1452