### PR TITLE
feat(auth): Classroom dialog UI + Google auth scope indicator (issue #1467)

### DIFF
--- a/bantz-overlay/src/renderer/classroom-dialog.js
+++ b/bantz-overlay/src/renderer/classroom-dialog.js
@@ -1,0 +1,385 @@
+/**
+ * Bantz Overlay — Classroom Dialog (Issue #1467)
+ *
+ * Provides two UI components for Google Classroom integration:
+ *
+ *   1. ClassroomDialog
+ *      - "Classroom'a Katıl" enrollment code form
+ *      - Calls window.overlayAPI.openClassroomEnrollment(code) on submit
+ *      - Shows success / error feedback inline
+ *
+ *   2. GoogleAuthScopeIndicator
+ *      - Shows which Google scopes are active (calendar / gmail / classroom)
+ *      - Calls window.overlayAPI.requestGoogleOAuth(['classroom']) when the
+ *        classroom scope badge is clicked and is not yet authorized
+ *      - Updates when 'auth:status' arrives via window.overlayAPI.onAuthStatus
+ *
+ * Both classes follow the existing Overlay component pattern:
+ *   - constructor() — set up state
+ *   - mount(parent) — inject DOM
+ *   - show() / hide() — toggle visibility
+ *
+ * Run tests: node bantz-overlay/tests/test_classroom_dialog.js
+ */
+
+'use strict';
+
+// ─── ClassroomDialog ──────────────────────────────────────────────────────────
+
+/**
+ * Modal dialog that lets the user join a Google Classroom course by pasting
+ * an enrollment / invitation code.
+ *
+ * Usage:
+ *   const dlg = new ClassroomDialog();
+ *   dlg.mount(document.body);
+ *   dlg.show();
+ */
+class ClassroomDialog {
+  constructor() {
+    this._visible = false;
+    this._root    = null;
+    this._input   = null;
+    this._status  = null;
+    this._pending = false;
+  }
+
+  /**
+   * Inject dialog DOM into the given parent element.
+   * Idempotent — second call is a no-op.
+   * @param {HTMLElement} parent
+   */
+  mount(parent) {
+    if (this._root) return; // already mounted
+
+    const overlay = document.createElement('div');
+    overlay.className  = 'classroom-dialog-overlay hidden';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', "Classroom'a Katıl");
+
+    const box = document.createElement('div');
+    box.className = 'classroom-dialog-box';
+
+    // ── Title ──
+    const title = document.createElement('h2');
+    title.className   = 'classroom-dialog-title';
+    title.textContent = "Classroom'a Katıl";
+
+    // ── Subtitle ──
+    const subtitle = document.createElement('p');
+    subtitle.className   = 'classroom-dialog-subtitle';
+    subtitle.textContent = 'Katılmak istediğin dersin kodunu gir.';
+
+    // ── Input ──
+    const input = document.createElement('input');
+    input.type        = 'text';
+    input.className   = 'classroom-dialog-input';
+    input.placeholder = 'Örn: abc123xz';
+    input.maxLength   = 32;
+    input.setAttribute('autocomplete', 'off');
+    input.setAttribute('aria-label', 'Classroom kodu');
+    this._input = input;
+
+    // ── Status message ──
+    const status = document.createElement('p');
+    status.className   = 'classroom-dialog-status hidden';
+    status.setAttribute('role', 'status');
+    this._status = status;
+
+    // ── Buttons ──
+    const btnRow = document.createElement('div');
+    btnRow.className = 'classroom-dialog-btn-row';
+
+    const btnJoin = document.createElement('button');
+    btnJoin.className   = 'classroom-dialog-btn classroom-dialog-btn--primary';
+    btnJoin.textContent = 'Katıl';
+    btnJoin.setAttribute('type', 'button');
+
+    const btnCancel = document.createElement('button');
+    btnCancel.className   = 'classroom-dialog-btn classroom-dialog-btn--secondary';
+    btnCancel.textContent = 'İptal';
+    btnCancel.setAttribute('type', 'button');
+
+    btnRow.appendChild(btnJoin);
+    btnRow.appendChild(btnCancel);
+
+    // ── Assemble ──
+    box.appendChild(title);
+    box.appendChild(subtitle);
+    box.appendChild(input);
+    box.appendChild(status);
+    box.appendChild(btnRow);
+    overlay.appendChild(box);
+    parent.appendChild(overlay);
+
+    this._root = overlay;
+
+    // ── Event wiring ──
+    btnJoin.addEventListener('click', () => this._submit());
+    btnCancel.addEventListener('click', () => this.hide());
+
+    // Close on Escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && this._visible) this.hide();
+    });
+
+    // Close on backdrop click (click outside the box)
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) this.hide();
+    });
+
+    // Also submit on Enter inside input
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') this._submit();
+    });
+  }
+
+  /** Show the dialog and focus the input. */
+  show() {
+    if (!this._root) return;
+    this._setStatus('', false);
+    if (this._input) this._input.value = '';
+    this._root.classList.remove('hidden');
+    this._visible = true;
+    if (this._input) this._input.focus();
+  }
+
+  /** Hide the dialog. */
+  hide() {
+    if (!this._root) return;
+    this._root.classList.add('hidden');
+    this._visible = false;
+  }
+
+  /** Whether the dialog is currently visible. */
+  get visible() {
+    return this._visible;
+  }
+
+  // ── Private Helpers ────────────────────────────────────────
+
+  /**
+   * Validate and submit the enrollment code.
+   * @private
+   */
+  async _submit() {
+    if (this._pending) return;
+
+    const raw = this._input ? this._input.value.trim() : '';
+    if (!raw) {
+      this._setStatus('Lütfen bir Classroom kodu gir.', 'error');
+      return;
+    }
+    // Enforce same rule as the IPC handler: alphanumeric, 1-32 chars
+    const clean = raw.replace(/[^a-zA-Z0-9]/g, '');
+    if (!clean) {
+      this._setStatus('Geçersiz kod — yalnızca harf ve rakam kabul edilir.', 'error');
+      return;
+    }
+
+    const api = (typeof window !== 'undefined') ? window.overlayAPI : null;
+    if (!api || typeof api.openClassroomEnrollment !== 'function') {
+      this._setStatus('overlayAPI mevcut değil.', 'error');
+      return;
+    }
+
+    this._pending = true;
+    this._setStatus('Açılıyor...', 'info');
+
+    let ok = false;
+    try {
+      ok = await api.openClassroomEnrollment(clean);
+    } catch (err) {
+      console.warn('[ClassroomDialog] openClassroomEnrollment error:', err);
+      ok = false;
+    } finally {
+      this._pending = false;
+    }
+
+    if (ok) {
+      this._setStatus('Tarayıcıda açıldı!', 'success');
+      setTimeout(() => this.hide(), 1500);
+    } else {
+      this._setStatus('Bağlantı açılamadı. Kodu kontrol et.', 'error');
+    }
+  }
+
+  /**
+   * Set the inline status message.
+   * @param {string} text
+   * @param {'error'|'success'|'info'|false} type  false → hide
+   * @private
+   */
+  _setStatus(text, type) {
+    if (!this._status) return;
+    this._status.textContent = text;
+    this._status.className   = 'classroom-dialog-status';
+    if (!type) {
+      this._status.classList.add('hidden');
+    } else {
+      this._status.classList.add(`classroom-dialog-status--${type}`);
+    }
+  }
+}
+
+// ─── GoogleAuthScopeIndicator ─────────────────────────────────────────────────
+
+/**
+ * Small status badge row showing which Google scopes are currently authorized.
+ * Clicking a missing scope badge triggers the OAuth flow for that scope.
+ *
+ * Usage:
+ *   const ind = new GoogleAuthScopeIndicator();
+ *   ind.mount(document.getElementById('hud-panel'));
+ *   // Automatically subscribes to auth:status updates.
+ *
+ * Emits no external events; self-contained.
+ */
+class GoogleAuthScopeIndicator {
+  /**
+   * @param {string[]} [scopes] - Which scopes to display. Defaults to all three.
+   */
+  constructor(scopes = ['calendar', 'gmail', 'classroom']) {
+    this._scopes  = scopes;
+    this._root    = null;
+    this._badges  = {}; // scope → badge element
+    this._status  = { calendar: false, gmail: false, classroom: false };
+  }
+
+  /**
+   * Inject badge row DOM into the given parent element.
+   * @param {HTMLElement} parent
+   */
+  mount(parent) {
+    if (this._root) return;
+
+    const container = document.createElement('div');
+    container.className = 'google-auth-scope-indicator';
+
+    const label = document.createElement('span');
+    label.className   = 'google-auth-scope-label';
+    label.textContent = 'Google:';
+    container.appendChild(label);
+
+    for (const scope of this._scopes) {
+      const badge = document.createElement('button');
+      badge.className = `google-auth-scope-badge google-auth-scope-badge--${scope} google-auth-scope-badge--inactive`;
+      badge.textContent = this._scopeLabel(scope);
+      badge.setAttribute('type', 'button');
+      badge.setAttribute('title', `${this._scopeLabel(scope)} yetkisi — tıkla ve etkinleştir`);
+      badge.dataset.scope = scope;
+      badge.addEventListener('click', () => this._onBadgeClick(scope));
+      container.appendChild(badge);
+      this._badges[scope] = badge;
+    }
+
+    parent.appendChild(container);
+    this._root = container;
+
+    // Subscribe to live auth status updates
+    const api = (typeof window !== 'undefined') ? window.overlayAPI : null;
+    if (api && typeof api.onAuthStatus === 'function') {
+      api.onAuthStatus((authStatus) => this._applyStatus(authStatus));
+    }
+
+    // Fetch current status
+    if (api && typeof api.getAuthStatus === 'function') {
+      api.getAuthStatus().then((s) => { if (s) this._applyStatus(s); }).catch(() => {});
+    }
+  }
+
+  /**
+   * Programmatically update which scopes are marked as authorized.
+   * @param {{ google?: boolean, calendar?: boolean, gmail?: boolean, classroom?: boolean, needsSetup?: boolean }} authStatus
+   */
+  _applyStatus(authStatus) {
+    if (!authStatus) return;
+
+    // The auth:status event shape from main.js: { google: bool, needsSetup: bool }
+    // For per-scope granularity we also handle { calendar, gmail, classroom } keys.
+    const scopeMap = {
+      calendar:  authStatus.calendar  ?? authStatus.google ?? false,
+      gmail:     authStatus.gmail     ?? authStatus.google ?? false,
+      classroom: authStatus.classroom ?? authStatus.google ?? false,
+    };
+
+    for (const scope of this._scopes) {
+      const active = !!scopeMap[scope];
+      this._status[scope] = active;
+      const badge = this._badges[scope];
+      if (!badge) continue;
+      badge.classList.remove('google-auth-scope-badge--active', 'google-auth-scope-badge--inactive');
+      badge.classList.add(active ? 'google-auth-scope-badge--active' : 'google-auth-scope-badge--inactive');
+      badge.setAttribute('title', active
+        ? `${this._scopeLabel(scope)} yetkisi aktif`
+        : `${this._scopeLabel(scope)} yetkisi yok — tıkla ve etkinleştir`
+      );
+    }
+  }
+
+  /**
+   * Handle badge click — trigger OAuth for that scope if not yet active.
+   * @param {string} scope
+   * @private
+   */
+  async _onBadgeClick(scope) {
+    if (this._status[scope]) return; // already authorized, nothing to do
+
+    const api = (typeof window !== 'undefined') ? window.overlayAPI : null;
+    if (!api || typeof api.requestGoogleOAuth !== 'function') return;
+
+    const badge = this._badges[scope];
+    if (badge) {
+      badge.classList.add('google-auth-scope-badge--pending');
+      badge.textContent = '…';
+    }
+
+    try {
+      const result = await api.requestGoogleOAuth([scope]);
+      if (result && result.success) {
+        this._status[scope] = true;
+        if (badge) {
+          badge.classList.remove('google-auth-scope-badge--pending');
+          badge.classList.remove('google-auth-scope-badge--inactive');
+          badge.classList.add('google-auth-scope-badge--active');
+          badge.textContent = this._scopeLabel(scope);
+        }
+      } else {
+        if (badge) {
+          badge.classList.remove('google-auth-scope-badge--pending');
+          badge.classList.add('google-auth-scope-badge--inactive');
+          badge.textContent = this._scopeLabel(scope);
+        }
+        console.warn('[AuthScopeIndicator] OAuth failed:', result && result.error);
+      }
+    } catch (err) {
+      if (badge) {
+        badge.classList.remove('google-auth-scope-badge--pending');
+        badge.classList.add('google-auth-scope-badge--inactive');
+        badge.textContent = this._scopeLabel(scope);
+      }
+      console.warn('[AuthScopeIndicator] OAuth error:', err);
+    }
+  }
+
+  /**
+   * Human-readable label for a scope key.
+   * @param {string} scope
+   * @returns {string}
+   * @private
+   */
+  _scopeLabel(scope) {
+    const MAP = { calendar: 'Takvim', gmail: 'Gmail', classroom: 'Classroom' };
+    return MAP[scope] || scope;
+  }
+}
+
+// ─── Export ───────────────────────────────────────────────────────────────────
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { ClassroomDialog, GoogleAuthScopeIndicator };
+} else if (typeof window !== 'undefined') {
+  window.ClassroomDialog         = ClassroomDialog;
+  window.GoogleAuthScopeIndicator = GoogleAuthScopeIndicator;
+}

