### PR TITLE
refactor(skills): consolidate skill definitions into package

### DIFF
--- a/src/bantz/skills/declarative/loader.py
+++ b/src/bantz/skills/declarative/loader.py
@@ -84,6 +84,15 @@ def _get_default_skill_dirs() -> list[Path]:
     if extra_dir:
         dirs.insert(0, Path(extra_dir))
 
+    # Built-in skill definitions shipped with the package
+    # (src/bantz/skills/definitions/ — declarative SKILL.md files)
+    try:
+        _pkg_definitions = Path(__file__).parent.parent / "definitions"
+        if _pkg_definitions.is_dir():
+            dirs.append(_pkg_definitions)
+    except Exception:
+        pass
+
     return dirs
 
 

--- a/src/bantz/skills/definitions/__init__.py
+++ b/src/bantz/skills/definitions/__init__.py
@@ -1,0 +1,1 @@
+# Skills package — Bantz skill modules.

--- a/src/bantz/skills/definitions/classroom/SKILL.md
+++ b/src/bantz/skills/definitions/classroom/SKILL.md
@@ -1,0 +1,40 @@
+# Classroom — Google Classroom Integration
+
+## Triggers (TR / EN)
+
+- "derslerim neler", "ödevlerim ne durumda", "classroom'a bak", "teslim durumu"
+- "my courses", "list assignments", "homework status", "classroom check"
+
+## Tools
+
+| Tool | Açıklama | Risk |
+|------|----------|------|
+| `google.classroom.courses` | Aktif/arşiv ders listesi | SAFE |
+| `google.classroom.coursework` | Bir dersin ödev/sınav listesi | SAFE |
+| `google.classroom.submissions` | Teslim durumları (teslim edildi, geç, not) | SAFE |
+
+## Instructions
+
+### Akış
+1. Kullanıcı "derslerimi göster" derse → `google.classroom.courses` çağır
+2. "X dersinin ödevleri" → course_id'yi bul → `google.classroom.coursework`
+3. "ödev durumum" → `google.classroom.submissions` ile teslim durumunu raporla
+
+### Kurallar
+- Tüm araçlar **read-only** — veri değiştirmez
+- OAuth scope: `classroom.courses.readonly`, `classroom.coursework.me`
+- Teslim edilmemiş ödevler **uyarı** ile gösterilmeli
+- Geç teslimler **kırmızı bayrak** ile işaretlenmeli
+
+## Slot Extraction
+
+| Slot | Tip | Kaynak |
+|------|-----|--------|
+| `course_name` | string | kullanıcı ifadesi → course_id'ye eşle |
+| `state` | enum | ACTIVE / ARCHIVED (default: ACTIVE) |
+| `course_id` | string | önceki courses sorgusundan |
+
+## Proactive
+
+- Günlük program (daily_program) ile entegre — yaklaşan ödev tarihleri hatırlat
+- Teslim edilmemiş ödev varsa sidebar'da uyarı göster

--- a/src/bantz/skills/definitions/daily-briefing/SKILL.md
+++ b/src/bantz/skills/definitions/daily-briefing/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: daily-briefing
+version: 1.0.0
+author: Bantz Team
+description: "Günlük brifing — Bugün ne yapmam gerekiyor?"
+icon: 📋
+tags:
+  - builtin
+  - daily
+  - productivity
+
+triggers:
+  - pattern: "(?i)(bugün|günlük).*(plan|program|ne\\s*yap|ne\\s*var|brifing|briefing|özet)"
+    intent: daily.briefing
+    examples:
+      - "bugün ne yapmam gerekiyor"
+      - "günlük planım ne"
+      - "bugünkü programım"
+      - "günlük brifing"
+    priority: 75
+
+  - pattern: "(?i)(yarın|haftaya).*(plan|program|ne\\s*var)"
+    intent: daily.tomorrow
+    examples:
+      - "yarın ne var"
+      - "yarınki planım"
+    priority: 70
+
+tools:
+  - name: daily.get_briefing
+    description: "Takvim, mail ve hatırlatıcılardan günlük brifing oluşturur"
+    handler: builtin:calendar.list_events
+    parameters:
+      - name: date
+        type: string
+        description: "Tarih (bugün/yarın/YYYY-MM-DD)"
+      - name: include_email
+        type: boolean
+        description: "Mail özetini dahil et"
+
+  - name: daily.get_schedule
+    description: "Günün saatlik programını getirir"
+    handler: builtin:calendar.list_events
+    parameters:
+      - name: date
+        type: string
+        description: "Tarih"
+
+permissions:
+  - calendar
+  - email
+
+config:
+  morning_briefing_time: "08:00"
+  include_weather: true
+---
+
+# Daily Briefing Skill — Günlük Brifing
+
+Sen Bantz'ın günlük planlama yeteneğisin.
+
+## Görevin
+
+"Bugün ne yapmam gerekiyor?" dendiğinde tüm kaynaklardan bütünsel bir günlük özet çıkar:
+
+1. **Takvim**: Bugünkü etkinlikler, toplantılar
+2. **Mail**: Önemli / okunmamış mailler (varsa)
+3. **Hatırlatıcılar**: Aktif hatırlatmalar
+
+## Yanıt Formatı
+
+```
+📋 Günlük Brifing — [Tarih]
+
+📅 Takvim:
+  09:00 - 10:00  Matematik dersi
+  14:00 - 15:30  Proje toplantısı
+  18:00          Spor
+
+📧 Mail:
+  3 okunmamış mail (1 önemli: Hoca'dan ödev hakkında)
+
+⏰ Hatırlatmalar:
+  - Kütüphane kitabını iade et (bugün son gün!)
+
+💡 Öneri: Bugün yoğun bir gün. 12:00-14:00 arası boş — öğle yemeği için uygun.
+```
+
+## Kurallar
+
+1. Her zaman Türkçe
+2. Saatleri 24 saat formatında göster
+3. Boş zamanları belirt
+4. Çakışma varsa uyar
+5. Eğer hiçbir şey yoksa: "Bugün takviminde bir şey yok. Rahat bir gün! 😊"

--- a/src/bantz/skills/definitions/file_search/SKILL.md
+++ b/src/bantz/skills/definitions/file_search/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: file-search
+version: 0.1.0
+author: Bantz Team
+description: "🔍 Semantic File Search — local filesystem indexing and semantic retrieval."
+icon: 🔍
+status: planned
+tags:
+  - future
+  - search
+  - embeddings
+
+dependencies:
+  - epic: "EPIC 1 — Ingest Store"
+    status: pending
+
+triggers:
+  - pattern: "(?i)(file|document|presentation|report|doc).*(find|search|where|which)"
+    intent: file_search.find
+    examples:
+      - "where was that presentation I made last month"
+      - "find the budget report"
+      - "search for that PDF"
+      - "I had something about this topic in my notes"
+    priority: 80
+
+  - pattern: "(?i)(index|scan|update files)"
+    intent: file_search.index
+    examples:
+      - "index my files"
+      - "scan my documents"
+    priority: 60
+
+tools:
+  - name: file_search.query
+    description: "Semantic file search — find files using natural language query"
+    handler: llm
+    parameters:
+      - name: query
+        type: string
+        description: "Natural language search query"
+      - name: file_types
+        type: string
+        description: "File types: pdf, docx, txt, all"
+        enum: ["pdf", "docx", "txt", "md", "all"]
+      - name: directory
+        type: string
+        description: "Search directory (default: ~/Documents)"
+
+  - name: file_search.index
+    description: "Index local filesystem for search"
+    handler: system
+    risk: medium
+    parameters:
+      - name: directories
+        type: array
+        description: "List of directories to index"
+      - name: force
+        type: boolean
+        description: "Rebuild index from scratch"
+
+  - name: file_search.recent
+    description: "List recently modified files"
+    handler: system
+    parameters:
+      - name: days
+        type: integer
+        description: "Number of days to look back"
+      - name: file_type
+        type: string
+        description: "File type filter"
+
+notes: |
+  Phase G+ feature. Will be activated after Ingest Store EPIC is complete.
+  PDF → text extraction (pdfplumber), DOCX → python-docx, TXT → direct read.
+  Embedding: sentence-transformers or Ollama embedding endpoint.
+  Index: SQLite FTS5 + embedding vector table.

--- a/src/bantz/skills/definitions/file_search/__init__.py
+++ b/src/bantz/skills/definitions/file_search/__init__.py
@@ -1,0 +1,141 @@
+"""Semantic File Search skill — local file indexing and semantic retrieval.
+
+Issue #1299: Future Capabilities — Phase G+
+
+Status: PLANNED — skeleton only.
+Dependencies: Ingest Store (EPIC 1).
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Supported file types for content extraction
+SUPPORTED_TYPES = {".pdf", ".docx", ".txt", ".md", ".rst", ".csv"}
+
+# Default directories to index
+DEFAULT_DIRS = [
+    Path.home() / "Documents",
+    Path.home() / "Desktop",
+    Path.home() / "Downloads",
+]
+
+
+@dataclass
+class FileResult:
+    """Search result entry."""
+
+    path: str
+    filename: str
+    score: float          # Similarity score 0-1
+    snippet: str = ""     # Relevant text snippet
+    file_type: str = ""
+    modified: Optional[datetime] = None
+    size_bytes: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "path": self.path,
+            "filename": self.filename,
+            "score": round(self.score, 3),
+            "file_type": self.file_type,
+        }
+        if self.snippet:
+            d["snippet"] = self.snippet[:200]
+        if self.modified:
+            d["modified"] = self.modified.isoformat()
+        if self.size_bytes:
+            d["size_kb"] = round(self.size_bytes / 1024, 1)
+        return d
+
+
+@dataclass
+class IndexStats:
+    """File index statistics."""
+
+    total_files: int = 0
+    indexed_files: int = 0
+    total_size_mb: float = 0.0
+    last_indexed: Optional[datetime] = None
+    directories: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total_files": self.total_files,
+            "indexed_files": self.indexed_files,
+            "total_size_mb": round(self.total_size_mb, 1),
+            "last_indexed": (
+                self.last_indexed.isoformat() if self.last_indexed else None
+            ),
+            "directories": self.directories,
+        }
+
+
+class FileSearchEngine(ABC):
+    """Abstract base for semantic file search.
+
+    Concrete implementation will be activated when
+    Ingest Store EPIC is complete.
+    """
+
+    @abstractmethod
+    def search(
+        self,
+        query: str,
+        *,
+        file_types: Optional[List[str]] = None,
+        directory: Optional[str] = None,
+        limit: int = 10,
+    ) -> List[FileResult]:
+        """Semantic search across indexed files."""
+        ...
+
+    @abstractmethod
+    def index_directory(
+        self,
+        directory: str,
+        *,
+        force: bool = False,
+    ) -> IndexStats:
+        """Index files in a directory for search."""
+        ...
+
+    @abstractmethod
+    def get_stats(self) -> IndexStats:
+        """Get current index statistics."""
+        ...
+
+
+class PlaceholderFileSearch(FileSearchEngine):
+    """Placeholder — returns stub data until Ingest Store is ready."""
+
+    def search(
+        self,
+        query: str,
+        *,
+        file_types: Optional[List[str]] = None,
+        directory: Optional[str] = None,
+        limit: int = 10,
+    ) -> List[FileResult]:
+        logger.info("[FileSearch] search called — stub mode: %s", query)
+        return []
+
+    def index_directory(
+        self,
+        directory: str,
+        *,
+        force: bool = False,
+    ) -> IndexStats:
+        return IndexStats(
+            directories=[directory],
+        )
+
+    def get_stats(self) -> IndexStats:
+        return IndexStats()

--- a/src/bantz/skills/definitions/finance/SKILL.md
+++ b/src/bantz/skills/definitions/finance/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: finance
+version: 0.1.0
+author: Bantz Team
+description: "💰 Finance Tracker — expense analysis from bank emails, budget tracking."
+icon: 💰
+status: planned
+tags:
+  - future
+  - finance
+  - gmail-dependent
+
+dependencies:
+  - epic: "EPIC 1 — Ingest Store"
+    status: pending
+  - epic: "EPIC 5 — Gmail Enhanced"
+    status: partial
+
+triggers:
+  - pattern: "(?i)(expense|spending|budget|finance|money|salary|bill).*(summary|report|analysis|how much|list)"
+    intent: finance.summary
+    examples:
+      - "how much did I spend this month"
+      - "what's my budget status"
+      - "show my bill summary"
+      - "what am I spending the most on"
+    priority: 75
+
+  - pattern: "(?i)(bank|account|credit|card).*(info|check|transactions)"
+    intent: finance.bank
+    examples:
+      - "show my bank transactions"
+      - "credit card statement"
+    priority: 70
+
+tools:
+  - name: finance.parse_expenses
+    description: "Parse expenses from bank emails"
+    handler: llm
+    risk: medium
+    parameters:
+      - name: period
+        type: string
+        description: "Period: this_month, last_month, this_week"
+        enum: ["this_month", "last_month", "this_week", "custom"]
+      - name: source
+        type: string
+        description: "Source: gmail, manual"
+        enum: ["gmail", "manual"]
+
+  - name: finance.monthly_summary
+    description: "Monthly expense summary with category breakdown"
+    handler: llm
+    parameters:
+      - name: month
+        type: string
+        description: "Month (YYYY-MM format, empty = current month)"
+
+  - name: finance.budget_alert
+    description: "Budget threshold check and alerts"
+    handler: llm
+    parameters:
+      - name: category
+        type: string
+        description: "Expense category (empty = all categories)"
+
+  - name: finance.categorize
+    description: "Categorize an expense (food, transport, entertainment, etc.)"
+    handler: llm
+    parameters:
+      - name: description
+        type: string
+        description: "Expense description"
+      - name: amount
+        type: number
+        description: "Amount (TRY)"
+
+graph_schema:
+  nodes:
+    - label: Transaction
+      properties: [amount, currency, date, description, category]
+    - label: Category
+      properties: [name, budget_limit]
+    - label: Merchant
+      properties: [name, type]
+  edges:
+    - type: BELONGS_TO
+      from: Transaction
+      to: Category
+    - type: PAID_TO
+      from: Transaction
+      to: Merchant
+
+notes: |
+  Phase G+ feature. Parse expenses from bank emails using regex + LLM.
+  Will be activated after Ingest Store and Gmail Enhanced EPICs are complete.
+  First version: email regex → expense list → category LLM.
+  Next version: graph integration for merchant analysis.

--- a/src/bantz/skills/definitions/finance/__init__.py
+++ b/src/bantz/skills/definitions/finance/__init__.py
@@ -1,0 +1,176 @@
+"""Finance Tracker skill — expense parsing and budget analysis.
+
+Issue #1299: Future Capabilities — Phase G+
+
+Status: PLANNED — skeleton only.
+Dependencies: Ingest Store (EPIC 1), Gmail Enhanced (EPIC 5).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ExpenseCategory(str, Enum):
+    """Expense categories."""
+
+    FOOD = "food"
+    TRANSPORT = "transport"
+    ENTERTAINMENT = "entertainment"
+    BILLS = "bills"
+    SHOPPING = "shopping"
+    HEALTH = "health"
+    EDUCATION = "education"
+    SUBSCRIPTION = "subscription"
+    OTHER = "other"
+
+
+@dataclass
+class Expense:
+    """Parsed expense record."""
+
+    amount: float
+    currency: str = "TRY"
+    category: ExpenseCategory = ExpenseCategory.OTHER
+    description: str = ""
+    merchant: str = ""
+    date: datetime = field(default_factory=datetime.now)
+    source: str = "manual"  # gmail | manual
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "amount": self.amount,
+            "currency": self.currency,
+            "category": self.category.value,
+            "description": self.description,
+            "merchant": self.merchant,
+            "date": self.date.isoformat(),
+            "source": self.source,
+        }
+
+
+@dataclass
+class BudgetAlert:
+    """Budget threshold alert."""
+
+    category: str
+    budget: float
+    spent: float
+    remaining: float
+    exceeded: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "category": self.category,
+            "budget": self.budget,
+            "spent": self.spent,
+            "remaining": self.remaining,
+            "exceeded": self.exceeded,
+        }
+
+
+class FinanceTracker(ABC):
+    """Abstract base for finance tracking.
+
+    Concrete implementation will be activated when
+    Ingest Store and Gmail Enhanced EPICs are complete.
+    """
+
+    @abstractmethod
+    def parse_expenses(
+        self,
+        period: str = "this_month",
+        source: str = "gmail",
+    ) -> List[Expense]:
+        """Parse expenses from bank emails or manual input."""
+        ...
+
+    @abstractmethod
+    def monthly_summary(
+        self,
+        month: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Generate monthly expense summary with category breakdown."""
+        ...
+
+    @abstractmethod
+    def check_budget(
+        self,
+        category: Optional[str] = None,
+    ) -> List[BudgetAlert]:
+        """Check budget limits and return alerts."""
+        ...
+
+    @abstractmethod
+    def categorize(
+        self,
+        description: str,
+        amount: float,
+    ) -> ExpenseCategory:
+        """Categorize an expense using LLM."""
+        ...
+
+
+# ── Bank Email Regex Patterns (Turkish banks) ───────────────────
+
+BANK_PATTERNS = {
+    "garanti": re.compile(
+        r"(\d+[.,]\d{2})\s*(?:TL|TRY).*?(?:harcama|ödeme)",
+        re.IGNORECASE,
+    ),
+    "is_bankasi": re.compile(
+        r"(\d+[.,]\d{2})\s*(?:TL|TRY).*?(?:işlem|tahsilat)",
+        re.IGNORECASE,
+    ),
+    "akbank": re.compile(
+        r"(\d+[.,]\d{2})\s*(?:TL|TRY)",
+        re.IGNORECASE,
+    ),
+}
+
+
+class PlaceholderFinanceTracker(FinanceTracker):
+    """Placeholder implementation — returns stub data.
+
+    Will be replaced with real implementation when dependencies
+    (Ingest Store, Gmail Enhanced) are available.
+    """
+
+    def parse_expenses(
+        self,
+        period: str = "this_month",
+        source: str = "gmail",
+    ) -> List[Expense]:
+        logger.info("[Finance] parse_expenses called — stub mode")
+        return []
+
+    def monthly_summary(
+        self,
+        month: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return {
+            "status": "planned",
+            "message": "Finance tracking is not yet active. "
+            "Will be activated after Ingest Store EPIC is complete.",
+        }
+
+    def check_budget(
+        self,
+        category: Optional[str] = None,
+    ) -> List[BudgetAlert]:
+        return []
+
+    def categorize(
+        self,
+        description: str,
+        amount: float,
+    ) -> ExpenseCategory:
+        return ExpenseCategory.OTHER

--- a/src/bantz/skills/definitions/greeting/SKILL.md
+++ b/src/bantz/skills/definitions/greeting/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: greeting
+version: 1.0.0
+author: Bantz Team
+description: "Selamlama ve vedalaşma — Bantz'ın kişilik katmanı."
+icon: 👋
+tags:
+  - builtin
+  - conversation
+  - personality
+
+triggers:
+  - pattern: "(?i)\\b(merhaba|selam|hey|günaydın|iyi\\s*(akşamlar|geceler|günler))\\b"
+    intent: greeting.hello
+    examples:
+      - "merhaba"
+      - "selam Bantz"
+      - "günaydın"
+      - "iyi akşamlar"
+    priority: 90
+
+  - pattern: "(?i)\\b(hoşça\\s*kal|görüşürüz|bay\\s*bay|iyi\\s*geceler|bye)\\b"
+    intent: greeting.goodbye
+    examples:
+      - "hoşça kal"
+      - "görüşürüz"
+      - "bay bay"
+      - "iyi geceler"
+    priority: 90
+
+  - pattern: "(?i)\\b(nasılsın|naber|ne\\s*haber|keyifler\\s*nasıl)\\b"
+    intent: greeting.howru
+    examples:
+      - "nasılsın"
+      - "naber"
+      - "ne haber"
+    priority: 80
+
+  - pattern: "(?i)\\b(teşekkür|sağ\\s*ol|eyvallah|mersi)\\b"
+    intent: greeting.thanks
+    examples:
+      - "teşekkürler"
+      - "sağ ol"
+      - "eyvallah"
+    priority: 85
+
+tools:
+  - name: greeting.respond
+    description: "Kullanıcıya kişilikli selamlama yanıtı üretir"
+    handler: llm
+    parameters:
+      - name: greeting_type
+        type: string
+        description: "Selamlama türü: hello, goodbye, howru, thanks"
+        required: true
+        enum: ["hello", "goodbye", "howru", "thanks"]
+      - name: time_of_day
+        type: string
+        description: "Günün saati: morning, afternoon, evening, night"
+
+permissions: []
+
+config:
+  personality: friendly
+  use_emoji: true
+---
+
+# Greeting Skill — Selamlama Kişiliği
+
+Sen **Bantz**, İclal'in kişisel yapay zeka asistanısın. Sıcak, samimi ve Türkçe konuşursun.
+
+## Kişilik Özelliklerin
+
+- Samimi ama profesyonel
+- Kısa ve öz
+- Emoji kullanabilirsin ama abartma
+- İsmiyle hitap edebilirsin: "İclal"
+- Espri yapabilirsin ama yeri geldiğinde ciddi ol
+
+## Selamlama Kuralları
+
+### Merhaba
+- Sabah (06-12): "Günaydın İclal! ☀️ Bugün sana nasıl yardımcı olabilirim?"
+- Öğlen (12-18): "İyi günler! Ne yapalım bugün?"
+- Akşam (18-22): "İyi akşamlar! Yardıma hazırım."
+- Gece (22-06): "Bu saatte çalışıyorsun ha 🌙 Ne yapabilirim?"
+
+### Vedalaşma
+- "Görüşürüz İclal! İyi günler 👋"
+- "Hoşça kal! İhtiyacın olursa buradayım."
+
+### Nasılsın
+- "İyiyim, teşekkürler! Sen nasılsın? Bir şeye ihtiyacın var mı?"
+- "Gayet iyiyim! Seni görmek güzel. Ne yapalım?"
+
+### Teşekkür
+- "Rica ederim! 😊"
+- "Ne demek, her zaman!"
+- "Bir şey değil, başka bir şey lazım mı?"

--- a/src/bantz/skills/definitions/health_reminder/SKILL.md
+++ b/src/bantz/skills/definitions/health_reminder/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: health-reminder
+version: 0.1.0
+author: Bantz Team
+description: "💊 Health Reminder — medication, water, ergonomics, and activity reminders."
+icon: 💊
+status: planned
+tags:
+  - future
+  - health
+  - scheduler-dependent
+
+dependencies:
+  - epic: "EPIC 6 — Scheduler"
+    status: pending
+
+triggers:
+  - pattern: "(?i)(medication|vitamin|pill).*(remind|add|when|did I take)"
+    intent: health.medication
+    examples:
+      - "remind me to take my medication"
+      - "did I forget to take my vitamin"
+      - "add my morning pill"
+    priority: 80
+
+  - pattern: "(?i)(drink water|take a break|rest|ergonomics|sitting time)"
+    intent: health.wellness
+    examples:
+      - "set up water drinking reminders"
+      - "how long have I been sitting"
+      - "is it time for a break"
+    priority: 70
+
+tools:
+  - name: health.add_medication
+    description: "Add medication/vitamin reminder"
+    handler: system
+    parameters:
+      - name: name
+        type: string
+        description: "Medication/vitamin name"
+      - name: schedule
+        type: string
+        description: "Schedule: morning, noon, evening, or cron"
+      - name: dose
+        type: string
+        description: "Dose information"
+
+  - name: health.water_reminder
+    description: "Water drinking reminder (Pomodoro-style interval)"
+    handler: system
+    parameters:
+      - name: interval_minutes
+        type: integer
+        description: "Reminder interval (minutes, default: 45)"
+      - name: daily_goal_ml
+        type: integer
+        description: "Daily goal (ml, default: 2500)"
+
+  - name: health.ergonomics
+    description: "Ergonomics reminder — sitting time tracking"
+    handler: system
+    parameters:
+      - name: max_sitting_minutes
+        type: integer
+        description: "Max sitting time (default: 90 minutes)"
+
+  - name: health.daily_log
+    description: "Daily health log (medication taken, water drunk, etc.)"
+    handler: system
+    parameters:
+      - name: action
+        type: string
+        description: "Action taken"
+        enum: ["medication_taken", "water_drunk", "break_taken", "exercise"]
+
+notes: |
+  Phase G+ feature. Low complexity — depends on Scheduler EPIC.
+  Cron-based reminders + D-Bus notification.
+  Medication tracking: SQLite medication_log table.
+  Ergonomics: X11/Wayland idle time API for sitting time calculation.

--- a/src/bantz/skills/definitions/health_reminder/__init__.py
+++ b/src/bantz/skills/definitions/health_reminder/__init__.py
@@ -1,0 +1,167 @@
+"""Health Reminder skill — medication, hydration, and ergonomics tracking.
+
+Issue #1299: Future Capabilities — Phase G+
+
+Status: PLANNED — skeleton only.
+Dependencies: Scheduler (EPIC 6).
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Medication:
+    """Medication/vitamin entry."""
+
+    name: str
+    dose: str = ""
+    schedule: str = "morning"  # morning | noon | evening | cron expression
+    active: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "dose": self.dose,
+            "schedule": self.schedule,
+            "active": self.active,
+        }
+
+
+@dataclass
+class HealthLog:
+    """Single health action log entry."""
+
+    action: str  # medication_taken | water_drunk | break_taken | exercise
+    details: str = ""
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "action": self.action,
+            "details": self.details,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+@dataclass
+class WaterConfig:
+    """Water reminder configuration."""
+
+    interval_minutes: int = 45
+    daily_goal_ml: int = 2500
+    consumed_ml: int = 0
+
+    @property
+    def remaining_ml(self) -> int:
+        return max(0, self.daily_goal_ml - self.consumed_ml)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "interval_minutes": self.interval_minutes,
+            "daily_goal_ml": self.daily_goal_ml,
+            "consumed_ml": self.consumed_ml,
+            "remaining_ml": self.remaining_ml,
+        }
+
+
+class HealthReminder(ABC):
+    """Abstract base for health reminder system.
+
+    Concrete implementation requires Scheduler EPIC.
+    """
+
+    @abstractmethod
+    def add_medication(
+        self,
+        name: str,
+        schedule: str = "morning",
+        dose: str = "",
+    ) -> Medication:
+        """Add a medication reminder."""
+        ...
+
+    @abstractmethod
+    def setup_water_reminder(
+        self,
+        interval_minutes: int = 45,
+        daily_goal_ml: int = 2500,
+    ) -> WaterConfig:
+        """Set up water drinking reminders."""
+        ...
+
+    @abstractmethod
+    def setup_ergonomics(
+        self,
+        max_sitting_minutes: int = 90,
+    ) -> Dict[str, Any]:
+        """Set up ergonomics reminder."""
+        ...
+
+    @abstractmethod
+    def log_action(
+        self,
+        action: str,
+        details: str = "",
+    ) -> HealthLog:
+        """Log a health action."""
+        ...
+
+    @abstractmethod
+    def get_daily_summary(self) -> Dict[str, Any]:
+        """Get today's health activity summary."""
+        ...
+
+
+class PlaceholderHealthReminder(HealthReminder):
+    """Placeholder — returns stub data."""
+
+    def add_medication(
+        self,
+        name: str,
+        schedule: str = "morning",
+        dose: str = "",
+    ) -> Medication:
+        logger.info("[HealthReminder] add_medication — stub mode")
+        return Medication(name=name, schedule=schedule, dose=dose)
+
+    def setup_water_reminder(
+        self,
+        interval_minutes: int = 45,
+        daily_goal_ml: int = 2500,
+    ) -> WaterConfig:
+        return WaterConfig(
+            interval_minutes=interval_minutes,
+            daily_goal_ml=daily_goal_ml,
+        )
+
+    def setup_ergonomics(
+        self,
+        max_sitting_minutes: int = 90,
+    ) -> Dict[str, Any]:
+        return {
+            "status": "planned",
+            "max_sitting_minutes": max_sitting_minutes,
+            "message": "Ergonomics reminder is not yet active.",
+        }
+
+    def log_action(
+        self,
+        action: str,
+        details: str = "",
+    ) -> HealthLog:
+        return HealthLog(action=action, details=details)
+
+    def get_daily_summary(self) -> Dict[str, Any]:
+        return {
+            "status": "planned",
+            "message": "Health tracking is not yet active. "
+            "Will be activated after Scheduler EPIC is complete.",
+        }