--- a/bantz-overlay/src/renderer/classroom-dialog.js
+++ b/bantz-overlay/src/renderer/classroom-dialog.js
@@ -42,6 +42,7 @@ class ClassroomDialog {
     this._input   = null;
     this._status  = null;
     this._pending = false;
+    this._onDocumentKeydown = null;
   }
 
   /**
@@ -120,9 +121,10 @@ class ClassroomDialog {
     btnCancel.addEventListener('click', () => this.hide());
 
     // Close on Escape
-    document.addEventListener('keydown', (e) => {
+    this._onDocumentKeydown = (e) => {
       if (e.key === 'Escape' && this._visible) this.hide();
-    });
+    };
+    document.addEventListener('keydown', this._onDocumentKeydown);
 
     // Close on backdrop click (click outside the box)
     overlay.addEventListener('click', (e) => {
@@ -152,6 +154,20 @@ class ClassroomDialog {
     this._visible = false;
   }
 
+  /**
+   * Tear down the dialog — removes global event listeners and DOM.
+   */
+  dispose() {
+    if (this._onDocumentKeydown) {
+      document.removeEventListener('keydown', this._onDocumentKeydown);
+      this._onDocumentKeydown = null;
+    }
+    if (this._root && this._root.parentNode) {
+      this._root.parentNode.removeChild(this._root);
+    }
+    this._root = null;
+  }
+
   /** Whether the dialog is currently visible. */
   get visible() {
     return this._visible;
@@ -172,7 +188,7 @@ class ClassroomDialog {
       return;
     }
     // Enforce same rule as the IPC handler: alphanumeric, 1-32 chars
-    const clean = raw.replace(/[^a-zA-Z0-9]/g, '');
+    const clean = raw.replace(/[^a-zA-Z0-9]/g, '').slice(0, 32);
     if (!clean) {
       this._setStatus('Geçersiz kod — yalnızca harf ve rakam kabul edilir.', 'error');
       return;
@@ -214,7 +230,14 @@ class ClassroomDialog {
   _setStatus(text, type) {
     if (!this._status) return;
     this._status.textContent = text;
-    this._status.className   = 'classroom-dialog-status';
+    // Use only classList to avoid desync with classList.add/remove elsewhere
+    this._status.classList.add('classroom-dialog-status');
+    this._status.classList.remove(
+      'hidden',
+      'classroom-dialog-status--error',
+      'classroom-dialog-status--success',
+      'classroom-dialog-status--info'
+    );
     if (!type) {
       this._status.classList.add('hidden');
     } else {
@@ -241,10 +264,11 @@ class GoogleAuthScopeIndicator {
    * @param {string[]} [scopes] - Which scopes to display. Defaults to all three.
    */
   constructor(scopes = ['calendar', 'gmail', 'classroom']) {
-    this._scopes  = scopes;
-    this._root    = null;
-    this._badges  = {}; // scope → badge element
-    this._status  = { calendar: false, gmail: false, classroom: false };
+    this._scopes       = scopes;
+    this._root         = null;
+    this._badges       = {}; // scope → badge element
+    this._status       = { calendar: false, gmail: false, classroom: false };
+    this._pendingScope = null;
   }
 
   /**
@@ -264,7 +288,7 @@ class GoogleAuthScopeIndicator {
 
     for (const scope of this._scopes) {
       const badge = document.createElement('button');
-      badge.className = `google-auth-scope-badge google-auth-scope-badge--${scope} google-auth-scope-badge--inactive`;
+      badge.classList.add('google-auth-scope-badge', `google-auth-scope-badge--${scope}`, 'google-auth-scope-badge--inactive');
       badge.textContent = this._scopeLabel(scope);
       badge.setAttribute('type', 'button');
       badge.setAttribute('title', `${this._scopeLabel(scope)} yetkisi — tıkla ve etkinleştir`);
@@ -325,10 +349,12 @@ class GoogleAuthScopeIndicator {
    */
   async _onBadgeClick(scope) {
     if (this._status[scope]) return; // already authorized, nothing to do
+    if (this._pendingScope !== null) return; // another scope request in progress
 
     const api = (typeof window !== 'undefined') ? window.overlayAPI : null;
     if (!api || typeof api.requestGoogleOAuth !== 'function') return;
 
+    this._pendingScope = scope;
     const badge = this._badges[scope];
     if (badge) {
       badge.classList.add('google-auth-scope-badge--pending');
@@ -360,6 +386,8 @@ class GoogleAuthScopeIndicator {
         badge.textContent = this._scopeLabel(scope);
       }
       console.warn('[AuthScopeIndicator] OAuth error:', err);
+    } finally {
+      this._pendingScope = null;
     }
   }
 

--- a/bantz-overlay/src/renderer/renderer.js
+++ b/bantz-overlay/src/renderer/renderer.js
@@ -936,6 +936,32 @@ checkFirstBootOrAbsence();
 // ─── Initialize Reasoning Chain ─────────────────────────────
 initReasoningChain();
 
+// ─── Classroom Dialog (Issue #1467) ────────────────────────
+let classroomDialog = null;
+let googleAuthScopeIndicator = null;
+
+function initClassroomDialog() {
+  if (!window.ClassroomDialog) {
+    console.warn('[Overlay] ClassroomDialog not loaded');
+    return;
+  }
+  classroomDialog = new window.ClassroomDialog();
+  classroomDialog.mount(document.body);
+  window.bantzClassroomDialog = classroomDialog;
+  console.log('[Overlay] Classroom dialog initialized');
+}
+
+function initGoogleAuthScopeIndicator() {
+  if (!window.GoogleAuthScopeIndicator) {
+    console.warn('[Overlay] GoogleAuthScopeIndicator not loaded');
+    return;
+  }
+  googleAuthScopeIndicator = new window.GoogleAuthScopeIndicator();
+  googleAuthScopeIndicator.mount(hudPanel);
+  window.bantzAuthScopeIndicator = googleAuthScopeIndicator;
+  console.log('[Overlay] Google auth scope indicator initialized');
+}
+
 // ─── Initialize Phone Call Overlay ──────────────────────────
 
 function initPhoneCallOverlay() {
@@ -950,6 +976,12 @@ function initPhoneCallOverlay() {
 }
 
 initPhoneCallOverlay();
+
+// ─── Initialize Classroom Dialog ───────────────────────────
+initClassroomDialog();
+
+// ─── Initialize Google Auth Scope Indicator ─────────────────
+initGoogleAuthScopeIndicator();
 
 // ─── Initialize Floating Text Input ─────────────────────────
 let textInput = null;
@@ -1006,6 +1038,8 @@ console.log('[Overlay]   ttsSync:', !!ttsSync);
 console.log('[Overlay]   reasoningChain:', !!reasoningChain);
 console.log('[Overlay]   phoneCallOverlay:', !!phoneCallOverlay);
 console.log('[Overlay]   textInput:', !!textInput);
+console.log('[Overlay]   classroomDialog:', !!classroomDialog);
+console.log('[Overlay]   googleAuthScopeIndicator:', !!googleAuthScopeIndicator);
 console.log('[Overlay]   hudPanel:', !!hudPanel);
 console.log('[Overlay]   sphereContainer:', !!sphereContainer);
 console.log('[Overlay] ═══════════════════');

--- a/bantz-overlay/src/renderer/renderer.js
+++ b/bantz-overlay/src/renderer/renderer.js
@@ -946,7 +946,7 @@ function initClassroomDialog() {
     return;
   }
   classroomDialog = new window.ClassroomDialog();
-  classroomDialog.mount(document.body);
+  classroomDialog.mount(hudPanel);
   window.bantzClassroomDialog = classroomDialog;
   console.log('[Overlay] Classroom dialog initialized');
 }

--- a/bantz-overlay/tests/test_classroom_dialog.js
+++ b/bantz-overlay/tests/test_classroom_dialog.js
@@ -25,7 +25,6 @@ const fs     = require('fs');
 class MockElement {
   constructor(tag) {
     this.tagName     = (tag || 'div').toUpperCase();
-    this.className   = '';
     this.textContent = '';
     this.innerHTML   = '';
     this.children    = [];
@@ -42,18 +41,24 @@ class MockElement {
     const self = this;
     this.style    = {};
     this.classList = {
-      add:      (...cs) => cs.forEach(c => { self._classes.add(c);    self.className = [...self._classes].join(' '); }),
-      remove:   (...cs) => cs.forEach(c => { self._classes.delete(c); self.className = [...self._classes].join(' '); }),
+      add:      (...cs) => cs.forEach(c => { self._classes.add(c);    /* className synced via getter */ }),
+      remove:   (...cs) => cs.forEach(c => { self._classes.delete(c); }),
       contains: (c) => self._classes.has(c),
       toggle:   (c) => {
         if (self._classes.has(c)) self._classes.delete(c); else self._classes.add(c);
-        self.className = [...self._classes].join(' ');
       },
       replace: (a, b) => {
         self._classes.delete(a); self._classes.add(b);
-        self.className = [...self._classes].join(' ');
       },
     };
+  }
+
+  // className getter/setter keeps _classes Set in sync
+  get className() {
+    return [...this._classes].join(' ');
+  }
+  set className(val) {
+    this._classes = new Set((val || '').split(' ').filter(Boolean));
   }
 
   appendChild(child) {
@@ -95,9 +100,8 @@ global.window = {
   GoogleAuthScopeIndicator: null,
 };
 
-// Silence console noise
+// Silence console noise — restored after tests
 const _origWarn = console.warn;
-// (keep for debugging, but suppress during normal run)
 console.warn = () => {};
 
 // ─── Load module under test ────────────────────────────────────────────────
@@ -117,6 +121,7 @@ assert.ok(GoogleAuthScopeIndicator,'GoogleAuthScopeIndicator exported');
 
 let passCount = 0;
 let failCount = 0;
+const _asyncTests = [];
 function test(name, fn) {
   try {
     fn();
@@ -128,16 +133,20 @@ function test(name, fn) {
     failCount++;
   }
 }
-async function testAsync(name, fn) {
-  try {
-    await fn();
-    console.log(`  ✓  ${name}`);
-    passCount++;
-  } catch (err) {
-    console.error(`  ✗  ${name}`);
-    console.error(`     ${err.message}`);
-    failCount++;
-  }
+function testAsync(name, fn) {
+  const promise = (async () => {
+    try {
+      await fn();
+      console.log(`  ✓  ${name}`);
+      passCount++;
+    } catch (err) {
+      console.error(`  ✗  ${name}`);
+      console.error(`     ${err.message}`);
+      failCount++;
+    }
+  })();
+  _asyncTests.push(promise);
+  return promise;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -598,5 +607,8 @@ test('_scopeLabel: returns Turkish labels', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 console.log(`\n${'─'.repeat(50)}`);
-console.log(`Tests: ${passCount + failCount}  ✓ ${passCount}  ✗ ${failCount}`);
-if (failCount > 0) process.exit(1);
+Promise.all(_asyncTests).then(() => {
+  console.warn = _origWarn; // restore
+  console.log(`Tests: ${passCount + failCount}  ✓ ${passCount}  ✗ ${failCount}`);
+  if (failCount > 0) process.exit(1);
+});

--- a/bantz-overlay/tests/test_classroom_dialog.js
+++ b/bantz-overlay/tests/test_classroom_dialog.js
@@ -1,0 +1,602 @@
+/**
+ * Bantz Overlay — Classroom Dialog Tests (Issue #1467)
+ *
+ * Covers:
+ *   AC1  window.overlayAPI.requestGoogleOAuth(['classroom']) is exposed and
+ *        invoked by GoogleAuthScopeIndicator on badge click.
+ *   AC2  window.overlayAPI.openClassroomEnrollment(code) is exposed and
+ *        called by ClassroomDialog with the sanitized code, which ultimately
+ *        opens https://classroom.google.com/c/<code>.
+ *   AC3  GoogleAuthScopeIndicator reflects classroom scope auth state after
+ *        an auth:status event (checking IngestStore readiness indirectly via
+ *        the scope-active state that gates sync).
+ *
+ * Run: node bantz-overlay/tests/test_classroom_dialog.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const path   = require('path');
+const fs     = require('fs');
+
+// ─── Minimal DOM Stub ──────────────────────────────────────────────────────
+
+class MockElement {
+  constructor(tag) {
+    this.tagName     = (tag || 'div').toUpperCase();
+    this.className   = '';
+    this.textContent = '';
+    this.innerHTML   = '';
+    this.children    = [];
+    this._listeners  = {};
+    this._classes    = new Set();
+    this.type        = '';
+    this.placeholder = '';
+    this.value       = '';
+    this.maxLength   = undefined;
+    this.parentNode  = null;
+    this.dataset     = {};
+    this._attrs      = {};
+
+    const self = this;
+    this.style    = {};
+    this.classList = {
+      add:      (...cs) => cs.forEach(c => { self._classes.add(c);    self.className = [...self._classes].join(' '); }),
+      remove:   (...cs) => cs.forEach(c => { self._classes.delete(c); self.className = [...self._classes].join(' '); }),
+      contains: (c) => self._classes.has(c),
+      toggle:   (c) => {
+        if (self._classes.has(c)) self._classes.delete(c); else self._classes.add(c);
+        self.className = [...self._classes].join(' ');
+      },
+      replace: (a, b) => {
+        self._classes.delete(a); self._classes.add(b);
+        self.className = [...self._classes].join(' ');
+      },
+    };
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+  setAttribute(k, v) { this._attrs[k] = v; }
+  getAttribute(k)    { return this._attrs[k]; }
+  addEventListener(type, fn) {
+    if (!this._listeners[type]) this._listeners[type] = [];
+    this._listeners[type].push(fn);
+  }
+  _fire(type, evt = {}) {
+    (this._listeners[type] || []).forEach(fn => fn({ target: this, ...evt }));
+  }
+  focus() {}
+}
+
+// Global document / window stubs
+const domElements = {};
+global.document = {
+  createElement(tag) { return new MockElement(tag); },
+  getElementById(id) { return domElements[id] || null; },
+  addEventListener(type, fn) {
+    if (!document._docListeners) document._docListeners = {};
+    if (!document._docListeners[type]) document._docListeners[type] = [];
+    document._docListeners[type].push(fn);
+  },
+  _fireDoc(type, evt = {}) {
+    ((document._docListeners || {})[type] || []).forEach(fn => fn(evt));
+  },
+  _docListeners: {},
+};
+
+global.window = {
+  overlayAPI: null,
+  ClassroomDialog: null,
+  GoogleAuthScopeIndicator: null,
+};
+
+// Silence console noise
+const _origWarn = console.warn;
+// (keep for debugging, but suppress during normal run)
+console.warn = () => {};
+
+// ─── Load module under test ────────────────────────────────────────────────
+
+const modulePath = path.resolve(__dirname, '..', 'src', 'renderer', 'classroom-dialog.js');
+const src = fs.readFileSync(modulePath, 'utf8');
+// eslint-disable-next-line no-new-func
+const moduleFactory = new Function('module', 'exports', 'window', 'document', src);
+const mod = { exports: {} };
+moduleFactory(mod, mod.exports, global.window, global.document);
+
+const { ClassroomDialog, GoogleAuthScopeIndicator } = mod.exports;
+assert.ok(ClassroomDialog,         'ClassroomDialog exported');
+assert.ok(GoogleAuthScopeIndicator,'GoogleAuthScopeIndicator exported');
+
+// ─── Helper ────────────────────────────────────────────────────────────────
+
+let passCount = 0;
+let failCount = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓  ${name}`);
+    passCount++;
+  } catch (err) {
+    console.error(`  ✗  ${name}`);
+    console.error(`     ${err.message}`);
+    failCount++;
+  }
+}
+async function testAsync(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓  ${name}`);
+    passCount++;
+  } catch (err) {
+    console.error(`  ✗  ${name}`);
+    console.error(`     ${err.message}`);
+    failCount++;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Block A — ClassroomDialog
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log('\n── ClassroomDialog ──');
+
+test('constructor: _visible starts false', () => {
+  const dlg = new ClassroomDialog();
+  assert.strictEqual(dlg.visible, false);
+});
+
+test('mount: creates root element with correct class', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  assert.ok(dlg._root, '_root set after mount');
+  // component sets className directly, so check the string
+  assert.ok(dlg._root.className.includes('classroom-dialog-overlay'), 'has overlay class');
+  assert.ok(dlg._root.className.includes('hidden'), 'starts hidden');
+});
+
+test('mount: is idempotent', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg.mount(parent);
+  assert.strictEqual(parent.children.length, 1, 'only one child appended');
+});
+
+test('mount: aria-modal and role attributes set', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  assert.strictEqual(dlg._root.getAttribute('role'), 'dialog');
+  assert.strictEqual(dlg._root.getAttribute('aria-modal'), 'true');
+});
+
+test('show: removes hidden class and sets visible', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg.show();
+  assert.strictEqual(dlg.visible, true);
+  assert.ok(!dlg._root._classes.has('hidden'), 'hidden class removed');
+});
+
+test('hide: adds hidden class back', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg.show();
+  dlg.hide();
+  assert.strictEqual(dlg.visible, false);
+  assert.ok(dlg._root._classes.has('hidden'), 'hidden class present');
+});
+
+test('show: clears input value', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = 'old-code';
+  dlg.show();
+  assert.strictEqual(dlg._input.value, '', 'input cleared on show');
+});
+
+test('_submit: empty input shows error status', async () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = '';
+  await dlg._submit();
+  assert.ok(dlg._status._classes.has('classroom-dialog-status--error'), 'error class set');
+  assert.ok(!dlg._status._classes.has('hidden'), 'status visible');
+});
+
+test('_submit: non-alphanumeric-only input shows error', async () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = '!!!';
+  await dlg._submit();
+  assert.ok(dlg._status._classes.has('classroom-dialog-status--error'));
+});
+
+// ─── AC2: openClassroomEnrollment called with correct code ───
+
+testAsync('AC2: _submit calls openClassroomEnrollment with sanitized code', async () => {
+  const calls = [];
+  global.window.overlayAPI = {
+    openClassroomEnrollment: async (code) => { calls.push(code); return true; },
+  };
+
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = 'abc123xz';
+  await dlg._submit();
+
+  assert.deepStrictEqual(calls, ['abc123xz'], 'correct code forwarded');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC2: _submit strips non-alphanumeric chars before calling API', async () => {
+  const calls = [];
+  global.window.overlayAPI = {
+    openClassroomEnrollment: async (code) => { calls.push(code); return true; },
+  };
+
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = 'abc-123 xz!';  // contains hyphens, space, exclamation
+  await dlg._submit();
+
+  assert.deepStrictEqual(calls, ['abc123xz'], 'non-alphanum stripped');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC2: _submit shows success status and auto-hides on ok=true', async () => {
+  global.window.overlayAPI = {
+    openClassroomEnrollment: async () => true,
+  };
+
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg.show();
+  dlg._input.value = 'validCode1';
+  await dlg._submit();
+
+  assert.ok(dlg._status._classes.has('classroom-dialog-status--success'), 'success class set');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC2: _submit shows error status on ok=false', async () => {
+  global.window.overlayAPI = {
+    openClassroomEnrollment: async () => false,
+  };
+
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = 'code99';
+  await dlg._submit();
+
+  assert.ok(dlg._status._classes.has('classroom-dialog-status--error'), 'error class set on failure');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC2: _submit shows error status when API throws', async () => {
+  global.window.overlayAPI = {
+    openClassroomEnrollment: async () => { throw new Error('IPC unavailable'); },
+  };
+
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = 'code42';
+  await dlg._submit();
+
+  assert.ok(dlg._status._classes.has('classroom-dialog-status--error'));
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC2: _submit is no-op when overlayAPI missing', async () => {
+  global.window.overlayAPI = null;
+
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = 'someCode';
+  await dlg._submit();
+
+  assert.ok(dlg._status._classes.has('classroom-dialog-status--error'), 'error shown when no API');
+});
+
+testAsync('AC2: _pending guard prevents double submission', async () => {
+  let callCount = 0;
+  global.window.overlayAPI = {
+    openClassroomEnrollment: async (code) => {
+      callCount++;
+      await new Promise(r => setTimeout(r, 10));
+      return true;
+    },
+  };
+
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._input.value = 'doubleCode';
+
+  // Fire _submit twice without awaiting first
+  const p1 = dlg._submit();
+  const p2 = dlg._submit(); // should be ignored because _pending === true
+  await Promise.all([p1, p2]);
+
+  assert.strictEqual(callCount, 1, 'API called exactly once');
+  global.window.overlayAPI = null;
+});
+
+test('_setStatus: sets text and success class', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._setStatus('OK!', 'success');
+  assert.strictEqual(dlg._status.textContent, 'OK!');
+  assert.ok(dlg._status._classes.has('classroom-dialog-status--success'));
+  assert.ok(!dlg._status._classes.has('hidden'));
+});
+
+test('_setStatus: type=false hides status', () => {
+  const dlg = new ClassroomDialog();
+  const parent = new MockElement('div');
+  dlg.mount(parent);
+  dlg._setStatus('', false);
+  assert.ok(dlg._status._classes.has('hidden'));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Block B — GoogleAuthScopeIndicator
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log('\n── GoogleAuthScopeIndicator ──');
+
+test('constructor: default scopes are calendar, gmail, classroom', () => {
+  const ind = new GoogleAuthScopeIndicator();
+  assert.deepStrictEqual(ind._scopes, ['calendar', 'gmail', 'classroom']);
+});
+
+test('constructor: accepts custom scopes', () => {
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  assert.deepStrictEqual(ind._scopes, ['classroom']);
+});
+
+test('mount: creates container with badge per scope', () => {
+  const ind = new GoogleAuthScopeIndicator(['calendar', 'gmail', 'classroom']);
+  const parent = new MockElement('div');
+  global.window.overlayAPI = { onAuthStatus: () => {}, getAuthStatus: () => Promise.resolve(null) };
+  ind.mount(parent);
+  assert.ok(ind._root, '_root set');
+  assert.ok(ind._badges['calendar'],  'calendar badge created');
+  assert.ok(ind._badges['gmail'],     'gmail badge created');
+  assert.ok(ind._badges['classroom'], 'classroom badge created');
+  global.window.overlayAPI = null;
+});
+
+test('mount: idempotent', () => {
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  global.window.overlayAPI = { onAuthStatus: () => {}, getAuthStatus: () => Promise.resolve(null) };
+  ind.mount(parent);
+  ind.mount(parent);
+  assert.strictEqual(parent.children.length, 1);
+  global.window.overlayAPI = null;
+});
+
+test('mount: badges start inactive', () => {
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  global.window.overlayAPI = { onAuthStatus: () => {}, getAuthStatus: () => Promise.resolve(null) };
+  ind.mount(parent);
+  const badge = ind._badges['classroom'];
+  // component sets className directly on creation, then _applyStatus uses classList
+  const cn = badge.className + ' ' + [...badge._classes].join(' ');
+  assert.ok(cn.includes('google-auth-scope-badge--inactive'), 'starts inactive');
+  assert.ok(!cn.includes('google-auth-scope-badge--active') || cn.includes('inactive'), 'not erroneously active');
+  global.window.overlayAPI = null;
+});
+
+// ─── AC3: _applyStatus reflects auth state ───
+
+test('AC3: _applyStatus marks classroom badge active when google=true', () => {
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  global.window.overlayAPI = { onAuthStatus: () => {}, getAuthStatus: () => Promise.resolve(null) };
+  ind.mount(parent);
+  ind._applyStatus({ google: true, needsSetup: false });
+  const badge = ind._badges['classroom'];
+  assert.ok(badge._classes.has('google-auth-scope-badge--active'),   'active after google:true');
+  assert.ok(!badge._classes.has('google-auth-scope-badge--inactive'), 'inactive removed');
+  global.window.overlayAPI = null;
+});
+
+test('AC3: _applyStatus marks classroom badge inactive when google=false', () => {
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  global.window.overlayAPI = { onAuthStatus: () => {}, getAuthStatus: () => Promise.resolve(null) };
+  ind.mount(parent);
+  ind._applyStatus({ google: true }); // first authorize
+  ind._applyStatus({ google: false }); // then revoke
+  const badge = ind._badges['classroom'];
+  assert.ok(badge._classes.has('google-auth-scope-badge--inactive'));
+  assert.ok(!badge._classes.has('google-auth-scope-badge--active'));
+  global.window.overlayAPI = null;
+});
+
+test('AC3: _applyStatus uses per-scope classroom key over generic google flag', () => {
+  const ind = new GoogleAuthScopeIndicator(['classroom', 'gmail']);
+  const parent = new MockElement('div');
+  global.window.overlayAPI = { onAuthStatus: () => {}, getAuthStatus: () => Promise.resolve(null) };
+  ind.mount(parent);
+  // classroom=true but gmail=false — generic google=false is overridden by specific keys
+  ind._applyStatus({ google: false, classroom: true, gmail: false });
+  assert.ok( ind._badges['classroom']._classes.has('google-auth-scope-badge--active'),   'classroom active via specific key');
+  assert.ok(!ind._badges['gmail']._classes.has('google-auth-scope-badge--active'),        'gmail inactive');
+  global.window.overlayAPI = null;
+});
+
+test('AC3: _applyStatus gracefully handles null/undefined', () => {
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  global.window.overlayAPI = { onAuthStatus: () => {}, getAuthStatus: () => Promise.resolve(null) };
+  ind.mount(parent);
+  // Should not throw
+  ind._applyStatus(null);
+  ind._applyStatus(undefined);
+  global.window.overlayAPI = null;
+});
+
+test('AC3: live onAuthStatus update propagates to badge', () => {
+  let storedCb = null;
+  global.window.overlayAPI = {
+    onAuthStatus: (cb) => { storedCb = cb; },
+    getAuthStatus: () => Promise.resolve(null),
+  };
+
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  ind.mount(parent);
+
+  // Simulate auth:status IPC event
+  storedCb({ google: true, needsSetup: false });
+
+  assert.ok(ind._badges['classroom']._classes.has('google-auth-scope-badge--active'),
+    'badge updated by live auth:status callback');
+  global.window.overlayAPI = null;
+});
+
+// ─── AC1: requestGoogleOAuth called on badge click ───
+
+testAsync('AC1: clicking inactive classroom badge calls requestGoogleOAuth(["classroom"])', async () => {
+  const oauthCalls = [];
+  global.window.overlayAPI = {
+    onAuthStatus: () => {},
+    getAuthStatus: () => Promise.resolve(null),
+    requestGoogleOAuth: async (scopes) => { oauthCalls.push(scopes); return { success: true, scopes }; },
+  };
+
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  ind.mount(parent);
+
+  // Simulate badge click
+  await ind._onBadgeClick('classroom');
+
+  assert.strictEqual(oauthCalls.length, 1, 'requestGoogleOAuth called once');
+  assert.deepStrictEqual(oauthCalls[0], ['classroom'], 'called with ["classroom"]');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC1: clicking already-active classroom badge does NOT call requestGoogleOAuth', async () => {
+  const oauthCalls = [];
+  global.window.overlayAPI = {
+    onAuthStatus: () => {},
+    getAuthStatus: () => Promise.resolve(null),
+    requestGoogleOAuth: async (scopes) => { oauthCalls.push(scopes); return { success: true, scopes }; },
+  };
+
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  ind.mount(parent);
+  ind._applyStatus({ google: true }); // mark active
+  await ind._onBadgeClick('classroom'); // already active — should be no-op
+
+  assert.strictEqual(oauthCalls.length, 0, 'requestGoogleOAuth NOT called for active scope');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC1: badge shows pending state during OAuth, then active on success', async () => {
+  global.window.overlayAPI = {
+    onAuthStatus: () => {},
+    getAuthStatus: () => Promise.resolve(null),
+    requestGoogleOAuth: async () => { return { success: true, scopes: ['classroom'] }; },
+  };
+
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  ind.mount(parent);
+  await ind._onBadgeClick('classroom');
+
+  const badge = ind._badges['classroom'];
+  assert.ok(badge._classes.has('google-auth-scope-badge--active'),   'active after success');
+  assert.ok(!badge._classes.has('google-auth-scope-badge--pending'), 'pending removed');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC1: badge recovers gracefully when OAuth fails (success:false)', async () => {
+  global.window.overlayAPI = {
+    onAuthStatus: () => {},
+    getAuthStatus: () => Promise.resolve(null),
+    requestGoogleOAuth: async () => { return { success: false, error: 'cancelled' }; },
+  };
+
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  ind.mount(parent);
+  await ind._onBadgeClick('classroom');
+
+  const badge = ind._badges['classroom'];
+  assert.ok(badge._classes.has('google-auth-scope-badge--inactive'), 'remains inactive on failure');
+  assert.ok(!badge._classes.has('google-auth-scope-badge--pending'),  'pending removed');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC1: badge recovers gracefully when requestGoogleOAuth throws', async () => {
+  global.window.overlayAPI = {
+    onAuthStatus: () => {},
+    getAuthStatus: () => Promise.resolve(null),
+    requestGoogleOAuth: async () => { throw new Error('IPC error'); },
+  };
+
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  ind.mount(parent);
+  await ind._onBadgeClick('classroom');
+
+  const badge = ind._badges['classroom'];
+  assert.ok(badge._classes.has('google-auth-scope-badge--inactive'), 'remains inactive after error');
+  global.window.overlayAPI = null;
+});
+
+testAsync('AC1: requestGoogleOAuth NOT called when overlayAPI missing', async () => {
+  global.window.overlayAPI = null;
+  const ind = new GoogleAuthScopeIndicator(['classroom']);
+  const parent = new MockElement('div');
+  // Can't mount without API — simulate detached state
+  ind._status['classroom'] = false;
+  ind._badges['classroom'] = new MockElement('button');
+  // Should not throw
+  await ind._onBadgeClick('classroom');
+  // No assertion needed beyond no-throw
+});
+
+// ─── _scopeLabel helper ───
+
+test('_scopeLabel: returns Turkish labels', () => {
+  const ind = new GoogleAuthScopeIndicator();
+  assert.strictEqual(ind._scopeLabel('calendar'),  'Takvim');
+  assert.strictEqual(ind._scopeLabel('gmail'),     'Gmail');
+  assert.strictEqual(ind._scopeLabel('classroom'), 'Classroom');
+  assert.strictEqual(ind._scopeLabel('unknown'),   'unknown'); // passthrough
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Results
+// ─────────────────────────────────────────────────────────────────────────────
+
+console.log(`\n${'─'.repeat(50)}`);
+console.log(`Tests: ${passCount + failCount}  ✓ ${passCount}  ✗ ${failCount}`);
+if (failCount > 0) process.exit(1);


### PR DESCRIPTION
## Summary

Implements the missing renderer-side UI for Issue #1467.

### IPC layer (already in `dev`)
- `ipcMain.handle('auth:request-google-oauth')` — `classroom` scope whitelisted, whitelist-validated, injected as safe identifiers
- `ipcMain.handle('classroom:open-enrollment')` — alphanumeric sanitisation, `shell.openExternal` to `https://classroom.google.com/c/<code>`
- `preload.js` — `window.overlayAPI.requestGoogleOAuth()` + `window.overlayAPI.openClassroomEnrollment()`

### New: `classroom-dialog.js`

#### `ClassroomDialog`
- "Classroom'a Katıl" modal with enrollment code input form
- Strips non-alphanum, caps at 32 chars before forwarding to IPC (mirrors server-side rule)
- Inline success/error feedback; auto-hides 1.5s after success
- Accessible: `role=dialog`, `aria-modal`, `aria-label`, Escape/Enter keyboard support
- Double-submit guard via `_pending` flag

#### `GoogleAuthScopeIndicator`
- Badge row: Takvim / Gmail / Classroom
- Subscribes to live `auth:status` IPC events via `onAuthStatus`
- Fetches initial state on mount via `getAuthStatus()`
- Clicking an inactive badge fires `requestGoogleOAuth([scope])` (AC1)
- Supports per-scope keys `{ classroom: bool }` or generic `{ google: bool }`
- Pending → active/inactive CSS class transitions with label restore on failure

### Modified: `renderer.js`
- `initClassroomDialog()` + `initGoogleAuthScopeIndicator()` wired into boot sequence
- Both reflected in diagnostic INIT SUMMARY log

### Tests: `tests/test_classroom_dialog.js`
35 tests, plain Node + assert, no external deps — same pattern as `test_news_image_popup.js`

| AC | Coverage |
|---|---|
| AC1 | `requestGoogleOAuth(['classroom'])` called on badge click; no-op when already active; recovers gracefully on failure/error |
| AC2 | `openClassroomEnrollment(code)` called with sanitized code; non-alphanum stripped; success/error/throw paths |
| AC3 | Scope indicator reflects `classroom` auth state; `_applyStatus` with per-scope and generic flags; live `onAuthStatus` propagation |

```
Tests: 35  ✓ 35  ✗ 0
```

Closes #1467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Google Classroom enrollment dialog enabling users to join classrooms using enrollment codes
  * Added Google Auth Scope Indicator displaying connection status to Calendar, Gmail, and Classroom with ability to request OAuth permissions

* **Tests**
  * Added comprehensive test suite for Google Classroom and authentication scope features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->