--- a/src/bantz/skills/definitions/news/SKILL.md
+++ b/src/bantz/skills/definitions/news/SKILL.md
@@ -1,0 +1,39 @@
+# News Skill — Issue #839
+
+## Triggers
+- "show me the news", "latest headlines", "what's happening"
+- "search news about {topic}", "AI news", "tech news"
+- "news briefing", "morning briefing", "daily news"
+- "haber", "haberler", "gündem" (TR → EN bridge handles)
+
+## Tools
+| Tool | Purpose |
+|------|---------|
+| `news.latest` | Get latest headlines (max_items) |
+| `news.search` | Search articles by keyword (query, max_results) |
+| `news.briefing` | Multi-category briefing (categories, max_items) |
+| `news.category` | Single category fetch (category, max_items) |
+
+## Available Categories
+`ai`, `tech`, `science`, `business`, `world`, `turkey`
+
+## Instructions
+You are a news assistant. When the user asks about news:
+
+1. **Latest headlines** → use `news.latest` with appropriate max_items (default 5)
+2. **Topic search** → use `news.search` with the user's query
+3. **Briefing** → use `news.briefing` with relevant categories
+4. **Category** → use `news.category` with the specific category
+
+Present articles clearly with title, source, and publication date.
+If the user asks in Turkish, respond in Turkish after processing.
+
+## Slot Extraction
+- `query`: search keyword extracted from user message
+- `category`: one of the available categories
+- `max_items`: number of articles requested (default 5)
+
+## Proactive
+- Signal collector fetches latest headlines every 30 min
+- Cross-analysis with calendar: suggest reading relevant news before meetings
+- News briefing included in morning proactive report

--- a/src/bantz/skills/definitions/pdf-summary/SKILL.md
+++ b/src/bantz/skills/definitions/pdf-summary/SKILL.md
@@ -1,0 +1,46 @@
+# PDF Summary Skill — Issue #1211
+
+## Triggers
+- "PDF'i özetle", "belgeyi oku", "dosyayı analiz et"
+- "attachment'ı aç", "eki oku", "PDF içeriği ne"
+- "summarize the PDF", "read the document", "what does the attachment say"
+- "belgeyi açıp bana ne yazdığını söyle"
+
+## Tools
+
+| Tool | Açıklama |
+|------|----------|
+| `pdf.extract_text` | PDF dosyasından metin çıkar |
+| `pdf.summarize` | PDF'den metin çıkar + özet hazırla |
+| `pdf.from_attachment` | Gmail ekinden PDF indir + metin çıkar |
+
+## Instructions
+
+Bu skill, kullanıcının PDF dosyalarını okumasını ve özetlemesini sağlar.
+
+### Akış
+1. Kullanıcı bir email eki veya dosya yolu belirtir
+2. `pdf.from_attachment` veya `pdf.extract_text` ile metin çıkarılır
+3. Çıkarılan metin finalizer LLM'e gönderilir
+4. LLM Türkçe özet üretir
+
+### Kurallar
+- Maksimum 50MB PDF (güvenlik limiti)
+- Maksimum 200 sayfa (performans limiti)
+- Metin 100K karakter ile sınırlı (LLM context)
+- Geçici dosyalar işlem sonrası temizlenir
+- Gmail eklerinde `pdf.from_attachment` kullanılır (download + extract tek adım)
+
+## Slot Extraction
+
+| Slot | Tip | Kaynak |
+|------|-----|--------|
+| `path` | string | Kullanıcı girdisi veya önceki tool sonucu |
+| `message_id` | string | Gmail mesaj bağlamından |
+| `attachment_id` | string | Gmail ek bağlamından |
+| `language` | string | Varsayılan "tr", kullanıcı belirtebilir |
+
+## Proactive
+
+- Email okunduğunda PDF eki varsa otomatik özet öner
+- "Bu emailin PDF ekini okumamı ister misiniz?" şeklinde proaktif öneri

--- a/src/bantz/skills/definitions/reporter/SKILL.md
+++ b/src/bantz/skills/definitions/reporter/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: reporter
+version: 0.1.0
+author: Bantz Team
+description: "📊 Report Generator — weekly/monthly activity reports, productivity analysis."
+icon: 📊
+status: planned
+tags:
+  - future
+  - reporting
+  - analytics
+
+dependencies:
+  - epic: "EPIC 3 — Observability"
+    status: pending
+
+triggers:
+  - pattern: "(?i)(report|statistics|summary|analytics).*(generate|create|prepare|show|weekly|monthly)"
+    intent: reporter.generate
+    examples:
+      - "generate weekly report"
+      - "show my activity summary this month"
+      - "show tool usage statistics"
+      - "prepare my productivity report"
+    priority: 75
+
+  - pattern: "(?i)(export|PDF|markdown).*(report|summary)"
+    intent: reporter.export
+    examples:
+      - "export the report as PDF"
+      - "markdown format report"
+    priority: 70
+
+tools:
+  - name: reporter.weekly
+    description: "Generate weekly activity report"
+    handler: llm
+    parameters:
+      - name: week
+        type: string
+        description: "Week (ISO format, empty = this week)"
+      - name: include_tools
+        type: boolean
+        description: "Include tool usage statistics"
+
+  - name: reporter.monthly
+    description: "Generate monthly activity report"
+    handler: llm
+    parameters:
+      - name: month
+        type: string
+        description: "Month (YYYY-MM, empty = this month)"
+
+  - name: reporter.productivity
+    description: "Productivity analysis — meeting/work ratio"
+    handler: llm
+    parameters:
+      - name: period
+        type: string
+        description: "Period: this_week, last_week, this_month"
+        enum: ["this_week", "last_week", "this_month"]
+
+  - name: reporter.export
+    description: "Export report as PDF or Markdown"
+    handler: system
+    risk: medium
+    parameters:
+      - name: report_type
+        type: string
+        description: "Report type: weekly, monthly, productivity"
+        enum: ["weekly", "monthly", "productivity"]
+      - name: format
+        type: string
+        description: "Output format"
+        enum: ["pdf", "markdown", "html"]
+
+notes: |
+  Phase G+ feature. Depends on Observability EPIC.
+  Tool usage statistics → from observability DB.
+  Calendar analysis → meeting/work ratio from Calendar API.
+  PDF export: weasyprint or reportlab.
+  Markdown export: jinja2 templates.

--- a/src/bantz/skills/definitions/reporter/__init__.py
+++ b/src/bantz/skills/definitions/reporter/__init__.py
@@ -1,0 +1,172 @@
+"""Report Generator skill — activity reporting and productivity analysis.
+
+Issue #1299: Future Capabilities — Phase G+
+
+Status: PLANNED — skeleton only.
+Dependencies: Observability (EPIC 3).
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ToolUsageStat:
+    """Tool usage statistics entry."""
+
+    tool_name: str
+    call_count: int = 0
+    success_count: int = 0
+    avg_latency_ms: float = 0.0
+    last_used: Optional[datetime] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "tool": self.tool_name,
+            "calls": self.call_count,
+            "successes": self.success_count,
+            "avg_latency_ms": round(self.avg_latency_ms, 1),
+        }
+        if self.last_used:
+            d["last_used"] = self.last_used.isoformat()
+        return d
+
+
+@dataclass
+class ProductivityMetric:
+    """Productivity analysis result."""
+
+    period: str
+    total_meetings_h: float = 0.0
+    total_work_h: float = 0.0
+    focus_ratio: float = 0.0  # work / (work + meetings)
+    tool_interactions: int = 0
+    tasks_completed: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "period": self.period,
+            "meetings_hours": round(self.total_meetings_h, 1),
+            "work_hours": round(self.total_work_h, 1),
+            "focus_ratio": round(self.focus_ratio, 2),
+            "tool_interactions": self.tool_interactions,
+            "tasks_completed": self.tasks_completed,
+        }
+
+
+@dataclass
+class Report:
+    """Generated report."""
+
+    report_type: str  # weekly | monthly | productivity
+    title: str
+    content: str = ""
+    period: str = ""
+    generated_at: datetime = field(default_factory=datetime.now)
+    tool_stats: List[ToolUsageStat] = field(default_factory=list)
+    productivity: Optional[ProductivityMetric] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "type": self.report_type,
+            "title": self.title,
+            "period": self.period,
+            "generated_at": self.generated_at.isoformat(),
+        }
+        if self.content:
+            d["content"] = self.content
+        if self.tool_stats:
+            d["tool_stats"] = [s.to_dict() for s in self.tool_stats]
+        if self.productivity:
+            d["productivity"] = self.productivity.to_dict()
+        return d
+
+
+class ReportGenerator(ABC):
+    """Abstract base for report generation.
+
+    Concrete implementation requires Observability EPIC.
+    """
+
+    @abstractmethod
+    def weekly_report(
+        self,
+        week: Optional[str] = None,
+        *,
+        include_tools: bool = True,
+    ) -> Report:
+        """Generate weekly activity report."""
+        ...
+
+    @abstractmethod
+    def monthly_report(
+        self,
+        month: Optional[str] = None,
+    ) -> Report:
+        """Generate monthly activity report."""
+        ...
+
+    @abstractmethod
+    def productivity_analysis(
+        self,
+        period: str = "this_week",
+    ) -> ProductivityMetric:
+        """Analyze productivity (meeting/work ratio)."""
+        ...
+
+    @abstractmethod
+    def export(
+        self,
+        report: Report,
+        fmt: str = "markdown",
+    ) -> str:
+        """Export report to a file. Returns file path."""
+        ...
+
+
+class PlaceholderReportGenerator(ReportGenerator):
+    """Placeholder — returns stub data."""
+
+    def weekly_report(
+        self,
+        week: Optional[str] = None,
+        *,
+        include_tools: bool = True,
+    ) -> Report:
+        logger.info("[Reporter] weekly_report — stub mode")
+        return Report(
+            report_type="weekly",
+            title="Weekly Report",
+            content="Report generator is not yet active. "
+            "Will be activated after Observability EPIC is complete.",
+        )
+
+    def monthly_report(
+        self,
+        month: Optional[str] = None,
+    ) -> Report:
+        return Report(
+            report_type="monthly",
+            title="Monthly Report",
+            content="Report generator is not yet active.",
+        )
+
+    def productivity_analysis(
+        self,
+        period: str = "this_week",
+    ) -> ProductivityMetric:
+        return ProductivityMetric(period=period)
+
+    def export(
+        self,
+        report: Report,
+        fmt: str = "markdown",
+    ) -> str:
+        return ""

--- a/src/bantz/skills/definitions/secret_manager/SKILL.md
+++ b/src/bantz/skills/definitions/secret_manager/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: secret-manager
+version: 0.1.0
+author: Bantz Team
+description: "🔐 Secret Manager — secure password management via KeePass/Bitwarden CLI."
+icon: 🔐
+status: planned
+tags:
+  - future
+  - security
+  - secrets
+
+dependencies:
+  - epic: "EPIC 4 — Policy Engine"
+    status: partial
+
+triggers:
+  - pattern: "(?i)(password|secret|key|credential).*(what|get|find|show|copy)"
+    intent: secret.retrieve
+    examples:
+      - "what was the server password"
+      - "get the AWS access key"
+      - "find that password"
+    priority: 90
+
+  - pattern: "(?i)(password|secret).*(create|generate)"
+    intent: secret.generate
+    examples:
+      - "generate a strong password"
+      - "create a 16-character password"
+    priority: 75
+
+tools:
+  - name: secret.retrieve
+    description: "Secure password/secret retrieval — requires confirmation"
+    handler: system
+    risk: high
+    confirm: true
+    parameters:
+      - name: query
+        type: string
+        description: "Secret name or description to search"
+      - name: vault
+        type: string
+        description: "Vault name (default: default)"
+
+  - name: secret.generate
+    description: "Strong password generator"
+    handler: system
+    risk: low
+    parameters:
+      - name: length
+        type: integer
+        description: "Password length (default: 20)"
+      - name: charset
+        type: string
+        description: "Character set: alphanumeric, full, pin"
+        enum: ["alphanumeric", "full", "pin"]
+
+  - name: secret.list
+    description: "List vault entries (names only, NOT values)"
+    handler: system
+    risk: medium
+    parameters:
+      - name: vault
+        type: string
+        description: "Vault name"
+      - name: filter
+        type: string
+        description: "Name filter"
+
+notes: |
+  Phase G+ feature. HIGH risk — policy engine must be fully active.
+  Clipboard copy → auto-clear after 30 seconds.
+  KeePass: keepassxc-cli | Bitwarden: bw CLI.
+  Secret values must NEVER be logged or published to event bus.

--- a/src/bantz/skills/definitions/secret_manager/__init__.py
+++ b/src/bantz/skills/definitions/secret_manager/__init__.py
@@ -1,0 +1,132 @@
+"""Secret Manager skill — secure credential retrieval and generation.
+
+Issue #1299: Future Capabilities — Phase G+
+
+Status: PLANNED — skeleton only.
+Dependencies: Policy Engine (EPIC 4).
+
+SECURITY: Secret values must NEVER be logged or published to EventBus.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import string
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SecretEntry:
+    """Metadata for a vault entry (value is NOT stored here)."""
+
+    name: str
+    vault: str = "default"
+    username: str = ""
+    url: str = ""
+    notes: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize metadata only — NEVER include secret values."""
+        d: Dict[str, Any] = {"name": self.name, "vault": self.vault}
+        if self.username:
+            d["username"] = self.username
+        if self.url:
+            d["url"] = self.url
+        return d
+
+
+class SecretManager(ABC):
+    """Abstract base for secret/password management.
+
+    Implementations should integrate with KeePass or Bitwarden CLI.
+    All operations requiring secret values must go through the
+    policy engine (HIGH risk → confirmation required).
+    """
+
+    @abstractmethod
+    def retrieve(
+        self,
+        query: str,
+        *,
+        vault: str = "default",
+    ) -> Optional[str]:
+        """Retrieve a secret value. Returns None if not found.
+
+        WARNING: The return value is sensitive — do NOT log it.
+        """
+        ...
+
+    @abstractmethod
+    def list_entries(
+        self,
+        *,
+        vault: str = "default",
+        filter_text: str = "",
+    ) -> List[SecretEntry]:
+        """List vault entries (metadata only, no values)."""
+        ...
+
+    @abstractmethod
+    def generate_password(
+        self,
+        length: int = 20,
+        charset: str = "full",
+    ) -> str:
+        """Generate a strong password."""
+        ...
+
+
+def generate_password(length: int = 20, charset: str = "full") -> str:
+    """Generate a cryptographically secure password.
+
+    This function is available even without a vault backend.
+
+    Args:
+        length: Password length (min 8, max 128).
+        charset: 'alphanumeric', 'full', or 'pin'.
+    """
+    length = max(8, min(128, length))
+
+    if charset == "pin":
+        alphabet = string.digits
+    elif charset == "alphanumeric":
+        alphabet = string.ascii_letters + string.digits
+    else:  # full
+        alphabet = string.ascii_letters + string.digits + string.punctuation
+
+    # Ensure at least one of each required type
+    password = list(secrets.choice(alphabet) for _ in range(length))
+    return "".join(password)
+
+
+class PlaceholderSecretManager(SecretManager):
+    """Placeholder — password generation works, vault access is stub."""
+
+    def retrieve(
+        self,
+        query: str,
+        *,
+        vault: str = "default",
+    ) -> Optional[str]:
+        logger.info("[SecretManager] retrieve called — stub mode")
+        return None
+
+    def list_entries(
+        self,
+        *,
+        vault: str = "default",
+        filter_text: str = "",
+    ) -> List[SecretEntry]:
+        return []
+
+    def generate_password(
+        self,
+        length: int = 20,
+        charset: str = "full",
+    ) -> str:
+        return generate_password(length, charset)

--- a/src/bantz/skills/definitions/system-info/SKILL.md
+++ b/src/bantz/skills/definitions/system-info/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: system-info
+version: 1.0.0
+author: Bantz Team
+description: "Sistem bilgisi ve sağlık kontrolü — CPU, RAM, disk, GPU durumu."
+icon: 🖥️
+tags:
+  - builtin
+  - system
+  - monitoring
+
+triggers:
+  - pattern: "(?i)(sistem|system|bilgisayar|pc).*(durumu|bilgi|info|sağlık|health|nasıl)"
+    intent: system.status
+    examples:
+      - "sistem durumu"
+      - "bilgisayarım nasıl"
+      - "system info"
+      - "pc sağlık kontrolü"
+    priority: 70
+
+  - pattern: "(?i)(cpu|ram|bellek|disk|gpu|işlemci).*(kullanım|durum|doluluk|kaç|ne\\s*kadar)"
+    intent: system.detail
+    examples:
+      - "CPU kullanımı kaç"
+      - "RAM ne kadar dolu"
+      - "disk durumu"
+      - "GPU sıcaklığı"
+    priority: 65
+
+  - pattern: "(?i)(pil|batarya|şarj|battery).*(durumu|kaç|yüzde)"
+    intent: system.battery
+    examples:
+      - "pil durumu"
+      - "şarj yüzde kaç"
+    priority: 65
+
+tools:
+  - name: system.health_check
+    description: "Kapsamlı sistem sağlık kontrolü"
+    handler: builtin:system.status
+    parameters:
+      - name: include_env
+        type: boolean
+        description: "Ortam değişkenlerini dahil et"
+
+permissions:
+  - system
+
+config:
+  show_gpu: true
+  show_battery: true
+---
+
+# System Info Skill — Sistem Bilgisi
+
+Sen Bantz'ın sistem izleme yeteneğisin.
+
+## Görevin
+
+Kullanıcı sistem durumunu sorduğunda anlaşılır, Türkçe bir özet sun.
+
+## Yanıt Formatı
+
+```
+🖥️ Sistem Durumu
+
+🔲 CPU: %45 kullanım (Intel i7-12700H, 8 çekirdek)
+🧠 RAM: 12.4 GB / 16 GB (%77)
+💾 Disk: 234 GB / 512 GB (%46)
+🎮 GPU: RTX 4060 — 42°C, %15 VRAM
+🔋 Pil: %82 (şarj oluyor)
+⏱️ Uptime: 3 gün 7 saat
+```
+
+## Kurallar
+
+1. Türkçe yanıt ver
+2. Yüzdeleri vurgula
+3. Kritik durumları uyar (%90+ CPU/RAM/Disk → ⚠️)
+4. GPU yoksa GPU satırını gösterme
+5. Dizüstü değilse pil satırını gösterme

--- a/src/bantz/skills/definitions/travel/SKILL.md
+++ b/src/bantz/skills/definitions/travel/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: travel
+version: 0.1.0
+author: Bantz Team
+description: "✈️ Travel Assistant — flight/hotel/car rental email tracking and calendar integration."
+icon: ✈️
+status: planned
+tags:
+  - future
+  - travel
+  - gmail-dependent
+  - calendar-dependent
+
+dependencies:
+  - epic: "EPIC 5 — Gmail Enhanced"
+    status: partial
+  - epic: "EPIC 2 — Graph Memory"
+    status: pending
+
+triggers:
+  - pattern: "(?i)(travel|flight|trip|vacation|hotel|plane).*(plan|info|calendar|when|list)"
+    intent: travel.info
+    examples:
+      - "what are my travel plans"
+      - "get my flight info"
+      - "show my trip calendar"
+      - "do I have a hotel reservation"
+    priority: 80
+
+  - pattern: "(?i)(check.?in|boarding|flight time|hotel check)"
+    intent: travel.reminder
+    examples:
+      - "when is my check-in time"
+      - "remind me of my flight time"
+    priority: 85
+
+tools:
+  - name: travel.parse_bookings
+    description: "Parse flight/hotel/car rental info from emails"
+    handler: llm
+    risk: medium
+    parameters:
+      - name: period
+        type: string
+        description: "Period: upcoming, past_month, all"
+        enum: ["upcoming", "past_month", "all"]
+
+  - name: travel.create_itinerary
+    description: "Create trip itinerary (add to Google Calendar)"
+    handler: system
+    risk: medium
+    confirm: true
+    parameters:
+      - name: trip_name
+        type: string
+        description: "Trip name"
+
+  - name: travel.set_reminders
+    description: "Set travel reminders (check-in, flight, hotel)"
+    handler: system
+    parameters:
+      - name: trip_name
+        type: string
+        description: "Trip name"
+      - name: reminder_types
+        type: array
+        description: "Reminder types: checkin, flight, hotel, car"
+
+graph_schema:
+  nodes:
+    - label: Trip
+      properties: [name, start_date, end_date, destination]
+    - label: Hotel
+      properties: [name, address, checkin, checkout, confirmation]
+    - label: Flight
+      properties: [airline, flight_no, departure, arrival, gate]
+    - label: Person
+      properties: [name, role]
+  edges:
+    - type: INCLUDES
+      from: Trip
+      to: Hotel
+    - type: INCLUDES
+      from: Trip
+      to: Flight
+    - type: TRAVELS
+      from: Person
+      to: Trip
+
+notes: |
+  Phase G+ feature. High complexity.
+  Parse travel emails (flights, hotels, cars) in multi-format from Gmail.
+  Auto-create itinerary on Google Calendar.
+  Proactive reminders: check-in (24h before), flight (3h before).

--- a/src/bantz/skills/definitions/travel/__init__.py
+++ b/src/bantz/skills/definitions/travel/__init__.py
@@ -1,0 +1,128 @@
+"""Travel Assistant skill — flight/hotel/car booking management.
+
+Issue #1299: Future Capabilities — Phase G+
+
+Status: PLANNED — skeleton only.
+Dependencies: Gmail Enhanced (EPIC 5), Graph Memory (EPIC 2).
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Booking:
+    """Generic booking record."""
+
+    booking_type: str  # flight | hotel | car
+    provider: str = ""
+    confirmation: str = ""
+    start: Optional[datetime] = None
+    end: Optional[datetime] = None
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "type": self.booking_type,
+            "provider": self.provider,
+        }
+        if self.confirmation:
+            d["confirmation"] = self.confirmation
+        if self.start:
+            d["start"] = self.start.isoformat()
+        if self.end:
+            d["end"] = self.end.isoformat()
+        if self.details:
+            d["details"] = self.details
+        return d
+
+
+@dataclass
+class Trip:
+    """Organized trip with bookings."""
+
+    name: str
+    destination: str = ""
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+    bookings: List[Booking] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"name": self.name}
+        if self.destination:
+            d["destination"] = self.destination
+        if self.start_date:
+            d["start_date"] = self.start_date.isoformat()
+        if self.end_date:
+            d["end_date"] = self.end_date.isoformat()
+        d["bookings"] = [b.to_dict() for b in self.bookings]
+        return d
+
+
+class TravelAssistant(ABC):
+    """Abstract base for travel management.
+
+    Concrete implementation depends on Gmail Enhanced and
+    Graf Bellek EPICs.
+    """
+
+    @abstractmethod
+    def parse_bookings(
+        self,
+        period: str = "upcoming",
+    ) -> List[Booking]:
+        """Parse booking information from emails."""
+        ...
+
+    @abstractmethod
+    def create_itinerary(
+        self,
+        trip_name: str,
+        bookings: List[Booking],
+    ) -> Trip:
+        """Create an organized trip itinerary."""
+        ...
+
+    @abstractmethod
+    def set_reminders(
+        self,
+        trip: Trip,
+        reminder_types: Optional[List[str]] = None,
+    ) -> int:
+        """Set proactive reminders for trip events.
+
+        Returns count of reminders created.
+        """
+        ...
+
+
+class PlaceholderTravelAssistant(TravelAssistant):
+    """Placeholder — returns stub data."""
+
+    def parse_bookings(
+        self,
+        period: str = "upcoming",
+    ) -> List[Booking]:
+        logger.info("[Travel] parse_bookings called — stub mode")
+        return []
+
+    def create_itinerary(
+        self,
+        trip_name: str,
+        bookings: Optional[List[Booking]] = None,
+    ) -> Trip:
+        return Trip(name=trip_name)
+
+    def set_reminders(
+        self,
+        trip: Trip,
+        reminder_types: Optional[List[str]] = None,
+    ) -> int:
+        return 0

--- a/src/bantz/skills/definitions/weather/SKILL.md
+++ b/src/bantz/skills/definitions/weather/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: weather
+version: 0.1.0
+author: Bantz Team
+description: "Hava durumu sorgulama ve takvim çapraz analizi."
+icon: 🌤️
+tags:
+  - builtin
+  - weather
+  - proactive
+
+triggers:
+  - pattern: "(?i)(hava|weather).*(durumu|nasıl|forecast|tahmin)"
+    intent: weather.current
+    examples:
+      - "bugün hava nasıl"
+      - "hava durumu"
+      - "yarın hava nasıl olacak"
+      - "hafta sonu hava durumu"
+    priority: 80
+
+  - pattern: "(?i)(yağmur|kar|güneş|rüzgar|sıcaklık|derece).*(var|yağ|ol|kaç)"
+    intent: weather.detail
+    examples:
+      - "yağmur yağacak mı"
+      - "kaç derece"
+      - "rüzgar var mı"
+    priority: 70
+
+tools:
+  - name: weather.get_current
+    description: "Mevcut hava durumunu getirir"
+    handler: llm
+    parameters:
+      - name: location
+        type: string
+        description: "Şehir adı (varsayılan: kullanıcı profili)"
+      - name: detail
+        type: string
+        description: "Detay seviyesi: brief, detailed, forecast"
+        enum: ["brief", "detailed", "forecast"]
+
+  - name: weather.get_forecast
+    description: "5 günlük hava durumu tahmini"
+    handler: llm
+    parameters:
+      - name: location
+        type: string
+        description: "Şehir adı"
+      - name: days
+        type: integer
+        description: "Kaç günlük tahmin (1-5)"
+
+permissions:
+  - network
+
+config:
+  default_location: "Istanbul"
+  units: metric
+  language: tr
+---
+
+# Weather Skill — Hava Durumu
+
+Sen Bantz'ın hava durumu yeteneğisin.
+
+## Görevin
+
+Kullanıcı hava durumunu sorduğunda:
+1. Konumu belirle (söylemediyse varsayılan: İstanbul)
+2. Güncel hava durumunu bildir
+3. Eğer takvimde dış mekan etkinliği varsa, çapraz analiz yap
+
+## Yanıt Formatı
+
+### Kısa yanıt (brief)
+"İstanbul'da şu an 22°C, parçalı bulutlu. ☁️"
+
+### Detaylı yanıt (detailed)
+"İstanbul Hava Durumu:
+🌡️ Sıcaklık: 22°C (hissedilen 24°C)
+💨 Rüzgar: 15 km/s KB
+💧 Nem: %65
+☁️ Durum: Parçalı bulutlu
+🌅 Gün batımı: 19:45"
+
+### Tahmin (forecast)
+Günlük tahminleri tablo formatında sun.
+
+## Takvim Çapraz Analizi
+
+Eğer kullanıcının takviminde dış mekan etkinliği varsa ve hava kötüyse:
+- "⚠️ Yarın 14:00'te 'Parkta piknik' etkinliğiniz var ama yağmur bekleniyor. Ertelemek ister misiniz?"
+
+## Kurallar
+
+1. Her zaman Türkçe yanıt ver
+2. Sıcaklık Celsius cinsinden
+3. Emin olmadığın bilgiyi uydurma — "Şu an hava durumu verisi alamıyorum" de
+4. Emoji kullan ama abartma


### PR DESCRIPTION
## Summary

Root-level `skills/` directory moved into `src/bantz/skills/definitions/` so
declarative SKILL.md files ship with the Python package and are auto-discovered.

### Changes
- `skills/` (project root) → `src/bantz/skills/definitions/` (14 categories: classroom, daily-briefing, file_search, finance, greeting, health_reminder, news, pdf-summary, reporter, secret_manager, system-info, travel, weather)
- `loader._get_default_skill_dirs()` now appends the bundled definitions directory as lowest-priority search path
- User's `~/.config/bantz/skills/` still overrides bundled definitions

### Why
The root `skills/` alongside `src/` was confusingly separate from the Python skill implementations in `src/bantz/skills/`. Both directories are now co-located inside the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added 13 built-in skills: Daily Briefing, File Search, Finance Tracking, Greeting, Health Reminders, News, PDF Summary, Reporter, Secret Manager, System Info, Travel Assistant, Weather, and Classroom integration.
* Enhanced skill discovery to automatically load built-in skill definitions from the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->